### PR TITLE
changes in VD geo to allow background from anode

### DIFF
--- a/dunecore/Geometry/gdml/dunevd10kt_3view_30deg_v3_refactored_1x8x14ref.gdml
+++ b/dunecore/Geometry/gdml/dunevd10kt_3view_30deg_v3_refactored_1x8x14ref.gdml
@@ -509,6 +509,11 @@
       y="167.7006"
       z="148.92"
       lunit="cm"/>
+   <box name="AnodePlate" 
+      x="0.02/2."
+      y="167.7006"
+      z="148.92"
+      lunit="cm"/>
    <box name="CRMActive" 
       x="650"
       y="167.7006"
@@ -10230,7 +10235,7 @@
      
    <volume name="volAnodePlate">
      <materialref ref="vm2000"/>
-     <solidref ref="CRMZPlane"/>
+     <solidref ref="AnodePlate"/>
   </volume>
    <volume name="volTPC">
      <materialref ref="LAr"/>
@@ -10238,25 +10243,25 @@
        <physvol>
        <volumeref ref="volTPCPlaneU"/>
        <position name="posPlaneU" unit="cm" 
-         x="324.98" y="0" z="0"/>
+         x="324.99" y="0" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volTPCPlaneV"/>
        <position name="posPlaneY" unit="cm" 
-         x="325" y="0" z="0"/>
+         x="325.01" y="0" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volTPCPlaneZ"/>
        <position name="posPlaneZ" unit="cm" 
-         x="325.02" y="0" z="0"/>
+         x="325.03" y="0" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volAnodePlate"/>
        <position name="posAnodePlate" unit="cm" 
-         x="325.04" y="0" z="0"/>
+         x="325.045" y="0" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
@@ -12749,120 +12754,120 @@
   </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-0" unit="cm" x="-328.05" y="-505.1018" z="-897.02"/>
+   <position name="posGroundGrid-0" unit="cm" x="-328.04" y="-505.1018" z="-897.02"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-1" unit="cm" x="-328.05" y="-169.7006" z="-897.02"/>
+   <position name="posGroundGrid-1" unit="cm" x="-328.04" y="-169.7006" z="-897.02"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-2" unit="cm" x="-328.05" y="165.7006" z="-897.02"/>
+   <position name="posGroundGrid-2" unit="cm" x="-328.04" y="165.7006" z="-897.02"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-3" unit="cm" x="-328.05" y="501.1018" z="-897.02"/>
+   <position name="posGroundGrid-3" unit="cm" x="-328.04" y="501.1018" z="-897.02"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-4" unit="cm" x="-328.05" y="-505.1018" z="-599.18"/>
+   <position name="posGroundGrid-4" unit="cm" x="-328.04" y="-505.1018" z="-599.18"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-5" unit="cm" x="-328.05" y="-169.7006" z="-599.18"/>
+   <position name="posGroundGrid-5" unit="cm" x="-328.04" y="-169.7006" z="-599.18"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-6" unit="cm" x="-328.05" y="165.7006" z="-599.18"/>
+   <position name="posGroundGrid-6" unit="cm" x="-328.04" y="165.7006" z="-599.18"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-7" unit="cm" x="-328.05" y="501.1018" z="-599.18"/>
+   <position name="posGroundGrid-7" unit="cm" x="-328.04" y="501.1018" z="-599.18"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-8" unit="cm" x="-328.05" y="-505.1018" z="-301.34"/>
+   <position name="posGroundGrid-8" unit="cm" x="-328.04" y="-505.1018" z="-301.34"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-9" unit="cm" x="-328.05" y="-169.7006" z="-301.34"/>
+   <position name="posGroundGrid-9" unit="cm" x="-328.04" y="-169.7006" z="-301.34"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-10" unit="cm" x="-328.05" y="165.7006" z="-301.34"/>
+   <position name="posGroundGrid-10" unit="cm" x="-328.04" y="165.7006" z="-301.34"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-11" unit="cm" x="-328.05" y="501.1018" z="-301.34"/>
+   <position name="posGroundGrid-11" unit="cm" x="-328.04" y="501.1018" z="-301.34"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-12" unit="cm" x="-328.05" y="-505.1018" z="-3.49999999999989"/>
+   <position name="posGroundGrid-12" unit="cm" x="-328.04" y="-505.1018" z="-3.49999999999989"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-13" unit="cm" x="-328.05" y="-169.7006" z="-3.49999999999989"/>
+   <position name="posGroundGrid-13" unit="cm" x="-328.04" y="-169.7006" z="-3.49999999999989"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-14" unit="cm" x="-328.05" y="165.7006" z="-3.49999999999989"/>
+   <position name="posGroundGrid-14" unit="cm" x="-328.04" y="165.7006" z="-3.49999999999989"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-15" unit="cm" x="-328.05" y="501.1018" z="-3.49999999999989"/>
+   <position name="posGroundGrid-15" unit="cm" x="-328.04" y="501.1018" z="-3.49999999999989"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-16" unit="cm" x="-328.05" y="-505.1018" z="294.34"/>
+   <position name="posGroundGrid-16" unit="cm" x="-328.04" y="-505.1018" z="294.34"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-17" unit="cm" x="-328.05" y="-169.7006" z="294.34"/>
+   <position name="posGroundGrid-17" unit="cm" x="-328.04" y="-169.7006" z="294.34"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-18" unit="cm" x="-328.05" y="165.7006" z="294.34"/>
+   <position name="posGroundGrid-18" unit="cm" x="-328.04" y="165.7006" z="294.34"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-19" unit="cm" x="-328.05" y="501.1018" z="294.34"/>
+   <position name="posGroundGrid-19" unit="cm" x="-328.04" y="501.1018" z="294.34"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-20" unit="cm" x="-328.05" y="-505.1018" z="592.18"/>
+   <position name="posGroundGrid-20" unit="cm" x="-328.04" y="-505.1018" z="592.18"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-21" unit="cm" x="-328.05" y="-169.7006" z="592.18"/>
+   <position name="posGroundGrid-21" unit="cm" x="-328.04" y="-169.7006" z="592.18"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-22" unit="cm" x="-328.05" y="165.7006" z="592.18"/>
+   <position name="posGroundGrid-22" unit="cm" x="-328.04" y="165.7006" z="592.18"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-23" unit="cm" x="-328.05" y="501.1018" z="592.18"/>
+   <position name="posGroundGrid-23" unit="cm" x="-328.04" y="501.1018" z="592.18"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-24" unit="cm" x="-328.05" y="-505.1018" z="890.02"/>
+   <position name="posGroundGrid-24" unit="cm" x="-328.04" y="-505.1018" z="890.02"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-25" unit="cm" x="-328.05" y="-169.7006" z="890.02"/>
+   <position name="posGroundGrid-25" unit="cm" x="-328.04" y="-169.7006" z="890.02"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-26" unit="cm" x="-328.05" y="165.7006" z="890.02"/>
+   <position name="posGroundGrid-26" unit="cm" x="-328.04" y="165.7006" z="890.02"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-27" unit="cm" x="-328.05" y="501.1018" z="890.02"/>
+   <position name="posGroundGrid-27" unit="cm" x="-328.04" y="501.1018" z="890.02"/>
       </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-0-0"/>
        <position name="posArapucaDouble0-Frame-0-0" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-632.8018" 
 	 z="-859.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -12870,14 +12875,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-0"/>
        <position name="posOpArapucaDouble0-Frame-0-0" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-632.8018" 
 	 z="-859.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-0-1"/>
        <position name="posArapucaDouble1-Frame-0-0" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-542.1018" 
 	 z="-1005.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -12885,14 +12890,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-1"/>
        <position name="posOpArapucaDouble1-Frame-0-0" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-542.1018" 
 	 z="-1005.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-0-2"/>
        <position name="posArapucaDouble2-Frame-0-0" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-468.1018" 
 	 z="-788.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -12900,14 +12905,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-2"/>
        <position name="posOpArapucaDouble2-Frame-0-0" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-468.1018" 
 	 z="-788.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-0-3"/>
        <position name="posArapucaDouble3-Frame-0-0" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-377.4018" 
 	 z="-934.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -12915,14 +12920,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-3"/>
        <position name="posOpArapucaDouble3-Frame-0-0" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-377.4018" 
 	 z="-934.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-1-0"/>
        <position name="posArapucaDouble0-Frame-0-1" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-632.8018" 
 	 z="-561.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -12930,14 +12935,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-0"/>
        <position name="posOpArapucaDouble0-Frame-0-1" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-632.8018" 
 	 z="-561.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-1-1"/>
        <position name="posArapucaDouble1-Frame-0-1" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-542.1018" 
 	 z="-707.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -12945,14 +12950,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-1"/>
        <position name="posOpArapucaDouble1-Frame-0-1" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-542.1018" 
 	 z="-707.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-1-2"/>
        <position name="posArapucaDouble2-Frame-0-1" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-468.1018" 
 	 z="-490.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -12960,14 +12965,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-2"/>
        <position name="posOpArapucaDouble2-Frame-0-1" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-468.1018" 
 	 z="-490.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-1-3"/>
        <position name="posArapucaDouble3-Frame-0-1" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-377.4018" 
 	 z="-636.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -12975,14 +12980,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-3"/>
        <position name="posOpArapucaDouble3-Frame-0-1" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-377.4018" 
 	 z="-636.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-2-0"/>
        <position name="posArapucaDouble0-Frame-0-2" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-632.8018" 
 	 z="-263.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -12990,14 +12995,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-0"/>
        <position name="posOpArapucaDouble0-Frame-0-2" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-632.8018" 
 	 z="-263.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-2-1"/>
        <position name="posArapucaDouble1-Frame-0-2" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-542.1018" 
 	 z="-409.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13005,14 +13010,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-1"/>
        <position name="posOpArapucaDouble1-Frame-0-2" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-542.1018" 
 	 z="-409.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-2-2"/>
        <position name="posArapucaDouble2-Frame-0-2" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-468.1018" 
 	 z="-192.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13020,14 +13025,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-2"/>
        <position name="posOpArapucaDouble2-Frame-0-2" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-468.1018" 
 	 z="-192.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-2-3"/>
        <position name="posArapucaDouble3-Frame-0-2" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-377.4018" 
 	 z="-338.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13035,14 +13040,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-3"/>
        <position name="posOpArapucaDouble3-Frame-0-2" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-377.4018" 
 	 z="-338.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-3-0"/>
        <position name="posArapucaDouble0-Frame-0-3" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-632.8018" 
 	 z="34.0000000000001"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13050,14 +13055,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-3-0"/>
        <position name="posOpArapucaDouble0-Frame-0-3" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-632.8018" 
 	 z="34.0000000000001"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-3-1"/>
        <position name="posArapucaDouble1-Frame-0-3" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-542.1018" 
 	 z="-112"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13065,14 +13070,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-3-1"/>
        <position name="posOpArapucaDouble1-Frame-0-3" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-542.1018" 
 	 z="-112"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-3-2"/>
        <position name="posArapucaDouble2-Frame-0-3" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-468.1018" 
 	 z="105"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13080,14 +13085,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-3-2"/>
        <position name="posOpArapucaDouble2-Frame-0-3" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-468.1018" 
 	 z="105"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-3-3"/>
        <position name="posArapucaDouble3-Frame-0-3" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-377.4018" 
 	 z="-40.9999999999999"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13095,14 +13100,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-3-3"/>
        <position name="posOpArapucaDouble3-Frame-0-3" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-377.4018" 
 	 z="-40.9999999999999"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-4-0"/>
        <position name="posArapucaDouble0-Frame-0-4" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-632.8018" 
 	 z="331.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13110,14 +13115,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-4-0"/>
        <position name="posOpArapucaDouble0-Frame-0-4" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-632.8018" 
 	 z="331.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-4-1"/>
        <position name="posArapucaDouble1-Frame-0-4" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-542.1018" 
 	 z="185.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13125,14 +13130,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-4-1"/>
        <position name="posOpArapucaDouble1-Frame-0-4" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-542.1018" 
 	 z="185.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-4-2"/>
        <position name="posArapucaDouble2-Frame-0-4" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-468.1018" 
 	 z="402.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13140,14 +13145,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-4-2"/>
        <position name="posOpArapucaDouble2-Frame-0-4" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-468.1018" 
 	 z="402.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-4-3"/>
        <position name="posArapucaDouble3-Frame-0-4" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-377.4018" 
 	 z="256.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13155,14 +13160,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-4-3"/>
        <position name="posOpArapucaDouble3-Frame-0-4" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-377.4018" 
 	 z="256.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-5-0"/>
        <position name="posArapucaDouble0-Frame-0-5" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-632.8018" 
 	 z="629.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13170,14 +13175,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-5-0"/>
        <position name="posOpArapucaDouble0-Frame-0-5" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-632.8018" 
 	 z="629.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-5-1"/>
        <position name="posArapucaDouble1-Frame-0-5" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-542.1018" 
 	 z="483.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13185,14 +13190,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-5-1"/>
        <position name="posOpArapucaDouble1-Frame-0-5" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-542.1018" 
 	 z="483.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-5-2"/>
        <position name="posArapucaDouble2-Frame-0-5" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-468.1018" 
 	 z="700.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13200,14 +13205,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-5-2"/>
        <position name="posOpArapucaDouble2-Frame-0-5" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-468.1018" 
 	 z="700.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-5-3"/>
        <position name="posArapucaDouble3-Frame-0-5" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-377.4018" 
 	 z="554.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13215,14 +13220,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-5-3"/>
        <position name="posOpArapucaDouble3-Frame-0-5" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-377.4018" 
 	 z="554.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-6-0"/>
        <position name="posArapucaDouble0-Frame-0-6" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-632.8018" 
 	 z="927.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13230,14 +13235,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-6-0"/>
        <position name="posOpArapucaDouble0-Frame-0-6" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-632.8018" 
 	 z="927.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-6-1"/>
        <position name="posArapucaDouble1-Frame-0-6" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-542.1018" 
 	 z="781.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13245,14 +13250,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-6-1"/>
        <position name="posOpArapucaDouble1-Frame-0-6" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-542.1018" 
 	 z="781.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-6-2"/>
        <position name="posArapucaDouble2-Frame-0-6" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-468.1018" 
 	 z="998.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13260,14 +13265,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-6-2"/>
        <position name="posOpArapucaDouble2-Frame-0-6" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-468.1018" 
 	 z="998.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-6-3"/>
        <position name="posArapucaDouble3-Frame-0-6" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-377.4018" 
 	 z="852.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13275,14 +13280,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-6-3"/>
        <position name="posOpArapucaDouble3-Frame-0-6" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-377.4018" 
 	 z="852.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-0-0"/>
        <position name="posArapucaDouble0-Frame-1-0" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-297.4006" 
 	 z="-859.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13290,14 +13295,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-0"/>
        <position name="posOpArapucaDouble0-Frame-1-0" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-297.4006" 
 	 z="-859.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-0-1"/>
        <position name="posArapucaDouble1-Frame-1-0" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-206.7006" 
 	 z="-1005.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13305,14 +13310,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-1"/>
        <position name="posOpArapucaDouble1-Frame-1-0" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-206.7006" 
 	 z="-1005.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-0-2"/>
        <position name="posArapucaDouble2-Frame-1-0" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-132.7006" 
 	 z="-788.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13320,14 +13325,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-2"/>
        <position name="posOpArapucaDouble2-Frame-1-0" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-132.7006" 
 	 z="-788.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-0-3"/>
        <position name="posArapucaDouble3-Frame-1-0" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-42.0006" 
 	 z="-934.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13335,14 +13340,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-3"/>
        <position name="posOpArapucaDouble3-Frame-1-0" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-42.0006" 
 	 z="-934.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-1-0"/>
        <position name="posArapucaDouble0-Frame-1-1" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-297.4006" 
 	 z="-561.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13350,14 +13355,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-0"/>
        <position name="posOpArapucaDouble0-Frame-1-1" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-297.4006" 
 	 z="-561.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-1-1"/>
        <position name="posArapucaDouble1-Frame-1-1" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-206.7006" 
 	 z="-707.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13365,14 +13370,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-1"/>
        <position name="posOpArapucaDouble1-Frame-1-1" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-206.7006" 
 	 z="-707.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-1-2"/>
        <position name="posArapucaDouble2-Frame-1-1" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-132.7006" 
 	 z="-490.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13380,14 +13385,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-2"/>
        <position name="posOpArapucaDouble2-Frame-1-1" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-132.7006" 
 	 z="-490.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-1-3"/>
        <position name="posArapucaDouble3-Frame-1-1" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-42.0006" 
 	 z="-636.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13395,14 +13400,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-3"/>
        <position name="posOpArapucaDouble3-Frame-1-1" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-42.0006" 
 	 z="-636.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-2-0"/>
        <position name="posArapucaDouble0-Frame-1-2" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-297.4006" 
 	 z="-263.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13410,14 +13415,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-0"/>
        <position name="posOpArapucaDouble0-Frame-1-2" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-297.4006" 
 	 z="-263.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-2-1"/>
        <position name="posArapucaDouble1-Frame-1-2" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-206.7006" 
 	 z="-409.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13425,14 +13430,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-1"/>
        <position name="posOpArapucaDouble1-Frame-1-2" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-206.7006" 
 	 z="-409.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-2-2"/>
        <position name="posArapucaDouble2-Frame-1-2" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-132.7006" 
 	 z="-192.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13440,14 +13445,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-2"/>
        <position name="posOpArapucaDouble2-Frame-1-2" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-132.7006" 
 	 z="-192.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-2-3"/>
        <position name="posArapucaDouble3-Frame-1-2" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-42.0006" 
 	 z="-338.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13455,14 +13460,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-3"/>
        <position name="posOpArapucaDouble3-Frame-1-2" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-42.0006" 
 	 z="-338.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-3-0"/>
        <position name="posArapucaDouble0-Frame-1-3" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-297.4006" 
 	 z="34.0000000000001"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13470,14 +13475,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-3-0"/>
        <position name="posOpArapucaDouble0-Frame-1-3" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-297.4006" 
 	 z="34.0000000000001"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-3-1"/>
        <position name="posArapucaDouble1-Frame-1-3" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-206.7006" 
 	 z="-112"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13485,14 +13490,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-3-1"/>
        <position name="posOpArapucaDouble1-Frame-1-3" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-206.7006" 
 	 z="-112"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-3-2"/>
        <position name="posArapucaDouble2-Frame-1-3" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-132.7006" 
 	 z="105"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13500,14 +13505,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-3-2"/>
        <position name="posOpArapucaDouble2-Frame-1-3" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-132.7006" 
 	 z="105"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-3-3"/>
        <position name="posArapucaDouble3-Frame-1-3" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-42.0006" 
 	 z="-40.9999999999999"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13515,14 +13520,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-3-3"/>
        <position name="posOpArapucaDouble3-Frame-1-3" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-42.0006" 
 	 z="-40.9999999999999"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-4-0"/>
        <position name="posArapucaDouble0-Frame-1-4" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-297.4006" 
 	 z="331.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13530,14 +13535,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-4-0"/>
        <position name="posOpArapucaDouble0-Frame-1-4" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-297.4006" 
 	 z="331.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-4-1"/>
        <position name="posArapucaDouble1-Frame-1-4" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-206.7006" 
 	 z="185.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13545,14 +13550,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-4-1"/>
        <position name="posOpArapucaDouble1-Frame-1-4" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-206.7006" 
 	 z="185.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-4-2"/>
        <position name="posArapucaDouble2-Frame-1-4" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-132.7006" 
 	 z="402.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13560,14 +13565,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-4-2"/>
        <position name="posOpArapucaDouble2-Frame-1-4" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-132.7006" 
 	 z="402.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-4-3"/>
        <position name="posArapucaDouble3-Frame-1-4" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-42.0006" 
 	 z="256.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13575,14 +13580,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-4-3"/>
        <position name="posOpArapucaDouble3-Frame-1-4" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-42.0006" 
 	 z="256.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-5-0"/>
        <position name="posArapucaDouble0-Frame-1-5" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-297.4006" 
 	 z="629.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13590,14 +13595,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-5-0"/>
        <position name="posOpArapucaDouble0-Frame-1-5" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-297.4006" 
 	 z="629.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-5-1"/>
        <position name="posArapucaDouble1-Frame-1-5" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-206.7006" 
 	 z="483.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13605,14 +13610,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-5-1"/>
        <position name="posOpArapucaDouble1-Frame-1-5" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-206.7006" 
 	 z="483.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-5-2"/>
        <position name="posArapucaDouble2-Frame-1-5" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-132.7006" 
 	 z="700.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13620,14 +13625,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-5-2"/>
        <position name="posOpArapucaDouble2-Frame-1-5" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-132.7006" 
 	 z="700.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-5-3"/>
        <position name="posArapucaDouble3-Frame-1-5" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-42.0006" 
 	 z="554.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13635,14 +13640,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-5-3"/>
        <position name="posOpArapucaDouble3-Frame-1-5" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-42.0006" 
 	 z="554.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-6-0"/>
        <position name="posArapucaDouble0-Frame-1-6" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-297.4006" 
 	 z="927.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13650,14 +13655,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-6-0"/>
        <position name="posOpArapucaDouble0-Frame-1-6" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-297.4006" 
 	 z="927.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-6-1"/>
        <position name="posArapucaDouble1-Frame-1-6" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-206.7006" 
 	 z="781.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13665,14 +13670,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-6-1"/>
        <position name="posOpArapucaDouble1-Frame-1-6" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-206.7006" 
 	 z="781.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-6-2"/>
        <position name="posArapucaDouble2-Frame-1-6" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-132.7006" 
 	 z="998.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13680,14 +13685,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-6-2"/>
        <position name="posOpArapucaDouble2-Frame-1-6" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-132.7006" 
 	 z="998.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-6-3"/>
        <position name="posArapucaDouble3-Frame-1-6" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-42.0006" 
 	 z="852.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13695,14 +13700,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-6-3"/>
        <position name="posOpArapucaDouble3-Frame-1-6" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-42.0006" 
 	 z="852.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-0-0"/>
        <position name="posArapucaDouble0-Frame-2-0" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="38.0006" 
 	 z="-859.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13710,14 +13715,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-0"/>
        <position name="posOpArapucaDouble0-Frame-2-0" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="38.0006" 
 	 z="-859.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-0-1"/>
        <position name="posArapucaDouble1-Frame-2-0" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="128.7006" 
 	 z="-1005.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13725,14 +13730,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-1"/>
        <position name="posOpArapucaDouble1-Frame-2-0" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="128.7006" 
 	 z="-1005.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-0-2"/>
        <position name="posArapucaDouble2-Frame-2-0" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="202.7006" 
 	 z="-788.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13740,14 +13745,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-2"/>
        <position name="posOpArapucaDouble2-Frame-2-0" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="202.7006" 
 	 z="-788.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-0-3"/>
        <position name="posArapucaDouble3-Frame-2-0" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="293.4006" 
 	 z="-934.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13755,14 +13760,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-3"/>
        <position name="posOpArapucaDouble3-Frame-2-0" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="293.4006" 
 	 z="-934.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-1-0"/>
        <position name="posArapucaDouble0-Frame-2-1" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="38.0006" 
 	 z="-561.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13770,14 +13775,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-0"/>
        <position name="posOpArapucaDouble0-Frame-2-1" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="38.0006" 
 	 z="-561.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-1-1"/>
        <position name="posArapucaDouble1-Frame-2-1" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="128.7006" 
 	 z="-707.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13785,14 +13790,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-1"/>
        <position name="posOpArapucaDouble1-Frame-2-1" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="128.7006" 
 	 z="-707.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-1-2"/>
        <position name="posArapucaDouble2-Frame-2-1" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="202.7006" 
 	 z="-490.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13800,14 +13805,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-2"/>
        <position name="posOpArapucaDouble2-Frame-2-1" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="202.7006" 
 	 z="-490.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-1-3"/>
        <position name="posArapucaDouble3-Frame-2-1" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="293.4006" 
 	 z="-636.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13815,14 +13820,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-3"/>
        <position name="posOpArapucaDouble3-Frame-2-1" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="293.4006" 
 	 z="-636.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-2-0"/>
        <position name="posArapucaDouble0-Frame-2-2" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="38.0006" 
 	 z="-263.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13830,14 +13835,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-0"/>
        <position name="posOpArapucaDouble0-Frame-2-2" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="38.0006" 
 	 z="-263.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-2-1"/>
        <position name="posArapucaDouble1-Frame-2-2" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="128.7006" 
 	 z="-409.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13845,14 +13850,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-1"/>
        <position name="posOpArapucaDouble1-Frame-2-2" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="128.7006" 
 	 z="-409.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-2-2"/>
        <position name="posArapucaDouble2-Frame-2-2" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="202.7006" 
 	 z="-192.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13860,14 +13865,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-2"/>
        <position name="posOpArapucaDouble2-Frame-2-2" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="202.7006" 
 	 z="-192.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-2-3"/>
        <position name="posArapucaDouble3-Frame-2-2" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="293.4006" 
 	 z="-338.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13875,14 +13880,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-3"/>
        <position name="posOpArapucaDouble3-Frame-2-2" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="293.4006" 
 	 z="-338.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-3-0"/>
        <position name="posArapucaDouble0-Frame-2-3" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="38.0006" 
 	 z="34.0000000000001"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13890,14 +13895,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-3-0"/>
        <position name="posOpArapucaDouble0-Frame-2-3" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="38.0006" 
 	 z="34.0000000000001"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-3-1"/>
        <position name="posArapucaDouble1-Frame-2-3" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="128.7006" 
 	 z="-112"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13905,14 +13910,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-3-1"/>
        <position name="posOpArapucaDouble1-Frame-2-3" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="128.7006" 
 	 z="-112"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-3-2"/>
        <position name="posArapucaDouble2-Frame-2-3" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="202.7006" 
 	 z="105"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13920,14 +13925,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-3-2"/>
        <position name="posOpArapucaDouble2-Frame-2-3" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="202.7006" 
 	 z="105"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-3-3"/>
        <position name="posArapucaDouble3-Frame-2-3" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="293.4006" 
 	 z="-40.9999999999999"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13935,14 +13940,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-3-3"/>
        <position name="posOpArapucaDouble3-Frame-2-3" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="293.4006" 
 	 z="-40.9999999999999"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-4-0"/>
        <position name="posArapucaDouble0-Frame-2-4" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="38.0006" 
 	 z="331.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13950,14 +13955,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-4-0"/>
        <position name="posOpArapucaDouble0-Frame-2-4" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="38.0006" 
 	 z="331.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-4-1"/>
        <position name="posArapucaDouble1-Frame-2-4" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="128.7006" 
 	 z="185.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13965,14 +13970,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-4-1"/>
        <position name="posOpArapucaDouble1-Frame-2-4" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="128.7006" 
 	 z="185.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-4-2"/>
        <position name="posArapucaDouble2-Frame-2-4" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="202.7006" 
 	 z="402.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13980,14 +13985,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-4-2"/>
        <position name="posOpArapucaDouble2-Frame-2-4" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="202.7006" 
 	 z="402.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-4-3"/>
        <position name="posArapucaDouble3-Frame-2-4" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="293.4006" 
 	 z="256.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13995,14 +14000,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-4-3"/>
        <position name="posOpArapucaDouble3-Frame-2-4" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="293.4006" 
 	 z="256.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-5-0"/>
        <position name="posArapucaDouble0-Frame-2-5" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="38.0006" 
 	 z="629.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -14010,14 +14015,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-5-0"/>
        <position name="posOpArapucaDouble0-Frame-2-5" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="38.0006" 
 	 z="629.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-5-1"/>
        <position name="posArapucaDouble1-Frame-2-5" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="128.7006" 
 	 z="483.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -14025,14 +14030,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-5-1"/>
        <position name="posOpArapucaDouble1-Frame-2-5" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="128.7006" 
 	 z="483.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-5-2"/>
        <position name="posArapucaDouble2-Frame-2-5" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="202.7006" 
 	 z="700.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -14040,14 +14045,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-5-2"/>
        <position name="posOpArapucaDouble2-Frame-2-5" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="202.7006" 
 	 z="700.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-5-3"/>
        <position name="posArapucaDouble3-Frame-2-5" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="293.4006" 
 	 z="554.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -14055,14 +14060,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-5-3"/>
        <position name="posOpArapucaDouble3-Frame-2-5" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="293.4006" 
 	 z="554.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-6-0"/>
        <position name="posArapucaDouble0-Frame-2-6" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="38.0006" 
 	 z="927.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -14070,14 +14075,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-6-0"/>
        <position name="posOpArapucaDouble0-Frame-2-6" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="38.0006" 
 	 z="927.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-6-1"/>
        <position name="posArapucaDouble1-Frame-2-6" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="128.7006" 
 	 z="781.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -14085,14 +14090,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-6-1"/>
        <position name="posOpArapucaDouble1-Frame-2-6" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="128.7006" 
 	 z="781.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-6-2"/>
        <position name="posArapucaDouble2-Frame-2-6" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="202.7006" 
 	 z="998.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -14100,14 +14105,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-6-2"/>
        <position name="posOpArapucaDouble2-Frame-2-6" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="202.7006" 
 	 z="998.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-6-3"/>
        <position name="posArapucaDouble3-Frame-2-6" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="293.4006" 
 	 z="852.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -14115,14 +14120,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-6-3"/>
        <position name="posOpArapucaDouble3-Frame-2-6" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="293.4006" 
 	 z="852.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-0-0"/>
        <position name="posArapucaDouble0-Frame-3-0" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="373.4018" 
 	 z="-859.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -14130,14 +14135,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-0"/>
        <position name="posOpArapucaDouble0-Frame-3-0" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="373.4018" 
 	 z="-859.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-0-1"/>
        <position name="posArapucaDouble1-Frame-3-0" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="464.1018" 
 	 z="-1005.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -14145,14 +14150,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-1"/>
        <position name="posOpArapucaDouble1-Frame-3-0" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="464.1018" 
 	 z="-1005.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-0-2"/>
        <position name="posArapucaDouble2-Frame-3-0" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="538.1018" 
 	 z="-788.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -14160,14 +14165,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-2"/>
        <position name="posOpArapucaDouble2-Frame-3-0" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="538.1018" 
 	 z="-788.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-0-3"/>
        <position name="posArapucaDouble3-Frame-3-0" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="628.8018" 
 	 z="-934.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -14175,14 +14180,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-3"/>
        <position name="posOpArapucaDouble3-Frame-3-0" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="628.8018" 
 	 z="-934.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-1-0"/>
        <position name="posArapucaDouble0-Frame-3-1" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="373.4018" 
 	 z="-561.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -14190,14 +14195,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-0"/>
        <position name="posOpArapucaDouble0-Frame-3-1" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="373.4018" 
 	 z="-561.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-1-1"/>
        <position name="posArapucaDouble1-Frame-3-1" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="464.1018" 
 	 z="-707.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -14205,14 +14210,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-1"/>
        <position name="posOpArapucaDouble1-Frame-3-1" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="464.1018" 
 	 z="-707.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-1-2"/>
        <position name="posArapucaDouble2-Frame-3-1" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="538.1018" 
 	 z="-490.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -14220,14 +14225,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-2"/>
        <position name="posOpArapucaDouble2-Frame-3-1" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="538.1018" 
 	 z="-490.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-1-3"/>
        <position name="posArapucaDouble3-Frame-3-1" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="628.8018" 
 	 z="-636.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -14235,14 +14240,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-3"/>
        <position name="posOpArapucaDouble3-Frame-3-1" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="628.8018" 
 	 z="-636.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-2-0"/>
        <position name="posArapucaDouble0-Frame-3-2" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="373.4018" 
 	 z="-263.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -14250,14 +14255,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-0"/>
        <position name="posOpArapucaDouble0-Frame-3-2" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="373.4018" 
 	 z="-263.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-2-1"/>
        <position name="posArapucaDouble1-Frame-3-2" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="464.1018" 
 	 z="-409.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -14265,14 +14270,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-1"/>
        <position name="posOpArapucaDouble1-Frame-3-2" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="464.1018" 
 	 z="-409.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-2-2"/>
        <position name="posArapucaDouble2-Frame-3-2" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="538.1018" 
 	 z="-192.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -14280,14 +14285,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-2"/>
        <position name="posOpArapucaDouble2-Frame-3-2" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="538.1018" 
 	 z="-192.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-2-3"/>
        <position name="posArapucaDouble3-Frame-3-2" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="628.8018" 
 	 z="-338.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -14295,14 +14300,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-3"/>
        <position name="posOpArapucaDouble3-Frame-3-2" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="628.8018" 
 	 z="-338.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-3-0"/>
        <position name="posArapucaDouble0-Frame-3-3" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="373.4018" 
 	 z="34.0000000000001"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -14310,14 +14315,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-3-0"/>
        <position name="posOpArapucaDouble0-Frame-3-3" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="373.4018" 
 	 z="34.0000000000001"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-3-1"/>
        <position name="posArapucaDouble1-Frame-3-3" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="464.1018" 
 	 z="-112"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -14325,14 +14330,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-3-1"/>
        <position name="posOpArapucaDouble1-Frame-3-3" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="464.1018" 
 	 z="-112"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-3-2"/>
        <position name="posArapucaDouble2-Frame-3-3" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="538.1018" 
 	 z="105"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -14340,14 +14345,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-3-2"/>
        <position name="posOpArapucaDouble2-Frame-3-3" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="538.1018" 
 	 z="105"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-3-3"/>
        <position name="posArapucaDouble3-Frame-3-3" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="628.8018" 
 	 z="-40.9999999999999"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -14355,14 +14360,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-3-3"/>
        <position name="posOpArapucaDouble3-Frame-3-3" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="628.8018" 
 	 z="-40.9999999999999"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-4-0"/>
        <position name="posArapucaDouble0-Frame-3-4" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="373.4018" 
 	 z="331.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -14370,14 +14375,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-4-0"/>
        <position name="posOpArapucaDouble0-Frame-3-4" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="373.4018" 
 	 z="331.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-4-1"/>
        <position name="posArapucaDouble1-Frame-3-4" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="464.1018" 
 	 z="185.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -14385,14 +14390,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-4-1"/>
        <position name="posOpArapucaDouble1-Frame-3-4" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="464.1018" 
 	 z="185.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-4-2"/>
        <position name="posArapucaDouble2-Frame-3-4" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="538.1018" 
 	 z="402.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -14400,14 +14405,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-4-2"/>
        <position name="posOpArapucaDouble2-Frame-3-4" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="538.1018" 
 	 z="402.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-4-3"/>
        <position name="posArapucaDouble3-Frame-3-4" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="628.8018" 
 	 z="256.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -14415,14 +14420,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-4-3"/>
        <position name="posOpArapucaDouble3-Frame-3-4" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="628.8018" 
 	 z="256.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-5-0"/>
        <position name="posArapucaDouble0-Frame-3-5" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="373.4018" 
 	 z="629.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -14430,14 +14435,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-5-0"/>
        <position name="posOpArapucaDouble0-Frame-3-5" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="373.4018" 
 	 z="629.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-5-1"/>
        <position name="posArapucaDouble1-Frame-3-5" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="464.1018" 
 	 z="483.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -14445,14 +14450,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-5-1"/>
        <position name="posOpArapucaDouble1-Frame-3-5" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="464.1018" 
 	 z="483.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-5-2"/>
        <position name="posArapucaDouble2-Frame-3-5" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="538.1018" 
 	 z="700.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -14460,14 +14465,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-5-2"/>
        <position name="posOpArapucaDouble2-Frame-3-5" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="538.1018" 
 	 z="700.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-5-3"/>
        <position name="posArapucaDouble3-Frame-3-5" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="628.8018" 
 	 z="554.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -14475,14 +14480,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-5-3"/>
        <position name="posOpArapucaDouble3-Frame-3-5" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="628.8018" 
 	 z="554.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-6-0"/>
        <position name="posArapucaDouble0-Frame-3-6" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="373.4018" 
 	 z="927.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -14490,14 +14495,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-6-0"/>
        <position name="posOpArapucaDouble0-Frame-3-6" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="373.4018" 
 	 z="927.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-6-1"/>
        <position name="posArapucaDouble1-Frame-3-6" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="464.1018" 
 	 z="781.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -14505,14 +14510,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-6-1"/>
        <position name="posOpArapucaDouble1-Frame-3-6" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="464.1018" 
 	 z="781.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-6-2"/>
        <position name="posArapucaDouble2-Frame-3-6" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="538.1018" 
 	 z="998.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -14520,14 +14525,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-6-2"/>
        <position name="posOpArapucaDouble2-Frame-3-6" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="538.1018" 
 	 z="998.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-6-3"/>
        <position name="posArapucaDouble3-Frame-3-6" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="628.8018" 
 	 z="852.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -14535,14 +14540,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-6-3"/>
        <position name="posOpArapucaDouble3-Frame-3-6" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="628.8018" 
 	 z="852.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-0"/>
        <position name="posArapuca0-Lat-0" unit="cm" 
-         x="285.02"
+         x="285.03"
 	 y="-732.8024" 
 	 z="-893.52"/>
        <rotationref ref="rIdentity"/>
@@ -14550,14 +14555,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-0"/>
        <position name="posOpArapuca0-Lat-0" unit="cm" 
-         x="285.02"
+         x="285.03"
 	 y="-732.0624" 
 	 z="-893.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-1"/>
        <position name="posArapuca1-Lat-0" unit="cm" 
-         x="210.02"
+         x="210.03"
 	 y="-732.8024" 
 	 z="-893.52"/>
        <rotationref ref="rIdentity"/>
@@ -14565,14 +14570,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-1"/>
        <position name="posOpArapuca1-Lat-0" unit="cm" 
-         x="210.02"
+         x="210.03"
 	 y="-732.0624" 
 	 z="-893.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-2"/>
        <position name="posArapuca2-Lat-0" unit="cm" 
-         x="135.02"
+         x="135.03"
 	 y="-732.8024" 
 	 z="-893.52"/>
        <rotationref ref="rIdentity"/>
@@ -14580,14 +14585,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-2"/>
        <position name="posOpArapuca2-Lat-0" unit="cm" 
-         x="135.02"
+         x="135.03"
 	 y="-732.0624" 
 	 z="-893.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-3"/>
        <position name="posArapuca3-Lat-0" unit="cm" 
-         x="60.02"
+         x="60.03"
 	 y="-732.8024" 
 	 z="-893.52"/>
        <rotationref ref="rIdentity"/>
@@ -14595,14 +14600,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-3"/>
        <position name="posOpArapuca3-Lat-0" unit="cm" 
-         x="60.02"
+         x="60.03"
 	 y="-732.0624" 
 	 z="-893.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-4"/>
        <position name="posArapuca4-Lat-0" unit="cm" 
-         x="285.02"
+         x="285.03"
 	 y="732.8024" 
 	 z="-893.52"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -14610,14 +14615,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-4"/>
        <position name="posOpArapuca4-Lat-0" unit="cm" 
-         x="285.02"
+         x="285.03"
 	 y="732.0624" 
 	 z="-893.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-5"/>
        <position name="posArapuca5-Lat-0" unit="cm" 
-         x="210.02"
+         x="210.03"
 	 y="732.8024" 
 	 z="-893.52"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -14625,14 +14630,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-5"/>
        <position name="posOpArapuca5-Lat-0" unit="cm" 
-         x="210.02"
+         x="210.03"
 	 y="732.0624" 
 	 z="-893.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-6"/>
        <position name="posArapuca6-Lat-0" unit="cm" 
-         x="135.02"
+         x="135.03"
 	 y="732.8024" 
 	 z="-893.52"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -14640,14 +14645,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-6"/>
        <position name="posOpArapuca6-Lat-0" unit="cm" 
-         x="135.02"
+         x="135.03"
 	 y="732.0624" 
 	 z="-893.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-7"/>
        <position name="posArapuca7-Lat-0" unit="cm" 
-         x="60.02"
+         x="60.03"
 	 y="732.8024" 
 	 z="-893.52"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -14655,14 +14660,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-7"/>
        <position name="posOpArapuca7-Lat-0" unit="cm" 
-         x="60.02"
+         x="60.03"
 	 y="732.0624" 
 	 z="-893.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-0"/>
        <position name="posArapuca0-Lat-1" unit="cm" 
-         x="285.02"
+         x="285.03"
 	 y="-732.8024" 
 	 z="-595.68"/>
        <rotationref ref="rIdentity"/>
@@ -14670,14 +14675,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-0"/>
        <position name="posOpArapuca0-Lat-1" unit="cm" 
-         x="285.02"
+         x="285.03"
 	 y="-732.0624" 
 	 z="-595.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-1"/>
        <position name="posArapuca1-Lat-1" unit="cm" 
-         x="210.02"
+         x="210.03"
 	 y="-732.8024" 
 	 z="-595.68"/>
        <rotationref ref="rIdentity"/>
@@ -14685,14 +14690,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-1"/>
        <position name="posOpArapuca1-Lat-1" unit="cm" 
-         x="210.02"
+         x="210.03"
 	 y="-732.0624" 
 	 z="-595.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-2"/>
        <position name="posArapuca2-Lat-1" unit="cm" 
-         x="135.02"
+         x="135.03"
 	 y="-732.8024" 
 	 z="-595.68"/>
        <rotationref ref="rIdentity"/>
@@ -14700,14 +14705,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-2"/>
        <position name="posOpArapuca2-Lat-1" unit="cm" 
-         x="135.02"
+         x="135.03"
 	 y="-732.0624" 
 	 z="-595.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-3"/>
        <position name="posArapuca3-Lat-1" unit="cm" 
-         x="60.02"
+         x="60.03"
 	 y="-732.8024" 
 	 z="-595.68"/>
        <rotationref ref="rIdentity"/>
@@ -14715,14 +14720,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-3"/>
        <position name="posOpArapuca3-Lat-1" unit="cm" 
-         x="60.02"
+         x="60.03"
 	 y="-732.0624" 
 	 z="-595.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-4"/>
        <position name="posArapuca4-Lat-1" unit="cm" 
-         x="285.02"
+         x="285.03"
 	 y="732.8024" 
 	 z="-595.68"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -14730,14 +14735,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-4"/>
        <position name="posOpArapuca4-Lat-1" unit="cm" 
-         x="285.02"
+         x="285.03"
 	 y="732.0624" 
 	 z="-595.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-5"/>
        <position name="posArapuca5-Lat-1" unit="cm" 
-         x="210.02"
+         x="210.03"
 	 y="732.8024" 
 	 z="-595.68"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -14745,14 +14750,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-5"/>
        <position name="posOpArapuca5-Lat-1" unit="cm" 
-         x="210.02"
+         x="210.03"
 	 y="732.0624" 
 	 z="-595.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-6"/>
        <position name="posArapuca6-Lat-1" unit="cm" 
-         x="135.02"
+         x="135.03"
 	 y="732.8024" 
 	 z="-595.68"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -14760,14 +14765,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-6"/>
        <position name="posOpArapuca6-Lat-1" unit="cm" 
-         x="135.02"
+         x="135.03"
 	 y="732.0624" 
 	 z="-595.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-7"/>
        <position name="posArapuca7-Lat-1" unit="cm" 
-         x="60.02"
+         x="60.03"
 	 y="732.8024" 
 	 z="-595.68"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -14775,14 +14780,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-7"/>
        <position name="posOpArapuca7-Lat-1" unit="cm" 
-         x="60.02"
+         x="60.03"
 	 y="732.0624" 
 	 z="-595.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-0"/>
        <position name="posArapuca0-Lat-2" unit="cm" 
-         x="285.02"
+         x="285.03"
 	 y="-732.8024" 
 	 z="-297.84"/>
        <rotationref ref="rIdentity"/>
@@ -14790,14 +14795,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-0"/>
        <position name="posOpArapuca0-Lat-2" unit="cm" 
-         x="285.02"
+         x="285.03"
 	 y="-732.0624" 
 	 z="-297.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-1"/>
        <position name="posArapuca1-Lat-2" unit="cm" 
-         x="210.02"
+         x="210.03"
 	 y="-732.8024" 
 	 z="-297.84"/>
        <rotationref ref="rIdentity"/>
@@ -14805,14 +14810,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-1"/>
        <position name="posOpArapuca1-Lat-2" unit="cm" 
-         x="210.02"
+         x="210.03"
 	 y="-732.0624" 
 	 z="-297.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-2"/>
        <position name="posArapuca2-Lat-2" unit="cm" 
-         x="135.02"
+         x="135.03"
 	 y="-732.8024" 
 	 z="-297.84"/>
        <rotationref ref="rIdentity"/>
@@ -14820,14 +14825,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-2"/>
        <position name="posOpArapuca2-Lat-2" unit="cm" 
-         x="135.02"
+         x="135.03"
 	 y="-732.0624" 
 	 z="-297.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-3"/>
        <position name="posArapuca3-Lat-2" unit="cm" 
-         x="60.02"
+         x="60.03"
 	 y="-732.8024" 
 	 z="-297.84"/>
        <rotationref ref="rIdentity"/>
@@ -14835,14 +14840,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-3"/>
        <position name="posOpArapuca3-Lat-2" unit="cm" 
-         x="60.02"
+         x="60.03"
 	 y="-732.0624" 
 	 z="-297.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-4"/>
        <position name="posArapuca4-Lat-2" unit="cm" 
-         x="285.02"
+         x="285.03"
 	 y="732.8024" 
 	 z="-297.84"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -14850,14 +14855,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-4"/>
        <position name="posOpArapuca4-Lat-2" unit="cm" 
-         x="285.02"
+         x="285.03"
 	 y="732.0624" 
 	 z="-297.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-5"/>
        <position name="posArapuca5-Lat-2" unit="cm" 
-         x="210.02"
+         x="210.03"
 	 y="732.8024" 
 	 z="-297.84"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -14865,14 +14870,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-5"/>
        <position name="posOpArapuca5-Lat-2" unit="cm" 
-         x="210.02"
+         x="210.03"
 	 y="732.0624" 
 	 z="-297.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-6"/>
        <position name="posArapuca6-Lat-2" unit="cm" 
-         x="135.02"
+         x="135.03"
 	 y="732.8024" 
 	 z="-297.84"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -14880,14 +14885,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-6"/>
        <position name="posOpArapuca6-Lat-2" unit="cm" 
-         x="135.02"
+         x="135.03"
 	 y="732.0624" 
 	 z="-297.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-7"/>
        <position name="posArapuca7-Lat-2" unit="cm" 
-         x="60.02"
+         x="60.03"
 	 y="732.8024" 
 	 z="-297.84"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -14895,14 +14900,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-7"/>
        <position name="posOpArapuca7-Lat-2" unit="cm" 
-         x="60.02"
+         x="60.03"
 	 y="732.0624" 
 	 z="-297.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_3-0"/>
        <position name="posArapuca0-Lat-3" unit="cm" 
-         x="285.02"
+         x="285.03"
 	 y="-732.8024" 
 	 z="-1.13686837721616e-13"/>
        <rotationref ref="rIdentity"/>
@@ -14910,14 +14915,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_3-0"/>
        <position name="posOpArapuca0-Lat-3" unit="cm" 
-         x="285.02"
+         x="285.03"
 	 y="-732.0624" 
 	 z="-1.13686837721616e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_3-1"/>
        <position name="posArapuca1-Lat-3" unit="cm" 
-         x="210.02"
+         x="210.03"
 	 y="-732.8024" 
 	 z="-1.13686837721616e-13"/>
        <rotationref ref="rIdentity"/>
@@ -14925,14 +14930,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_3-1"/>
        <position name="posOpArapuca1-Lat-3" unit="cm" 
-         x="210.02"
+         x="210.03"
 	 y="-732.0624" 
 	 z="-1.13686837721616e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_3-2"/>
        <position name="posArapuca2-Lat-3" unit="cm" 
-         x="135.02"
+         x="135.03"
 	 y="-732.8024" 
 	 z="-1.13686837721616e-13"/>
        <rotationref ref="rIdentity"/>
@@ -14940,14 +14945,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_3-2"/>
        <position name="posOpArapuca2-Lat-3" unit="cm" 
-         x="135.02"
+         x="135.03"
 	 y="-732.0624" 
 	 z="-1.13686837721616e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_3-3"/>
        <position name="posArapuca3-Lat-3" unit="cm" 
-         x="60.02"
+         x="60.03"
 	 y="-732.8024" 
 	 z="-1.13686837721616e-13"/>
        <rotationref ref="rIdentity"/>
@@ -14955,14 +14960,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_3-3"/>
        <position name="posOpArapuca3-Lat-3" unit="cm" 
-         x="60.02"
+         x="60.03"
 	 y="-732.0624" 
 	 z="-1.13686837721616e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_3-4"/>
        <position name="posArapuca4-Lat-3" unit="cm" 
-         x="285.02"
+         x="285.03"
 	 y="732.8024" 
 	 z="-1.13686837721616e-13"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -14970,14 +14975,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_3-4"/>
        <position name="posOpArapuca4-Lat-3" unit="cm" 
-         x="285.02"
+         x="285.03"
 	 y="732.0624" 
 	 z="-1.13686837721616e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_3-5"/>
        <position name="posArapuca5-Lat-3" unit="cm" 
-         x="210.02"
+         x="210.03"
 	 y="732.8024" 
 	 z="-1.13686837721616e-13"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -14985,14 +14990,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_3-5"/>
        <position name="posOpArapuca5-Lat-3" unit="cm" 
-         x="210.02"
+         x="210.03"
 	 y="732.0624" 
 	 z="-1.13686837721616e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_3-6"/>
        <position name="posArapuca6-Lat-3" unit="cm" 
-         x="135.02"
+         x="135.03"
 	 y="732.8024" 
 	 z="-1.13686837721616e-13"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -15000,14 +15005,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_3-6"/>
        <position name="posOpArapuca6-Lat-3" unit="cm" 
-         x="135.02"
+         x="135.03"
 	 y="732.0624" 
 	 z="-1.13686837721616e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_3-7"/>
        <position name="posArapuca7-Lat-3" unit="cm" 
-         x="60.02"
+         x="60.03"
 	 y="732.8024" 
 	 z="-1.13686837721616e-13"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -15015,14 +15020,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_3-7"/>
        <position name="posOpArapuca7-Lat-3" unit="cm" 
-         x="60.02"
+         x="60.03"
 	 y="732.0624" 
 	 z="-1.13686837721616e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_4-0"/>
        <position name="posArapuca0-Lat-4" unit="cm" 
-         x="285.02"
+         x="285.03"
 	 y="-732.8024" 
 	 z="297.84"/>
        <rotationref ref="rIdentity"/>
@@ -15030,14 +15035,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_4-0"/>
        <position name="posOpArapuca0-Lat-4" unit="cm" 
-         x="285.02"
+         x="285.03"
 	 y="-732.0624" 
 	 z="297.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_4-1"/>
        <position name="posArapuca1-Lat-4" unit="cm" 
-         x="210.02"
+         x="210.03"
 	 y="-732.8024" 
 	 z="297.84"/>
        <rotationref ref="rIdentity"/>
@@ -15045,14 +15050,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_4-1"/>
        <position name="posOpArapuca1-Lat-4" unit="cm" 
-         x="210.02"
+         x="210.03"
 	 y="-732.0624" 
 	 z="297.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_4-2"/>
        <position name="posArapuca2-Lat-4" unit="cm" 
-         x="135.02"
+         x="135.03"
 	 y="-732.8024" 
 	 z="297.84"/>
        <rotationref ref="rIdentity"/>
@@ -15060,14 +15065,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_4-2"/>
        <position name="posOpArapuca2-Lat-4" unit="cm" 
-         x="135.02"
+         x="135.03"
 	 y="-732.0624" 
 	 z="297.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_4-3"/>
        <position name="posArapuca3-Lat-4" unit="cm" 
-         x="60.02"
+         x="60.03"
 	 y="-732.8024" 
 	 z="297.84"/>
        <rotationref ref="rIdentity"/>
@@ -15075,14 +15080,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_4-3"/>
        <position name="posOpArapuca3-Lat-4" unit="cm" 
-         x="60.02"
+         x="60.03"
 	 y="-732.0624" 
 	 z="297.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_4-4"/>
        <position name="posArapuca4-Lat-4" unit="cm" 
-         x="285.02"
+         x="285.03"
 	 y="732.8024" 
 	 z="297.84"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -15090,14 +15095,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_4-4"/>
        <position name="posOpArapuca4-Lat-4" unit="cm" 
-         x="285.02"
+         x="285.03"
 	 y="732.0624" 
 	 z="297.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_4-5"/>
        <position name="posArapuca5-Lat-4" unit="cm" 
-         x="210.02"
+         x="210.03"
 	 y="732.8024" 
 	 z="297.84"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -15105,14 +15110,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_4-5"/>
        <position name="posOpArapuca5-Lat-4" unit="cm" 
-         x="210.02"
+         x="210.03"
 	 y="732.0624" 
 	 z="297.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_4-6"/>
        <position name="posArapuca6-Lat-4" unit="cm" 
-         x="135.02"
+         x="135.03"
 	 y="732.8024" 
 	 z="297.84"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -15120,14 +15125,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_4-6"/>
        <position name="posOpArapuca6-Lat-4" unit="cm" 
-         x="135.02"
+         x="135.03"
 	 y="732.0624" 
 	 z="297.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_4-7"/>
        <position name="posArapuca7-Lat-4" unit="cm" 
-         x="60.02"
+         x="60.03"
 	 y="732.8024" 
 	 z="297.84"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -15135,14 +15140,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_4-7"/>
        <position name="posOpArapuca7-Lat-4" unit="cm" 
-         x="60.02"
+         x="60.03"
 	 y="732.0624" 
 	 z="297.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_5-0"/>
        <position name="posArapuca0-Lat-5" unit="cm" 
-         x="285.02"
+         x="285.03"
 	 y="-732.8024" 
 	 z="595.68"/>
        <rotationref ref="rIdentity"/>
@@ -15150,14 +15155,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_5-0"/>
        <position name="posOpArapuca0-Lat-5" unit="cm" 
-         x="285.02"
+         x="285.03"
 	 y="-732.0624" 
 	 z="595.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_5-1"/>
        <position name="posArapuca1-Lat-5" unit="cm" 
-         x="210.02"
+         x="210.03"
 	 y="-732.8024" 
 	 z="595.68"/>
        <rotationref ref="rIdentity"/>
@@ -15165,14 +15170,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_5-1"/>
        <position name="posOpArapuca1-Lat-5" unit="cm" 
-         x="210.02"
+         x="210.03"
 	 y="-732.0624" 
 	 z="595.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_5-2"/>
        <position name="posArapuca2-Lat-5" unit="cm" 
-         x="135.02"
+         x="135.03"
 	 y="-732.8024" 
 	 z="595.68"/>
        <rotationref ref="rIdentity"/>
@@ -15180,14 +15185,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_5-2"/>
        <position name="posOpArapuca2-Lat-5" unit="cm" 
-         x="135.02"
+         x="135.03"
 	 y="-732.0624" 
 	 z="595.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_5-3"/>
        <position name="posArapuca3-Lat-5" unit="cm" 
-         x="60.02"
+         x="60.03"
 	 y="-732.8024" 
 	 z="595.68"/>
        <rotationref ref="rIdentity"/>
@@ -15195,14 +15200,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_5-3"/>
        <position name="posOpArapuca3-Lat-5" unit="cm" 
-         x="60.02"
+         x="60.03"
 	 y="-732.0624" 
 	 z="595.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_5-4"/>
        <position name="posArapuca4-Lat-5" unit="cm" 
-         x="285.02"
+         x="285.03"
 	 y="732.8024" 
 	 z="595.68"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -15210,14 +15215,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_5-4"/>
        <position name="posOpArapuca4-Lat-5" unit="cm" 
-         x="285.02"
+         x="285.03"
 	 y="732.0624" 
 	 z="595.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_5-5"/>
        <position name="posArapuca5-Lat-5" unit="cm" 
-         x="210.02"
+         x="210.03"
 	 y="732.8024" 
 	 z="595.68"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -15225,14 +15230,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_5-5"/>
        <position name="posOpArapuca5-Lat-5" unit="cm" 
-         x="210.02"
+         x="210.03"
 	 y="732.0624" 
 	 z="595.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_5-6"/>
        <position name="posArapuca6-Lat-5" unit="cm" 
-         x="135.02"
+         x="135.03"
 	 y="732.8024" 
 	 z="595.68"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -15240,14 +15245,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_5-6"/>
        <position name="posOpArapuca6-Lat-5" unit="cm" 
-         x="135.02"
+         x="135.03"
 	 y="732.0624" 
 	 z="595.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_5-7"/>
        <position name="posArapuca7-Lat-5" unit="cm" 
-         x="60.02"
+         x="60.03"
 	 y="732.8024" 
 	 z="595.68"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -15255,14 +15260,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_5-7"/>
        <position name="posOpArapuca7-Lat-5" unit="cm" 
-         x="60.02"
+         x="60.03"
 	 y="732.0624" 
 	 z="595.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_6-0"/>
        <position name="posArapuca0-Lat-6" unit="cm" 
-         x="285.02"
+         x="285.03"
 	 y="-732.8024" 
 	 z="893.52"/>
        <rotationref ref="rIdentity"/>
@@ -15270,14 +15275,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_6-0"/>
        <position name="posOpArapuca0-Lat-6" unit="cm" 
-         x="285.02"
+         x="285.03"
 	 y="-732.0624" 
 	 z="893.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_6-1"/>
        <position name="posArapuca1-Lat-6" unit="cm" 
-         x="210.02"
+         x="210.03"
 	 y="-732.8024" 
 	 z="893.52"/>
        <rotationref ref="rIdentity"/>
@@ -15285,14 +15290,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_6-1"/>
        <position name="posOpArapuca1-Lat-6" unit="cm" 
-         x="210.02"
+         x="210.03"
 	 y="-732.0624" 
 	 z="893.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_6-2"/>
        <position name="posArapuca2-Lat-6" unit="cm" 
-         x="135.02"
+         x="135.03"
 	 y="-732.8024" 
 	 z="893.52"/>
        <rotationref ref="rIdentity"/>
@@ -15300,14 +15305,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_6-2"/>
        <position name="posOpArapuca2-Lat-6" unit="cm" 
-         x="135.02"
+         x="135.03"
 	 y="-732.0624" 
 	 z="893.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_6-3"/>
        <position name="posArapuca3-Lat-6" unit="cm" 
-         x="60.02"
+         x="60.03"
 	 y="-732.8024" 
 	 z="893.52"/>
        <rotationref ref="rIdentity"/>
@@ -15315,14 +15320,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_6-3"/>
        <position name="posOpArapuca3-Lat-6" unit="cm" 
-         x="60.02"
+         x="60.03"
 	 y="-732.0624" 
 	 z="893.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_6-4"/>
        <position name="posArapuca4-Lat-6" unit="cm" 
-         x="285.02"
+         x="285.03"
 	 y="732.8024" 
 	 z="893.52"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -15330,14 +15335,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_6-4"/>
        <position name="posOpArapuca4-Lat-6" unit="cm" 
-         x="285.02"
+         x="285.03"
 	 y="732.0624" 
 	 z="893.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_6-5"/>
        <position name="posArapuca5-Lat-6" unit="cm" 
-         x="210.02"
+         x="210.03"
 	 y="732.8024" 
 	 z="893.52"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -15345,14 +15350,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_6-5"/>
        <position name="posOpArapuca5-Lat-6" unit="cm" 
-         x="210.02"
+         x="210.03"
 	 y="732.0624" 
 	 z="893.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_6-6"/>
        <position name="posArapuca6-Lat-6" unit="cm" 
-         x="135.02"
+         x="135.03"
 	 y="732.8024" 
 	 z="893.52"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -15360,14 +15365,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_6-6"/>
        <position name="posOpArapuca6-Lat-6" unit="cm" 
-         x="135.02"
+         x="135.03"
 	 y="732.0624" 
 	 z="893.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_6-7"/>
        <position name="posArapuca7-Lat-6" unit="cm" 
-         x="60.02"
+         x="60.03"
 	 y="732.8024" 
 	 z="893.52"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -15375,7 +15380,7 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_6-7"/>
        <position name="posOpArapuca7-Lat-6" unit="cm" 
-         x="60.02"
+         x="60.03"
 	 y="732.0624" 
 	 z="893.52"/>
      </physvol>

--- a/dunecore/Geometry/gdml/dunevd10kt_3view_30deg_v3_refactored_1x8x14ref.gdml
+++ b/dunecore/Geometry/gdml/dunevd10kt_3view_30deg_v3_refactored_1x8x14ref.gdml
@@ -490,7 +490,7 @@
     
 
    <box name="CRM"
-      x="650.08" 
+      x="650.1" 
       y="167.7006" 
       z="148.92"
       lunit="cm"/>
@@ -3424,12 +3424,12 @@
 
 
     <box name="Cryostat" lunit="cm" 
-      x="850.32" 
+      x="850.34" 
       y="1545.8448" 
       z="2292.12"/>
 
     <box name="ArgonInterior" lunit="cm" 
-      x="850.08"
+      x="850.1"
       y="1545.6048"
       z="2291.88"/>
 
@@ -3439,12 +3439,12 @@
       z="2291.88"/>
 
     <box name="ExternalAuxOut" lunit="cm" 
-      x="850.08 - 100"
+      x="850.1 - 100"
       y="1545.6048 - 2*2.5 - 2*40"
       z="2291.88"/>
 
     <box name="ExternalAuxIn" lunit="cm" 
-      x="850.08"
+      x="850.1"
       y="1356.7748"
       z="2291.88 + 1"/>
 
@@ -3552,7 +3552,7 @@
     </subtraction>
 
     <box name="FoamPadBlock" lunit="cm"
-      x="1010.32"
+      x="1010.34"
       y="1705.8448"
       z="2452.12" />
 
@@ -3563,7 +3563,7 @@
     </subtraction>
 
     <box name="SteelSupportBlock" lunit="cm"
-      x="1210.32"
+      x="1210.34"
       y="1905.8448"
       z="2652.12" />
 
@@ -3574,13 +3574,13 @@
     </subtraction>
 
     <box name="DetEnclosure" lunit="cm" 
-      x="1310.32"
+      x="1310.34"
       y="2105.8448"
       z="2852.12"/>
 
 
     <box name="World" lunit="cm" 
-      x="9310.32" 
+      x="9310.34" 
       y="10105.8448" 
       z="10852.12"/>
 </solids>
@@ -10238,31 +10238,31 @@
        <physvol>
        <volumeref ref="volTPCPlaneU"/>
        <position name="posPlaneU" unit="cm" 
-         x="324.97" y="0" z="0"/>
+         x="324.98" y="0" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volTPCPlaneV"/>
        <position name="posPlaneY" unit="cm" 
-         x="324.99" y="0" z="0"/>
+         x="325" y="0" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volTPCPlaneZ"/>
        <position name="posPlaneZ" unit="cm" 
-         x="325.01" y="0" z="0"/>
+         x="325.02" y="0" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volAnodePlate"/>
        <position name="posAnodePlate" unit="cm" 
-         x="325.03" y="0" z="0"/>
+         x="325.04" y="0" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volTPCActive"/>
        <position name="posActive" unit="cm" 
-        x="-0.04" y="" z="0"/>
+        x="-0.05" y="" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
    </volume>
@@ -11637,7 +11637,7 @@
       <solidref ref="Cryostat" />
       <physvol>
         <volumeref ref="volGaseousArgon"/>
-        <position name="posGaseousArgon" unit="cm" x="375.04" y="0" z="0"/>
+        <position name="posGaseousArgon" unit="cm" x="375.05" y="0" z="0"/>
       </physvol>
       <physvol>
         <volumeref ref="volSteelShell"/>
@@ -12209,660 +12209,660 @@
       </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper0" unit="cm"  x="-322.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper0" unit="cm"  x="-322.05" y="-675.1024" z="0" />
      <rotation name="rotFS0" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper1" unit="cm"  x="-316.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper1" unit="cm"  x="-316.05" y="-675.1024" z="0" />
      <rotation name="rotFS1" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper2" unit="cm"  x="-310.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper2" unit="cm"  x="-310.05" y="-675.1024" z="0" />
      <rotation name="rotFS2" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper3" unit="cm"  x="-304.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper3" unit="cm"  x="-304.05" y="-675.1024" z="0" />
      <rotation name="rotFS3" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper4" unit="cm"  x="-298.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper4" unit="cm"  x="-298.05" y="-675.1024" z="0" />
      <rotation name="rotFS4" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper5" unit="cm"  x="-292.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper5" unit="cm"  x="-292.05" y="-675.1024" z="0" />
      <rotation name="rotFS5" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper6" unit="cm"  x="-286.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper6" unit="cm"  x="-286.05" y="-675.1024" z="0" />
      <rotation name="rotFS6" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper7" unit="cm"  x="-280.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper7" unit="cm"  x="-280.05" y="-675.1024" z="0" />
      <rotation name="rotFS7" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper8" unit="cm"  x="-274.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper8" unit="cm"  x="-274.05" y="-675.1024" z="0" />
      <rotation name="rotFS8" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper9" unit="cm"  x="-268.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper9" unit="cm"  x="-268.05" y="-675.1024" z="0" />
      <rotation name="rotFS9" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper10" unit="cm"  x="-262.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper10" unit="cm"  x="-262.05" y="-675.1024" z="0" />
      <rotation name="rotFS10" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper11" unit="cm"  x="-256.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper11" unit="cm"  x="-256.05" y="-675.1024" z="0" />
      <rotation name="rotFS11" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper12" unit="cm"  x="-250.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper12" unit="cm"  x="-250.05" y="-675.1024" z="0" />
      <rotation name="rotFS12" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper13" unit="cm"  x="-244.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper13" unit="cm"  x="-244.05" y="-675.1024" z="0" />
      <rotation name="rotFS13" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper14" unit="cm"  x="-238.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper14" unit="cm"  x="-238.05" y="-675.1024" z="0" />
      <rotation name="rotFS14" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper15" unit="cm"  x="-232.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper15" unit="cm"  x="-232.05" y="-675.1024" z="0" />
      <rotation name="rotFS15" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper16" unit="cm"  x="-226.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper16" unit="cm"  x="-226.05" y="-675.1024" z="0" />
      <rotation name="rotFS16" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper17" unit="cm"  x="-220.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper17" unit="cm"  x="-220.05" y="-675.1024" z="0" />
      <rotation name="rotFS17" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper18" unit="cm"  x="-214.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper18" unit="cm"  x="-214.05" y="-675.1024" z="0" />
      <rotation name="rotFS18" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper19" unit="cm"  x="-208.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper19" unit="cm"  x="-208.05" y="-675.1024" z="0" />
      <rotation name="rotFS19" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper20" unit="cm"  x="-202.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper20" unit="cm"  x="-202.05" y="-675.1024" z="0" />
      <rotation name="rotFS20" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper21" unit="cm"  x="-196.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper21" unit="cm"  x="-196.05" y="-675.1024" z="0" />
      <rotation name="rotFS21" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper22" unit="cm"  x="-190.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper22" unit="cm"  x="-190.05" y="-675.1024" z="0" />
      <rotation name="rotFS22" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper23" unit="cm"  x="-184.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper23" unit="cm"  x="-184.05" y="-675.1024" z="0" />
      <rotation name="rotFS23" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper24" unit="cm"  x="-178.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper24" unit="cm"  x="-178.05" y="-675.1024" z="0" />
      <rotation name="rotFS24" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper25" unit="cm"  x="-172.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper25" unit="cm"  x="-172.05" y="-675.1024" z="0" />
      <rotation name="rotFS25" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper26" unit="cm"  x="-166.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper26" unit="cm"  x="-166.05" y="-675.1024" z="0" />
      <rotation name="rotFS26" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper27" unit="cm"  x="-160.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper27" unit="cm"  x="-160.05" y="-675.1024" z="0" />
      <rotation name="rotFS27" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper28" unit="cm"  x="-154.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper28" unit="cm"  x="-154.05" y="-675.1024" z="0" />
      <rotation name="rotFS28" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper29" unit="cm"  x="-148.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper29" unit="cm"  x="-148.05" y="-675.1024" z="0" />
      <rotation name="rotFS29" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper30" unit="cm"  x="-142.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper30" unit="cm"  x="-142.05" y="-675.1024" z="0" />
      <rotation name="rotFS30" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper31" unit="cm"  x="-136.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper31" unit="cm"  x="-136.05" y="-675.1024" z="0" />
      <rotation name="rotFS31" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper32" unit="cm"  x="-130.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper32" unit="cm"  x="-130.05" y="-675.1024" z="0" />
      <rotation name="rotFS32" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper33" unit="cm"  x="-124.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper33" unit="cm"  x="-124.05" y="-675.1024" z="0" />
      <rotation name="rotFS33" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper34" unit="cm"  x="-118.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper34" unit="cm"  x="-118.05" y="-675.1024" z="0" />
      <rotation name="rotFS34" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper35" unit="cm"  x="-112.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper35" unit="cm"  x="-112.05" y="-675.1024" z="0" />
      <rotation name="rotFS35" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper36" unit="cm"  x="-106.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper36" unit="cm"  x="-106.05" y="-675.1024" z="0" />
      <rotation name="rotFS36" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper37" unit="cm"  x="-100.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper37" unit="cm"  x="-100.05" y="-675.1024" z="0" />
      <rotation name="rotFS37" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper38" unit="cm"  x="-94.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper38" unit="cm"  x="-94.0500000000001" y="-675.1024" z="0" />
      <rotation name="rotFS38" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper39" unit="cm"  x="-88.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper39" unit="cm"  x="-88.0500000000001" y="-675.1024" z="0" />
      <rotation name="rotFS39" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper40" unit="cm"  x="-82.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper40" unit="cm"  x="-82.0500000000001" y="-675.1024" z="0" />
      <rotation name="rotFS40" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper41" unit="cm"  x="-76.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper41" unit="cm"  x="-76.0500000000001" y="-675.1024" z="0" />
      <rotation name="rotFS41" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper42" unit="cm"  x="-70.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper42" unit="cm"  x="-70.0500000000001" y="-675.1024" z="0" />
      <rotation name="rotFS42" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper43" unit="cm"  x="-64.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper43" unit="cm"  x="-64.0500000000001" y="-675.1024" z="0" />
      <rotation name="rotFS43" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper44" unit="cm"  x="-58.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper44" unit="cm"  x="-58.0500000000001" y="-675.1024" z="0" />
      <rotation name="rotFS44" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper45" unit="cm"  x="-52.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper45" unit="cm"  x="-52.0500000000001" y="-675.1024" z="0" />
      <rotation name="rotFS45" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper46" unit="cm"  x="-46.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper46" unit="cm"  x="-46.0500000000001" y="-675.1024" z="0" />
      <rotation name="rotFS46" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper47" unit="cm"  x="-40.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper47" unit="cm"  x="-40.0500000000001" y="-675.1024" z="0" />
      <rotation name="rotFS47" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper48" unit="cm"  x="-34.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper48" unit="cm"  x="-34.0500000000001" y="-675.1024" z="0" />
      <rotation name="rotFS48" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper49" unit="cm"  x="-28.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper49" unit="cm"  x="-28.0500000000001" y="-675.1024" z="0" />
      <rotation name="rotFS49" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper50" unit="cm"  x="-22.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper50" unit="cm"  x="-22.0500000000001" y="-675.1024" z="0" />
      <rotation name="rotFS50" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper51" unit="cm"  x="-16.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper51" unit="cm"  x="-16.0500000000001" y="-675.1024" z="0" />
      <rotation name="rotFS51" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper52" unit="cm"  x="-10.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper52" unit="cm"  x="-10.0500000000001" y="-675.1024" z="0" />
      <rotation name="rotFS52" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper53" unit="cm"  x="-4.04000000000001" y="-675.1024" z="0" />
+     <position name="posFieldShaper53" unit="cm"  x="-4.05000000000005" y="-675.1024" z="0" />
      <rotation name="rotFS53" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper54" unit="cm"  x="1.95999999999999" y="-675.1024" z="0" />
+     <position name="posFieldShaper54" unit="cm"  x="1.94999999999995" y="-675.1024" z="0" />
      <rotation name="rotFS54" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper55" unit="cm"  x="7.95999999999999" y="-675.1024" z="0" />
+     <position name="posFieldShaper55" unit="cm"  x="7.94999999999995" y="-675.1024" z="0" />
      <rotation name="rotFS55" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper56" unit="cm"  x="13.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper56" unit="cm"  x="13.9499999999999" y="-675.1024" z="0" />
      <rotation name="rotFS56" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper57" unit="cm"  x="19.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper57" unit="cm"  x="19.9499999999999" y="-675.1024" z="0" />
      <rotation name="rotFS57" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper58" unit="cm"  x="25.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper58" unit="cm"  x="25.9499999999999" y="-675.1024" z="0" />
      <rotation name="rotFS58" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper59" unit="cm"  x="31.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper59" unit="cm"  x="31.9499999999999" y="-675.1024" z="0" />
      <rotation name="rotFS59" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper60" unit="cm"  x="37.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper60" unit="cm"  x="37.9499999999999" y="-675.1024" z="0" />
      <rotation name="rotFS60" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper61" unit="cm"  x="43.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper61" unit="cm"  x="43.9499999999999" y="-675.1024" z="0" />
      <rotation name="rotFS61" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper62" unit="cm"  x="49.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper62" unit="cm"  x="49.9499999999999" y="-675.1024" z="0" />
      <rotation name="rotFS62" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper63" unit="cm"  x="55.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper63" unit="cm"  x="55.9499999999999" y="-675.1024" z="0" />
      <rotation name="rotFS63" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper64" unit="cm"  x="61.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper64" unit="cm"  x="61.9499999999999" y="-675.1024" z="0" />
      <rotation name="rotFS64" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper65" unit="cm"  x="67.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper65" unit="cm"  x="67.9499999999999" y="-675.1024" z="0" />
      <rotation name="rotFS65" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper66" unit="cm"  x="73.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper66" unit="cm"  x="73.9499999999999" y="-675.1024" z="0" />
      <rotation name="rotFS66" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper67" unit="cm"  x="79.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper67" unit="cm"  x="79.9499999999999" y="-675.1024" z="0" />
      <rotation name="rotFS67" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper68" unit="cm"  x="85.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper68" unit="cm"  x="85.9499999999999" y="-675.1024" z="0" />
      <rotation name="rotFS68" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper69" unit="cm"  x="91.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper69" unit="cm"  x="91.9499999999999" y="-675.1024" z="0" />
      <rotation name="rotFS69" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper70" unit="cm"  x="97.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper70" unit="cm"  x="97.9499999999999" y="-675.1024" z="0" />
      <rotation name="rotFS70" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper71" unit="cm"  x="103.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper71" unit="cm"  x="103.95" y="-675.1024" z="0" />
      <rotation name="rotFS71" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper72" unit="cm"  x="109.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper72" unit="cm"  x="109.95" y="-675.1024" z="0" />
      <rotation name="rotFS72" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper73" unit="cm"  x="115.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper73" unit="cm"  x="115.95" y="-675.1024" z="0" />
      <rotation name="rotFS73" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper74" unit="cm"  x="121.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper74" unit="cm"  x="121.95" y="-675.1024" z="0" />
      <rotation name="rotFS74" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper75" unit="cm"  x="127.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper75" unit="cm"  x="127.95" y="-675.1024" z="0" />
      <rotation name="rotFS75" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper76" unit="cm"  x="133.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper76" unit="cm"  x="133.95" y="-675.1024" z="0" />
      <rotation name="rotFS76" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper77" unit="cm"  x="139.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper77" unit="cm"  x="139.95" y="-675.1024" z="0" />
      <rotation name="rotFS77" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper78" unit="cm"  x="145.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper78" unit="cm"  x="145.95" y="-675.1024" z="0" />
      <rotation name="rotFS78" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper79" unit="cm"  x="151.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper79" unit="cm"  x="151.95" y="-675.1024" z="0" />
      <rotation name="rotFS79" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper80" unit="cm"  x="157.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper80" unit="cm"  x="157.95" y="-675.1024" z="0" />
      <rotation name="rotFS80" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper81" unit="cm"  x="163.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper81" unit="cm"  x="163.95" y="-675.1024" z="0" />
      <rotation name="rotFS81" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper82" unit="cm"  x="169.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper82" unit="cm"  x="169.95" y="-675.1024" z="0" />
      <rotation name="rotFS82" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper83" unit="cm"  x="175.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper83" unit="cm"  x="175.95" y="-675.1024" z="0" />
      <rotation name="rotFS83" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper84" unit="cm"  x="181.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper84" unit="cm"  x="181.95" y="-675.1024" z="0" />
      <rotation name="rotFS84" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper85" unit="cm"  x="187.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper85" unit="cm"  x="187.95" y="-675.1024" z="0" />
      <rotation name="rotFS85" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper86" unit="cm"  x="193.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper86" unit="cm"  x="193.95" y="-675.1024" z="0" />
      <rotation name="rotFS86" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper87" unit="cm"  x="199.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper87" unit="cm"  x="199.95" y="-675.1024" z="0" />
      <rotation name="rotFS87" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper88" unit="cm"  x="205.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper88" unit="cm"  x="205.95" y="-675.1024" z="0" />
      <rotation name="rotFS88" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper89" unit="cm"  x="211.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper89" unit="cm"  x="211.95" y="-675.1024" z="0" />
      <rotation name="rotFS89" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper90" unit="cm"  x="217.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper90" unit="cm"  x="217.95" y="-675.1024" z="0" />
      <rotation name="rotFS90" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper91" unit="cm"  x="223.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper91" unit="cm"  x="223.95" y="-675.1024" z="0" />
      <rotation name="rotFS91" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper92" unit="cm"  x="229.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper92" unit="cm"  x="229.95" y="-675.1024" z="0" />
      <rotation name="rotFS92" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper93" unit="cm"  x="235.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper93" unit="cm"  x="235.95" y="-675.1024" z="0" />
      <rotation name="rotFS93" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper94" unit="cm"  x="241.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper94" unit="cm"  x="241.95" y="-675.1024" z="0" />
      <rotation name="rotFS94" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper95" unit="cm"  x="247.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper95" unit="cm"  x="247.95" y="-675.1024" z="0" />
      <rotation name="rotFS95" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper96" unit="cm"  x="253.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper96" unit="cm"  x="253.95" y="-675.1024" z="0" />
      <rotation name="rotFS96" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper97" unit="cm"  x="259.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper97" unit="cm"  x="259.95" y="-675.1024" z="0" />
      <rotation name="rotFS97" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper98" unit="cm"  x="265.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper98" unit="cm"  x="265.95" y="-675.1024" z="0" />
      <rotation name="rotFS98" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper99" unit="cm"  x="271.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper99" unit="cm"  x="271.95" y="-675.1024" z="0" />
      <rotation name="rotFS99" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper100" unit="cm"  x="277.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper100" unit="cm"  x="277.95" y="-675.1024" z="0" />
      <rotation name="rotFS100" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper101" unit="cm"  x="283.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper101" unit="cm"  x="283.95" y="-675.1024" z="0" />
      <rotation name="rotFS101" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper102" unit="cm"  x="289.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper102" unit="cm"  x="289.95" y="-675.1024" z="0" />
      <rotation name="rotFS102" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper103" unit="cm"  x="295.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper103" unit="cm"  x="295.95" y="-675.1024" z="0" />
      <rotation name="rotFS103" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper104" unit="cm"  x="301.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper104" unit="cm"  x="301.95" y="-675.1024" z="0" />
      <rotation name="rotFS104" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper105" unit="cm"  x="307.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper105" unit="cm"  x="307.95" y="-675.1024" z="0" />
      <rotation name="rotFS105" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper106" unit="cm"  x="313.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper106" unit="cm"  x="313.95" y="-675.1024" z="0" />
      <rotation name="rotFS106" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper107" unit="cm"  x="319.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper107" unit="cm"  x="319.95" y="-675.1024" z="0" />
      <rotation name="rotFS107" unit="deg" x="0" y="0" z="90" />
   </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-0" unit="cm" x="-328.04" y="-505.1018" z="-897.02"/>
+   <position name="posGroundGrid-0" unit="cm" x="-328.05" y="-505.1018" z="-897.02"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-1" unit="cm" x="-328.04" y="-169.7006" z="-897.02"/>
+   <position name="posGroundGrid-1" unit="cm" x="-328.05" y="-169.7006" z="-897.02"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-2" unit="cm" x="-328.04" y="165.7006" z="-897.02"/>
+   <position name="posGroundGrid-2" unit="cm" x="-328.05" y="165.7006" z="-897.02"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-3" unit="cm" x="-328.04" y="501.1018" z="-897.02"/>
+   <position name="posGroundGrid-3" unit="cm" x="-328.05" y="501.1018" z="-897.02"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-4" unit="cm" x="-328.04" y="-505.1018" z="-599.18"/>
+   <position name="posGroundGrid-4" unit="cm" x="-328.05" y="-505.1018" z="-599.18"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-5" unit="cm" x="-328.04" y="-169.7006" z="-599.18"/>
+   <position name="posGroundGrid-5" unit="cm" x="-328.05" y="-169.7006" z="-599.18"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-6" unit="cm" x="-328.04" y="165.7006" z="-599.18"/>
+   <position name="posGroundGrid-6" unit="cm" x="-328.05" y="165.7006" z="-599.18"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-7" unit="cm" x="-328.04" y="501.1018" z="-599.18"/>
+   <position name="posGroundGrid-7" unit="cm" x="-328.05" y="501.1018" z="-599.18"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-8" unit="cm" x="-328.04" y="-505.1018" z="-301.34"/>
+   <position name="posGroundGrid-8" unit="cm" x="-328.05" y="-505.1018" z="-301.34"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-9" unit="cm" x="-328.04" y="-169.7006" z="-301.34"/>
+   <position name="posGroundGrid-9" unit="cm" x="-328.05" y="-169.7006" z="-301.34"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-10" unit="cm" x="-328.04" y="165.7006" z="-301.34"/>
+   <position name="posGroundGrid-10" unit="cm" x="-328.05" y="165.7006" z="-301.34"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-11" unit="cm" x="-328.04" y="501.1018" z="-301.34"/>
+   <position name="posGroundGrid-11" unit="cm" x="-328.05" y="501.1018" z="-301.34"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-12" unit="cm" x="-328.04" y="-505.1018" z="-3.49999999999989"/>
+   <position name="posGroundGrid-12" unit="cm" x="-328.05" y="-505.1018" z="-3.49999999999989"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-13" unit="cm" x="-328.04" y="-169.7006" z="-3.49999999999989"/>
+   <position name="posGroundGrid-13" unit="cm" x="-328.05" y="-169.7006" z="-3.49999999999989"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-14" unit="cm" x="-328.04" y="165.7006" z="-3.49999999999989"/>
+   <position name="posGroundGrid-14" unit="cm" x="-328.05" y="165.7006" z="-3.49999999999989"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-15" unit="cm" x="-328.04" y="501.1018" z="-3.49999999999989"/>
+   <position name="posGroundGrid-15" unit="cm" x="-328.05" y="501.1018" z="-3.49999999999989"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-16" unit="cm" x="-328.04" y="-505.1018" z="294.34"/>
+   <position name="posGroundGrid-16" unit="cm" x="-328.05" y="-505.1018" z="294.34"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-17" unit="cm" x="-328.04" y="-169.7006" z="294.34"/>
+   <position name="posGroundGrid-17" unit="cm" x="-328.05" y="-169.7006" z="294.34"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-18" unit="cm" x="-328.04" y="165.7006" z="294.34"/>
+   <position name="posGroundGrid-18" unit="cm" x="-328.05" y="165.7006" z="294.34"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-19" unit="cm" x="-328.04" y="501.1018" z="294.34"/>
+   <position name="posGroundGrid-19" unit="cm" x="-328.05" y="501.1018" z="294.34"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-20" unit="cm" x="-328.04" y="-505.1018" z="592.18"/>
+   <position name="posGroundGrid-20" unit="cm" x="-328.05" y="-505.1018" z="592.18"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-21" unit="cm" x="-328.04" y="-169.7006" z="592.18"/>
+   <position name="posGroundGrid-21" unit="cm" x="-328.05" y="-169.7006" z="592.18"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-22" unit="cm" x="-328.04" y="165.7006" z="592.18"/>
+   <position name="posGroundGrid-22" unit="cm" x="-328.05" y="165.7006" z="592.18"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-23" unit="cm" x="-328.04" y="501.1018" z="592.18"/>
+   <position name="posGroundGrid-23" unit="cm" x="-328.05" y="501.1018" z="592.18"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-24" unit="cm" x="-328.04" y="-505.1018" z="890.02"/>
+   <position name="posGroundGrid-24" unit="cm" x="-328.05" y="-505.1018" z="890.02"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-25" unit="cm" x="-328.04" y="-169.7006" z="890.02"/>
+   <position name="posGroundGrid-25" unit="cm" x="-328.05" y="-169.7006" z="890.02"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-26" unit="cm" x="-328.04" y="165.7006" z="890.02"/>
+   <position name="posGroundGrid-26" unit="cm" x="-328.05" y="165.7006" z="890.02"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-27" unit="cm" x="-328.04" y="501.1018" z="890.02"/>
+   <position name="posGroundGrid-27" unit="cm" x="-328.05" y="501.1018" z="890.02"/>
       </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-0-0"/>
        <position name="posArapucaDouble0-Frame-0-0" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-632.8018" 
 	 z="-859.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -12870,14 +12870,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-0"/>
        <position name="posOpArapucaDouble0-Frame-0-0" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-632.8018" 
 	 z="-859.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-0-1"/>
        <position name="posArapucaDouble1-Frame-0-0" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-542.1018" 
 	 z="-1005.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -12885,14 +12885,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-1"/>
        <position name="posOpArapucaDouble1-Frame-0-0" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-542.1018" 
 	 z="-1005.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-0-2"/>
        <position name="posArapucaDouble2-Frame-0-0" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-468.1018" 
 	 z="-788.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -12900,14 +12900,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-2"/>
        <position name="posOpArapucaDouble2-Frame-0-0" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-468.1018" 
 	 z="-788.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-0-3"/>
        <position name="posArapucaDouble3-Frame-0-0" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-377.4018" 
 	 z="-934.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -12915,14 +12915,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-3"/>
        <position name="posOpArapucaDouble3-Frame-0-0" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-377.4018" 
 	 z="-934.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-1-0"/>
        <position name="posArapucaDouble0-Frame-0-1" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-632.8018" 
 	 z="-561.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -12930,14 +12930,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-0"/>
        <position name="posOpArapucaDouble0-Frame-0-1" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-632.8018" 
 	 z="-561.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-1-1"/>
        <position name="posArapucaDouble1-Frame-0-1" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-542.1018" 
 	 z="-707.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -12945,14 +12945,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-1"/>
        <position name="posOpArapucaDouble1-Frame-0-1" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-542.1018" 
 	 z="-707.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-1-2"/>
        <position name="posArapucaDouble2-Frame-0-1" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-468.1018" 
 	 z="-490.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -12960,14 +12960,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-2"/>
        <position name="posOpArapucaDouble2-Frame-0-1" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-468.1018" 
 	 z="-490.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-1-3"/>
        <position name="posArapucaDouble3-Frame-0-1" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-377.4018" 
 	 z="-636.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -12975,14 +12975,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-3"/>
        <position name="posOpArapucaDouble3-Frame-0-1" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-377.4018" 
 	 z="-636.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-2-0"/>
        <position name="posArapucaDouble0-Frame-0-2" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-632.8018" 
 	 z="-263.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -12990,14 +12990,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-0"/>
        <position name="posOpArapucaDouble0-Frame-0-2" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-632.8018" 
 	 z="-263.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-2-1"/>
        <position name="posArapucaDouble1-Frame-0-2" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-542.1018" 
 	 z="-409.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13005,14 +13005,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-1"/>
        <position name="posOpArapucaDouble1-Frame-0-2" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-542.1018" 
 	 z="-409.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-2-2"/>
        <position name="posArapucaDouble2-Frame-0-2" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-468.1018" 
 	 z="-192.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13020,14 +13020,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-2"/>
        <position name="posOpArapucaDouble2-Frame-0-2" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-468.1018" 
 	 z="-192.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-2-3"/>
        <position name="posArapucaDouble3-Frame-0-2" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-377.4018" 
 	 z="-338.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13035,14 +13035,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-3"/>
        <position name="posOpArapucaDouble3-Frame-0-2" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-377.4018" 
 	 z="-338.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-3-0"/>
        <position name="posArapucaDouble0-Frame-0-3" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-632.8018" 
 	 z="34.0000000000001"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13050,14 +13050,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-3-0"/>
        <position name="posOpArapucaDouble0-Frame-0-3" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-632.8018" 
 	 z="34.0000000000001"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-3-1"/>
        <position name="posArapucaDouble1-Frame-0-3" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-542.1018" 
 	 z="-112"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13065,14 +13065,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-3-1"/>
        <position name="posOpArapucaDouble1-Frame-0-3" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-542.1018" 
 	 z="-112"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-3-2"/>
        <position name="posArapucaDouble2-Frame-0-3" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-468.1018" 
 	 z="105"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13080,14 +13080,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-3-2"/>
        <position name="posOpArapucaDouble2-Frame-0-3" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-468.1018" 
 	 z="105"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-3-3"/>
        <position name="posArapucaDouble3-Frame-0-3" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-377.4018" 
 	 z="-40.9999999999999"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13095,14 +13095,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-3-3"/>
        <position name="posOpArapucaDouble3-Frame-0-3" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-377.4018" 
 	 z="-40.9999999999999"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-4-0"/>
        <position name="posArapucaDouble0-Frame-0-4" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-632.8018" 
 	 z="331.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13110,14 +13110,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-4-0"/>
        <position name="posOpArapucaDouble0-Frame-0-4" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-632.8018" 
 	 z="331.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-4-1"/>
        <position name="posArapucaDouble1-Frame-0-4" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-542.1018" 
 	 z="185.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13125,14 +13125,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-4-1"/>
        <position name="posOpArapucaDouble1-Frame-0-4" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-542.1018" 
 	 z="185.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-4-2"/>
        <position name="posArapucaDouble2-Frame-0-4" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-468.1018" 
 	 z="402.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13140,14 +13140,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-4-2"/>
        <position name="posOpArapucaDouble2-Frame-0-4" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-468.1018" 
 	 z="402.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-4-3"/>
        <position name="posArapucaDouble3-Frame-0-4" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-377.4018" 
 	 z="256.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13155,14 +13155,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-4-3"/>
        <position name="posOpArapucaDouble3-Frame-0-4" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-377.4018" 
 	 z="256.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-5-0"/>
        <position name="posArapucaDouble0-Frame-0-5" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-632.8018" 
 	 z="629.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13170,14 +13170,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-5-0"/>
        <position name="posOpArapucaDouble0-Frame-0-5" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-632.8018" 
 	 z="629.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-5-1"/>
        <position name="posArapucaDouble1-Frame-0-5" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-542.1018" 
 	 z="483.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13185,14 +13185,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-5-1"/>
        <position name="posOpArapucaDouble1-Frame-0-5" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-542.1018" 
 	 z="483.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-5-2"/>
        <position name="posArapucaDouble2-Frame-0-5" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-468.1018" 
 	 z="700.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13200,14 +13200,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-5-2"/>
        <position name="posOpArapucaDouble2-Frame-0-5" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-468.1018" 
 	 z="700.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-5-3"/>
        <position name="posArapucaDouble3-Frame-0-5" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-377.4018" 
 	 z="554.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13215,14 +13215,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-5-3"/>
        <position name="posOpArapucaDouble3-Frame-0-5" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-377.4018" 
 	 z="554.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-6-0"/>
        <position name="posArapucaDouble0-Frame-0-6" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-632.8018" 
 	 z="927.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13230,14 +13230,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-6-0"/>
        <position name="posOpArapucaDouble0-Frame-0-6" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-632.8018" 
 	 z="927.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-6-1"/>
        <position name="posArapucaDouble1-Frame-0-6" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-542.1018" 
 	 z="781.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13245,14 +13245,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-6-1"/>
        <position name="posOpArapucaDouble1-Frame-0-6" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-542.1018" 
 	 z="781.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-6-2"/>
        <position name="posArapucaDouble2-Frame-0-6" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-468.1018" 
 	 z="998.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13260,14 +13260,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-6-2"/>
        <position name="posOpArapucaDouble2-Frame-0-6" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-468.1018" 
 	 z="998.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-6-3"/>
        <position name="posArapucaDouble3-Frame-0-6" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-377.4018" 
 	 z="852.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13275,14 +13275,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-6-3"/>
        <position name="posOpArapucaDouble3-Frame-0-6" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-377.4018" 
 	 z="852.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-0-0"/>
        <position name="posArapucaDouble0-Frame-1-0" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-297.4006" 
 	 z="-859.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13290,14 +13290,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-0"/>
        <position name="posOpArapucaDouble0-Frame-1-0" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-297.4006" 
 	 z="-859.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-0-1"/>
        <position name="posArapucaDouble1-Frame-1-0" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-206.7006" 
 	 z="-1005.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13305,14 +13305,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-1"/>
        <position name="posOpArapucaDouble1-Frame-1-0" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-206.7006" 
 	 z="-1005.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-0-2"/>
        <position name="posArapucaDouble2-Frame-1-0" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-132.7006" 
 	 z="-788.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13320,14 +13320,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-2"/>
        <position name="posOpArapucaDouble2-Frame-1-0" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-132.7006" 
 	 z="-788.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-0-3"/>
        <position name="posArapucaDouble3-Frame-1-0" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-42.0006" 
 	 z="-934.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13335,14 +13335,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-3"/>
        <position name="posOpArapucaDouble3-Frame-1-0" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-42.0006" 
 	 z="-934.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-1-0"/>
        <position name="posArapucaDouble0-Frame-1-1" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-297.4006" 
 	 z="-561.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13350,14 +13350,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-0"/>
        <position name="posOpArapucaDouble0-Frame-1-1" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-297.4006" 
 	 z="-561.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-1-1"/>
        <position name="posArapucaDouble1-Frame-1-1" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-206.7006" 
 	 z="-707.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13365,14 +13365,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-1"/>
        <position name="posOpArapucaDouble1-Frame-1-1" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-206.7006" 
 	 z="-707.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-1-2"/>
        <position name="posArapucaDouble2-Frame-1-1" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-132.7006" 
 	 z="-490.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13380,14 +13380,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-2"/>
        <position name="posOpArapucaDouble2-Frame-1-1" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-132.7006" 
 	 z="-490.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-1-3"/>
        <position name="posArapucaDouble3-Frame-1-1" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-42.0006" 
 	 z="-636.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13395,14 +13395,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-3"/>
        <position name="posOpArapucaDouble3-Frame-1-1" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-42.0006" 
 	 z="-636.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-2-0"/>
        <position name="posArapucaDouble0-Frame-1-2" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-297.4006" 
 	 z="-263.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13410,14 +13410,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-0"/>
        <position name="posOpArapucaDouble0-Frame-1-2" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-297.4006" 
 	 z="-263.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-2-1"/>
        <position name="posArapucaDouble1-Frame-1-2" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-206.7006" 
 	 z="-409.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13425,14 +13425,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-1"/>
        <position name="posOpArapucaDouble1-Frame-1-2" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-206.7006" 
 	 z="-409.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-2-2"/>
        <position name="posArapucaDouble2-Frame-1-2" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-132.7006" 
 	 z="-192.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13440,14 +13440,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-2"/>
        <position name="posOpArapucaDouble2-Frame-1-2" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-132.7006" 
 	 z="-192.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-2-3"/>
        <position name="posArapucaDouble3-Frame-1-2" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-42.0006" 
 	 z="-338.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13455,14 +13455,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-3"/>
        <position name="posOpArapucaDouble3-Frame-1-2" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-42.0006" 
 	 z="-338.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-3-0"/>
        <position name="posArapucaDouble0-Frame-1-3" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-297.4006" 
 	 z="34.0000000000001"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13470,14 +13470,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-3-0"/>
        <position name="posOpArapucaDouble0-Frame-1-3" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-297.4006" 
 	 z="34.0000000000001"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-3-1"/>
        <position name="posArapucaDouble1-Frame-1-3" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-206.7006" 
 	 z="-112"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13485,14 +13485,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-3-1"/>
        <position name="posOpArapucaDouble1-Frame-1-3" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-206.7006" 
 	 z="-112"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-3-2"/>
        <position name="posArapucaDouble2-Frame-1-3" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-132.7006" 
 	 z="105"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13500,14 +13500,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-3-2"/>
        <position name="posOpArapucaDouble2-Frame-1-3" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-132.7006" 
 	 z="105"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-3-3"/>
        <position name="posArapucaDouble3-Frame-1-3" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-42.0006" 
 	 z="-40.9999999999999"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13515,14 +13515,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-3-3"/>
        <position name="posOpArapucaDouble3-Frame-1-3" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-42.0006" 
 	 z="-40.9999999999999"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-4-0"/>
        <position name="posArapucaDouble0-Frame-1-4" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-297.4006" 
 	 z="331.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13530,14 +13530,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-4-0"/>
        <position name="posOpArapucaDouble0-Frame-1-4" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-297.4006" 
 	 z="331.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-4-1"/>
        <position name="posArapucaDouble1-Frame-1-4" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-206.7006" 
 	 z="185.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13545,14 +13545,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-4-1"/>
        <position name="posOpArapucaDouble1-Frame-1-4" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-206.7006" 
 	 z="185.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-4-2"/>
        <position name="posArapucaDouble2-Frame-1-4" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-132.7006" 
 	 z="402.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13560,14 +13560,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-4-2"/>
        <position name="posOpArapucaDouble2-Frame-1-4" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-132.7006" 
 	 z="402.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-4-3"/>
        <position name="posArapucaDouble3-Frame-1-4" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-42.0006" 
 	 z="256.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13575,14 +13575,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-4-3"/>
        <position name="posOpArapucaDouble3-Frame-1-4" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-42.0006" 
 	 z="256.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-5-0"/>
        <position name="posArapucaDouble0-Frame-1-5" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-297.4006" 
 	 z="629.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13590,14 +13590,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-5-0"/>
        <position name="posOpArapucaDouble0-Frame-1-5" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-297.4006" 
 	 z="629.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-5-1"/>
        <position name="posArapucaDouble1-Frame-1-5" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-206.7006" 
 	 z="483.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13605,14 +13605,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-5-1"/>
        <position name="posOpArapucaDouble1-Frame-1-5" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-206.7006" 
 	 z="483.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-5-2"/>
        <position name="posArapucaDouble2-Frame-1-5" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-132.7006" 
 	 z="700.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13620,14 +13620,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-5-2"/>
        <position name="posOpArapucaDouble2-Frame-1-5" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-132.7006" 
 	 z="700.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-5-3"/>
        <position name="posArapucaDouble3-Frame-1-5" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-42.0006" 
 	 z="554.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13635,14 +13635,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-5-3"/>
        <position name="posOpArapucaDouble3-Frame-1-5" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-42.0006" 
 	 z="554.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-6-0"/>
        <position name="posArapucaDouble0-Frame-1-6" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-297.4006" 
 	 z="927.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13650,14 +13650,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-6-0"/>
        <position name="posOpArapucaDouble0-Frame-1-6" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-297.4006" 
 	 z="927.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-6-1"/>
        <position name="posArapucaDouble1-Frame-1-6" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-206.7006" 
 	 z="781.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13665,14 +13665,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-6-1"/>
        <position name="posOpArapucaDouble1-Frame-1-6" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-206.7006" 
 	 z="781.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-6-2"/>
        <position name="posArapucaDouble2-Frame-1-6" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-132.7006" 
 	 z="998.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13680,14 +13680,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-6-2"/>
        <position name="posOpArapucaDouble2-Frame-1-6" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-132.7006" 
 	 z="998.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-6-3"/>
        <position name="posArapucaDouble3-Frame-1-6" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-42.0006" 
 	 z="852.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13695,14 +13695,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-6-3"/>
        <position name="posOpArapucaDouble3-Frame-1-6" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-42.0006" 
 	 z="852.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-0-0"/>
        <position name="posArapucaDouble0-Frame-2-0" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="38.0006" 
 	 z="-859.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13710,14 +13710,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-0"/>
        <position name="posOpArapucaDouble0-Frame-2-0" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="38.0006" 
 	 z="-859.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-0-1"/>
        <position name="posArapucaDouble1-Frame-2-0" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="128.7006" 
 	 z="-1005.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13725,14 +13725,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-1"/>
        <position name="posOpArapucaDouble1-Frame-2-0" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="128.7006" 
 	 z="-1005.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-0-2"/>
        <position name="posArapucaDouble2-Frame-2-0" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="202.7006" 
 	 z="-788.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13740,14 +13740,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-2"/>
        <position name="posOpArapucaDouble2-Frame-2-0" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="202.7006" 
 	 z="-788.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-0-3"/>
        <position name="posArapucaDouble3-Frame-2-0" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="293.4006" 
 	 z="-934.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13755,14 +13755,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-3"/>
        <position name="posOpArapucaDouble3-Frame-2-0" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="293.4006" 
 	 z="-934.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-1-0"/>
        <position name="posArapucaDouble0-Frame-2-1" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="38.0006" 
 	 z="-561.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13770,14 +13770,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-0"/>
        <position name="posOpArapucaDouble0-Frame-2-1" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="38.0006" 
 	 z="-561.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-1-1"/>
        <position name="posArapucaDouble1-Frame-2-1" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="128.7006" 
 	 z="-707.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13785,14 +13785,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-1"/>
        <position name="posOpArapucaDouble1-Frame-2-1" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="128.7006" 
 	 z="-707.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-1-2"/>
        <position name="posArapucaDouble2-Frame-2-1" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="202.7006" 
 	 z="-490.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13800,14 +13800,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-2"/>
        <position name="posOpArapucaDouble2-Frame-2-1" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="202.7006" 
 	 z="-490.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-1-3"/>
        <position name="posArapucaDouble3-Frame-2-1" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="293.4006" 
 	 z="-636.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13815,14 +13815,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-3"/>
        <position name="posOpArapucaDouble3-Frame-2-1" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="293.4006" 
 	 z="-636.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-2-0"/>
        <position name="posArapucaDouble0-Frame-2-2" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="38.0006" 
 	 z="-263.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13830,14 +13830,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-0"/>
        <position name="posOpArapucaDouble0-Frame-2-2" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="38.0006" 
 	 z="-263.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-2-1"/>
        <position name="posArapucaDouble1-Frame-2-2" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="128.7006" 
 	 z="-409.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13845,14 +13845,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-1"/>
        <position name="posOpArapucaDouble1-Frame-2-2" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="128.7006" 
 	 z="-409.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-2-2"/>
        <position name="posArapucaDouble2-Frame-2-2" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="202.7006" 
 	 z="-192.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13860,14 +13860,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-2"/>
        <position name="posOpArapucaDouble2-Frame-2-2" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="202.7006" 
 	 z="-192.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-2-3"/>
        <position name="posArapucaDouble3-Frame-2-2" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="293.4006" 
 	 z="-338.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13875,14 +13875,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-3"/>
        <position name="posOpArapucaDouble3-Frame-2-2" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="293.4006" 
 	 z="-338.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-3-0"/>
        <position name="posArapucaDouble0-Frame-2-3" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="38.0006" 
 	 z="34.0000000000001"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13890,14 +13890,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-3-0"/>
        <position name="posOpArapucaDouble0-Frame-2-3" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="38.0006" 
 	 z="34.0000000000001"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-3-1"/>
        <position name="posArapucaDouble1-Frame-2-3" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="128.7006" 
 	 z="-112"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13905,14 +13905,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-3-1"/>
        <position name="posOpArapucaDouble1-Frame-2-3" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="128.7006" 
 	 z="-112"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-3-2"/>
        <position name="posArapucaDouble2-Frame-2-3" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="202.7006" 
 	 z="105"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13920,14 +13920,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-3-2"/>
        <position name="posOpArapucaDouble2-Frame-2-3" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="202.7006" 
 	 z="105"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-3-3"/>
        <position name="posArapucaDouble3-Frame-2-3" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="293.4006" 
 	 z="-40.9999999999999"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13935,14 +13935,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-3-3"/>
        <position name="posOpArapucaDouble3-Frame-2-3" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="293.4006" 
 	 z="-40.9999999999999"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-4-0"/>
        <position name="posArapucaDouble0-Frame-2-4" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="38.0006" 
 	 z="331.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13950,14 +13950,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-4-0"/>
        <position name="posOpArapucaDouble0-Frame-2-4" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="38.0006" 
 	 z="331.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-4-1"/>
        <position name="posArapucaDouble1-Frame-2-4" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="128.7006" 
 	 z="185.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13965,14 +13965,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-4-1"/>
        <position name="posOpArapucaDouble1-Frame-2-4" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="128.7006" 
 	 z="185.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-4-2"/>
        <position name="posArapucaDouble2-Frame-2-4" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="202.7006" 
 	 z="402.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13980,14 +13980,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-4-2"/>
        <position name="posOpArapucaDouble2-Frame-2-4" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="202.7006" 
 	 z="402.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-4-3"/>
        <position name="posArapucaDouble3-Frame-2-4" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="293.4006" 
 	 z="256.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -13995,14 +13995,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-4-3"/>
        <position name="posOpArapucaDouble3-Frame-2-4" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="293.4006" 
 	 z="256.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-5-0"/>
        <position name="posArapucaDouble0-Frame-2-5" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="38.0006" 
 	 z="629.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -14010,14 +14010,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-5-0"/>
        <position name="posOpArapucaDouble0-Frame-2-5" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="38.0006" 
 	 z="629.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-5-1"/>
        <position name="posArapucaDouble1-Frame-2-5" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="128.7006" 
 	 z="483.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -14025,14 +14025,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-5-1"/>
        <position name="posOpArapucaDouble1-Frame-2-5" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="128.7006" 
 	 z="483.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-5-2"/>
        <position name="posArapucaDouble2-Frame-2-5" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="202.7006" 
 	 z="700.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -14040,14 +14040,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-5-2"/>
        <position name="posOpArapucaDouble2-Frame-2-5" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="202.7006" 
 	 z="700.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-5-3"/>
        <position name="posArapucaDouble3-Frame-2-5" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="293.4006" 
 	 z="554.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -14055,14 +14055,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-5-3"/>
        <position name="posOpArapucaDouble3-Frame-2-5" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="293.4006" 
 	 z="554.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-6-0"/>
        <position name="posArapucaDouble0-Frame-2-6" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="38.0006" 
 	 z="927.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -14070,14 +14070,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-6-0"/>
        <position name="posOpArapucaDouble0-Frame-2-6" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="38.0006" 
 	 z="927.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-6-1"/>
        <position name="posArapucaDouble1-Frame-2-6" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="128.7006" 
 	 z="781.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -14085,14 +14085,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-6-1"/>
        <position name="posOpArapucaDouble1-Frame-2-6" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="128.7006" 
 	 z="781.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-6-2"/>
        <position name="posArapucaDouble2-Frame-2-6" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="202.7006" 
 	 z="998.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -14100,14 +14100,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-6-2"/>
        <position name="posOpArapucaDouble2-Frame-2-6" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="202.7006" 
 	 z="998.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-6-3"/>
        <position name="posArapucaDouble3-Frame-2-6" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="293.4006" 
 	 z="852.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -14115,14 +14115,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-6-3"/>
        <position name="posOpArapucaDouble3-Frame-2-6" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="293.4006" 
 	 z="852.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-0-0"/>
        <position name="posArapucaDouble0-Frame-3-0" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="373.4018" 
 	 z="-859.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -14130,14 +14130,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-0"/>
        <position name="posOpArapucaDouble0-Frame-3-0" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="373.4018" 
 	 z="-859.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-0-1"/>
        <position name="posArapucaDouble1-Frame-3-0" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="464.1018" 
 	 z="-1005.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -14145,14 +14145,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-1"/>
        <position name="posOpArapucaDouble1-Frame-3-0" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="464.1018" 
 	 z="-1005.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-0-2"/>
        <position name="posArapucaDouble2-Frame-3-0" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="538.1018" 
 	 z="-788.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -14160,14 +14160,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-2"/>
        <position name="posOpArapucaDouble2-Frame-3-0" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="538.1018" 
 	 z="-788.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-0-3"/>
        <position name="posArapucaDouble3-Frame-3-0" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="628.8018" 
 	 z="-934.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -14175,14 +14175,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-3"/>
        <position name="posOpArapucaDouble3-Frame-3-0" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="628.8018" 
 	 z="-934.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-1-0"/>
        <position name="posArapucaDouble0-Frame-3-1" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="373.4018" 
 	 z="-561.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -14190,14 +14190,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-0"/>
        <position name="posOpArapucaDouble0-Frame-3-1" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="373.4018" 
 	 z="-561.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-1-1"/>
        <position name="posArapucaDouble1-Frame-3-1" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="464.1018" 
 	 z="-707.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -14205,14 +14205,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-1"/>
        <position name="posOpArapucaDouble1-Frame-3-1" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="464.1018" 
 	 z="-707.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-1-2"/>
        <position name="posArapucaDouble2-Frame-3-1" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="538.1018" 
 	 z="-490.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -14220,14 +14220,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-2"/>
        <position name="posOpArapucaDouble2-Frame-3-1" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="538.1018" 
 	 z="-490.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-1-3"/>
        <position name="posArapucaDouble3-Frame-3-1" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="628.8018" 
 	 z="-636.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -14235,14 +14235,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-3"/>
        <position name="posOpArapucaDouble3-Frame-3-1" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="628.8018" 
 	 z="-636.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-2-0"/>
        <position name="posArapucaDouble0-Frame-3-2" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="373.4018" 
 	 z="-263.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -14250,14 +14250,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-0"/>
        <position name="posOpArapucaDouble0-Frame-3-2" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="373.4018" 
 	 z="-263.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-2-1"/>
        <position name="posArapucaDouble1-Frame-3-2" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="464.1018" 
 	 z="-409.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -14265,14 +14265,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-1"/>
        <position name="posOpArapucaDouble1-Frame-3-2" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="464.1018" 
 	 z="-409.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-2-2"/>
        <position name="posArapucaDouble2-Frame-3-2" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="538.1018" 
 	 z="-192.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -14280,14 +14280,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-2"/>
        <position name="posOpArapucaDouble2-Frame-3-2" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="538.1018" 
 	 z="-192.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-2-3"/>
        <position name="posArapucaDouble3-Frame-3-2" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="628.8018" 
 	 z="-338.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -14295,14 +14295,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-3"/>
        <position name="posOpArapucaDouble3-Frame-3-2" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="628.8018" 
 	 z="-338.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-3-0"/>
        <position name="posArapucaDouble0-Frame-3-3" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="373.4018" 
 	 z="34.0000000000001"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -14310,14 +14310,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-3-0"/>
        <position name="posOpArapucaDouble0-Frame-3-3" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="373.4018" 
 	 z="34.0000000000001"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-3-1"/>
        <position name="posArapucaDouble1-Frame-3-3" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="464.1018" 
 	 z="-112"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -14325,14 +14325,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-3-1"/>
        <position name="posOpArapucaDouble1-Frame-3-3" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="464.1018" 
 	 z="-112"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-3-2"/>
        <position name="posArapucaDouble2-Frame-3-3" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="538.1018" 
 	 z="105"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -14340,14 +14340,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-3-2"/>
        <position name="posOpArapucaDouble2-Frame-3-3" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="538.1018" 
 	 z="105"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-3-3"/>
        <position name="posArapucaDouble3-Frame-3-3" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="628.8018" 
 	 z="-40.9999999999999"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -14355,14 +14355,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-3-3"/>
        <position name="posOpArapucaDouble3-Frame-3-3" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="628.8018" 
 	 z="-40.9999999999999"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-4-0"/>
        <position name="posArapucaDouble0-Frame-3-4" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="373.4018" 
 	 z="331.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -14370,14 +14370,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-4-0"/>
        <position name="posOpArapucaDouble0-Frame-3-4" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="373.4018" 
 	 z="331.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-4-1"/>
        <position name="posArapucaDouble1-Frame-3-4" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="464.1018" 
 	 z="185.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -14385,14 +14385,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-4-1"/>
        <position name="posOpArapucaDouble1-Frame-3-4" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="464.1018" 
 	 z="185.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-4-2"/>
        <position name="posArapucaDouble2-Frame-3-4" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="538.1018" 
 	 z="402.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -14400,14 +14400,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-4-2"/>
        <position name="posOpArapucaDouble2-Frame-3-4" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="538.1018" 
 	 z="402.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-4-3"/>
        <position name="posArapucaDouble3-Frame-3-4" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="628.8018" 
 	 z="256.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -14415,14 +14415,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-4-3"/>
        <position name="posOpArapucaDouble3-Frame-3-4" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="628.8018" 
 	 z="256.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-5-0"/>
        <position name="posArapucaDouble0-Frame-3-5" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="373.4018" 
 	 z="629.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -14430,14 +14430,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-5-0"/>
        <position name="posOpArapucaDouble0-Frame-3-5" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="373.4018" 
 	 z="629.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-5-1"/>
        <position name="posArapucaDouble1-Frame-3-5" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="464.1018" 
 	 z="483.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -14445,14 +14445,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-5-1"/>
        <position name="posOpArapucaDouble1-Frame-3-5" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="464.1018" 
 	 z="483.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-5-2"/>
        <position name="posArapucaDouble2-Frame-3-5" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="538.1018" 
 	 z="700.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -14460,14 +14460,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-5-2"/>
        <position name="posOpArapucaDouble2-Frame-3-5" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="538.1018" 
 	 z="700.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-5-3"/>
        <position name="posArapucaDouble3-Frame-3-5" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="628.8018" 
 	 z="554.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -14475,14 +14475,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-5-3"/>
        <position name="posOpArapucaDouble3-Frame-3-5" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="628.8018" 
 	 z="554.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-6-0"/>
        <position name="posArapucaDouble0-Frame-3-6" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="373.4018" 
 	 z="927.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -14490,14 +14490,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-6-0"/>
        <position name="posOpArapucaDouble0-Frame-3-6" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="373.4018" 
 	 z="927.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-6-1"/>
        <position name="posArapucaDouble1-Frame-3-6" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="464.1018" 
 	 z="781.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -14505,14 +14505,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-6-1"/>
        <position name="posOpArapucaDouble1-Frame-3-6" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="464.1018" 
 	 z="781.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-6-2"/>
        <position name="posArapucaDouble2-Frame-3-6" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="538.1018" 
 	 z="998.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -14520,14 +14520,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-6-2"/>
        <position name="posOpArapucaDouble2-Frame-3-6" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="538.1018" 
 	 z="998.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-6-3"/>
        <position name="posArapucaDouble3-Frame-3-6" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="628.8018" 
 	 z="852.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -14535,14 +14535,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-6-3"/>
        <position name="posOpArapucaDouble3-Frame-3-6" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="628.8018" 
 	 z="852.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-0"/>
        <position name="posArapuca0-Lat-0" unit="cm" 
-         x="285.01"
+         x="285.02"
 	 y="-732.8024" 
 	 z="-893.52"/>
        <rotationref ref="rIdentity"/>
@@ -14550,14 +14550,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-0"/>
        <position name="posOpArapuca0-Lat-0" unit="cm" 
-         x="285.01"
+         x="285.02"
 	 y="-732.0624" 
 	 z="-893.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-1"/>
        <position name="posArapuca1-Lat-0" unit="cm" 
-         x="210.01"
+         x="210.02"
 	 y="-732.8024" 
 	 z="-893.52"/>
        <rotationref ref="rIdentity"/>
@@ -14565,14 +14565,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-1"/>
        <position name="posOpArapuca1-Lat-0" unit="cm" 
-         x="210.01"
+         x="210.02"
 	 y="-732.0624" 
 	 z="-893.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-2"/>
        <position name="posArapuca2-Lat-0" unit="cm" 
-         x="135.01"
+         x="135.02"
 	 y="-732.8024" 
 	 z="-893.52"/>
        <rotationref ref="rIdentity"/>
@@ -14580,14 +14580,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-2"/>
        <position name="posOpArapuca2-Lat-0" unit="cm" 
-         x="135.01"
+         x="135.02"
 	 y="-732.0624" 
 	 z="-893.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-3"/>
        <position name="posArapuca3-Lat-0" unit="cm" 
-         x="60.01"
+         x="60.02"
 	 y="-732.8024" 
 	 z="-893.52"/>
        <rotationref ref="rIdentity"/>
@@ -14595,14 +14595,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-3"/>
        <position name="posOpArapuca3-Lat-0" unit="cm" 
-         x="60.01"
+         x="60.02"
 	 y="-732.0624" 
 	 z="-893.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-4"/>
        <position name="posArapuca4-Lat-0" unit="cm" 
-         x="285.01"
+         x="285.02"
 	 y="732.8024" 
 	 z="-893.52"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -14610,14 +14610,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-4"/>
        <position name="posOpArapuca4-Lat-0" unit="cm" 
-         x="285.01"
+         x="285.02"
 	 y="732.0624" 
 	 z="-893.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-5"/>
        <position name="posArapuca5-Lat-0" unit="cm" 
-         x="210.01"
+         x="210.02"
 	 y="732.8024" 
 	 z="-893.52"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -14625,14 +14625,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-5"/>
        <position name="posOpArapuca5-Lat-0" unit="cm" 
-         x="210.01"
+         x="210.02"
 	 y="732.0624" 
 	 z="-893.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-6"/>
        <position name="posArapuca6-Lat-0" unit="cm" 
-         x="135.01"
+         x="135.02"
 	 y="732.8024" 
 	 z="-893.52"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -14640,14 +14640,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-6"/>
        <position name="posOpArapuca6-Lat-0" unit="cm" 
-         x="135.01"
+         x="135.02"
 	 y="732.0624" 
 	 z="-893.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-7"/>
        <position name="posArapuca7-Lat-0" unit="cm" 
-         x="60.01"
+         x="60.02"
 	 y="732.8024" 
 	 z="-893.52"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -14655,14 +14655,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-7"/>
        <position name="posOpArapuca7-Lat-0" unit="cm" 
-         x="60.01"
+         x="60.02"
 	 y="732.0624" 
 	 z="-893.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-0"/>
        <position name="posArapuca0-Lat-1" unit="cm" 
-         x="285.01"
+         x="285.02"
 	 y="-732.8024" 
 	 z="-595.68"/>
        <rotationref ref="rIdentity"/>
@@ -14670,14 +14670,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-0"/>
        <position name="posOpArapuca0-Lat-1" unit="cm" 
-         x="285.01"
+         x="285.02"
 	 y="-732.0624" 
 	 z="-595.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-1"/>
        <position name="posArapuca1-Lat-1" unit="cm" 
-         x="210.01"
+         x="210.02"
 	 y="-732.8024" 
 	 z="-595.68"/>
        <rotationref ref="rIdentity"/>
@@ -14685,14 +14685,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-1"/>
        <position name="posOpArapuca1-Lat-1" unit="cm" 
-         x="210.01"
+         x="210.02"
 	 y="-732.0624" 
 	 z="-595.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-2"/>
        <position name="posArapuca2-Lat-1" unit="cm" 
-         x="135.01"
+         x="135.02"
 	 y="-732.8024" 
 	 z="-595.68"/>
        <rotationref ref="rIdentity"/>
@@ -14700,14 +14700,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-2"/>
        <position name="posOpArapuca2-Lat-1" unit="cm" 
-         x="135.01"
+         x="135.02"
 	 y="-732.0624" 
 	 z="-595.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-3"/>
        <position name="posArapuca3-Lat-1" unit="cm" 
-         x="60.01"
+         x="60.02"
 	 y="-732.8024" 
 	 z="-595.68"/>
        <rotationref ref="rIdentity"/>
@@ -14715,14 +14715,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-3"/>
        <position name="posOpArapuca3-Lat-1" unit="cm" 
-         x="60.01"
+         x="60.02"
 	 y="-732.0624" 
 	 z="-595.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-4"/>
        <position name="posArapuca4-Lat-1" unit="cm" 
-         x="285.01"
+         x="285.02"
 	 y="732.8024" 
 	 z="-595.68"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -14730,14 +14730,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-4"/>
        <position name="posOpArapuca4-Lat-1" unit="cm" 
-         x="285.01"
+         x="285.02"
 	 y="732.0624" 
 	 z="-595.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-5"/>
        <position name="posArapuca5-Lat-1" unit="cm" 
-         x="210.01"
+         x="210.02"
 	 y="732.8024" 
 	 z="-595.68"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -14745,14 +14745,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-5"/>
        <position name="posOpArapuca5-Lat-1" unit="cm" 
-         x="210.01"
+         x="210.02"
 	 y="732.0624" 
 	 z="-595.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-6"/>
        <position name="posArapuca6-Lat-1" unit="cm" 
-         x="135.01"
+         x="135.02"
 	 y="732.8024" 
 	 z="-595.68"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -14760,14 +14760,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-6"/>
        <position name="posOpArapuca6-Lat-1" unit="cm" 
-         x="135.01"
+         x="135.02"
 	 y="732.0624" 
 	 z="-595.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-7"/>
        <position name="posArapuca7-Lat-1" unit="cm" 
-         x="60.01"
+         x="60.02"
 	 y="732.8024" 
 	 z="-595.68"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -14775,14 +14775,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-7"/>
        <position name="posOpArapuca7-Lat-1" unit="cm" 
-         x="60.01"
+         x="60.02"
 	 y="732.0624" 
 	 z="-595.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-0"/>
        <position name="posArapuca0-Lat-2" unit="cm" 
-         x="285.01"
+         x="285.02"
 	 y="-732.8024" 
 	 z="-297.84"/>
        <rotationref ref="rIdentity"/>
@@ -14790,14 +14790,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-0"/>
        <position name="posOpArapuca0-Lat-2" unit="cm" 
-         x="285.01"
+         x="285.02"
 	 y="-732.0624" 
 	 z="-297.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-1"/>
        <position name="posArapuca1-Lat-2" unit="cm" 
-         x="210.01"
+         x="210.02"
 	 y="-732.8024" 
 	 z="-297.84"/>
        <rotationref ref="rIdentity"/>
@@ -14805,14 +14805,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-1"/>
        <position name="posOpArapuca1-Lat-2" unit="cm" 
-         x="210.01"
+         x="210.02"
 	 y="-732.0624" 
 	 z="-297.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-2"/>
        <position name="posArapuca2-Lat-2" unit="cm" 
-         x="135.01"
+         x="135.02"
 	 y="-732.8024" 
 	 z="-297.84"/>
        <rotationref ref="rIdentity"/>
@@ -14820,14 +14820,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-2"/>
        <position name="posOpArapuca2-Lat-2" unit="cm" 
-         x="135.01"
+         x="135.02"
 	 y="-732.0624" 
 	 z="-297.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-3"/>
        <position name="posArapuca3-Lat-2" unit="cm" 
-         x="60.01"
+         x="60.02"
 	 y="-732.8024" 
 	 z="-297.84"/>
        <rotationref ref="rIdentity"/>
@@ -14835,14 +14835,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-3"/>
        <position name="posOpArapuca3-Lat-2" unit="cm" 
-         x="60.01"
+         x="60.02"
 	 y="-732.0624" 
 	 z="-297.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-4"/>
        <position name="posArapuca4-Lat-2" unit="cm" 
-         x="285.01"
+         x="285.02"
 	 y="732.8024" 
 	 z="-297.84"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -14850,14 +14850,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-4"/>
        <position name="posOpArapuca4-Lat-2" unit="cm" 
-         x="285.01"
+         x="285.02"
 	 y="732.0624" 
 	 z="-297.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-5"/>
        <position name="posArapuca5-Lat-2" unit="cm" 
-         x="210.01"
+         x="210.02"
 	 y="732.8024" 
 	 z="-297.84"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -14865,14 +14865,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-5"/>
        <position name="posOpArapuca5-Lat-2" unit="cm" 
-         x="210.01"
+         x="210.02"
 	 y="732.0624" 
 	 z="-297.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-6"/>
        <position name="posArapuca6-Lat-2" unit="cm" 
-         x="135.01"
+         x="135.02"
 	 y="732.8024" 
 	 z="-297.84"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -14880,14 +14880,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-6"/>
        <position name="posOpArapuca6-Lat-2" unit="cm" 
-         x="135.01"
+         x="135.02"
 	 y="732.0624" 
 	 z="-297.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-7"/>
        <position name="posArapuca7-Lat-2" unit="cm" 
-         x="60.01"
+         x="60.02"
 	 y="732.8024" 
 	 z="-297.84"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -14895,14 +14895,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-7"/>
        <position name="posOpArapuca7-Lat-2" unit="cm" 
-         x="60.01"
+         x="60.02"
 	 y="732.0624" 
 	 z="-297.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_3-0"/>
        <position name="posArapuca0-Lat-3" unit="cm" 
-         x="285.01"
+         x="285.02"
 	 y="-732.8024" 
 	 z="-1.13686837721616e-13"/>
        <rotationref ref="rIdentity"/>
@@ -14910,14 +14910,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_3-0"/>
        <position name="posOpArapuca0-Lat-3" unit="cm" 
-         x="285.01"
+         x="285.02"
 	 y="-732.0624" 
 	 z="-1.13686837721616e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_3-1"/>
        <position name="posArapuca1-Lat-3" unit="cm" 
-         x="210.01"
+         x="210.02"
 	 y="-732.8024" 
 	 z="-1.13686837721616e-13"/>
        <rotationref ref="rIdentity"/>
@@ -14925,14 +14925,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_3-1"/>
        <position name="posOpArapuca1-Lat-3" unit="cm" 
-         x="210.01"
+         x="210.02"
 	 y="-732.0624" 
 	 z="-1.13686837721616e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_3-2"/>
        <position name="posArapuca2-Lat-3" unit="cm" 
-         x="135.01"
+         x="135.02"
 	 y="-732.8024" 
 	 z="-1.13686837721616e-13"/>
        <rotationref ref="rIdentity"/>
@@ -14940,14 +14940,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_3-2"/>
        <position name="posOpArapuca2-Lat-3" unit="cm" 
-         x="135.01"
+         x="135.02"
 	 y="-732.0624" 
 	 z="-1.13686837721616e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_3-3"/>
        <position name="posArapuca3-Lat-3" unit="cm" 
-         x="60.01"
+         x="60.02"
 	 y="-732.8024" 
 	 z="-1.13686837721616e-13"/>
        <rotationref ref="rIdentity"/>
@@ -14955,14 +14955,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_3-3"/>
        <position name="posOpArapuca3-Lat-3" unit="cm" 
-         x="60.01"
+         x="60.02"
 	 y="-732.0624" 
 	 z="-1.13686837721616e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_3-4"/>
        <position name="posArapuca4-Lat-3" unit="cm" 
-         x="285.01"
+         x="285.02"
 	 y="732.8024" 
 	 z="-1.13686837721616e-13"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -14970,14 +14970,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_3-4"/>
        <position name="posOpArapuca4-Lat-3" unit="cm" 
-         x="285.01"
+         x="285.02"
 	 y="732.0624" 
 	 z="-1.13686837721616e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_3-5"/>
        <position name="posArapuca5-Lat-3" unit="cm" 
-         x="210.01"
+         x="210.02"
 	 y="732.8024" 
 	 z="-1.13686837721616e-13"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -14985,14 +14985,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_3-5"/>
        <position name="posOpArapuca5-Lat-3" unit="cm" 
-         x="210.01"
+         x="210.02"
 	 y="732.0624" 
 	 z="-1.13686837721616e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_3-6"/>
        <position name="posArapuca6-Lat-3" unit="cm" 
-         x="135.01"
+         x="135.02"
 	 y="732.8024" 
 	 z="-1.13686837721616e-13"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -15000,14 +15000,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_3-6"/>
        <position name="posOpArapuca6-Lat-3" unit="cm" 
-         x="135.01"
+         x="135.02"
 	 y="732.0624" 
 	 z="-1.13686837721616e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_3-7"/>
        <position name="posArapuca7-Lat-3" unit="cm" 
-         x="60.01"
+         x="60.02"
 	 y="732.8024" 
 	 z="-1.13686837721616e-13"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -15015,14 +15015,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_3-7"/>
        <position name="posOpArapuca7-Lat-3" unit="cm" 
-         x="60.01"
+         x="60.02"
 	 y="732.0624" 
 	 z="-1.13686837721616e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_4-0"/>
        <position name="posArapuca0-Lat-4" unit="cm" 
-         x="285.01"
+         x="285.02"
 	 y="-732.8024" 
 	 z="297.84"/>
        <rotationref ref="rIdentity"/>
@@ -15030,14 +15030,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_4-0"/>
        <position name="posOpArapuca0-Lat-4" unit="cm" 
-         x="285.01"
+         x="285.02"
 	 y="-732.0624" 
 	 z="297.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_4-1"/>
        <position name="posArapuca1-Lat-4" unit="cm" 
-         x="210.01"
+         x="210.02"
 	 y="-732.8024" 
 	 z="297.84"/>
        <rotationref ref="rIdentity"/>
@@ -15045,14 +15045,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_4-1"/>
        <position name="posOpArapuca1-Lat-4" unit="cm" 
-         x="210.01"
+         x="210.02"
 	 y="-732.0624" 
 	 z="297.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_4-2"/>
        <position name="posArapuca2-Lat-4" unit="cm" 
-         x="135.01"
+         x="135.02"
 	 y="-732.8024" 
 	 z="297.84"/>
        <rotationref ref="rIdentity"/>
@@ -15060,14 +15060,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_4-2"/>
        <position name="posOpArapuca2-Lat-4" unit="cm" 
-         x="135.01"
+         x="135.02"
 	 y="-732.0624" 
 	 z="297.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_4-3"/>
        <position name="posArapuca3-Lat-4" unit="cm" 
-         x="60.01"
+         x="60.02"
 	 y="-732.8024" 
 	 z="297.84"/>
        <rotationref ref="rIdentity"/>
@@ -15075,14 +15075,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_4-3"/>
        <position name="posOpArapuca3-Lat-4" unit="cm" 
-         x="60.01"
+         x="60.02"
 	 y="-732.0624" 
 	 z="297.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_4-4"/>
        <position name="posArapuca4-Lat-4" unit="cm" 
-         x="285.01"
+         x="285.02"
 	 y="732.8024" 
 	 z="297.84"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -15090,14 +15090,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_4-4"/>
        <position name="posOpArapuca4-Lat-4" unit="cm" 
-         x="285.01"
+         x="285.02"
 	 y="732.0624" 
 	 z="297.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_4-5"/>
        <position name="posArapuca5-Lat-4" unit="cm" 
-         x="210.01"
+         x="210.02"
 	 y="732.8024" 
 	 z="297.84"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -15105,14 +15105,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_4-5"/>
        <position name="posOpArapuca5-Lat-4" unit="cm" 
-         x="210.01"
+         x="210.02"
 	 y="732.0624" 
 	 z="297.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_4-6"/>
        <position name="posArapuca6-Lat-4" unit="cm" 
-         x="135.01"
+         x="135.02"
 	 y="732.8024" 
 	 z="297.84"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -15120,14 +15120,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_4-6"/>
        <position name="posOpArapuca6-Lat-4" unit="cm" 
-         x="135.01"
+         x="135.02"
 	 y="732.0624" 
 	 z="297.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_4-7"/>
        <position name="posArapuca7-Lat-4" unit="cm" 
-         x="60.01"
+         x="60.02"
 	 y="732.8024" 
 	 z="297.84"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -15135,14 +15135,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_4-7"/>
        <position name="posOpArapuca7-Lat-4" unit="cm" 
-         x="60.01"
+         x="60.02"
 	 y="732.0624" 
 	 z="297.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_5-0"/>
        <position name="posArapuca0-Lat-5" unit="cm" 
-         x="285.01"
+         x="285.02"
 	 y="-732.8024" 
 	 z="595.68"/>
        <rotationref ref="rIdentity"/>
@@ -15150,14 +15150,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_5-0"/>
        <position name="posOpArapuca0-Lat-5" unit="cm" 
-         x="285.01"
+         x="285.02"
 	 y="-732.0624" 
 	 z="595.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_5-1"/>
        <position name="posArapuca1-Lat-5" unit="cm" 
-         x="210.01"
+         x="210.02"
 	 y="-732.8024" 
 	 z="595.68"/>
        <rotationref ref="rIdentity"/>
@@ -15165,14 +15165,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_5-1"/>
        <position name="posOpArapuca1-Lat-5" unit="cm" 
-         x="210.01"
+         x="210.02"
 	 y="-732.0624" 
 	 z="595.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_5-2"/>
        <position name="posArapuca2-Lat-5" unit="cm" 
-         x="135.01"
+         x="135.02"
 	 y="-732.8024" 
 	 z="595.68"/>
        <rotationref ref="rIdentity"/>
@@ -15180,14 +15180,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_5-2"/>
        <position name="posOpArapuca2-Lat-5" unit="cm" 
-         x="135.01"
+         x="135.02"
 	 y="-732.0624" 
 	 z="595.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_5-3"/>
        <position name="posArapuca3-Lat-5" unit="cm" 
-         x="60.01"
+         x="60.02"
 	 y="-732.8024" 
 	 z="595.68"/>
        <rotationref ref="rIdentity"/>
@@ -15195,14 +15195,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_5-3"/>
        <position name="posOpArapuca3-Lat-5" unit="cm" 
-         x="60.01"
+         x="60.02"
 	 y="-732.0624" 
 	 z="595.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_5-4"/>
        <position name="posArapuca4-Lat-5" unit="cm" 
-         x="285.01"
+         x="285.02"
 	 y="732.8024" 
 	 z="595.68"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -15210,14 +15210,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_5-4"/>
        <position name="posOpArapuca4-Lat-5" unit="cm" 
-         x="285.01"
+         x="285.02"
 	 y="732.0624" 
 	 z="595.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_5-5"/>
        <position name="posArapuca5-Lat-5" unit="cm" 
-         x="210.01"
+         x="210.02"
 	 y="732.8024" 
 	 z="595.68"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -15225,14 +15225,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_5-5"/>
        <position name="posOpArapuca5-Lat-5" unit="cm" 
-         x="210.01"
+         x="210.02"
 	 y="732.0624" 
 	 z="595.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_5-6"/>
        <position name="posArapuca6-Lat-5" unit="cm" 
-         x="135.01"
+         x="135.02"
 	 y="732.8024" 
 	 z="595.68"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -15240,14 +15240,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_5-6"/>
        <position name="posOpArapuca6-Lat-5" unit="cm" 
-         x="135.01"
+         x="135.02"
 	 y="732.0624" 
 	 z="595.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_5-7"/>
        <position name="posArapuca7-Lat-5" unit="cm" 
-         x="60.01"
+         x="60.02"
 	 y="732.8024" 
 	 z="595.68"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -15255,14 +15255,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_5-7"/>
        <position name="posOpArapuca7-Lat-5" unit="cm" 
-         x="60.01"
+         x="60.02"
 	 y="732.0624" 
 	 z="595.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_6-0"/>
        <position name="posArapuca0-Lat-6" unit="cm" 
-         x="285.01"
+         x="285.02"
 	 y="-732.8024" 
 	 z="893.52"/>
        <rotationref ref="rIdentity"/>
@@ -15270,14 +15270,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_6-0"/>
        <position name="posOpArapuca0-Lat-6" unit="cm" 
-         x="285.01"
+         x="285.02"
 	 y="-732.0624" 
 	 z="893.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_6-1"/>
        <position name="posArapuca1-Lat-6" unit="cm" 
-         x="210.01"
+         x="210.02"
 	 y="-732.8024" 
 	 z="893.52"/>
        <rotationref ref="rIdentity"/>
@@ -15285,14 +15285,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_6-1"/>
        <position name="posOpArapuca1-Lat-6" unit="cm" 
-         x="210.01"
+         x="210.02"
 	 y="-732.0624" 
 	 z="893.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_6-2"/>
        <position name="posArapuca2-Lat-6" unit="cm" 
-         x="135.01"
+         x="135.02"
 	 y="-732.8024" 
 	 z="893.52"/>
        <rotationref ref="rIdentity"/>
@@ -15300,14 +15300,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_6-2"/>
        <position name="posOpArapuca2-Lat-6" unit="cm" 
-         x="135.01"
+         x="135.02"
 	 y="-732.0624" 
 	 z="893.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_6-3"/>
        <position name="posArapuca3-Lat-6" unit="cm" 
-         x="60.01"
+         x="60.02"
 	 y="-732.8024" 
 	 z="893.52"/>
        <rotationref ref="rIdentity"/>
@@ -15315,14 +15315,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_6-3"/>
        <position name="posOpArapuca3-Lat-6" unit="cm" 
-         x="60.01"
+         x="60.02"
 	 y="-732.0624" 
 	 z="893.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_6-4"/>
        <position name="posArapuca4-Lat-6" unit="cm" 
-         x="285.01"
+         x="285.02"
 	 y="732.8024" 
 	 z="893.52"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -15330,14 +15330,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_6-4"/>
        <position name="posOpArapuca4-Lat-6" unit="cm" 
-         x="285.01"
+         x="285.02"
 	 y="732.0624" 
 	 z="893.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_6-5"/>
        <position name="posArapuca5-Lat-6" unit="cm" 
-         x="210.01"
+         x="210.02"
 	 y="732.8024" 
 	 z="893.52"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -15345,14 +15345,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_6-5"/>
        <position name="posOpArapuca5-Lat-6" unit="cm" 
-         x="210.01"
+         x="210.02"
 	 y="732.0624" 
 	 z="893.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_6-6"/>
        <position name="posArapuca6-Lat-6" unit="cm" 
-         x="135.01"
+         x="135.02"
 	 y="732.8024" 
 	 z="893.52"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -15360,14 +15360,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_6-6"/>
        <position name="posOpArapuca6-Lat-6" unit="cm" 
-         x="135.01"
+         x="135.02"
 	 y="732.0624" 
 	 z="893.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_6-7"/>
        <position name="posArapuca7-Lat-6" unit="cm" 
-         x="60.01"
+         x="60.02"
 	 y="732.8024" 
 	 z="893.52"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -15375,7 +15375,7 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_6-7"/>
        <position name="posOpArapuca7-Lat-6" unit="cm" 
-         x="60.01"
+         x="60.02"
 	 y="732.0624" 
 	 z="893.52"/>
      </physvol>
@@ -15415,7 +15415,7 @@
 
       <physvol>
         <volumeref ref="volDetEnclosure"/>
-	<position name="posDetEnclosure" unit="cm" x="50.04" y="-1.13686837721616e-13" z="1045.94"/>
+	<position name="posDetEnclosure" unit="cm" x="50.0500000000001" y="-1.13686837721616e-13" z="1045.94"/>
       </physvol>
 
     </volume>

--- a/dunecore/Geometry/gdml/dunevd10kt_3view_30deg_v3_refactored_1x8x14ref.gdml
+++ b/dunecore/Geometry/gdml/dunevd10kt_3view_30deg_v3_refactored_1x8x14ref.gdml
@@ -10227,24 +10227,35 @@
          <rotationref ref="rPlus90AboutX"/>
        </physvol>
   </volume>
+     
+   <volume name="volAnodePlate">
+     <materialref ref="vm2000"/>
+     <solidref ref="CRMZPlane"/>
+  </volume>
    <volume name="volTPC">
      <materialref ref="LAr"/>
        <solidref ref="CRM"/>
        <physvol>
        <volumeref ref="volTPCPlaneU"/>
        <position name="posPlaneU" unit="cm" 
-         x="324.99" y="0" z="0"/>
+         x="324.97" y="0" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volTPCPlaneV"/>
        <position name="posPlaneY" unit="cm" 
-         x="325.01" y="0" z="0"/>
+         x="324.99" y="0" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volTPCPlaneZ"/>
        <position name="posPlaneZ" unit="cm" 
+         x="325.01" y="0" z="0"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate" unit="cm" 
          x="325.03" y="0" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -14531,7 +14542,7 @@
      <physvol>
        <volumeref ref="volArapucaLat_0-0"/>
        <position name="posArapuca0-Lat-0" unit="cm" 
-         x="285.03"
+         x="285.01"
 	 y="-732.8024" 
 	 z="-893.52"/>
        <rotationref ref="rIdentity"/>
@@ -14539,14 +14550,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-0"/>
        <position name="posOpArapuca0-Lat-0" unit="cm" 
-         x="285.03"
+         x="285.01"
 	 y="-732.0624" 
 	 z="-893.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-1"/>
        <position name="posArapuca1-Lat-0" unit="cm" 
-         x="210.03"
+         x="210.01"
 	 y="-732.8024" 
 	 z="-893.52"/>
        <rotationref ref="rIdentity"/>
@@ -14554,14 +14565,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-1"/>
        <position name="posOpArapuca1-Lat-0" unit="cm" 
-         x="210.03"
+         x="210.01"
 	 y="-732.0624" 
 	 z="-893.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-2"/>
        <position name="posArapuca2-Lat-0" unit="cm" 
-         x="135.03"
+         x="135.01"
 	 y="-732.8024" 
 	 z="-893.52"/>
        <rotationref ref="rIdentity"/>
@@ -14569,14 +14580,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-2"/>
        <position name="posOpArapuca2-Lat-0" unit="cm" 
-         x="135.03"
+         x="135.01"
 	 y="-732.0624" 
 	 z="-893.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-3"/>
        <position name="posArapuca3-Lat-0" unit="cm" 
-         x="60.03"
+         x="60.01"
 	 y="-732.8024" 
 	 z="-893.52"/>
        <rotationref ref="rIdentity"/>
@@ -14584,14 +14595,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-3"/>
        <position name="posOpArapuca3-Lat-0" unit="cm" 
-         x="60.03"
+         x="60.01"
 	 y="-732.0624" 
 	 z="-893.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-4"/>
        <position name="posArapuca4-Lat-0" unit="cm" 
-         x="285.03"
+         x="285.01"
 	 y="732.8024" 
 	 z="-893.52"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -14599,14 +14610,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-4"/>
        <position name="posOpArapuca4-Lat-0" unit="cm" 
-         x="285.03"
+         x="285.01"
 	 y="732.0624" 
 	 z="-893.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-5"/>
        <position name="posArapuca5-Lat-0" unit="cm" 
-         x="210.03"
+         x="210.01"
 	 y="732.8024" 
 	 z="-893.52"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -14614,14 +14625,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-5"/>
        <position name="posOpArapuca5-Lat-0" unit="cm" 
-         x="210.03"
+         x="210.01"
 	 y="732.0624" 
 	 z="-893.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-6"/>
        <position name="posArapuca6-Lat-0" unit="cm" 
-         x="135.03"
+         x="135.01"
 	 y="732.8024" 
 	 z="-893.52"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -14629,14 +14640,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-6"/>
        <position name="posOpArapuca6-Lat-0" unit="cm" 
-         x="135.03"
+         x="135.01"
 	 y="732.0624" 
 	 z="-893.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-7"/>
        <position name="posArapuca7-Lat-0" unit="cm" 
-         x="60.03"
+         x="60.01"
 	 y="732.8024" 
 	 z="-893.52"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -14644,14 +14655,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-7"/>
        <position name="posOpArapuca7-Lat-0" unit="cm" 
-         x="60.03"
+         x="60.01"
 	 y="732.0624" 
 	 z="-893.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-0"/>
        <position name="posArapuca0-Lat-1" unit="cm" 
-         x="285.03"
+         x="285.01"
 	 y="-732.8024" 
 	 z="-595.68"/>
        <rotationref ref="rIdentity"/>
@@ -14659,14 +14670,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-0"/>
        <position name="posOpArapuca0-Lat-1" unit="cm" 
-         x="285.03"
+         x="285.01"
 	 y="-732.0624" 
 	 z="-595.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-1"/>
        <position name="posArapuca1-Lat-1" unit="cm" 
-         x="210.03"
+         x="210.01"
 	 y="-732.8024" 
 	 z="-595.68"/>
        <rotationref ref="rIdentity"/>
@@ -14674,14 +14685,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-1"/>
        <position name="posOpArapuca1-Lat-1" unit="cm" 
-         x="210.03"
+         x="210.01"
 	 y="-732.0624" 
 	 z="-595.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-2"/>
        <position name="posArapuca2-Lat-1" unit="cm" 
-         x="135.03"
+         x="135.01"
 	 y="-732.8024" 
 	 z="-595.68"/>
        <rotationref ref="rIdentity"/>
@@ -14689,14 +14700,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-2"/>
        <position name="posOpArapuca2-Lat-1" unit="cm" 
-         x="135.03"
+         x="135.01"
 	 y="-732.0624" 
 	 z="-595.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-3"/>
        <position name="posArapuca3-Lat-1" unit="cm" 
-         x="60.03"
+         x="60.01"
 	 y="-732.8024" 
 	 z="-595.68"/>
        <rotationref ref="rIdentity"/>
@@ -14704,14 +14715,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-3"/>
        <position name="posOpArapuca3-Lat-1" unit="cm" 
-         x="60.03"
+         x="60.01"
 	 y="-732.0624" 
 	 z="-595.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-4"/>
        <position name="posArapuca4-Lat-1" unit="cm" 
-         x="285.03"
+         x="285.01"
 	 y="732.8024" 
 	 z="-595.68"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -14719,14 +14730,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-4"/>
        <position name="posOpArapuca4-Lat-1" unit="cm" 
-         x="285.03"
+         x="285.01"
 	 y="732.0624" 
 	 z="-595.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-5"/>
        <position name="posArapuca5-Lat-1" unit="cm" 
-         x="210.03"
+         x="210.01"
 	 y="732.8024" 
 	 z="-595.68"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -14734,14 +14745,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-5"/>
        <position name="posOpArapuca5-Lat-1" unit="cm" 
-         x="210.03"
+         x="210.01"
 	 y="732.0624" 
 	 z="-595.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-6"/>
        <position name="posArapuca6-Lat-1" unit="cm" 
-         x="135.03"
+         x="135.01"
 	 y="732.8024" 
 	 z="-595.68"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -14749,14 +14760,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-6"/>
        <position name="posOpArapuca6-Lat-1" unit="cm" 
-         x="135.03"
+         x="135.01"
 	 y="732.0624" 
 	 z="-595.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-7"/>
        <position name="posArapuca7-Lat-1" unit="cm" 
-         x="60.03"
+         x="60.01"
 	 y="732.8024" 
 	 z="-595.68"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -14764,14 +14775,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-7"/>
        <position name="posOpArapuca7-Lat-1" unit="cm" 
-         x="60.03"
+         x="60.01"
 	 y="732.0624" 
 	 z="-595.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-0"/>
        <position name="posArapuca0-Lat-2" unit="cm" 
-         x="285.03"
+         x="285.01"
 	 y="-732.8024" 
 	 z="-297.84"/>
        <rotationref ref="rIdentity"/>
@@ -14779,14 +14790,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-0"/>
        <position name="posOpArapuca0-Lat-2" unit="cm" 
-         x="285.03"
+         x="285.01"
 	 y="-732.0624" 
 	 z="-297.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-1"/>
        <position name="posArapuca1-Lat-2" unit="cm" 
-         x="210.03"
+         x="210.01"
 	 y="-732.8024" 
 	 z="-297.84"/>
        <rotationref ref="rIdentity"/>
@@ -14794,14 +14805,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-1"/>
        <position name="posOpArapuca1-Lat-2" unit="cm" 
-         x="210.03"
+         x="210.01"
 	 y="-732.0624" 
 	 z="-297.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-2"/>
        <position name="posArapuca2-Lat-2" unit="cm" 
-         x="135.03"
+         x="135.01"
 	 y="-732.8024" 
 	 z="-297.84"/>
        <rotationref ref="rIdentity"/>
@@ -14809,14 +14820,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-2"/>
        <position name="posOpArapuca2-Lat-2" unit="cm" 
-         x="135.03"
+         x="135.01"
 	 y="-732.0624" 
 	 z="-297.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-3"/>
        <position name="posArapuca3-Lat-2" unit="cm" 
-         x="60.03"
+         x="60.01"
 	 y="-732.8024" 
 	 z="-297.84"/>
        <rotationref ref="rIdentity"/>
@@ -14824,14 +14835,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-3"/>
        <position name="posOpArapuca3-Lat-2" unit="cm" 
-         x="60.03"
+         x="60.01"
 	 y="-732.0624" 
 	 z="-297.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-4"/>
        <position name="posArapuca4-Lat-2" unit="cm" 
-         x="285.03"
+         x="285.01"
 	 y="732.8024" 
 	 z="-297.84"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -14839,14 +14850,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-4"/>
        <position name="posOpArapuca4-Lat-2" unit="cm" 
-         x="285.03"
+         x="285.01"
 	 y="732.0624" 
 	 z="-297.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-5"/>
        <position name="posArapuca5-Lat-2" unit="cm" 
-         x="210.03"
+         x="210.01"
 	 y="732.8024" 
 	 z="-297.84"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -14854,14 +14865,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-5"/>
        <position name="posOpArapuca5-Lat-2" unit="cm" 
-         x="210.03"
+         x="210.01"
 	 y="732.0624" 
 	 z="-297.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-6"/>
        <position name="posArapuca6-Lat-2" unit="cm" 
-         x="135.03"
+         x="135.01"
 	 y="732.8024" 
 	 z="-297.84"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -14869,14 +14880,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-6"/>
        <position name="posOpArapuca6-Lat-2" unit="cm" 
-         x="135.03"
+         x="135.01"
 	 y="732.0624" 
 	 z="-297.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-7"/>
        <position name="posArapuca7-Lat-2" unit="cm" 
-         x="60.03"
+         x="60.01"
 	 y="732.8024" 
 	 z="-297.84"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -14884,14 +14895,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-7"/>
        <position name="posOpArapuca7-Lat-2" unit="cm" 
-         x="60.03"
+         x="60.01"
 	 y="732.0624" 
 	 z="-297.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_3-0"/>
        <position name="posArapuca0-Lat-3" unit="cm" 
-         x="285.03"
+         x="285.01"
 	 y="-732.8024" 
 	 z="-1.13686837721616e-13"/>
        <rotationref ref="rIdentity"/>
@@ -14899,14 +14910,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_3-0"/>
        <position name="posOpArapuca0-Lat-3" unit="cm" 
-         x="285.03"
+         x="285.01"
 	 y="-732.0624" 
 	 z="-1.13686837721616e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_3-1"/>
        <position name="posArapuca1-Lat-3" unit="cm" 
-         x="210.03"
+         x="210.01"
 	 y="-732.8024" 
 	 z="-1.13686837721616e-13"/>
        <rotationref ref="rIdentity"/>
@@ -14914,14 +14925,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_3-1"/>
        <position name="posOpArapuca1-Lat-3" unit="cm" 
-         x="210.03"
+         x="210.01"
 	 y="-732.0624" 
 	 z="-1.13686837721616e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_3-2"/>
        <position name="posArapuca2-Lat-3" unit="cm" 
-         x="135.03"
+         x="135.01"
 	 y="-732.8024" 
 	 z="-1.13686837721616e-13"/>
        <rotationref ref="rIdentity"/>
@@ -14929,14 +14940,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_3-2"/>
        <position name="posOpArapuca2-Lat-3" unit="cm" 
-         x="135.03"
+         x="135.01"
 	 y="-732.0624" 
 	 z="-1.13686837721616e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_3-3"/>
        <position name="posArapuca3-Lat-3" unit="cm" 
-         x="60.03"
+         x="60.01"
 	 y="-732.8024" 
 	 z="-1.13686837721616e-13"/>
        <rotationref ref="rIdentity"/>
@@ -14944,14 +14955,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_3-3"/>
        <position name="posOpArapuca3-Lat-3" unit="cm" 
-         x="60.03"
+         x="60.01"
 	 y="-732.0624" 
 	 z="-1.13686837721616e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_3-4"/>
        <position name="posArapuca4-Lat-3" unit="cm" 
-         x="285.03"
+         x="285.01"
 	 y="732.8024" 
 	 z="-1.13686837721616e-13"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -14959,14 +14970,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_3-4"/>
        <position name="posOpArapuca4-Lat-3" unit="cm" 
-         x="285.03"
+         x="285.01"
 	 y="732.0624" 
 	 z="-1.13686837721616e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_3-5"/>
        <position name="posArapuca5-Lat-3" unit="cm" 
-         x="210.03"
+         x="210.01"
 	 y="732.8024" 
 	 z="-1.13686837721616e-13"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -14974,14 +14985,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_3-5"/>
        <position name="posOpArapuca5-Lat-3" unit="cm" 
-         x="210.03"
+         x="210.01"
 	 y="732.0624" 
 	 z="-1.13686837721616e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_3-6"/>
        <position name="posArapuca6-Lat-3" unit="cm" 
-         x="135.03"
+         x="135.01"
 	 y="732.8024" 
 	 z="-1.13686837721616e-13"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -14989,14 +15000,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_3-6"/>
        <position name="posOpArapuca6-Lat-3" unit="cm" 
-         x="135.03"
+         x="135.01"
 	 y="732.0624" 
 	 z="-1.13686837721616e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_3-7"/>
        <position name="posArapuca7-Lat-3" unit="cm" 
-         x="60.03"
+         x="60.01"
 	 y="732.8024" 
 	 z="-1.13686837721616e-13"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -15004,14 +15015,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_3-7"/>
        <position name="posOpArapuca7-Lat-3" unit="cm" 
-         x="60.03"
+         x="60.01"
 	 y="732.0624" 
 	 z="-1.13686837721616e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_4-0"/>
        <position name="posArapuca0-Lat-4" unit="cm" 
-         x="285.03"
+         x="285.01"
 	 y="-732.8024" 
 	 z="297.84"/>
        <rotationref ref="rIdentity"/>
@@ -15019,14 +15030,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_4-0"/>
        <position name="posOpArapuca0-Lat-4" unit="cm" 
-         x="285.03"
+         x="285.01"
 	 y="-732.0624" 
 	 z="297.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_4-1"/>
        <position name="posArapuca1-Lat-4" unit="cm" 
-         x="210.03"
+         x="210.01"
 	 y="-732.8024" 
 	 z="297.84"/>
        <rotationref ref="rIdentity"/>
@@ -15034,14 +15045,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_4-1"/>
        <position name="posOpArapuca1-Lat-4" unit="cm" 
-         x="210.03"
+         x="210.01"
 	 y="-732.0624" 
 	 z="297.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_4-2"/>
        <position name="posArapuca2-Lat-4" unit="cm" 
-         x="135.03"
+         x="135.01"
 	 y="-732.8024" 
 	 z="297.84"/>
        <rotationref ref="rIdentity"/>
@@ -15049,14 +15060,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_4-2"/>
        <position name="posOpArapuca2-Lat-4" unit="cm" 
-         x="135.03"
+         x="135.01"
 	 y="-732.0624" 
 	 z="297.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_4-3"/>
        <position name="posArapuca3-Lat-4" unit="cm" 
-         x="60.03"
+         x="60.01"
 	 y="-732.8024" 
 	 z="297.84"/>
        <rotationref ref="rIdentity"/>
@@ -15064,14 +15075,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_4-3"/>
        <position name="posOpArapuca3-Lat-4" unit="cm" 
-         x="60.03"
+         x="60.01"
 	 y="-732.0624" 
 	 z="297.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_4-4"/>
        <position name="posArapuca4-Lat-4" unit="cm" 
-         x="285.03"
+         x="285.01"
 	 y="732.8024" 
 	 z="297.84"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -15079,14 +15090,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_4-4"/>
        <position name="posOpArapuca4-Lat-4" unit="cm" 
-         x="285.03"
+         x="285.01"
 	 y="732.0624" 
 	 z="297.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_4-5"/>
        <position name="posArapuca5-Lat-4" unit="cm" 
-         x="210.03"
+         x="210.01"
 	 y="732.8024" 
 	 z="297.84"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -15094,14 +15105,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_4-5"/>
        <position name="posOpArapuca5-Lat-4" unit="cm" 
-         x="210.03"
+         x="210.01"
 	 y="732.0624" 
 	 z="297.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_4-6"/>
        <position name="posArapuca6-Lat-4" unit="cm" 
-         x="135.03"
+         x="135.01"
 	 y="732.8024" 
 	 z="297.84"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -15109,14 +15120,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_4-6"/>
        <position name="posOpArapuca6-Lat-4" unit="cm" 
-         x="135.03"
+         x="135.01"
 	 y="732.0624" 
 	 z="297.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_4-7"/>
        <position name="posArapuca7-Lat-4" unit="cm" 
-         x="60.03"
+         x="60.01"
 	 y="732.8024" 
 	 z="297.84"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -15124,14 +15135,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_4-7"/>
        <position name="posOpArapuca7-Lat-4" unit="cm" 
-         x="60.03"
+         x="60.01"
 	 y="732.0624" 
 	 z="297.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_5-0"/>
        <position name="posArapuca0-Lat-5" unit="cm" 
-         x="285.03"
+         x="285.01"
 	 y="-732.8024" 
 	 z="595.68"/>
        <rotationref ref="rIdentity"/>
@@ -15139,14 +15150,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_5-0"/>
        <position name="posOpArapuca0-Lat-5" unit="cm" 
-         x="285.03"
+         x="285.01"
 	 y="-732.0624" 
 	 z="595.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_5-1"/>
        <position name="posArapuca1-Lat-5" unit="cm" 
-         x="210.03"
+         x="210.01"
 	 y="-732.8024" 
 	 z="595.68"/>
        <rotationref ref="rIdentity"/>
@@ -15154,14 +15165,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_5-1"/>
        <position name="posOpArapuca1-Lat-5" unit="cm" 
-         x="210.03"
+         x="210.01"
 	 y="-732.0624" 
 	 z="595.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_5-2"/>
        <position name="posArapuca2-Lat-5" unit="cm" 
-         x="135.03"
+         x="135.01"
 	 y="-732.8024" 
 	 z="595.68"/>
        <rotationref ref="rIdentity"/>
@@ -15169,14 +15180,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_5-2"/>
        <position name="posOpArapuca2-Lat-5" unit="cm" 
-         x="135.03"
+         x="135.01"
 	 y="-732.0624" 
 	 z="595.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_5-3"/>
        <position name="posArapuca3-Lat-5" unit="cm" 
-         x="60.03"
+         x="60.01"
 	 y="-732.8024" 
 	 z="595.68"/>
        <rotationref ref="rIdentity"/>
@@ -15184,14 +15195,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_5-3"/>
        <position name="posOpArapuca3-Lat-5" unit="cm" 
-         x="60.03"
+         x="60.01"
 	 y="-732.0624" 
 	 z="595.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_5-4"/>
        <position name="posArapuca4-Lat-5" unit="cm" 
-         x="285.03"
+         x="285.01"
 	 y="732.8024" 
 	 z="595.68"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -15199,14 +15210,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_5-4"/>
        <position name="posOpArapuca4-Lat-5" unit="cm" 
-         x="285.03"
+         x="285.01"
 	 y="732.0624" 
 	 z="595.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_5-5"/>
        <position name="posArapuca5-Lat-5" unit="cm" 
-         x="210.03"
+         x="210.01"
 	 y="732.8024" 
 	 z="595.68"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -15214,14 +15225,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_5-5"/>
        <position name="posOpArapuca5-Lat-5" unit="cm" 
-         x="210.03"
+         x="210.01"
 	 y="732.0624" 
 	 z="595.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_5-6"/>
        <position name="posArapuca6-Lat-5" unit="cm" 
-         x="135.03"
+         x="135.01"
 	 y="732.8024" 
 	 z="595.68"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -15229,14 +15240,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_5-6"/>
        <position name="posOpArapuca6-Lat-5" unit="cm" 
-         x="135.03"
+         x="135.01"
 	 y="732.0624" 
 	 z="595.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_5-7"/>
        <position name="posArapuca7-Lat-5" unit="cm" 
-         x="60.03"
+         x="60.01"
 	 y="732.8024" 
 	 z="595.68"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -15244,14 +15255,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_5-7"/>
        <position name="posOpArapuca7-Lat-5" unit="cm" 
-         x="60.03"
+         x="60.01"
 	 y="732.0624" 
 	 z="595.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_6-0"/>
        <position name="posArapuca0-Lat-6" unit="cm" 
-         x="285.03"
+         x="285.01"
 	 y="-732.8024" 
 	 z="893.52"/>
        <rotationref ref="rIdentity"/>
@@ -15259,14 +15270,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_6-0"/>
        <position name="posOpArapuca0-Lat-6" unit="cm" 
-         x="285.03"
+         x="285.01"
 	 y="-732.0624" 
 	 z="893.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_6-1"/>
        <position name="posArapuca1-Lat-6" unit="cm" 
-         x="210.03"
+         x="210.01"
 	 y="-732.8024" 
 	 z="893.52"/>
        <rotationref ref="rIdentity"/>
@@ -15274,14 +15285,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_6-1"/>
        <position name="posOpArapuca1-Lat-6" unit="cm" 
-         x="210.03"
+         x="210.01"
 	 y="-732.0624" 
 	 z="893.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_6-2"/>
        <position name="posArapuca2-Lat-6" unit="cm" 
-         x="135.03"
+         x="135.01"
 	 y="-732.8024" 
 	 z="893.52"/>
        <rotationref ref="rIdentity"/>
@@ -15289,14 +15300,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_6-2"/>
        <position name="posOpArapuca2-Lat-6" unit="cm" 
-         x="135.03"
+         x="135.01"
 	 y="-732.0624" 
 	 z="893.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_6-3"/>
        <position name="posArapuca3-Lat-6" unit="cm" 
-         x="60.03"
+         x="60.01"
 	 y="-732.8024" 
 	 z="893.52"/>
        <rotationref ref="rIdentity"/>
@@ -15304,14 +15315,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_6-3"/>
        <position name="posOpArapuca3-Lat-6" unit="cm" 
-         x="60.03"
+         x="60.01"
 	 y="-732.0624" 
 	 z="893.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_6-4"/>
        <position name="posArapuca4-Lat-6" unit="cm" 
-         x="285.03"
+         x="285.01"
 	 y="732.8024" 
 	 z="893.52"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -15319,14 +15330,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_6-4"/>
        <position name="posOpArapuca4-Lat-6" unit="cm" 
-         x="285.03"
+         x="285.01"
 	 y="732.0624" 
 	 z="893.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_6-5"/>
        <position name="posArapuca5-Lat-6" unit="cm" 
-         x="210.03"
+         x="210.01"
 	 y="732.8024" 
 	 z="893.52"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -15334,14 +15345,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_6-5"/>
        <position name="posOpArapuca5-Lat-6" unit="cm" 
-         x="210.03"
+         x="210.01"
 	 y="732.0624" 
 	 z="893.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_6-6"/>
        <position name="posArapuca6-Lat-6" unit="cm" 
-         x="135.03"
+         x="135.01"
 	 y="732.8024" 
 	 z="893.52"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -15349,14 +15360,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_6-6"/>
        <position name="posOpArapuca6-Lat-6" unit="cm" 
-         x="135.03"
+         x="135.01"
 	 y="732.0624" 
 	 z="893.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_6-7"/>
        <position name="posArapuca7-Lat-6" unit="cm" 
-         x="60.03"
+         x="60.01"
 	 y="732.8024" 
 	 z="893.52"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -15364,7 +15375,7 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_6-7"/>
        <position name="posOpArapuca7-Lat-6" unit="cm" 
-         x="60.03"
+         x="60.01"
 	 y="732.0624" 
 	 z="893.52"/>
      </physvol>

--- a/dunecore/Geometry/gdml/dunevd10kt_3view_30deg_v3_refactored_1x8x14ref_nowires.gdml
+++ b/dunecore/Geometry/gdml/dunevd10kt_3view_30deg_v3_refactored_1x8x14ref_nowires.gdml
@@ -490,7 +490,7 @@
     
 
    <box name="CRM"
-      x="650.08" 
+      x="650.1" 
       y="167.7006" 
       z="148.92"
       lunit="cm"/>
@@ -559,12 +559,12 @@
 
 
     <box name="Cryostat" lunit="cm" 
-      x="850.32" 
+      x="850.34" 
       y="1545.8448" 
       z="2292.12"/>
 
     <box name="ArgonInterior" lunit="cm" 
-      x="850.08"
+      x="850.1"
       y="1545.6048"
       z="2291.88"/>
 
@@ -574,12 +574,12 @@
       z="2291.88"/>
 
     <box name="ExternalAuxOut" lunit="cm" 
-      x="850.08 - 100"
+      x="850.1 - 100"
       y="1545.6048 - 2*2.5 - 2*40"
       z="2291.88"/>
 
     <box name="ExternalAuxIn" lunit="cm" 
-      x="850.08"
+      x="850.1"
       y="1356.7748"
       z="2291.88 + 1"/>
 
@@ -687,7 +687,7 @@
     </subtraction>
 
     <box name="FoamPadBlock" lunit="cm"
-      x="1010.32"
+      x="1010.34"
       y="1705.8448"
       z="2452.12" />
 
@@ -698,7 +698,7 @@
     </subtraction>
 
     <box name="SteelSupportBlock" lunit="cm"
-      x="1210.32"
+      x="1210.34"
       y="1905.8448"
       z="2652.12" />
 
@@ -709,13 +709,13 @@
     </subtraction>
 
     <box name="DetEnclosure" lunit="cm" 
-      x="1310.32"
+      x="1310.34"
       y="2105.8448"
       z="2852.12"/>
 
 
     <box name="World" lunit="cm" 
-      x="9310.32" 
+      x="9310.34" 
       y="10105.8448" 
       z="10852.12"/>
 </solids>
@@ -761,31 +761,31 @@
        <physvol>
        <volumeref ref="volTPCPlaneU"/>
        <position name="posPlaneU" unit="cm" 
-         x="324.97" y="0" z="0"/>
+         x="324.98" y="0" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volTPCPlaneV"/>
        <position name="posPlaneY" unit="cm" 
-         x="324.99" y="0" z="0"/>
+         x="325" y="0" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volTPCPlaneZ"/>
        <position name="posPlaneZ" unit="cm" 
-         x="325.01" y="0" z="0"/>
+         x="325.02" y="0" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volAnodePlate"/>
        <position name="posAnodePlate" unit="cm" 
-         x="325.03" y="0" z="0"/>
+         x="325.04" y="0" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volTPCActive"/>
        <position name="posActive" unit="cm" 
-        x="-0.04" y="" z="0"/>
+        x="-0.05" y="" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
    </volume>
@@ -2160,7 +2160,7 @@
       <solidref ref="Cryostat" />
       <physvol>
         <volumeref ref="volGaseousArgon"/>
-        <position name="posGaseousArgon" unit="cm" x="375.04" y="0" z="0"/>
+        <position name="posGaseousArgon" unit="cm" x="375.05" y="0" z="0"/>
       </physvol>
       <physvol>
         <volumeref ref="volSteelShell"/>
@@ -2732,660 +2732,660 @@
       </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper0" unit="cm"  x="-322.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper0" unit="cm"  x="-322.05" y="-675.1024" z="0" />
      <rotation name="rotFS0" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper1" unit="cm"  x="-316.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper1" unit="cm"  x="-316.05" y="-675.1024" z="0" />
      <rotation name="rotFS1" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper2" unit="cm"  x="-310.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper2" unit="cm"  x="-310.05" y="-675.1024" z="0" />
      <rotation name="rotFS2" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper3" unit="cm"  x="-304.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper3" unit="cm"  x="-304.05" y="-675.1024" z="0" />
      <rotation name="rotFS3" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper4" unit="cm"  x="-298.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper4" unit="cm"  x="-298.05" y="-675.1024" z="0" />
      <rotation name="rotFS4" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper5" unit="cm"  x="-292.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper5" unit="cm"  x="-292.05" y="-675.1024" z="0" />
      <rotation name="rotFS5" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper6" unit="cm"  x="-286.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper6" unit="cm"  x="-286.05" y="-675.1024" z="0" />
      <rotation name="rotFS6" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper7" unit="cm"  x="-280.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper7" unit="cm"  x="-280.05" y="-675.1024" z="0" />
      <rotation name="rotFS7" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper8" unit="cm"  x="-274.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper8" unit="cm"  x="-274.05" y="-675.1024" z="0" />
      <rotation name="rotFS8" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper9" unit="cm"  x="-268.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper9" unit="cm"  x="-268.05" y="-675.1024" z="0" />
      <rotation name="rotFS9" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper10" unit="cm"  x="-262.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper10" unit="cm"  x="-262.05" y="-675.1024" z="0" />
      <rotation name="rotFS10" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper11" unit="cm"  x="-256.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper11" unit="cm"  x="-256.05" y="-675.1024" z="0" />
      <rotation name="rotFS11" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper12" unit="cm"  x="-250.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper12" unit="cm"  x="-250.05" y="-675.1024" z="0" />
      <rotation name="rotFS12" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper13" unit="cm"  x="-244.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper13" unit="cm"  x="-244.05" y="-675.1024" z="0" />
      <rotation name="rotFS13" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper14" unit="cm"  x="-238.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper14" unit="cm"  x="-238.05" y="-675.1024" z="0" />
      <rotation name="rotFS14" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper15" unit="cm"  x="-232.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper15" unit="cm"  x="-232.05" y="-675.1024" z="0" />
      <rotation name="rotFS15" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper16" unit="cm"  x="-226.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper16" unit="cm"  x="-226.05" y="-675.1024" z="0" />
      <rotation name="rotFS16" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper17" unit="cm"  x="-220.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper17" unit="cm"  x="-220.05" y="-675.1024" z="0" />
      <rotation name="rotFS17" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper18" unit="cm"  x="-214.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper18" unit="cm"  x="-214.05" y="-675.1024" z="0" />
      <rotation name="rotFS18" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper19" unit="cm"  x="-208.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper19" unit="cm"  x="-208.05" y="-675.1024" z="0" />
      <rotation name="rotFS19" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper20" unit="cm"  x="-202.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper20" unit="cm"  x="-202.05" y="-675.1024" z="0" />
      <rotation name="rotFS20" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper21" unit="cm"  x="-196.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper21" unit="cm"  x="-196.05" y="-675.1024" z="0" />
      <rotation name="rotFS21" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper22" unit="cm"  x="-190.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper22" unit="cm"  x="-190.05" y="-675.1024" z="0" />
      <rotation name="rotFS22" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper23" unit="cm"  x="-184.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper23" unit="cm"  x="-184.05" y="-675.1024" z="0" />
      <rotation name="rotFS23" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper24" unit="cm"  x="-178.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper24" unit="cm"  x="-178.05" y="-675.1024" z="0" />
      <rotation name="rotFS24" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper25" unit="cm"  x="-172.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper25" unit="cm"  x="-172.05" y="-675.1024" z="0" />
      <rotation name="rotFS25" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper26" unit="cm"  x="-166.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper26" unit="cm"  x="-166.05" y="-675.1024" z="0" />
      <rotation name="rotFS26" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper27" unit="cm"  x="-160.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper27" unit="cm"  x="-160.05" y="-675.1024" z="0" />
      <rotation name="rotFS27" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper28" unit="cm"  x="-154.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper28" unit="cm"  x="-154.05" y="-675.1024" z="0" />
      <rotation name="rotFS28" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper29" unit="cm"  x="-148.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper29" unit="cm"  x="-148.05" y="-675.1024" z="0" />
      <rotation name="rotFS29" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper30" unit="cm"  x="-142.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper30" unit="cm"  x="-142.05" y="-675.1024" z="0" />
      <rotation name="rotFS30" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper31" unit="cm"  x="-136.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper31" unit="cm"  x="-136.05" y="-675.1024" z="0" />
      <rotation name="rotFS31" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper32" unit="cm"  x="-130.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper32" unit="cm"  x="-130.05" y="-675.1024" z="0" />
      <rotation name="rotFS32" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper33" unit="cm"  x="-124.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper33" unit="cm"  x="-124.05" y="-675.1024" z="0" />
      <rotation name="rotFS33" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper34" unit="cm"  x="-118.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper34" unit="cm"  x="-118.05" y="-675.1024" z="0" />
      <rotation name="rotFS34" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper35" unit="cm"  x="-112.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper35" unit="cm"  x="-112.05" y="-675.1024" z="0" />
      <rotation name="rotFS35" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper36" unit="cm"  x="-106.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper36" unit="cm"  x="-106.05" y="-675.1024" z="0" />
      <rotation name="rotFS36" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper37" unit="cm"  x="-100.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper37" unit="cm"  x="-100.05" y="-675.1024" z="0" />
      <rotation name="rotFS37" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper38" unit="cm"  x="-94.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper38" unit="cm"  x="-94.0500000000001" y="-675.1024" z="0" />
      <rotation name="rotFS38" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper39" unit="cm"  x="-88.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper39" unit="cm"  x="-88.0500000000001" y="-675.1024" z="0" />
      <rotation name="rotFS39" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper40" unit="cm"  x="-82.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper40" unit="cm"  x="-82.0500000000001" y="-675.1024" z="0" />
      <rotation name="rotFS40" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper41" unit="cm"  x="-76.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper41" unit="cm"  x="-76.0500000000001" y="-675.1024" z="0" />
      <rotation name="rotFS41" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper42" unit="cm"  x="-70.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper42" unit="cm"  x="-70.0500000000001" y="-675.1024" z="0" />
      <rotation name="rotFS42" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper43" unit="cm"  x="-64.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper43" unit="cm"  x="-64.0500000000001" y="-675.1024" z="0" />
      <rotation name="rotFS43" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper44" unit="cm"  x="-58.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper44" unit="cm"  x="-58.0500000000001" y="-675.1024" z="0" />
      <rotation name="rotFS44" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper45" unit="cm"  x="-52.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper45" unit="cm"  x="-52.0500000000001" y="-675.1024" z="0" />
      <rotation name="rotFS45" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper46" unit="cm"  x="-46.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper46" unit="cm"  x="-46.0500000000001" y="-675.1024" z="0" />
      <rotation name="rotFS46" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper47" unit="cm"  x="-40.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper47" unit="cm"  x="-40.0500000000001" y="-675.1024" z="0" />
      <rotation name="rotFS47" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper48" unit="cm"  x="-34.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper48" unit="cm"  x="-34.0500000000001" y="-675.1024" z="0" />
      <rotation name="rotFS48" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper49" unit="cm"  x="-28.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper49" unit="cm"  x="-28.0500000000001" y="-675.1024" z="0" />
      <rotation name="rotFS49" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper50" unit="cm"  x="-22.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper50" unit="cm"  x="-22.0500000000001" y="-675.1024" z="0" />
      <rotation name="rotFS50" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper51" unit="cm"  x="-16.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper51" unit="cm"  x="-16.0500000000001" y="-675.1024" z="0" />
      <rotation name="rotFS51" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper52" unit="cm"  x="-10.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper52" unit="cm"  x="-10.0500000000001" y="-675.1024" z="0" />
      <rotation name="rotFS52" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper53" unit="cm"  x="-4.04000000000001" y="-675.1024" z="0" />
+     <position name="posFieldShaper53" unit="cm"  x="-4.05000000000005" y="-675.1024" z="0" />
      <rotation name="rotFS53" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper54" unit="cm"  x="1.95999999999999" y="-675.1024" z="0" />
+     <position name="posFieldShaper54" unit="cm"  x="1.94999999999995" y="-675.1024" z="0" />
      <rotation name="rotFS54" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper55" unit="cm"  x="7.95999999999999" y="-675.1024" z="0" />
+     <position name="posFieldShaper55" unit="cm"  x="7.94999999999995" y="-675.1024" z="0" />
      <rotation name="rotFS55" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper56" unit="cm"  x="13.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper56" unit="cm"  x="13.9499999999999" y="-675.1024" z="0" />
      <rotation name="rotFS56" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper57" unit="cm"  x="19.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper57" unit="cm"  x="19.9499999999999" y="-675.1024" z="0" />
      <rotation name="rotFS57" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper58" unit="cm"  x="25.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper58" unit="cm"  x="25.9499999999999" y="-675.1024" z="0" />
      <rotation name="rotFS58" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper59" unit="cm"  x="31.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper59" unit="cm"  x="31.9499999999999" y="-675.1024" z="0" />
      <rotation name="rotFS59" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper60" unit="cm"  x="37.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper60" unit="cm"  x="37.9499999999999" y="-675.1024" z="0" />
      <rotation name="rotFS60" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper61" unit="cm"  x="43.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper61" unit="cm"  x="43.9499999999999" y="-675.1024" z="0" />
      <rotation name="rotFS61" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper62" unit="cm"  x="49.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper62" unit="cm"  x="49.9499999999999" y="-675.1024" z="0" />
      <rotation name="rotFS62" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper63" unit="cm"  x="55.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper63" unit="cm"  x="55.9499999999999" y="-675.1024" z="0" />
      <rotation name="rotFS63" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper64" unit="cm"  x="61.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper64" unit="cm"  x="61.9499999999999" y="-675.1024" z="0" />
      <rotation name="rotFS64" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper65" unit="cm"  x="67.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper65" unit="cm"  x="67.9499999999999" y="-675.1024" z="0" />
      <rotation name="rotFS65" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper66" unit="cm"  x="73.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper66" unit="cm"  x="73.9499999999999" y="-675.1024" z="0" />
      <rotation name="rotFS66" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper67" unit="cm"  x="79.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper67" unit="cm"  x="79.9499999999999" y="-675.1024" z="0" />
      <rotation name="rotFS67" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper68" unit="cm"  x="85.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper68" unit="cm"  x="85.9499999999999" y="-675.1024" z="0" />
      <rotation name="rotFS68" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper69" unit="cm"  x="91.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper69" unit="cm"  x="91.9499999999999" y="-675.1024" z="0" />
      <rotation name="rotFS69" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper70" unit="cm"  x="97.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper70" unit="cm"  x="97.9499999999999" y="-675.1024" z="0" />
      <rotation name="rotFS70" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper71" unit="cm"  x="103.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper71" unit="cm"  x="103.95" y="-675.1024" z="0" />
      <rotation name="rotFS71" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper72" unit="cm"  x="109.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper72" unit="cm"  x="109.95" y="-675.1024" z="0" />
      <rotation name="rotFS72" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper73" unit="cm"  x="115.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper73" unit="cm"  x="115.95" y="-675.1024" z="0" />
      <rotation name="rotFS73" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper74" unit="cm"  x="121.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper74" unit="cm"  x="121.95" y="-675.1024" z="0" />
      <rotation name="rotFS74" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper75" unit="cm"  x="127.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper75" unit="cm"  x="127.95" y="-675.1024" z="0" />
      <rotation name="rotFS75" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper76" unit="cm"  x="133.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper76" unit="cm"  x="133.95" y="-675.1024" z="0" />
      <rotation name="rotFS76" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper77" unit="cm"  x="139.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper77" unit="cm"  x="139.95" y="-675.1024" z="0" />
      <rotation name="rotFS77" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper78" unit="cm"  x="145.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper78" unit="cm"  x="145.95" y="-675.1024" z="0" />
      <rotation name="rotFS78" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper79" unit="cm"  x="151.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper79" unit="cm"  x="151.95" y="-675.1024" z="0" />
      <rotation name="rotFS79" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper80" unit="cm"  x="157.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper80" unit="cm"  x="157.95" y="-675.1024" z="0" />
      <rotation name="rotFS80" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper81" unit="cm"  x="163.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper81" unit="cm"  x="163.95" y="-675.1024" z="0" />
      <rotation name="rotFS81" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper82" unit="cm"  x="169.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper82" unit="cm"  x="169.95" y="-675.1024" z="0" />
      <rotation name="rotFS82" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper83" unit="cm"  x="175.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper83" unit="cm"  x="175.95" y="-675.1024" z="0" />
      <rotation name="rotFS83" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper84" unit="cm"  x="181.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper84" unit="cm"  x="181.95" y="-675.1024" z="0" />
      <rotation name="rotFS84" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper85" unit="cm"  x="187.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper85" unit="cm"  x="187.95" y="-675.1024" z="0" />
      <rotation name="rotFS85" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper86" unit="cm"  x="193.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper86" unit="cm"  x="193.95" y="-675.1024" z="0" />
      <rotation name="rotFS86" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper87" unit="cm"  x="199.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper87" unit="cm"  x="199.95" y="-675.1024" z="0" />
      <rotation name="rotFS87" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper88" unit="cm"  x="205.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper88" unit="cm"  x="205.95" y="-675.1024" z="0" />
      <rotation name="rotFS88" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper89" unit="cm"  x="211.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper89" unit="cm"  x="211.95" y="-675.1024" z="0" />
      <rotation name="rotFS89" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper90" unit="cm"  x="217.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper90" unit="cm"  x="217.95" y="-675.1024" z="0" />
      <rotation name="rotFS90" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper91" unit="cm"  x="223.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper91" unit="cm"  x="223.95" y="-675.1024" z="0" />
      <rotation name="rotFS91" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper92" unit="cm"  x="229.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper92" unit="cm"  x="229.95" y="-675.1024" z="0" />
      <rotation name="rotFS92" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper93" unit="cm"  x="235.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper93" unit="cm"  x="235.95" y="-675.1024" z="0" />
      <rotation name="rotFS93" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper94" unit="cm"  x="241.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper94" unit="cm"  x="241.95" y="-675.1024" z="0" />
      <rotation name="rotFS94" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper95" unit="cm"  x="247.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper95" unit="cm"  x="247.95" y="-675.1024" z="0" />
      <rotation name="rotFS95" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper96" unit="cm"  x="253.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper96" unit="cm"  x="253.95" y="-675.1024" z="0" />
      <rotation name="rotFS96" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper97" unit="cm"  x="259.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper97" unit="cm"  x="259.95" y="-675.1024" z="0" />
      <rotation name="rotFS97" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper98" unit="cm"  x="265.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper98" unit="cm"  x="265.95" y="-675.1024" z="0" />
      <rotation name="rotFS98" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper99" unit="cm"  x="271.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper99" unit="cm"  x="271.95" y="-675.1024" z="0" />
      <rotation name="rotFS99" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper100" unit="cm"  x="277.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper100" unit="cm"  x="277.95" y="-675.1024" z="0" />
      <rotation name="rotFS100" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper101" unit="cm"  x="283.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper101" unit="cm"  x="283.95" y="-675.1024" z="0" />
      <rotation name="rotFS101" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper102" unit="cm"  x="289.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper102" unit="cm"  x="289.95" y="-675.1024" z="0" />
      <rotation name="rotFS102" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper103" unit="cm"  x="295.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper103" unit="cm"  x="295.95" y="-675.1024" z="0" />
      <rotation name="rotFS103" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper104" unit="cm"  x="301.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper104" unit="cm"  x="301.95" y="-675.1024" z="0" />
      <rotation name="rotFS104" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper105" unit="cm"  x="307.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper105" unit="cm"  x="307.95" y="-675.1024" z="0" />
      <rotation name="rotFS105" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper106" unit="cm"  x="313.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper106" unit="cm"  x="313.95" y="-675.1024" z="0" />
      <rotation name="rotFS106" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper107" unit="cm"  x="319.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper107" unit="cm"  x="319.95" y="-675.1024" z="0" />
      <rotation name="rotFS107" unit="deg" x="0" y="0" z="90" />
   </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-0" unit="cm" x="-328.04" y="-505.1018" z="-897.02"/>
+   <position name="posGroundGrid-0" unit="cm" x="-328.05" y="-505.1018" z="-897.02"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-1" unit="cm" x="-328.04" y="-169.7006" z="-897.02"/>
+   <position name="posGroundGrid-1" unit="cm" x="-328.05" y="-169.7006" z="-897.02"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-2" unit="cm" x="-328.04" y="165.7006" z="-897.02"/>
+   <position name="posGroundGrid-2" unit="cm" x="-328.05" y="165.7006" z="-897.02"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-3" unit="cm" x="-328.04" y="501.1018" z="-897.02"/>
+   <position name="posGroundGrid-3" unit="cm" x="-328.05" y="501.1018" z="-897.02"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-4" unit="cm" x="-328.04" y="-505.1018" z="-599.18"/>
+   <position name="posGroundGrid-4" unit="cm" x="-328.05" y="-505.1018" z="-599.18"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-5" unit="cm" x="-328.04" y="-169.7006" z="-599.18"/>
+   <position name="posGroundGrid-5" unit="cm" x="-328.05" y="-169.7006" z="-599.18"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-6" unit="cm" x="-328.04" y="165.7006" z="-599.18"/>
+   <position name="posGroundGrid-6" unit="cm" x="-328.05" y="165.7006" z="-599.18"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-7" unit="cm" x="-328.04" y="501.1018" z="-599.18"/>
+   <position name="posGroundGrid-7" unit="cm" x="-328.05" y="501.1018" z="-599.18"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-8" unit="cm" x="-328.04" y="-505.1018" z="-301.34"/>
+   <position name="posGroundGrid-8" unit="cm" x="-328.05" y="-505.1018" z="-301.34"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-9" unit="cm" x="-328.04" y="-169.7006" z="-301.34"/>
+   <position name="posGroundGrid-9" unit="cm" x="-328.05" y="-169.7006" z="-301.34"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-10" unit="cm" x="-328.04" y="165.7006" z="-301.34"/>
+   <position name="posGroundGrid-10" unit="cm" x="-328.05" y="165.7006" z="-301.34"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-11" unit="cm" x="-328.04" y="501.1018" z="-301.34"/>
+   <position name="posGroundGrid-11" unit="cm" x="-328.05" y="501.1018" z="-301.34"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-12" unit="cm" x="-328.04" y="-505.1018" z="-3.49999999999989"/>
+   <position name="posGroundGrid-12" unit="cm" x="-328.05" y="-505.1018" z="-3.49999999999989"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-13" unit="cm" x="-328.04" y="-169.7006" z="-3.49999999999989"/>
+   <position name="posGroundGrid-13" unit="cm" x="-328.05" y="-169.7006" z="-3.49999999999989"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-14" unit="cm" x="-328.04" y="165.7006" z="-3.49999999999989"/>
+   <position name="posGroundGrid-14" unit="cm" x="-328.05" y="165.7006" z="-3.49999999999989"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-15" unit="cm" x="-328.04" y="501.1018" z="-3.49999999999989"/>
+   <position name="posGroundGrid-15" unit="cm" x="-328.05" y="501.1018" z="-3.49999999999989"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-16" unit="cm" x="-328.04" y="-505.1018" z="294.34"/>
+   <position name="posGroundGrid-16" unit="cm" x="-328.05" y="-505.1018" z="294.34"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-17" unit="cm" x="-328.04" y="-169.7006" z="294.34"/>
+   <position name="posGroundGrid-17" unit="cm" x="-328.05" y="-169.7006" z="294.34"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-18" unit="cm" x="-328.04" y="165.7006" z="294.34"/>
+   <position name="posGroundGrid-18" unit="cm" x="-328.05" y="165.7006" z="294.34"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-19" unit="cm" x="-328.04" y="501.1018" z="294.34"/>
+   <position name="posGroundGrid-19" unit="cm" x="-328.05" y="501.1018" z="294.34"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-20" unit="cm" x="-328.04" y="-505.1018" z="592.18"/>
+   <position name="posGroundGrid-20" unit="cm" x="-328.05" y="-505.1018" z="592.18"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-21" unit="cm" x="-328.04" y="-169.7006" z="592.18"/>
+   <position name="posGroundGrid-21" unit="cm" x="-328.05" y="-169.7006" z="592.18"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-22" unit="cm" x="-328.04" y="165.7006" z="592.18"/>
+   <position name="posGroundGrid-22" unit="cm" x="-328.05" y="165.7006" z="592.18"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-23" unit="cm" x="-328.04" y="501.1018" z="592.18"/>
+   <position name="posGroundGrid-23" unit="cm" x="-328.05" y="501.1018" z="592.18"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-24" unit="cm" x="-328.04" y="-505.1018" z="890.02"/>
+   <position name="posGroundGrid-24" unit="cm" x="-328.05" y="-505.1018" z="890.02"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-25" unit="cm" x="-328.04" y="-169.7006" z="890.02"/>
+   <position name="posGroundGrid-25" unit="cm" x="-328.05" y="-169.7006" z="890.02"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-26" unit="cm" x="-328.04" y="165.7006" z="890.02"/>
+   <position name="posGroundGrid-26" unit="cm" x="-328.05" y="165.7006" z="890.02"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-27" unit="cm" x="-328.04" y="501.1018" z="890.02"/>
+   <position name="posGroundGrid-27" unit="cm" x="-328.05" y="501.1018" z="890.02"/>
       </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-0-0"/>
        <position name="posArapucaDouble0-Frame-0-0" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-632.8018" 
 	 z="-859.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3393,14 +3393,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-0"/>
        <position name="posOpArapucaDouble0-Frame-0-0" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-632.8018" 
 	 z="-859.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-0-1"/>
        <position name="posArapucaDouble1-Frame-0-0" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-542.1018" 
 	 z="-1005.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3408,14 +3408,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-1"/>
        <position name="posOpArapucaDouble1-Frame-0-0" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-542.1018" 
 	 z="-1005.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-0-2"/>
        <position name="posArapucaDouble2-Frame-0-0" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-468.1018" 
 	 z="-788.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3423,14 +3423,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-2"/>
        <position name="posOpArapucaDouble2-Frame-0-0" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-468.1018" 
 	 z="-788.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-0-3"/>
        <position name="posArapucaDouble3-Frame-0-0" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-377.4018" 
 	 z="-934.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3438,14 +3438,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-3"/>
        <position name="posOpArapucaDouble3-Frame-0-0" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-377.4018" 
 	 z="-934.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-1-0"/>
        <position name="posArapucaDouble0-Frame-0-1" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-632.8018" 
 	 z="-561.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3453,14 +3453,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-0"/>
        <position name="posOpArapucaDouble0-Frame-0-1" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-632.8018" 
 	 z="-561.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-1-1"/>
        <position name="posArapucaDouble1-Frame-0-1" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-542.1018" 
 	 z="-707.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3468,14 +3468,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-1"/>
        <position name="posOpArapucaDouble1-Frame-0-1" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-542.1018" 
 	 z="-707.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-1-2"/>
        <position name="posArapucaDouble2-Frame-0-1" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-468.1018" 
 	 z="-490.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3483,14 +3483,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-2"/>
        <position name="posOpArapucaDouble2-Frame-0-1" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-468.1018" 
 	 z="-490.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-1-3"/>
        <position name="posArapucaDouble3-Frame-0-1" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-377.4018" 
 	 z="-636.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3498,14 +3498,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-3"/>
        <position name="posOpArapucaDouble3-Frame-0-1" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-377.4018" 
 	 z="-636.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-2-0"/>
        <position name="posArapucaDouble0-Frame-0-2" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-632.8018" 
 	 z="-263.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3513,14 +3513,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-0"/>
        <position name="posOpArapucaDouble0-Frame-0-2" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-632.8018" 
 	 z="-263.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-2-1"/>
        <position name="posArapucaDouble1-Frame-0-2" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-542.1018" 
 	 z="-409.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3528,14 +3528,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-1"/>
        <position name="posOpArapucaDouble1-Frame-0-2" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-542.1018" 
 	 z="-409.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-2-2"/>
        <position name="posArapucaDouble2-Frame-0-2" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-468.1018" 
 	 z="-192.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3543,14 +3543,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-2"/>
        <position name="posOpArapucaDouble2-Frame-0-2" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-468.1018" 
 	 z="-192.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-2-3"/>
        <position name="posArapucaDouble3-Frame-0-2" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-377.4018" 
 	 z="-338.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3558,14 +3558,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-3"/>
        <position name="posOpArapucaDouble3-Frame-0-2" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-377.4018" 
 	 z="-338.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-3-0"/>
        <position name="posArapucaDouble0-Frame-0-3" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-632.8018" 
 	 z="34.0000000000001"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3573,14 +3573,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-3-0"/>
        <position name="posOpArapucaDouble0-Frame-0-3" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-632.8018" 
 	 z="34.0000000000001"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-3-1"/>
        <position name="posArapucaDouble1-Frame-0-3" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-542.1018" 
 	 z="-112"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3588,14 +3588,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-3-1"/>
        <position name="posOpArapucaDouble1-Frame-0-3" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-542.1018" 
 	 z="-112"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-3-2"/>
        <position name="posArapucaDouble2-Frame-0-3" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-468.1018" 
 	 z="105"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3603,14 +3603,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-3-2"/>
        <position name="posOpArapucaDouble2-Frame-0-3" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-468.1018" 
 	 z="105"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-3-3"/>
        <position name="posArapucaDouble3-Frame-0-3" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-377.4018" 
 	 z="-40.9999999999999"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3618,14 +3618,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-3-3"/>
        <position name="posOpArapucaDouble3-Frame-0-3" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-377.4018" 
 	 z="-40.9999999999999"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-4-0"/>
        <position name="posArapucaDouble0-Frame-0-4" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-632.8018" 
 	 z="331.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3633,14 +3633,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-4-0"/>
        <position name="posOpArapucaDouble0-Frame-0-4" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-632.8018" 
 	 z="331.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-4-1"/>
        <position name="posArapucaDouble1-Frame-0-4" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-542.1018" 
 	 z="185.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3648,14 +3648,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-4-1"/>
        <position name="posOpArapucaDouble1-Frame-0-4" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-542.1018" 
 	 z="185.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-4-2"/>
        <position name="posArapucaDouble2-Frame-0-4" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-468.1018" 
 	 z="402.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3663,14 +3663,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-4-2"/>
        <position name="posOpArapucaDouble2-Frame-0-4" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-468.1018" 
 	 z="402.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-4-3"/>
        <position name="posArapucaDouble3-Frame-0-4" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-377.4018" 
 	 z="256.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3678,14 +3678,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-4-3"/>
        <position name="posOpArapucaDouble3-Frame-0-4" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-377.4018" 
 	 z="256.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-5-0"/>
        <position name="posArapucaDouble0-Frame-0-5" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-632.8018" 
 	 z="629.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3693,14 +3693,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-5-0"/>
        <position name="posOpArapucaDouble0-Frame-0-5" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-632.8018" 
 	 z="629.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-5-1"/>
        <position name="posArapucaDouble1-Frame-0-5" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-542.1018" 
 	 z="483.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3708,14 +3708,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-5-1"/>
        <position name="posOpArapucaDouble1-Frame-0-5" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-542.1018" 
 	 z="483.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-5-2"/>
        <position name="posArapucaDouble2-Frame-0-5" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-468.1018" 
 	 z="700.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3723,14 +3723,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-5-2"/>
        <position name="posOpArapucaDouble2-Frame-0-5" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-468.1018" 
 	 z="700.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-5-3"/>
        <position name="posArapucaDouble3-Frame-0-5" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-377.4018" 
 	 z="554.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3738,14 +3738,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-5-3"/>
        <position name="posOpArapucaDouble3-Frame-0-5" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-377.4018" 
 	 z="554.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-6-0"/>
        <position name="posArapucaDouble0-Frame-0-6" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-632.8018" 
 	 z="927.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3753,14 +3753,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-6-0"/>
        <position name="posOpArapucaDouble0-Frame-0-6" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-632.8018" 
 	 z="927.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-6-1"/>
        <position name="posArapucaDouble1-Frame-0-6" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-542.1018" 
 	 z="781.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3768,14 +3768,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-6-1"/>
        <position name="posOpArapucaDouble1-Frame-0-6" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-542.1018" 
 	 z="781.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-6-2"/>
        <position name="posArapucaDouble2-Frame-0-6" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-468.1018" 
 	 z="998.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3783,14 +3783,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-6-2"/>
        <position name="posOpArapucaDouble2-Frame-0-6" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-468.1018" 
 	 z="998.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-6-3"/>
        <position name="posArapucaDouble3-Frame-0-6" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-377.4018" 
 	 z="852.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3798,14 +3798,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-6-3"/>
        <position name="posOpArapucaDouble3-Frame-0-6" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-377.4018" 
 	 z="852.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-0-0"/>
        <position name="posArapucaDouble0-Frame-1-0" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-297.4006" 
 	 z="-859.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3813,14 +3813,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-0"/>
        <position name="posOpArapucaDouble0-Frame-1-0" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-297.4006" 
 	 z="-859.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-0-1"/>
        <position name="posArapucaDouble1-Frame-1-0" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-206.7006" 
 	 z="-1005.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3828,14 +3828,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-1"/>
        <position name="posOpArapucaDouble1-Frame-1-0" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-206.7006" 
 	 z="-1005.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-0-2"/>
        <position name="posArapucaDouble2-Frame-1-0" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-132.7006" 
 	 z="-788.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3843,14 +3843,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-2"/>
        <position name="posOpArapucaDouble2-Frame-1-0" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-132.7006" 
 	 z="-788.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-0-3"/>
        <position name="posArapucaDouble3-Frame-1-0" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-42.0006" 
 	 z="-934.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3858,14 +3858,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-3"/>
        <position name="posOpArapucaDouble3-Frame-1-0" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-42.0006" 
 	 z="-934.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-1-0"/>
        <position name="posArapucaDouble0-Frame-1-1" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-297.4006" 
 	 z="-561.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3873,14 +3873,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-0"/>
        <position name="posOpArapucaDouble0-Frame-1-1" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-297.4006" 
 	 z="-561.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-1-1"/>
        <position name="posArapucaDouble1-Frame-1-1" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-206.7006" 
 	 z="-707.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3888,14 +3888,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-1"/>
        <position name="posOpArapucaDouble1-Frame-1-1" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-206.7006" 
 	 z="-707.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-1-2"/>
        <position name="posArapucaDouble2-Frame-1-1" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-132.7006" 
 	 z="-490.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3903,14 +3903,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-2"/>
        <position name="posOpArapucaDouble2-Frame-1-1" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-132.7006" 
 	 z="-490.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-1-3"/>
        <position name="posArapucaDouble3-Frame-1-1" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-42.0006" 
 	 z="-636.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3918,14 +3918,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-3"/>
        <position name="posOpArapucaDouble3-Frame-1-1" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-42.0006" 
 	 z="-636.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-2-0"/>
        <position name="posArapucaDouble0-Frame-1-2" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-297.4006" 
 	 z="-263.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3933,14 +3933,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-0"/>
        <position name="posOpArapucaDouble0-Frame-1-2" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-297.4006" 
 	 z="-263.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-2-1"/>
        <position name="posArapucaDouble1-Frame-1-2" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-206.7006" 
 	 z="-409.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3948,14 +3948,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-1"/>
        <position name="posOpArapucaDouble1-Frame-1-2" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-206.7006" 
 	 z="-409.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-2-2"/>
        <position name="posArapucaDouble2-Frame-1-2" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-132.7006" 
 	 z="-192.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3963,14 +3963,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-2"/>
        <position name="posOpArapucaDouble2-Frame-1-2" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-132.7006" 
 	 z="-192.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-2-3"/>
        <position name="posArapucaDouble3-Frame-1-2" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-42.0006" 
 	 z="-338.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3978,14 +3978,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-3"/>
        <position name="posOpArapucaDouble3-Frame-1-2" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-42.0006" 
 	 z="-338.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-3-0"/>
        <position name="posArapucaDouble0-Frame-1-3" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-297.4006" 
 	 z="34.0000000000001"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3993,14 +3993,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-3-0"/>
        <position name="posOpArapucaDouble0-Frame-1-3" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-297.4006" 
 	 z="34.0000000000001"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-3-1"/>
        <position name="posArapucaDouble1-Frame-1-3" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-206.7006" 
 	 z="-112"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4008,14 +4008,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-3-1"/>
        <position name="posOpArapucaDouble1-Frame-1-3" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-206.7006" 
 	 z="-112"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-3-2"/>
        <position name="posArapucaDouble2-Frame-1-3" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-132.7006" 
 	 z="105"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4023,14 +4023,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-3-2"/>
        <position name="posOpArapucaDouble2-Frame-1-3" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-132.7006" 
 	 z="105"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-3-3"/>
        <position name="posArapucaDouble3-Frame-1-3" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-42.0006" 
 	 z="-40.9999999999999"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4038,14 +4038,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-3-3"/>
        <position name="posOpArapucaDouble3-Frame-1-3" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-42.0006" 
 	 z="-40.9999999999999"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-4-0"/>
        <position name="posArapucaDouble0-Frame-1-4" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-297.4006" 
 	 z="331.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4053,14 +4053,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-4-0"/>
        <position name="posOpArapucaDouble0-Frame-1-4" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-297.4006" 
 	 z="331.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-4-1"/>
        <position name="posArapucaDouble1-Frame-1-4" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-206.7006" 
 	 z="185.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4068,14 +4068,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-4-1"/>
        <position name="posOpArapucaDouble1-Frame-1-4" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-206.7006" 
 	 z="185.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-4-2"/>
        <position name="posArapucaDouble2-Frame-1-4" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-132.7006" 
 	 z="402.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4083,14 +4083,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-4-2"/>
        <position name="posOpArapucaDouble2-Frame-1-4" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-132.7006" 
 	 z="402.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-4-3"/>
        <position name="posArapucaDouble3-Frame-1-4" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-42.0006" 
 	 z="256.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4098,14 +4098,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-4-3"/>
        <position name="posOpArapucaDouble3-Frame-1-4" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-42.0006" 
 	 z="256.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-5-0"/>
        <position name="posArapucaDouble0-Frame-1-5" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-297.4006" 
 	 z="629.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4113,14 +4113,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-5-0"/>
        <position name="posOpArapucaDouble0-Frame-1-5" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-297.4006" 
 	 z="629.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-5-1"/>
        <position name="posArapucaDouble1-Frame-1-5" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-206.7006" 
 	 z="483.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4128,14 +4128,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-5-1"/>
        <position name="posOpArapucaDouble1-Frame-1-5" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-206.7006" 
 	 z="483.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-5-2"/>
        <position name="posArapucaDouble2-Frame-1-5" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-132.7006" 
 	 z="700.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4143,14 +4143,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-5-2"/>
        <position name="posOpArapucaDouble2-Frame-1-5" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-132.7006" 
 	 z="700.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-5-3"/>
        <position name="posArapucaDouble3-Frame-1-5" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-42.0006" 
 	 z="554.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4158,14 +4158,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-5-3"/>
        <position name="posOpArapucaDouble3-Frame-1-5" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-42.0006" 
 	 z="554.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-6-0"/>
        <position name="posArapucaDouble0-Frame-1-6" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-297.4006" 
 	 z="927.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4173,14 +4173,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-6-0"/>
        <position name="posOpArapucaDouble0-Frame-1-6" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-297.4006" 
 	 z="927.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-6-1"/>
        <position name="posArapucaDouble1-Frame-1-6" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-206.7006" 
 	 z="781.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4188,14 +4188,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-6-1"/>
        <position name="posOpArapucaDouble1-Frame-1-6" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-206.7006" 
 	 z="781.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-6-2"/>
        <position name="posArapucaDouble2-Frame-1-6" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-132.7006" 
 	 z="998.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4203,14 +4203,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-6-2"/>
        <position name="posOpArapucaDouble2-Frame-1-6" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-132.7006" 
 	 z="998.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-6-3"/>
        <position name="posArapucaDouble3-Frame-1-6" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-42.0006" 
 	 z="852.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4218,14 +4218,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-6-3"/>
        <position name="posOpArapucaDouble3-Frame-1-6" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-42.0006" 
 	 z="852.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-0-0"/>
        <position name="posArapucaDouble0-Frame-2-0" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="38.0006" 
 	 z="-859.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4233,14 +4233,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-0"/>
        <position name="posOpArapucaDouble0-Frame-2-0" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="38.0006" 
 	 z="-859.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-0-1"/>
        <position name="posArapucaDouble1-Frame-2-0" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="128.7006" 
 	 z="-1005.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4248,14 +4248,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-1"/>
        <position name="posOpArapucaDouble1-Frame-2-0" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="128.7006" 
 	 z="-1005.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-0-2"/>
        <position name="posArapucaDouble2-Frame-2-0" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="202.7006" 
 	 z="-788.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4263,14 +4263,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-2"/>
        <position name="posOpArapucaDouble2-Frame-2-0" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="202.7006" 
 	 z="-788.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-0-3"/>
        <position name="posArapucaDouble3-Frame-2-0" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="293.4006" 
 	 z="-934.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4278,14 +4278,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-3"/>
        <position name="posOpArapucaDouble3-Frame-2-0" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="293.4006" 
 	 z="-934.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-1-0"/>
        <position name="posArapucaDouble0-Frame-2-1" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="38.0006" 
 	 z="-561.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4293,14 +4293,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-0"/>
        <position name="posOpArapucaDouble0-Frame-2-1" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="38.0006" 
 	 z="-561.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-1-1"/>
        <position name="posArapucaDouble1-Frame-2-1" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="128.7006" 
 	 z="-707.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4308,14 +4308,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-1"/>
        <position name="posOpArapucaDouble1-Frame-2-1" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="128.7006" 
 	 z="-707.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-1-2"/>
        <position name="posArapucaDouble2-Frame-2-1" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="202.7006" 
 	 z="-490.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4323,14 +4323,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-2"/>
        <position name="posOpArapucaDouble2-Frame-2-1" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="202.7006" 
 	 z="-490.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-1-3"/>
        <position name="posArapucaDouble3-Frame-2-1" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="293.4006" 
 	 z="-636.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4338,14 +4338,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-3"/>
        <position name="posOpArapucaDouble3-Frame-2-1" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="293.4006" 
 	 z="-636.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-2-0"/>
        <position name="posArapucaDouble0-Frame-2-2" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="38.0006" 
 	 z="-263.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4353,14 +4353,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-0"/>
        <position name="posOpArapucaDouble0-Frame-2-2" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="38.0006" 
 	 z="-263.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-2-1"/>
        <position name="posArapucaDouble1-Frame-2-2" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="128.7006" 
 	 z="-409.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4368,14 +4368,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-1"/>
        <position name="posOpArapucaDouble1-Frame-2-2" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="128.7006" 
 	 z="-409.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-2-2"/>
        <position name="posArapucaDouble2-Frame-2-2" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="202.7006" 
 	 z="-192.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4383,14 +4383,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-2"/>
        <position name="posOpArapucaDouble2-Frame-2-2" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="202.7006" 
 	 z="-192.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-2-3"/>
        <position name="posArapucaDouble3-Frame-2-2" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="293.4006" 
 	 z="-338.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4398,14 +4398,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-3"/>
        <position name="posOpArapucaDouble3-Frame-2-2" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="293.4006" 
 	 z="-338.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-3-0"/>
        <position name="posArapucaDouble0-Frame-2-3" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="38.0006" 
 	 z="34.0000000000001"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4413,14 +4413,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-3-0"/>
        <position name="posOpArapucaDouble0-Frame-2-3" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="38.0006" 
 	 z="34.0000000000001"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-3-1"/>
        <position name="posArapucaDouble1-Frame-2-3" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="128.7006" 
 	 z="-112"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4428,14 +4428,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-3-1"/>
        <position name="posOpArapucaDouble1-Frame-2-3" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="128.7006" 
 	 z="-112"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-3-2"/>
        <position name="posArapucaDouble2-Frame-2-3" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="202.7006" 
 	 z="105"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4443,14 +4443,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-3-2"/>
        <position name="posOpArapucaDouble2-Frame-2-3" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="202.7006" 
 	 z="105"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-3-3"/>
        <position name="posArapucaDouble3-Frame-2-3" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="293.4006" 
 	 z="-40.9999999999999"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4458,14 +4458,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-3-3"/>
        <position name="posOpArapucaDouble3-Frame-2-3" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="293.4006" 
 	 z="-40.9999999999999"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-4-0"/>
        <position name="posArapucaDouble0-Frame-2-4" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="38.0006" 
 	 z="331.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4473,14 +4473,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-4-0"/>
        <position name="posOpArapucaDouble0-Frame-2-4" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="38.0006" 
 	 z="331.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-4-1"/>
        <position name="posArapucaDouble1-Frame-2-4" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="128.7006" 
 	 z="185.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4488,14 +4488,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-4-1"/>
        <position name="posOpArapucaDouble1-Frame-2-4" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="128.7006" 
 	 z="185.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-4-2"/>
        <position name="posArapucaDouble2-Frame-2-4" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="202.7006" 
 	 z="402.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4503,14 +4503,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-4-2"/>
        <position name="posOpArapucaDouble2-Frame-2-4" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="202.7006" 
 	 z="402.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-4-3"/>
        <position name="posArapucaDouble3-Frame-2-4" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="293.4006" 
 	 z="256.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4518,14 +4518,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-4-3"/>
        <position name="posOpArapucaDouble3-Frame-2-4" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="293.4006" 
 	 z="256.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-5-0"/>
        <position name="posArapucaDouble0-Frame-2-5" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="38.0006" 
 	 z="629.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4533,14 +4533,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-5-0"/>
        <position name="posOpArapucaDouble0-Frame-2-5" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="38.0006" 
 	 z="629.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-5-1"/>
        <position name="posArapucaDouble1-Frame-2-5" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="128.7006" 
 	 z="483.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4548,14 +4548,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-5-1"/>
        <position name="posOpArapucaDouble1-Frame-2-5" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="128.7006" 
 	 z="483.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-5-2"/>
        <position name="posArapucaDouble2-Frame-2-5" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="202.7006" 
 	 z="700.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4563,14 +4563,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-5-2"/>
        <position name="posOpArapucaDouble2-Frame-2-5" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="202.7006" 
 	 z="700.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-5-3"/>
        <position name="posArapucaDouble3-Frame-2-5" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="293.4006" 
 	 z="554.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4578,14 +4578,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-5-3"/>
        <position name="posOpArapucaDouble3-Frame-2-5" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="293.4006" 
 	 z="554.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-6-0"/>
        <position name="posArapucaDouble0-Frame-2-6" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="38.0006" 
 	 z="927.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4593,14 +4593,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-6-0"/>
        <position name="posOpArapucaDouble0-Frame-2-6" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="38.0006" 
 	 z="927.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-6-1"/>
        <position name="posArapucaDouble1-Frame-2-6" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="128.7006" 
 	 z="781.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4608,14 +4608,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-6-1"/>
        <position name="posOpArapucaDouble1-Frame-2-6" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="128.7006" 
 	 z="781.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-6-2"/>
        <position name="posArapucaDouble2-Frame-2-6" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="202.7006" 
 	 z="998.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4623,14 +4623,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-6-2"/>
        <position name="posOpArapucaDouble2-Frame-2-6" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="202.7006" 
 	 z="998.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-6-3"/>
        <position name="posArapucaDouble3-Frame-2-6" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="293.4006" 
 	 z="852.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4638,14 +4638,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-6-3"/>
        <position name="posOpArapucaDouble3-Frame-2-6" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="293.4006" 
 	 z="852.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-0-0"/>
        <position name="posArapucaDouble0-Frame-3-0" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="373.4018" 
 	 z="-859.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4653,14 +4653,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-0"/>
        <position name="posOpArapucaDouble0-Frame-3-0" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="373.4018" 
 	 z="-859.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-0-1"/>
        <position name="posArapucaDouble1-Frame-3-0" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="464.1018" 
 	 z="-1005.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4668,14 +4668,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-1"/>
        <position name="posOpArapucaDouble1-Frame-3-0" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="464.1018" 
 	 z="-1005.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-0-2"/>
        <position name="posArapucaDouble2-Frame-3-0" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="538.1018" 
 	 z="-788.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4683,14 +4683,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-2"/>
        <position name="posOpArapucaDouble2-Frame-3-0" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="538.1018" 
 	 z="-788.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-0-3"/>
        <position name="posArapucaDouble3-Frame-3-0" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="628.8018" 
 	 z="-934.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4698,14 +4698,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-3"/>
        <position name="posOpArapucaDouble3-Frame-3-0" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="628.8018" 
 	 z="-934.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-1-0"/>
        <position name="posArapucaDouble0-Frame-3-1" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="373.4018" 
 	 z="-561.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4713,14 +4713,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-0"/>
        <position name="posOpArapucaDouble0-Frame-3-1" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="373.4018" 
 	 z="-561.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-1-1"/>
        <position name="posArapucaDouble1-Frame-3-1" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="464.1018" 
 	 z="-707.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4728,14 +4728,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-1"/>
        <position name="posOpArapucaDouble1-Frame-3-1" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="464.1018" 
 	 z="-707.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-1-2"/>
        <position name="posArapucaDouble2-Frame-3-1" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="538.1018" 
 	 z="-490.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4743,14 +4743,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-2"/>
        <position name="posOpArapucaDouble2-Frame-3-1" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="538.1018" 
 	 z="-490.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-1-3"/>
        <position name="posArapucaDouble3-Frame-3-1" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="628.8018" 
 	 z="-636.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4758,14 +4758,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-3"/>
        <position name="posOpArapucaDouble3-Frame-3-1" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="628.8018" 
 	 z="-636.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-2-0"/>
        <position name="posArapucaDouble0-Frame-3-2" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="373.4018" 
 	 z="-263.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4773,14 +4773,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-0"/>
        <position name="posOpArapucaDouble0-Frame-3-2" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="373.4018" 
 	 z="-263.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-2-1"/>
        <position name="posArapucaDouble1-Frame-3-2" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="464.1018" 
 	 z="-409.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4788,14 +4788,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-1"/>
        <position name="posOpArapucaDouble1-Frame-3-2" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="464.1018" 
 	 z="-409.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-2-2"/>
        <position name="posArapucaDouble2-Frame-3-2" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="538.1018" 
 	 z="-192.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4803,14 +4803,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-2"/>
        <position name="posOpArapucaDouble2-Frame-3-2" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="538.1018" 
 	 z="-192.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-2-3"/>
        <position name="posArapucaDouble3-Frame-3-2" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="628.8018" 
 	 z="-338.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4818,14 +4818,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-3"/>
        <position name="posOpArapucaDouble3-Frame-3-2" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="628.8018" 
 	 z="-338.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-3-0"/>
        <position name="posArapucaDouble0-Frame-3-3" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="373.4018" 
 	 z="34.0000000000001"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4833,14 +4833,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-3-0"/>
        <position name="posOpArapucaDouble0-Frame-3-3" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="373.4018" 
 	 z="34.0000000000001"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-3-1"/>
        <position name="posArapucaDouble1-Frame-3-3" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="464.1018" 
 	 z="-112"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4848,14 +4848,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-3-1"/>
        <position name="posOpArapucaDouble1-Frame-3-3" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="464.1018" 
 	 z="-112"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-3-2"/>
        <position name="posArapucaDouble2-Frame-3-3" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="538.1018" 
 	 z="105"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4863,14 +4863,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-3-2"/>
        <position name="posOpArapucaDouble2-Frame-3-3" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="538.1018" 
 	 z="105"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-3-3"/>
        <position name="posArapucaDouble3-Frame-3-3" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="628.8018" 
 	 z="-40.9999999999999"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4878,14 +4878,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-3-3"/>
        <position name="posOpArapucaDouble3-Frame-3-3" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="628.8018" 
 	 z="-40.9999999999999"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-4-0"/>
        <position name="posArapucaDouble0-Frame-3-4" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="373.4018" 
 	 z="331.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4893,14 +4893,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-4-0"/>
        <position name="posOpArapucaDouble0-Frame-3-4" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="373.4018" 
 	 z="331.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-4-1"/>
        <position name="posArapucaDouble1-Frame-3-4" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="464.1018" 
 	 z="185.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4908,14 +4908,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-4-1"/>
        <position name="posOpArapucaDouble1-Frame-3-4" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="464.1018" 
 	 z="185.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-4-2"/>
        <position name="posArapucaDouble2-Frame-3-4" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="538.1018" 
 	 z="402.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4923,14 +4923,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-4-2"/>
        <position name="posOpArapucaDouble2-Frame-3-4" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="538.1018" 
 	 z="402.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-4-3"/>
        <position name="posArapucaDouble3-Frame-3-4" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="628.8018" 
 	 z="256.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4938,14 +4938,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-4-3"/>
        <position name="posOpArapucaDouble3-Frame-3-4" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="628.8018" 
 	 z="256.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-5-0"/>
        <position name="posArapucaDouble0-Frame-3-5" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="373.4018" 
 	 z="629.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4953,14 +4953,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-5-0"/>
        <position name="posOpArapucaDouble0-Frame-3-5" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="373.4018" 
 	 z="629.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-5-1"/>
        <position name="posArapucaDouble1-Frame-3-5" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="464.1018" 
 	 z="483.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4968,14 +4968,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-5-1"/>
        <position name="posOpArapucaDouble1-Frame-3-5" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="464.1018" 
 	 z="483.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-5-2"/>
        <position name="posArapucaDouble2-Frame-3-5" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="538.1018" 
 	 z="700.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4983,14 +4983,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-5-2"/>
        <position name="posOpArapucaDouble2-Frame-3-5" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="538.1018" 
 	 z="700.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-5-3"/>
        <position name="posArapucaDouble3-Frame-3-5" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="628.8018" 
 	 z="554.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4998,14 +4998,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-5-3"/>
        <position name="posOpArapucaDouble3-Frame-3-5" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="628.8018" 
 	 z="554.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-6-0"/>
        <position name="posArapucaDouble0-Frame-3-6" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="373.4018" 
 	 z="927.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -5013,14 +5013,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-6-0"/>
        <position name="posOpArapucaDouble0-Frame-3-6" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="373.4018" 
 	 z="927.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-6-1"/>
        <position name="posArapucaDouble1-Frame-3-6" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="464.1018" 
 	 z="781.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -5028,14 +5028,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-6-1"/>
        <position name="posOpArapucaDouble1-Frame-3-6" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="464.1018" 
 	 z="781.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-6-2"/>
        <position name="posArapucaDouble2-Frame-3-6" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="538.1018" 
 	 z="998.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -5043,14 +5043,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-6-2"/>
        <position name="posOpArapucaDouble2-Frame-3-6" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="538.1018" 
 	 z="998.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-6-3"/>
        <position name="posArapucaDouble3-Frame-3-6" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="628.8018" 
 	 z="852.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -5058,14 +5058,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-6-3"/>
        <position name="posOpArapucaDouble3-Frame-3-6" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="628.8018" 
 	 z="852.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-0"/>
        <position name="posArapuca0-Lat-0" unit="cm" 
-         x="285.01"
+         x="285.02"
 	 y="-732.8024" 
 	 z="-893.52"/>
        <rotationref ref="rIdentity"/>
@@ -5073,14 +5073,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-0"/>
        <position name="posOpArapuca0-Lat-0" unit="cm" 
-         x="285.01"
+         x="285.02"
 	 y="-732.0624" 
 	 z="-893.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-1"/>
        <position name="posArapuca1-Lat-0" unit="cm" 
-         x="210.01"
+         x="210.02"
 	 y="-732.8024" 
 	 z="-893.52"/>
        <rotationref ref="rIdentity"/>
@@ -5088,14 +5088,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-1"/>
        <position name="posOpArapuca1-Lat-0" unit="cm" 
-         x="210.01"
+         x="210.02"
 	 y="-732.0624" 
 	 z="-893.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-2"/>
        <position name="posArapuca2-Lat-0" unit="cm" 
-         x="135.01"
+         x="135.02"
 	 y="-732.8024" 
 	 z="-893.52"/>
        <rotationref ref="rIdentity"/>
@@ -5103,14 +5103,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-2"/>
        <position name="posOpArapuca2-Lat-0" unit="cm" 
-         x="135.01"
+         x="135.02"
 	 y="-732.0624" 
 	 z="-893.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-3"/>
        <position name="posArapuca3-Lat-0" unit="cm" 
-         x="60.01"
+         x="60.02"
 	 y="-732.8024" 
 	 z="-893.52"/>
        <rotationref ref="rIdentity"/>
@@ -5118,14 +5118,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-3"/>
        <position name="posOpArapuca3-Lat-0" unit="cm" 
-         x="60.01"
+         x="60.02"
 	 y="-732.0624" 
 	 z="-893.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-4"/>
        <position name="posArapuca4-Lat-0" unit="cm" 
-         x="285.01"
+         x="285.02"
 	 y="732.8024" 
 	 z="-893.52"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5133,14 +5133,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-4"/>
        <position name="posOpArapuca4-Lat-0" unit="cm" 
-         x="285.01"
+         x="285.02"
 	 y="732.0624" 
 	 z="-893.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-5"/>
        <position name="posArapuca5-Lat-0" unit="cm" 
-         x="210.01"
+         x="210.02"
 	 y="732.8024" 
 	 z="-893.52"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5148,14 +5148,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-5"/>
        <position name="posOpArapuca5-Lat-0" unit="cm" 
-         x="210.01"
+         x="210.02"
 	 y="732.0624" 
 	 z="-893.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-6"/>
        <position name="posArapuca6-Lat-0" unit="cm" 
-         x="135.01"
+         x="135.02"
 	 y="732.8024" 
 	 z="-893.52"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5163,14 +5163,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-6"/>
        <position name="posOpArapuca6-Lat-0" unit="cm" 
-         x="135.01"
+         x="135.02"
 	 y="732.0624" 
 	 z="-893.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-7"/>
        <position name="posArapuca7-Lat-0" unit="cm" 
-         x="60.01"
+         x="60.02"
 	 y="732.8024" 
 	 z="-893.52"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5178,14 +5178,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-7"/>
        <position name="posOpArapuca7-Lat-0" unit="cm" 
-         x="60.01"
+         x="60.02"
 	 y="732.0624" 
 	 z="-893.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-0"/>
        <position name="posArapuca0-Lat-1" unit="cm" 
-         x="285.01"
+         x="285.02"
 	 y="-732.8024" 
 	 z="-595.68"/>
        <rotationref ref="rIdentity"/>
@@ -5193,14 +5193,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-0"/>
        <position name="posOpArapuca0-Lat-1" unit="cm" 
-         x="285.01"
+         x="285.02"
 	 y="-732.0624" 
 	 z="-595.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-1"/>
        <position name="posArapuca1-Lat-1" unit="cm" 
-         x="210.01"
+         x="210.02"
 	 y="-732.8024" 
 	 z="-595.68"/>
        <rotationref ref="rIdentity"/>
@@ -5208,14 +5208,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-1"/>
        <position name="posOpArapuca1-Lat-1" unit="cm" 
-         x="210.01"
+         x="210.02"
 	 y="-732.0624" 
 	 z="-595.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-2"/>
        <position name="posArapuca2-Lat-1" unit="cm" 
-         x="135.01"
+         x="135.02"
 	 y="-732.8024" 
 	 z="-595.68"/>
        <rotationref ref="rIdentity"/>
@@ -5223,14 +5223,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-2"/>
        <position name="posOpArapuca2-Lat-1" unit="cm" 
-         x="135.01"
+         x="135.02"
 	 y="-732.0624" 
 	 z="-595.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-3"/>
        <position name="posArapuca3-Lat-1" unit="cm" 
-         x="60.01"
+         x="60.02"
 	 y="-732.8024" 
 	 z="-595.68"/>
        <rotationref ref="rIdentity"/>
@@ -5238,14 +5238,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-3"/>
        <position name="posOpArapuca3-Lat-1" unit="cm" 
-         x="60.01"
+         x="60.02"
 	 y="-732.0624" 
 	 z="-595.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-4"/>
        <position name="posArapuca4-Lat-1" unit="cm" 
-         x="285.01"
+         x="285.02"
 	 y="732.8024" 
 	 z="-595.68"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5253,14 +5253,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-4"/>
        <position name="posOpArapuca4-Lat-1" unit="cm" 
-         x="285.01"
+         x="285.02"
 	 y="732.0624" 
 	 z="-595.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-5"/>
        <position name="posArapuca5-Lat-1" unit="cm" 
-         x="210.01"
+         x="210.02"
 	 y="732.8024" 
 	 z="-595.68"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5268,14 +5268,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-5"/>
        <position name="posOpArapuca5-Lat-1" unit="cm" 
-         x="210.01"
+         x="210.02"
 	 y="732.0624" 
 	 z="-595.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-6"/>
        <position name="posArapuca6-Lat-1" unit="cm" 
-         x="135.01"
+         x="135.02"
 	 y="732.8024" 
 	 z="-595.68"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5283,14 +5283,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-6"/>
        <position name="posOpArapuca6-Lat-1" unit="cm" 
-         x="135.01"
+         x="135.02"
 	 y="732.0624" 
 	 z="-595.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-7"/>
        <position name="posArapuca7-Lat-1" unit="cm" 
-         x="60.01"
+         x="60.02"
 	 y="732.8024" 
 	 z="-595.68"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5298,14 +5298,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-7"/>
        <position name="posOpArapuca7-Lat-1" unit="cm" 
-         x="60.01"
+         x="60.02"
 	 y="732.0624" 
 	 z="-595.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-0"/>
        <position name="posArapuca0-Lat-2" unit="cm" 
-         x="285.01"
+         x="285.02"
 	 y="-732.8024" 
 	 z="-297.84"/>
        <rotationref ref="rIdentity"/>
@@ -5313,14 +5313,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-0"/>
        <position name="posOpArapuca0-Lat-2" unit="cm" 
-         x="285.01"
+         x="285.02"
 	 y="-732.0624" 
 	 z="-297.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-1"/>
        <position name="posArapuca1-Lat-2" unit="cm" 
-         x="210.01"
+         x="210.02"
 	 y="-732.8024" 
 	 z="-297.84"/>
        <rotationref ref="rIdentity"/>
@@ -5328,14 +5328,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-1"/>
        <position name="posOpArapuca1-Lat-2" unit="cm" 
-         x="210.01"
+         x="210.02"
 	 y="-732.0624" 
 	 z="-297.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-2"/>
        <position name="posArapuca2-Lat-2" unit="cm" 
-         x="135.01"
+         x="135.02"
 	 y="-732.8024" 
 	 z="-297.84"/>
        <rotationref ref="rIdentity"/>
@@ -5343,14 +5343,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-2"/>
        <position name="posOpArapuca2-Lat-2" unit="cm" 
-         x="135.01"
+         x="135.02"
 	 y="-732.0624" 
 	 z="-297.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-3"/>
        <position name="posArapuca3-Lat-2" unit="cm" 
-         x="60.01"
+         x="60.02"
 	 y="-732.8024" 
 	 z="-297.84"/>
        <rotationref ref="rIdentity"/>
@@ -5358,14 +5358,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-3"/>
        <position name="posOpArapuca3-Lat-2" unit="cm" 
-         x="60.01"
+         x="60.02"
 	 y="-732.0624" 
 	 z="-297.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-4"/>
        <position name="posArapuca4-Lat-2" unit="cm" 
-         x="285.01"
+         x="285.02"
 	 y="732.8024" 
 	 z="-297.84"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5373,14 +5373,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-4"/>
        <position name="posOpArapuca4-Lat-2" unit="cm" 
-         x="285.01"
+         x="285.02"
 	 y="732.0624" 
 	 z="-297.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-5"/>
        <position name="posArapuca5-Lat-2" unit="cm" 
-         x="210.01"
+         x="210.02"
 	 y="732.8024" 
 	 z="-297.84"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5388,14 +5388,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-5"/>
        <position name="posOpArapuca5-Lat-2" unit="cm" 
-         x="210.01"
+         x="210.02"
 	 y="732.0624" 
 	 z="-297.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-6"/>
        <position name="posArapuca6-Lat-2" unit="cm" 
-         x="135.01"
+         x="135.02"
 	 y="732.8024" 
 	 z="-297.84"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5403,14 +5403,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-6"/>
        <position name="posOpArapuca6-Lat-2" unit="cm" 
-         x="135.01"
+         x="135.02"
 	 y="732.0624" 
 	 z="-297.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-7"/>
        <position name="posArapuca7-Lat-2" unit="cm" 
-         x="60.01"
+         x="60.02"
 	 y="732.8024" 
 	 z="-297.84"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5418,14 +5418,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-7"/>
        <position name="posOpArapuca7-Lat-2" unit="cm" 
-         x="60.01"
+         x="60.02"
 	 y="732.0624" 
 	 z="-297.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_3-0"/>
        <position name="posArapuca0-Lat-3" unit="cm" 
-         x="285.01"
+         x="285.02"
 	 y="-732.8024" 
 	 z="-1.13686837721616e-13"/>
        <rotationref ref="rIdentity"/>
@@ -5433,14 +5433,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_3-0"/>
        <position name="posOpArapuca0-Lat-3" unit="cm" 
-         x="285.01"
+         x="285.02"
 	 y="-732.0624" 
 	 z="-1.13686837721616e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_3-1"/>
        <position name="posArapuca1-Lat-3" unit="cm" 
-         x="210.01"
+         x="210.02"
 	 y="-732.8024" 
 	 z="-1.13686837721616e-13"/>
        <rotationref ref="rIdentity"/>
@@ -5448,14 +5448,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_3-1"/>
        <position name="posOpArapuca1-Lat-3" unit="cm" 
-         x="210.01"
+         x="210.02"
 	 y="-732.0624" 
 	 z="-1.13686837721616e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_3-2"/>
        <position name="posArapuca2-Lat-3" unit="cm" 
-         x="135.01"
+         x="135.02"
 	 y="-732.8024" 
 	 z="-1.13686837721616e-13"/>
        <rotationref ref="rIdentity"/>
@@ -5463,14 +5463,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_3-2"/>
        <position name="posOpArapuca2-Lat-3" unit="cm" 
-         x="135.01"
+         x="135.02"
 	 y="-732.0624" 
 	 z="-1.13686837721616e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_3-3"/>
        <position name="posArapuca3-Lat-3" unit="cm" 
-         x="60.01"
+         x="60.02"
 	 y="-732.8024" 
 	 z="-1.13686837721616e-13"/>
        <rotationref ref="rIdentity"/>
@@ -5478,14 +5478,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_3-3"/>
        <position name="posOpArapuca3-Lat-3" unit="cm" 
-         x="60.01"
+         x="60.02"
 	 y="-732.0624" 
 	 z="-1.13686837721616e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_3-4"/>
        <position name="posArapuca4-Lat-3" unit="cm" 
-         x="285.01"
+         x="285.02"
 	 y="732.8024" 
 	 z="-1.13686837721616e-13"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5493,14 +5493,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_3-4"/>
        <position name="posOpArapuca4-Lat-3" unit="cm" 
-         x="285.01"
+         x="285.02"
 	 y="732.0624" 
 	 z="-1.13686837721616e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_3-5"/>
        <position name="posArapuca5-Lat-3" unit="cm" 
-         x="210.01"
+         x="210.02"
 	 y="732.8024" 
 	 z="-1.13686837721616e-13"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5508,14 +5508,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_3-5"/>
        <position name="posOpArapuca5-Lat-3" unit="cm" 
-         x="210.01"
+         x="210.02"
 	 y="732.0624" 
 	 z="-1.13686837721616e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_3-6"/>
        <position name="posArapuca6-Lat-3" unit="cm" 
-         x="135.01"
+         x="135.02"
 	 y="732.8024" 
 	 z="-1.13686837721616e-13"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5523,14 +5523,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_3-6"/>
        <position name="posOpArapuca6-Lat-3" unit="cm" 
-         x="135.01"
+         x="135.02"
 	 y="732.0624" 
 	 z="-1.13686837721616e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_3-7"/>
        <position name="posArapuca7-Lat-3" unit="cm" 
-         x="60.01"
+         x="60.02"
 	 y="732.8024" 
 	 z="-1.13686837721616e-13"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5538,14 +5538,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_3-7"/>
        <position name="posOpArapuca7-Lat-3" unit="cm" 
-         x="60.01"
+         x="60.02"
 	 y="732.0624" 
 	 z="-1.13686837721616e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_4-0"/>
        <position name="posArapuca0-Lat-4" unit="cm" 
-         x="285.01"
+         x="285.02"
 	 y="-732.8024" 
 	 z="297.84"/>
        <rotationref ref="rIdentity"/>
@@ -5553,14 +5553,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_4-0"/>
        <position name="posOpArapuca0-Lat-4" unit="cm" 
-         x="285.01"
+         x="285.02"
 	 y="-732.0624" 
 	 z="297.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_4-1"/>
        <position name="posArapuca1-Lat-4" unit="cm" 
-         x="210.01"
+         x="210.02"
 	 y="-732.8024" 
 	 z="297.84"/>
        <rotationref ref="rIdentity"/>
@@ -5568,14 +5568,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_4-1"/>
        <position name="posOpArapuca1-Lat-4" unit="cm" 
-         x="210.01"
+         x="210.02"
 	 y="-732.0624" 
 	 z="297.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_4-2"/>
        <position name="posArapuca2-Lat-4" unit="cm" 
-         x="135.01"
+         x="135.02"
 	 y="-732.8024" 
 	 z="297.84"/>
        <rotationref ref="rIdentity"/>
@@ -5583,14 +5583,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_4-2"/>
        <position name="posOpArapuca2-Lat-4" unit="cm" 
-         x="135.01"
+         x="135.02"
 	 y="-732.0624" 
 	 z="297.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_4-3"/>
        <position name="posArapuca3-Lat-4" unit="cm" 
-         x="60.01"
+         x="60.02"
 	 y="-732.8024" 
 	 z="297.84"/>
        <rotationref ref="rIdentity"/>
@@ -5598,14 +5598,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_4-3"/>
        <position name="posOpArapuca3-Lat-4" unit="cm" 
-         x="60.01"
+         x="60.02"
 	 y="-732.0624" 
 	 z="297.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_4-4"/>
        <position name="posArapuca4-Lat-4" unit="cm" 
-         x="285.01"
+         x="285.02"
 	 y="732.8024" 
 	 z="297.84"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5613,14 +5613,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_4-4"/>
        <position name="posOpArapuca4-Lat-4" unit="cm" 
-         x="285.01"
+         x="285.02"
 	 y="732.0624" 
 	 z="297.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_4-5"/>
        <position name="posArapuca5-Lat-4" unit="cm" 
-         x="210.01"
+         x="210.02"
 	 y="732.8024" 
 	 z="297.84"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5628,14 +5628,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_4-5"/>
        <position name="posOpArapuca5-Lat-4" unit="cm" 
-         x="210.01"
+         x="210.02"
 	 y="732.0624" 
 	 z="297.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_4-6"/>
        <position name="posArapuca6-Lat-4" unit="cm" 
-         x="135.01"
+         x="135.02"
 	 y="732.8024" 
 	 z="297.84"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5643,14 +5643,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_4-6"/>
        <position name="posOpArapuca6-Lat-4" unit="cm" 
-         x="135.01"
+         x="135.02"
 	 y="732.0624" 
 	 z="297.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_4-7"/>
        <position name="posArapuca7-Lat-4" unit="cm" 
-         x="60.01"
+         x="60.02"
 	 y="732.8024" 
 	 z="297.84"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5658,14 +5658,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_4-7"/>
        <position name="posOpArapuca7-Lat-4" unit="cm" 
-         x="60.01"
+         x="60.02"
 	 y="732.0624" 
 	 z="297.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_5-0"/>
        <position name="posArapuca0-Lat-5" unit="cm" 
-         x="285.01"
+         x="285.02"
 	 y="-732.8024" 
 	 z="595.68"/>
        <rotationref ref="rIdentity"/>
@@ -5673,14 +5673,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_5-0"/>
        <position name="posOpArapuca0-Lat-5" unit="cm" 
-         x="285.01"
+         x="285.02"
 	 y="-732.0624" 
 	 z="595.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_5-1"/>
        <position name="posArapuca1-Lat-5" unit="cm" 
-         x="210.01"
+         x="210.02"
 	 y="-732.8024" 
 	 z="595.68"/>
        <rotationref ref="rIdentity"/>
@@ -5688,14 +5688,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_5-1"/>
        <position name="posOpArapuca1-Lat-5" unit="cm" 
-         x="210.01"
+         x="210.02"
 	 y="-732.0624" 
 	 z="595.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_5-2"/>
        <position name="posArapuca2-Lat-5" unit="cm" 
-         x="135.01"
+         x="135.02"
 	 y="-732.8024" 
 	 z="595.68"/>
        <rotationref ref="rIdentity"/>
@@ -5703,14 +5703,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_5-2"/>
        <position name="posOpArapuca2-Lat-5" unit="cm" 
-         x="135.01"
+         x="135.02"
 	 y="-732.0624" 
 	 z="595.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_5-3"/>
        <position name="posArapuca3-Lat-5" unit="cm" 
-         x="60.01"
+         x="60.02"
 	 y="-732.8024" 
 	 z="595.68"/>
        <rotationref ref="rIdentity"/>
@@ -5718,14 +5718,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_5-3"/>
        <position name="posOpArapuca3-Lat-5" unit="cm" 
-         x="60.01"
+         x="60.02"
 	 y="-732.0624" 
 	 z="595.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_5-4"/>
        <position name="posArapuca4-Lat-5" unit="cm" 
-         x="285.01"
+         x="285.02"
 	 y="732.8024" 
 	 z="595.68"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5733,14 +5733,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_5-4"/>
        <position name="posOpArapuca4-Lat-5" unit="cm" 
-         x="285.01"
+         x="285.02"
 	 y="732.0624" 
 	 z="595.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_5-5"/>
        <position name="posArapuca5-Lat-5" unit="cm" 
-         x="210.01"
+         x="210.02"
 	 y="732.8024" 
 	 z="595.68"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5748,14 +5748,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_5-5"/>
        <position name="posOpArapuca5-Lat-5" unit="cm" 
-         x="210.01"
+         x="210.02"
 	 y="732.0624" 
 	 z="595.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_5-6"/>
        <position name="posArapuca6-Lat-5" unit="cm" 
-         x="135.01"
+         x="135.02"
 	 y="732.8024" 
 	 z="595.68"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5763,14 +5763,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_5-6"/>
        <position name="posOpArapuca6-Lat-5" unit="cm" 
-         x="135.01"
+         x="135.02"
 	 y="732.0624" 
 	 z="595.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_5-7"/>
        <position name="posArapuca7-Lat-5" unit="cm" 
-         x="60.01"
+         x="60.02"
 	 y="732.8024" 
 	 z="595.68"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5778,14 +5778,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_5-7"/>
        <position name="posOpArapuca7-Lat-5" unit="cm" 
-         x="60.01"
+         x="60.02"
 	 y="732.0624" 
 	 z="595.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_6-0"/>
        <position name="posArapuca0-Lat-6" unit="cm" 
-         x="285.01"
+         x="285.02"
 	 y="-732.8024" 
 	 z="893.52"/>
        <rotationref ref="rIdentity"/>
@@ -5793,14 +5793,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_6-0"/>
        <position name="posOpArapuca0-Lat-6" unit="cm" 
-         x="285.01"
+         x="285.02"
 	 y="-732.0624" 
 	 z="893.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_6-1"/>
        <position name="posArapuca1-Lat-6" unit="cm" 
-         x="210.01"
+         x="210.02"
 	 y="-732.8024" 
 	 z="893.52"/>
        <rotationref ref="rIdentity"/>
@@ -5808,14 +5808,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_6-1"/>
        <position name="posOpArapuca1-Lat-6" unit="cm" 
-         x="210.01"
+         x="210.02"
 	 y="-732.0624" 
 	 z="893.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_6-2"/>
        <position name="posArapuca2-Lat-6" unit="cm" 
-         x="135.01"
+         x="135.02"
 	 y="-732.8024" 
 	 z="893.52"/>
        <rotationref ref="rIdentity"/>
@@ -5823,14 +5823,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_6-2"/>
        <position name="posOpArapuca2-Lat-6" unit="cm" 
-         x="135.01"
+         x="135.02"
 	 y="-732.0624" 
 	 z="893.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_6-3"/>
        <position name="posArapuca3-Lat-6" unit="cm" 
-         x="60.01"
+         x="60.02"
 	 y="-732.8024" 
 	 z="893.52"/>
        <rotationref ref="rIdentity"/>
@@ -5838,14 +5838,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_6-3"/>
        <position name="posOpArapuca3-Lat-6" unit="cm" 
-         x="60.01"
+         x="60.02"
 	 y="-732.0624" 
 	 z="893.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_6-4"/>
        <position name="posArapuca4-Lat-6" unit="cm" 
-         x="285.01"
+         x="285.02"
 	 y="732.8024" 
 	 z="893.52"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5853,14 +5853,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_6-4"/>
        <position name="posOpArapuca4-Lat-6" unit="cm" 
-         x="285.01"
+         x="285.02"
 	 y="732.0624" 
 	 z="893.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_6-5"/>
        <position name="posArapuca5-Lat-6" unit="cm" 
-         x="210.01"
+         x="210.02"
 	 y="732.8024" 
 	 z="893.52"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5868,14 +5868,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_6-5"/>
        <position name="posOpArapuca5-Lat-6" unit="cm" 
-         x="210.01"
+         x="210.02"
 	 y="732.0624" 
 	 z="893.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_6-6"/>
        <position name="posArapuca6-Lat-6" unit="cm" 
-         x="135.01"
+         x="135.02"
 	 y="732.8024" 
 	 z="893.52"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5883,14 +5883,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_6-6"/>
        <position name="posOpArapuca6-Lat-6" unit="cm" 
-         x="135.01"
+         x="135.02"
 	 y="732.0624" 
 	 z="893.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_6-7"/>
        <position name="posArapuca7-Lat-6" unit="cm" 
-         x="60.01"
+         x="60.02"
 	 y="732.8024" 
 	 z="893.52"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5898,7 +5898,7 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_6-7"/>
        <position name="posOpArapuca7-Lat-6" unit="cm" 
-         x="60.01"
+         x="60.02"
 	 y="732.0624" 
 	 z="893.52"/>
      </physvol>
@@ -5938,7 +5938,7 @@
 
       <physvol>
         <volumeref ref="volDetEnclosure"/>
-	<position name="posDetEnclosure" unit="cm" x="50.04" y="-1.13686837721616e-13" z="1045.94"/>
+	<position name="posDetEnclosure" unit="cm" x="50.0500000000001" y="-1.13686837721616e-13" z="1045.94"/>
       </physvol>
 
     </volume>

--- a/dunecore/Geometry/gdml/dunevd10kt_3view_30deg_v3_refactored_1x8x14ref_nowires.gdml
+++ b/dunecore/Geometry/gdml/dunevd10kt_3view_30deg_v3_refactored_1x8x14ref_nowires.gdml
@@ -509,6 +509,11 @@
       y="167.7006"
       z="148.92"
       lunit="cm"/>
+   <box name="AnodePlate" 
+      x="0.02/2."
+      y="167.7006"
+      z="148.92"
+      lunit="cm"/>
    <box name="CRMActive" 
       x="650"
       y="167.7006"
@@ -753,7 +758,7 @@
      
    <volume name="volAnodePlate">
      <materialref ref="vm2000"/>
-     <solidref ref="CRMZPlane"/>
+     <solidref ref="AnodePlate"/>
   </volume>
    <volume name="volTPC">
      <materialref ref="LAr"/>
@@ -761,25 +766,25 @@
        <physvol>
        <volumeref ref="volTPCPlaneU"/>
        <position name="posPlaneU" unit="cm" 
-         x="324.98" y="0" z="0"/>
+         x="324.99" y="0" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volTPCPlaneV"/>
        <position name="posPlaneY" unit="cm" 
-         x="325" y="0" z="0"/>
+         x="325.01" y="0" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volTPCPlaneZ"/>
        <position name="posPlaneZ" unit="cm" 
-         x="325.02" y="0" z="0"/>
+         x="325.03" y="0" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volAnodePlate"/>
        <position name="posAnodePlate" unit="cm" 
-         x="325.04" y="0" z="0"/>
+         x="325.045" y="0" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
@@ -3272,120 +3277,120 @@
   </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-0" unit="cm" x="-328.05" y="-505.1018" z="-897.02"/>
+   <position name="posGroundGrid-0" unit="cm" x="-328.04" y="-505.1018" z="-897.02"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-1" unit="cm" x="-328.05" y="-169.7006" z="-897.02"/>
+   <position name="posGroundGrid-1" unit="cm" x="-328.04" y="-169.7006" z="-897.02"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-2" unit="cm" x="-328.05" y="165.7006" z="-897.02"/>
+   <position name="posGroundGrid-2" unit="cm" x="-328.04" y="165.7006" z="-897.02"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-3" unit="cm" x="-328.05" y="501.1018" z="-897.02"/>
+   <position name="posGroundGrid-3" unit="cm" x="-328.04" y="501.1018" z="-897.02"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-4" unit="cm" x="-328.05" y="-505.1018" z="-599.18"/>
+   <position name="posGroundGrid-4" unit="cm" x="-328.04" y="-505.1018" z="-599.18"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-5" unit="cm" x="-328.05" y="-169.7006" z="-599.18"/>
+   <position name="posGroundGrid-5" unit="cm" x="-328.04" y="-169.7006" z="-599.18"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-6" unit="cm" x="-328.05" y="165.7006" z="-599.18"/>
+   <position name="posGroundGrid-6" unit="cm" x="-328.04" y="165.7006" z="-599.18"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-7" unit="cm" x="-328.05" y="501.1018" z="-599.18"/>
+   <position name="posGroundGrid-7" unit="cm" x="-328.04" y="501.1018" z="-599.18"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-8" unit="cm" x="-328.05" y="-505.1018" z="-301.34"/>
+   <position name="posGroundGrid-8" unit="cm" x="-328.04" y="-505.1018" z="-301.34"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-9" unit="cm" x="-328.05" y="-169.7006" z="-301.34"/>
+   <position name="posGroundGrid-9" unit="cm" x="-328.04" y="-169.7006" z="-301.34"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-10" unit="cm" x="-328.05" y="165.7006" z="-301.34"/>
+   <position name="posGroundGrid-10" unit="cm" x="-328.04" y="165.7006" z="-301.34"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-11" unit="cm" x="-328.05" y="501.1018" z="-301.34"/>
+   <position name="posGroundGrid-11" unit="cm" x="-328.04" y="501.1018" z="-301.34"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-12" unit="cm" x="-328.05" y="-505.1018" z="-3.49999999999989"/>
+   <position name="posGroundGrid-12" unit="cm" x="-328.04" y="-505.1018" z="-3.49999999999989"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-13" unit="cm" x="-328.05" y="-169.7006" z="-3.49999999999989"/>
+   <position name="posGroundGrid-13" unit="cm" x="-328.04" y="-169.7006" z="-3.49999999999989"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-14" unit="cm" x="-328.05" y="165.7006" z="-3.49999999999989"/>
+   <position name="posGroundGrid-14" unit="cm" x="-328.04" y="165.7006" z="-3.49999999999989"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-15" unit="cm" x="-328.05" y="501.1018" z="-3.49999999999989"/>
+   <position name="posGroundGrid-15" unit="cm" x="-328.04" y="501.1018" z="-3.49999999999989"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-16" unit="cm" x="-328.05" y="-505.1018" z="294.34"/>
+   <position name="posGroundGrid-16" unit="cm" x="-328.04" y="-505.1018" z="294.34"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-17" unit="cm" x="-328.05" y="-169.7006" z="294.34"/>
+   <position name="posGroundGrid-17" unit="cm" x="-328.04" y="-169.7006" z="294.34"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-18" unit="cm" x="-328.05" y="165.7006" z="294.34"/>
+   <position name="posGroundGrid-18" unit="cm" x="-328.04" y="165.7006" z="294.34"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-19" unit="cm" x="-328.05" y="501.1018" z="294.34"/>
+   <position name="posGroundGrid-19" unit="cm" x="-328.04" y="501.1018" z="294.34"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-20" unit="cm" x="-328.05" y="-505.1018" z="592.18"/>
+   <position name="posGroundGrid-20" unit="cm" x="-328.04" y="-505.1018" z="592.18"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-21" unit="cm" x="-328.05" y="-169.7006" z="592.18"/>
+   <position name="posGroundGrid-21" unit="cm" x="-328.04" y="-169.7006" z="592.18"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-22" unit="cm" x="-328.05" y="165.7006" z="592.18"/>
+   <position name="posGroundGrid-22" unit="cm" x="-328.04" y="165.7006" z="592.18"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-23" unit="cm" x="-328.05" y="501.1018" z="592.18"/>
+   <position name="posGroundGrid-23" unit="cm" x="-328.04" y="501.1018" z="592.18"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-24" unit="cm" x="-328.05" y="-505.1018" z="890.02"/>
+   <position name="posGroundGrid-24" unit="cm" x="-328.04" y="-505.1018" z="890.02"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-25" unit="cm" x="-328.05" y="-169.7006" z="890.02"/>
+   <position name="posGroundGrid-25" unit="cm" x="-328.04" y="-169.7006" z="890.02"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-26" unit="cm" x="-328.05" y="165.7006" z="890.02"/>
+   <position name="posGroundGrid-26" unit="cm" x="-328.04" y="165.7006" z="890.02"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-27" unit="cm" x="-328.05" y="501.1018" z="890.02"/>
+   <position name="posGroundGrid-27" unit="cm" x="-328.04" y="501.1018" z="890.02"/>
       </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-0-0"/>
        <position name="posArapucaDouble0-Frame-0-0" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-632.8018" 
 	 z="-859.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3393,14 +3398,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-0"/>
        <position name="posOpArapucaDouble0-Frame-0-0" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-632.8018" 
 	 z="-859.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-0-1"/>
        <position name="posArapucaDouble1-Frame-0-0" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-542.1018" 
 	 z="-1005.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3408,14 +3413,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-1"/>
        <position name="posOpArapucaDouble1-Frame-0-0" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-542.1018" 
 	 z="-1005.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-0-2"/>
        <position name="posArapucaDouble2-Frame-0-0" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-468.1018" 
 	 z="-788.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3423,14 +3428,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-2"/>
        <position name="posOpArapucaDouble2-Frame-0-0" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-468.1018" 
 	 z="-788.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-0-3"/>
        <position name="posArapucaDouble3-Frame-0-0" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-377.4018" 
 	 z="-934.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3438,14 +3443,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-3"/>
        <position name="posOpArapucaDouble3-Frame-0-0" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-377.4018" 
 	 z="-934.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-1-0"/>
        <position name="posArapucaDouble0-Frame-0-1" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-632.8018" 
 	 z="-561.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3453,14 +3458,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-0"/>
        <position name="posOpArapucaDouble0-Frame-0-1" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-632.8018" 
 	 z="-561.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-1-1"/>
        <position name="posArapucaDouble1-Frame-0-1" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-542.1018" 
 	 z="-707.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3468,14 +3473,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-1"/>
        <position name="posOpArapucaDouble1-Frame-0-1" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-542.1018" 
 	 z="-707.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-1-2"/>
        <position name="posArapucaDouble2-Frame-0-1" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-468.1018" 
 	 z="-490.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3483,14 +3488,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-2"/>
        <position name="posOpArapucaDouble2-Frame-0-1" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-468.1018" 
 	 z="-490.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-1-3"/>
        <position name="posArapucaDouble3-Frame-0-1" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-377.4018" 
 	 z="-636.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3498,14 +3503,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-3"/>
        <position name="posOpArapucaDouble3-Frame-0-1" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-377.4018" 
 	 z="-636.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-2-0"/>
        <position name="posArapucaDouble0-Frame-0-2" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-632.8018" 
 	 z="-263.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3513,14 +3518,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-0"/>
        <position name="posOpArapucaDouble0-Frame-0-2" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-632.8018" 
 	 z="-263.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-2-1"/>
        <position name="posArapucaDouble1-Frame-0-2" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-542.1018" 
 	 z="-409.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3528,14 +3533,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-1"/>
        <position name="posOpArapucaDouble1-Frame-0-2" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-542.1018" 
 	 z="-409.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-2-2"/>
        <position name="posArapucaDouble2-Frame-0-2" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-468.1018" 
 	 z="-192.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3543,14 +3548,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-2"/>
        <position name="posOpArapucaDouble2-Frame-0-2" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-468.1018" 
 	 z="-192.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-2-3"/>
        <position name="posArapucaDouble3-Frame-0-2" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-377.4018" 
 	 z="-338.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3558,14 +3563,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-3"/>
        <position name="posOpArapucaDouble3-Frame-0-2" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-377.4018" 
 	 z="-338.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-3-0"/>
        <position name="posArapucaDouble0-Frame-0-3" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-632.8018" 
 	 z="34.0000000000001"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3573,14 +3578,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-3-0"/>
        <position name="posOpArapucaDouble0-Frame-0-3" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-632.8018" 
 	 z="34.0000000000001"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-3-1"/>
        <position name="posArapucaDouble1-Frame-0-3" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-542.1018" 
 	 z="-112"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3588,14 +3593,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-3-1"/>
        <position name="posOpArapucaDouble1-Frame-0-3" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-542.1018" 
 	 z="-112"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-3-2"/>
        <position name="posArapucaDouble2-Frame-0-3" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-468.1018" 
 	 z="105"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3603,14 +3608,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-3-2"/>
        <position name="posOpArapucaDouble2-Frame-0-3" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-468.1018" 
 	 z="105"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-3-3"/>
        <position name="posArapucaDouble3-Frame-0-3" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-377.4018" 
 	 z="-40.9999999999999"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3618,14 +3623,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-3-3"/>
        <position name="posOpArapucaDouble3-Frame-0-3" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-377.4018" 
 	 z="-40.9999999999999"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-4-0"/>
        <position name="posArapucaDouble0-Frame-0-4" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-632.8018" 
 	 z="331.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3633,14 +3638,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-4-0"/>
        <position name="posOpArapucaDouble0-Frame-0-4" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-632.8018" 
 	 z="331.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-4-1"/>
        <position name="posArapucaDouble1-Frame-0-4" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-542.1018" 
 	 z="185.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3648,14 +3653,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-4-1"/>
        <position name="posOpArapucaDouble1-Frame-0-4" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-542.1018" 
 	 z="185.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-4-2"/>
        <position name="posArapucaDouble2-Frame-0-4" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-468.1018" 
 	 z="402.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3663,14 +3668,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-4-2"/>
        <position name="posOpArapucaDouble2-Frame-0-4" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-468.1018" 
 	 z="402.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-4-3"/>
        <position name="posArapucaDouble3-Frame-0-4" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-377.4018" 
 	 z="256.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3678,14 +3683,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-4-3"/>
        <position name="posOpArapucaDouble3-Frame-0-4" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-377.4018" 
 	 z="256.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-5-0"/>
        <position name="posArapucaDouble0-Frame-0-5" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-632.8018" 
 	 z="629.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3693,14 +3698,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-5-0"/>
        <position name="posOpArapucaDouble0-Frame-0-5" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-632.8018" 
 	 z="629.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-5-1"/>
        <position name="posArapucaDouble1-Frame-0-5" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-542.1018" 
 	 z="483.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3708,14 +3713,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-5-1"/>
        <position name="posOpArapucaDouble1-Frame-0-5" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-542.1018" 
 	 z="483.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-5-2"/>
        <position name="posArapucaDouble2-Frame-0-5" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-468.1018" 
 	 z="700.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3723,14 +3728,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-5-2"/>
        <position name="posOpArapucaDouble2-Frame-0-5" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-468.1018" 
 	 z="700.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-5-3"/>
        <position name="posArapucaDouble3-Frame-0-5" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-377.4018" 
 	 z="554.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3738,14 +3743,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-5-3"/>
        <position name="posOpArapucaDouble3-Frame-0-5" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-377.4018" 
 	 z="554.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-6-0"/>
        <position name="posArapucaDouble0-Frame-0-6" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-632.8018" 
 	 z="927.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3753,14 +3758,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-6-0"/>
        <position name="posOpArapucaDouble0-Frame-0-6" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-632.8018" 
 	 z="927.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-6-1"/>
        <position name="posArapucaDouble1-Frame-0-6" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-542.1018" 
 	 z="781.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3768,14 +3773,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-6-1"/>
        <position name="posOpArapucaDouble1-Frame-0-6" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-542.1018" 
 	 z="781.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-6-2"/>
        <position name="posArapucaDouble2-Frame-0-6" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-468.1018" 
 	 z="998.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3783,14 +3788,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-6-2"/>
        <position name="posOpArapucaDouble2-Frame-0-6" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-468.1018" 
 	 z="998.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-6-3"/>
        <position name="posArapucaDouble3-Frame-0-6" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-377.4018" 
 	 z="852.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3798,14 +3803,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-6-3"/>
        <position name="posOpArapucaDouble3-Frame-0-6" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-377.4018" 
 	 z="852.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-0-0"/>
        <position name="posArapucaDouble0-Frame-1-0" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-297.4006" 
 	 z="-859.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3813,14 +3818,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-0"/>
        <position name="posOpArapucaDouble0-Frame-1-0" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-297.4006" 
 	 z="-859.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-0-1"/>
        <position name="posArapucaDouble1-Frame-1-0" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-206.7006" 
 	 z="-1005.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3828,14 +3833,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-1"/>
        <position name="posOpArapucaDouble1-Frame-1-0" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-206.7006" 
 	 z="-1005.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-0-2"/>
        <position name="posArapucaDouble2-Frame-1-0" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-132.7006" 
 	 z="-788.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3843,14 +3848,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-2"/>
        <position name="posOpArapucaDouble2-Frame-1-0" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-132.7006" 
 	 z="-788.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-0-3"/>
        <position name="posArapucaDouble3-Frame-1-0" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-42.0006" 
 	 z="-934.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3858,14 +3863,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-3"/>
        <position name="posOpArapucaDouble3-Frame-1-0" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-42.0006" 
 	 z="-934.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-1-0"/>
        <position name="posArapucaDouble0-Frame-1-1" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-297.4006" 
 	 z="-561.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3873,14 +3878,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-0"/>
        <position name="posOpArapucaDouble0-Frame-1-1" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-297.4006" 
 	 z="-561.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-1-1"/>
        <position name="posArapucaDouble1-Frame-1-1" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-206.7006" 
 	 z="-707.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3888,14 +3893,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-1"/>
        <position name="posOpArapucaDouble1-Frame-1-1" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-206.7006" 
 	 z="-707.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-1-2"/>
        <position name="posArapucaDouble2-Frame-1-1" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-132.7006" 
 	 z="-490.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3903,14 +3908,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-2"/>
        <position name="posOpArapucaDouble2-Frame-1-1" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-132.7006" 
 	 z="-490.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-1-3"/>
        <position name="posArapucaDouble3-Frame-1-1" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-42.0006" 
 	 z="-636.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3918,14 +3923,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-3"/>
        <position name="posOpArapucaDouble3-Frame-1-1" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-42.0006" 
 	 z="-636.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-2-0"/>
        <position name="posArapucaDouble0-Frame-1-2" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-297.4006" 
 	 z="-263.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3933,14 +3938,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-0"/>
        <position name="posOpArapucaDouble0-Frame-1-2" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-297.4006" 
 	 z="-263.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-2-1"/>
        <position name="posArapucaDouble1-Frame-1-2" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-206.7006" 
 	 z="-409.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3948,14 +3953,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-1"/>
        <position name="posOpArapucaDouble1-Frame-1-2" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-206.7006" 
 	 z="-409.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-2-2"/>
        <position name="posArapucaDouble2-Frame-1-2" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-132.7006" 
 	 z="-192.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3963,14 +3968,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-2"/>
        <position name="posOpArapucaDouble2-Frame-1-2" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-132.7006" 
 	 z="-192.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-2-3"/>
        <position name="posArapucaDouble3-Frame-1-2" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-42.0006" 
 	 z="-338.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3978,14 +3983,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-3"/>
        <position name="posOpArapucaDouble3-Frame-1-2" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-42.0006" 
 	 z="-338.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-3-0"/>
        <position name="posArapucaDouble0-Frame-1-3" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-297.4006" 
 	 z="34.0000000000001"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3993,14 +3998,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-3-0"/>
        <position name="posOpArapucaDouble0-Frame-1-3" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-297.4006" 
 	 z="34.0000000000001"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-3-1"/>
        <position name="posArapucaDouble1-Frame-1-3" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-206.7006" 
 	 z="-112"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4008,14 +4013,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-3-1"/>
        <position name="posOpArapucaDouble1-Frame-1-3" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-206.7006" 
 	 z="-112"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-3-2"/>
        <position name="posArapucaDouble2-Frame-1-3" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-132.7006" 
 	 z="105"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4023,14 +4028,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-3-2"/>
        <position name="posOpArapucaDouble2-Frame-1-3" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-132.7006" 
 	 z="105"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-3-3"/>
        <position name="posArapucaDouble3-Frame-1-3" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-42.0006" 
 	 z="-40.9999999999999"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4038,14 +4043,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-3-3"/>
        <position name="posOpArapucaDouble3-Frame-1-3" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-42.0006" 
 	 z="-40.9999999999999"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-4-0"/>
        <position name="posArapucaDouble0-Frame-1-4" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-297.4006" 
 	 z="331.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4053,14 +4058,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-4-0"/>
        <position name="posOpArapucaDouble0-Frame-1-4" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-297.4006" 
 	 z="331.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-4-1"/>
        <position name="posArapucaDouble1-Frame-1-4" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-206.7006" 
 	 z="185.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4068,14 +4073,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-4-1"/>
        <position name="posOpArapucaDouble1-Frame-1-4" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-206.7006" 
 	 z="185.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-4-2"/>
        <position name="posArapucaDouble2-Frame-1-4" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-132.7006" 
 	 z="402.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4083,14 +4088,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-4-2"/>
        <position name="posOpArapucaDouble2-Frame-1-4" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-132.7006" 
 	 z="402.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-4-3"/>
        <position name="posArapucaDouble3-Frame-1-4" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-42.0006" 
 	 z="256.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4098,14 +4103,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-4-3"/>
        <position name="posOpArapucaDouble3-Frame-1-4" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-42.0006" 
 	 z="256.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-5-0"/>
        <position name="posArapucaDouble0-Frame-1-5" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-297.4006" 
 	 z="629.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4113,14 +4118,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-5-0"/>
        <position name="posOpArapucaDouble0-Frame-1-5" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-297.4006" 
 	 z="629.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-5-1"/>
        <position name="posArapucaDouble1-Frame-1-5" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-206.7006" 
 	 z="483.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4128,14 +4133,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-5-1"/>
        <position name="posOpArapucaDouble1-Frame-1-5" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-206.7006" 
 	 z="483.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-5-2"/>
        <position name="posArapucaDouble2-Frame-1-5" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-132.7006" 
 	 z="700.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4143,14 +4148,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-5-2"/>
        <position name="posOpArapucaDouble2-Frame-1-5" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-132.7006" 
 	 z="700.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-5-3"/>
        <position name="posArapucaDouble3-Frame-1-5" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-42.0006" 
 	 z="554.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4158,14 +4163,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-5-3"/>
        <position name="posOpArapucaDouble3-Frame-1-5" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-42.0006" 
 	 z="554.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-6-0"/>
        <position name="posArapucaDouble0-Frame-1-6" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-297.4006" 
 	 z="927.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4173,14 +4178,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-6-0"/>
        <position name="posOpArapucaDouble0-Frame-1-6" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-297.4006" 
 	 z="927.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-6-1"/>
        <position name="posArapucaDouble1-Frame-1-6" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-206.7006" 
 	 z="781.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4188,14 +4193,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-6-1"/>
        <position name="posOpArapucaDouble1-Frame-1-6" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-206.7006" 
 	 z="781.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-6-2"/>
        <position name="posArapucaDouble2-Frame-1-6" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-132.7006" 
 	 z="998.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4203,14 +4208,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-6-2"/>
        <position name="posOpArapucaDouble2-Frame-1-6" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-132.7006" 
 	 z="998.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-6-3"/>
        <position name="posArapucaDouble3-Frame-1-6" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-42.0006" 
 	 z="852.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4218,14 +4223,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-6-3"/>
        <position name="posOpArapucaDouble3-Frame-1-6" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-42.0006" 
 	 z="852.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-0-0"/>
        <position name="posArapucaDouble0-Frame-2-0" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="38.0006" 
 	 z="-859.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4233,14 +4238,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-0"/>
        <position name="posOpArapucaDouble0-Frame-2-0" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="38.0006" 
 	 z="-859.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-0-1"/>
        <position name="posArapucaDouble1-Frame-2-0" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="128.7006" 
 	 z="-1005.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4248,14 +4253,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-1"/>
        <position name="posOpArapucaDouble1-Frame-2-0" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="128.7006" 
 	 z="-1005.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-0-2"/>
        <position name="posArapucaDouble2-Frame-2-0" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="202.7006" 
 	 z="-788.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4263,14 +4268,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-2"/>
        <position name="posOpArapucaDouble2-Frame-2-0" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="202.7006" 
 	 z="-788.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-0-3"/>
        <position name="posArapucaDouble3-Frame-2-0" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="293.4006" 
 	 z="-934.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4278,14 +4283,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-3"/>
        <position name="posOpArapucaDouble3-Frame-2-0" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="293.4006" 
 	 z="-934.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-1-0"/>
        <position name="posArapucaDouble0-Frame-2-1" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="38.0006" 
 	 z="-561.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4293,14 +4298,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-0"/>
        <position name="posOpArapucaDouble0-Frame-2-1" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="38.0006" 
 	 z="-561.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-1-1"/>
        <position name="posArapucaDouble1-Frame-2-1" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="128.7006" 
 	 z="-707.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4308,14 +4313,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-1"/>
        <position name="posOpArapucaDouble1-Frame-2-1" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="128.7006" 
 	 z="-707.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-1-2"/>
        <position name="posArapucaDouble2-Frame-2-1" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="202.7006" 
 	 z="-490.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4323,14 +4328,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-2"/>
        <position name="posOpArapucaDouble2-Frame-2-1" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="202.7006" 
 	 z="-490.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-1-3"/>
        <position name="posArapucaDouble3-Frame-2-1" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="293.4006" 
 	 z="-636.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4338,14 +4343,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-3"/>
        <position name="posOpArapucaDouble3-Frame-2-1" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="293.4006" 
 	 z="-636.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-2-0"/>
        <position name="posArapucaDouble0-Frame-2-2" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="38.0006" 
 	 z="-263.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4353,14 +4358,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-0"/>
        <position name="posOpArapucaDouble0-Frame-2-2" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="38.0006" 
 	 z="-263.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-2-1"/>
        <position name="posArapucaDouble1-Frame-2-2" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="128.7006" 
 	 z="-409.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4368,14 +4373,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-1"/>
        <position name="posOpArapucaDouble1-Frame-2-2" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="128.7006" 
 	 z="-409.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-2-2"/>
        <position name="posArapucaDouble2-Frame-2-2" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="202.7006" 
 	 z="-192.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4383,14 +4388,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-2"/>
        <position name="posOpArapucaDouble2-Frame-2-2" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="202.7006" 
 	 z="-192.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-2-3"/>
        <position name="posArapucaDouble3-Frame-2-2" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="293.4006" 
 	 z="-338.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4398,14 +4403,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-3"/>
        <position name="posOpArapucaDouble3-Frame-2-2" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="293.4006" 
 	 z="-338.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-3-0"/>
        <position name="posArapucaDouble0-Frame-2-3" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="38.0006" 
 	 z="34.0000000000001"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4413,14 +4418,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-3-0"/>
        <position name="posOpArapucaDouble0-Frame-2-3" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="38.0006" 
 	 z="34.0000000000001"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-3-1"/>
        <position name="posArapucaDouble1-Frame-2-3" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="128.7006" 
 	 z="-112"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4428,14 +4433,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-3-1"/>
        <position name="posOpArapucaDouble1-Frame-2-3" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="128.7006" 
 	 z="-112"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-3-2"/>
        <position name="posArapucaDouble2-Frame-2-3" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="202.7006" 
 	 z="105"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4443,14 +4448,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-3-2"/>
        <position name="posOpArapucaDouble2-Frame-2-3" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="202.7006" 
 	 z="105"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-3-3"/>
        <position name="posArapucaDouble3-Frame-2-3" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="293.4006" 
 	 z="-40.9999999999999"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4458,14 +4463,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-3-3"/>
        <position name="posOpArapucaDouble3-Frame-2-3" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="293.4006" 
 	 z="-40.9999999999999"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-4-0"/>
        <position name="posArapucaDouble0-Frame-2-4" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="38.0006" 
 	 z="331.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4473,14 +4478,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-4-0"/>
        <position name="posOpArapucaDouble0-Frame-2-4" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="38.0006" 
 	 z="331.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-4-1"/>
        <position name="posArapucaDouble1-Frame-2-4" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="128.7006" 
 	 z="185.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4488,14 +4493,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-4-1"/>
        <position name="posOpArapucaDouble1-Frame-2-4" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="128.7006" 
 	 z="185.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-4-2"/>
        <position name="posArapucaDouble2-Frame-2-4" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="202.7006" 
 	 z="402.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4503,14 +4508,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-4-2"/>
        <position name="posOpArapucaDouble2-Frame-2-4" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="202.7006" 
 	 z="402.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-4-3"/>
        <position name="posArapucaDouble3-Frame-2-4" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="293.4006" 
 	 z="256.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4518,14 +4523,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-4-3"/>
        <position name="posOpArapucaDouble3-Frame-2-4" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="293.4006" 
 	 z="256.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-5-0"/>
        <position name="posArapucaDouble0-Frame-2-5" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="38.0006" 
 	 z="629.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4533,14 +4538,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-5-0"/>
        <position name="posOpArapucaDouble0-Frame-2-5" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="38.0006" 
 	 z="629.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-5-1"/>
        <position name="posArapucaDouble1-Frame-2-5" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="128.7006" 
 	 z="483.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4548,14 +4553,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-5-1"/>
        <position name="posOpArapucaDouble1-Frame-2-5" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="128.7006" 
 	 z="483.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-5-2"/>
        <position name="posArapucaDouble2-Frame-2-5" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="202.7006" 
 	 z="700.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4563,14 +4568,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-5-2"/>
        <position name="posOpArapucaDouble2-Frame-2-5" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="202.7006" 
 	 z="700.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-5-3"/>
        <position name="posArapucaDouble3-Frame-2-5" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="293.4006" 
 	 z="554.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4578,14 +4583,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-5-3"/>
        <position name="posOpArapucaDouble3-Frame-2-5" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="293.4006" 
 	 z="554.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-6-0"/>
        <position name="posArapucaDouble0-Frame-2-6" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="38.0006" 
 	 z="927.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4593,14 +4598,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-6-0"/>
        <position name="posOpArapucaDouble0-Frame-2-6" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="38.0006" 
 	 z="927.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-6-1"/>
        <position name="posArapucaDouble1-Frame-2-6" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="128.7006" 
 	 z="781.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4608,14 +4613,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-6-1"/>
        <position name="posOpArapucaDouble1-Frame-2-6" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="128.7006" 
 	 z="781.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-6-2"/>
        <position name="posArapucaDouble2-Frame-2-6" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="202.7006" 
 	 z="998.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4623,14 +4628,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-6-2"/>
        <position name="posOpArapucaDouble2-Frame-2-6" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="202.7006" 
 	 z="998.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-6-3"/>
        <position name="posArapucaDouble3-Frame-2-6" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="293.4006" 
 	 z="852.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4638,14 +4643,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-6-3"/>
        <position name="posOpArapucaDouble3-Frame-2-6" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="293.4006" 
 	 z="852.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-0-0"/>
        <position name="posArapucaDouble0-Frame-3-0" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="373.4018" 
 	 z="-859.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4653,14 +4658,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-0"/>
        <position name="posOpArapucaDouble0-Frame-3-0" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="373.4018" 
 	 z="-859.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-0-1"/>
        <position name="posArapucaDouble1-Frame-3-0" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="464.1018" 
 	 z="-1005.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4668,14 +4673,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-1"/>
        <position name="posOpArapucaDouble1-Frame-3-0" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="464.1018" 
 	 z="-1005.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-0-2"/>
        <position name="posArapucaDouble2-Frame-3-0" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="538.1018" 
 	 z="-788.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4683,14 +4688,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-2"/>
        <position name="posOpArapucaDouble2-Frame-3-0" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="538.1018" 
 	 z="-788.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-0-3"/>
        <position name="posArapucaDouble3-Frame-3-0" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="628.8018" 
 	 z="-934.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4698,14 +4703,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-3"/>
        <position name="posOpArapucaDouble3-Frame-3-0" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="628.8018" 
 	 z="-934.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-1-0"/>
        <position name="posArapucaDouble0-Frame-3-1" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="373.4018" 
 	 z="-561.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4713,14 +4718,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-0"/>
        <position name="posOpArapucaDouble0-Frame-3-1" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="373.4018" 
 	 z="-561.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-1-1"/>
        <position name="posArapucaDouble1-Frame-3-1" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="464.1018" 
 	 z="-707.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4728,14 +4733,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-1"/>
        <position name="posOpArapucaDouble1-Frame-3-1" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="464.1018" 
 	 z="-707.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-1-2"/>
        <position name="posArapucaDouble2-Frame-3-1" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="538.1018" 
 	 z="-490.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4743,14 +4748,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-2"/>
        <position name="posOpArapucaDouble2-Frame-3-1" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="538.1018" 
 	 z="-490.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-1-3"/>
        <position name="posArapucaDouble3-Frame-3-1" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="628.8018" 
 	 z="-636.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4758,14 +4763,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-3"/>
        <position name="posOpArapucaDouble3-Frame-3-1" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="628.8018" 
 	 z="-636.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-2-0"/>
        <position name="posArapucaDouble0-Frame-3-2" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="373.4018" 
 	 z="-263.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4773,14 +4778,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-0"/>
        <position name="posOpArapucaDouble0-Frame-3-2" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="373.4018" 
 	 z="-263.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-2-1"/>
        <position name="posArapucaDouble1-Frame-3-2" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="464.1018" 
 	 z="-409.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4788,14 +4793,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-1"/>
        <position name="posOpArapucaDouble1-Frame-3-2" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="464.1018" 
 	 z="-409.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-2-2"/>
        <position name="posArapucaDouble2-Frame-3-2" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="538.1018" 
 	 z="-192.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4803,14 +4808,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-2"/>
        <position name="posOpArapucaDouble2-Frame-3-2" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="538.1018" 
 	 z="-192.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-2-3"/>
        <position name="posArapucaDouble3-Frame-3-2" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="628.8018" 
 	 z="-338.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4818,14 +4823,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-3"/>
        <position name="posOpArapucaDouble3-Frame-3-2" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="628.8018" 
 	 z="-338.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-3-0"/>
        <position name="posArapucaDouble0-Frame-3-3" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="373.4018" 
 	 z="34.0000000000001"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4833,14 +4838,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-3-0"/>
        <position name="posOpArapucaDouble0-Frame-3-3" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="373.4018" 
 	 z="34.0000000000001"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-3-1"/>
        <position name="posArapucaDouble1-Frame-3-3" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="464.1018" 
 	 z="-112"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4848,14 +4853,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-3-1"/>
        <position name="posOpArapucaDouble1-Frame-3-3" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="464.1018" 
 	 z="-112"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-3-2"/>
        <position name="posArapucaDouble2-Frame-3-3" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="538.1018" 
 	 z="105"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4863,14 +4868,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-3-2"/>
        <position name="posOpArapucaDouble2-Frame-3-3" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="538.1018" 
 	 z="105"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-3-3"/>
        <position name="posArapucaDouble3-Frame-3-3" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="628.8018" 
 	 z="-40.9999999999999"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4878,14 +4883,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-3-3"/>
        <position name="posOpArapucaDouble3-Frame-3-3" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="628.8018" 
 	 z="-40.9999999999999"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-4-0"/>
        <position name="posArapucaDouble0-Frame-3-4" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="373.4018" 
 	 z="331.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4893,14 +4898,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-4-0"/>
        <position name="posOpArapucaDouble0-Frame-3-4" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="373.4018" 
 	 z="331.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-4-1"/>
        <position name="posArapucaDouble1-Frame-3-4" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="464.1018" 
 	 z="185.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4908,14 +4913,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-4-1"/>
        <position name="posOpArapucaDouble1-Frame-3-4" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="464.1018" 
 	 z="185.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-4-2"/>
        <position name="posArapucaDouble2-Frame-3-4" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="538.1018" 
 	 z="402.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4923,14 +4928,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-4-2"/>
        <position name="posOpArapucaDouble2-Frame-3-4" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="538.1018" 
 	 z="402.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-4-3"/>
        <position name="posArapucaDouble3-Frame-3-4" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="628.8018" 
 	 z="256.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4938,14 +4943,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-4-3"/>
        <position name="posOpArapucaDouble3-Frame-3-4" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="628.8018" 
 	 z="256.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-5-0"/>
        <position name="posArapucaDouble0-Frame-3-5" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="373.4018" 
 	 z="629.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4953,14 +4958,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-5-0"/>
        <position name="posOpArapucaDouble0-Frame-3-5" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="373.4018" 
 	 z="629.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-5-1"/>
        <position name="posArapucaDouble1-Frame-3-5" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="464.1018" 
 	 z="483.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4968,14 +4973,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-5-1"/>
        <position name="posOpArapucaDouble1-Frame-3-5" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="464.1018" 
 	 z="483.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-5-2"/>
        <position name="posArapucaDouble2-Frame-3-5" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="538.1018" 
 	 z="700.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4983,14 +4988,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-5-2"/>
        <position name="posOpArapucaDouble2-Frame-3-5" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="538.1018" 
 	 z="700.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-5-3"/>
        <position name="posArapucaDouble3-Frame-3-5" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="628.8018" 
 	 z="554.68"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4998,14 +5003,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-5-3"/>
        <position name="posOpArapucaDouble3-Frame-3-5" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="628.8018" 
 	 z="554.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-6-0"/>
        <position name="posArapucaDouble0-Frame-3-6" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="373.4018" 
 	 z="927.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -5013,14 +5018,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-6-0"/>
        <position name="posOpArapucaDouble0-Frame-3-6" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="373.4018" 
 	 z="927.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-6-1"/>
        <position name="posArapucaDouble1-Frame-3-6" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="464.1018" 
 	 z="781.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -5028,14 +5033,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-6-1"/>
        <position name="posOpArapucaDouble1-Frame-3-6" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="464.1018" 
 	 z="781.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-6-2"/>
        <position name="posArapucaDouble2-Frame-3-6" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="538.1018" 
 	 z="998.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -5043,14 +5048,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-6-2"/>
        <position name="posOpArapucaDouble2-Frame-3-6" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="538.1018" 
 	 z="998.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-6-3"/>
        <position name="posArapucaDouble3-Frame-3-6" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="628.8018" 
 	 z="852.52"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -5058,14 +5063,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-6-3"/>
        <position name="posOpArapucaDouble3-Frame-3-6" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="628.8018" 
 	 z="852.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-0"/>
        <position name="posArapuca0-Lat-0" unit="cm" 
-         x="285.02"
+         x="285.03"
 	 y="-732.8024" 
 	 z="-893.52"/>
        <rotationref ref="rIdentity"/>
@@ -5073,14 +5078,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-0"/>
        <position name="posOpArapuca0-Lat-0" unit="cm" 
-         x="285.02"
+         x="285.03"
 	 y="-732.0624" 
 	 z="-893.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-1"/>
        <position name="posArapuca1-Lat-0" unit="cm" 
-         x="210.02"
+         x="210.03"
 	 y="-732.8024" 
 	 z="-893.52"/>
        <rotationref ref="rIdentity"/>
@@ -5088,14 +5093,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-1"/>
        <position name="posOpArapuca1-Lat-0" unit="cm" 
-         x="210.02"
+         x="210.03"
 	 y="-732.0624" 
 	 z="-893.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-2"/>
        <position name="posArapuca2-Lat-0" unit="cm" 
-         x="135.02"
+         x="135.03"
 	 y="-732.8024" 
 	 z="-893.52"/>
        <rotationref ref="rIdentity"/>
@@ -5103,14 +5108,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-2"/>
        <position name="posOpArapuca2-Lat-0" unit="cm" 
-         x="135.02"
+         x="135.03"
 	 y="-732.0624" 
 	 z="-893.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-3"/>
        <position name="posArapuca3-Lat-0" unit="cm" 
-         x="60.02"
+         x="60.03"
 	 y="-732.8024" 
 	 z="-893.52"/>
        <rotationref ref="rIdentity"/>
@@ -5118,14 +5123,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-3"/>
        <position name="posOpArapuca3-Lat-0" unit="cm" 
-         x="60.02"
+         x="60.03"
 	 y="-732.0624" 
 	 z="-893.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-4"/>
        <position name="posArapuca4-Lat-0" unit="cm" 
-         x="285.02"
+         x="285.03"
 	 y="732.8024" 
 	 z="-893.52"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5133,14 +5138,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-4"/>
        <position name="posOpArapuca4-Lat-0" unit="cm" 
-         x="285.02"
+         x="285.03"
 	 y="732.0624" 
 	 z="-893.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-5"/>
        <position name="posArapuca5-Lat-0" unit="cm" 
-         x="210.02"
+         x="210.03"
 	 y="732.8024" 
 	 z="-893.52"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5148,14 +5153,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-5"/>
        <position name="posOpArapuca5-Lat-0" unit="cm" 
-         x="210.02"
+         x="210.03"
 	 y="732.0624" 
 	 z="-893.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-6"/>
        <position name="posArapuca6-Lat-0" unit="cm" 
-         x="135.02"
+         x="135.03"
 	 y="732.8024" 
 	 z="-893.52"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5163,14 +5168,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-6"/>
        <position name="posOpArapuca6-Lat-0" unit="cm" 
-         x="135.02"
+         x="135.03"
 	 y="732.0624" 
 	 z="-893.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-7"/>
        <position name="posArapuca7-Lat-0" unit="cm" 
-         x="60.02"
+         x="60.03"
 	 y="732.8024" 
 	 z="-893.52"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5178,14 +5183,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-7"/>
        <position name="posOpArapuca7-Lat-0" unit="cm" 
-         x="60.02"
+         x="60.03"
 	 y="732.0624" 
 	 z="-893.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-0"/>
        <position name="posArapuca0-Lat-1" unit="cm" 
-         x="285.02"
+         x="285.03"
 	 y="-732.8024" 
 	 z="-595.68"/>
        <rotationref ref="rIdentity"/>
@@ -5193,14 +5198,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-0"/>
        <position name="posOpArapuca0-Lat-1" unit="cm" 
-         x="285.02"
+         x="285.03"
 	 y="-732.0624" 
 	 z="-595.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-1"/>
        <position name="posArapuca1-Lat-1" unit="cm" 
-         x="210.02"
+         x="210.03"
 	 y="-732.8024" 
 	 z="-595.68"/>
        <rotationref ref="rIdentity"/>
@@ -5208,14 +5213,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-1"/>
        <position name="posOpArapuca1-Lat-1" unit="cm" 
-         x="210.02"
+         x="210.03"
 	 y="-732.0624" 
 	 z="-595.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-2"/>
        <position name="posArapuca2-Lat-1" unit="cm" 
-         x="135.02"
+         x="135.03"
 	 y="-732.8024" 
 	 z="-595.68"/>
        <rotationref ref="rIdentity"/>
@@ -5223,14 +5228,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-2"/>
        <position name="posOpArapuca2-Lat-1" unit="cm" 
-         x="135.02"
+         x="135.03"
 	 y="-732.0624" 
 	 z="-595.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-3"/>
        <position name="posArapuca3-Lat-1" unit="cm" 
-         x="60.02"
+         x="60.03"
 	 y="-732.8024" 
 	 z="-595.68"/>
        <rotationref ref="rIdentity"/>
@@ -5238,14 +5243,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-3"/>
        <position name="posOpArapuca3-Lat-1" unit="cm" 
-         x="60.02"
+         x="60.03"
 	 y="-732.0624" 
 	 z="-595.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-4"/>
        <position name="posArapuca4-Lat-1" unit="cm" 
-         x="285.02"
+         x="285.03"
 	 y="732.8024" 
 	 z="-595.68"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5253,14 +5258,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-4"/>
        <position name="posOpArapuca4-Lat-1" unit="cm" 
-         x="285.02"
+         x="285.03"
 	 y="732.0624" 
 	 z="-595.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-5"/>
        <position name="posArapuca5-Lat-1" unit="cm" 
-         x="210.02"
+         x="210.03"
 	 y="732.8024" 
 	 z="-595.68"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5268,14 +5273,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-5"/>
        <position name="posOpArapuca5-Lat-1" unit="cm" 
-         x="210.02"
+         x="210.03"
 	 y="732.0624" 
 	 z="-595.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-6"/>
        <position name="posArapuca6-Lat-1" unit="cm" 
-         x="135.02"
+         x="135.03"
 	 y="732.8024" 
 	 z="-595.68"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5283,14 +5288,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-6"/>
        <position name="posOpArapuca6-Lat-1" unit="cm" 
-         x="135.02"
+         x="135.03"
 	 y="732.0624" 
 	 z="-595.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-7"/>
        <position name="posArapuca7-Lat-1" unit="cm" 
-         x="60.02"
+         x="60.03"
 	 y="732.8024" 
 	 z="-595.68"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5298,14 +5303,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-7"/>
        <position name="posOpArapuca7-Lat-1" unit="cm" 
-         x="60.02"
+         x="60.03"
 	 y="732.0624" 
 	 z="-595.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-0"/>
        <position name="posArapuca0-Lat-2" unit="cm" 
-         x="285.02"
+         x="285.03"
 	 y="-732.8024" 
 	 z="-297.84"/>
        <rotationref ref="rIdentity"/>
@@ -5313,14 +5318,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-0"/>
        <position name="posOpArapuca0-Lat-2" unit="cm" 
-         x="285.02"
+         x="285.03"
 	 y="-732.0624" 
 	 z="-297.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-1"/>
        <position name="posArapuca1-Lat-2" unit="cm" 
-         x="210.02"
+         x="210.03"
 	 y="-732.8024" 
 	 z="-297.84"/>
        <rotationref ref="rIdentity"/>
@@ -5328,14 +5333,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-1"/>
        <position name="posOpArapuca1-Lat-2" unit="cm" 
-         x="210.02"
+         x="210.03"
 	 y="-732.0624" 
 	 z="-297.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-2"/>
        <position name="posArapuca2-Lat-2" unit="cm" 
-         x="135.02"
+         x="135.03"
 	 y="-732.8024" 
 	 z="-297.84"/>
        <rotationref ref="rIdentity"/>
@@ -5343,14 +5348,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-2"/>
        <position name="posOpArapuca2-Lat-2" unit="cm" 
-         x="135.02"
+         x="135.03"
 	 y="-732.0624" 
 	 z="-297.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-3"/>
        <position name="posArapuca3-Lat-2" unit="cm" 
-         x="60.02"
+         x="60.03"
 	 y="-732.8024" 
 	 z="-297.84"/>
        <rotationref ref="rIdentity"/>
@@ -5358,14 +5363,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-3"/>
        <position name="posOpArapuca3-Lat-2" unit="cm" 
-         x="60.02"
+         x="60.03"
 	 y="-732.0624" 
 	 z="-297.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-4"/>
        <position name="posArapuca4-Lat-2" unit="cm" 
-         x="285.02"
+         x="285.03"
 	 y="732.8024" 
 	 z="-297.84"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5373,14 +5378,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-4"/>
        <position name="posOpArapuca4-Lat-2" unit="cm" 
-         x="285.02"
+         x="285.03"
 	 y="732.0624" 
 	 z="-297.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-5"/>
        <position name="posArapuca5-Lat-2" unit="cm" 
-         x="210.02"
+         x="210.03"
 	 y="732.8024" 
 	 z="-297.84"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5388,14 +5393,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-5"/>
        <position name="posOpArapuca5-Lat-2" unit="cm" 
-         x="210.02"
+         x="210.03"
 	 y="732.0624" 
 	 z="-297.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-6"/>
        <position name="posArapuca6-Lat-2" unit="cm" 
-         x="135.02"
+         x="135.03"
 	 y="732.8024" 
 	 z="-297.84"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5403,14 +5408,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-6"/>
        <position name="posOpArapuca6-Lat-2" unit="cm" 
-         x="135.02"
+         x="135.03"
 	 y="732.0624" 
 	 z="-297.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-7"/>
        <position name="posArapuca7-Lat-2" unit="cm" 
-         x="60.02"
+         x="60.03"
 	 y="732.8024" 
 	 z="-297.84"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5418,14 +5423,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-7"/>
        <position name="posOpArapuca7-Lat-2" unit="cm" 
-         x="60.02"
+         x="60.03"
 	 y="732.0624" 
 	 z="-297.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_3-0"/>
        <position name="posArapuca0-Lat-3" unit="cm" 
-         x="285.02"
+         x="285.03"
 	 y="-732.8024" 
 	 z="-1.13686837721616e-13"/>
        <rotationref ref="rIdentity"/>
@@ -5433,14 +5438,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_3-0"/>
        <position name="posOpArapuca0-Lat-3" unit="cm" 
-         x="285.02"
+         x="285.03"
 	 y="-732.0624" 
 	 z="-1.13686837721616e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_3-1"/>
        <position name="posArapuca1-Lat-3" unit="cm" 
-         x="210.02"
+         x="210.03"
 	 y="-732.8024" 
 	 z="-1.13686837721616e-13"/>
        <rotationref ref="rIdentity"/>
@@ -5448,14 +5453,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_3-1"/>
        <position name="posOpArapuca1-Lat-3" unit="cm" 
-         x="210.02"
+         x="210.03"
 	 y="-732.0624" 
 	 z="-1.13686837721616e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_3-2"/>
        <position name="posArapuca2-Lat-3" unit="cm" 
-         x="135.02"
+         x="135.03"
 	 y="-732.8024" 
 	 z="-1.13686837721616e-13"/>
        <rotationref ref="rIdentity"/>
@@ -5463,14 +5468,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_3-2"/>
        <position name="posOpArapuca2-Lat-3" unit="cm" 
-         x="135.02"
+         x="135.03"
 	 y="-732.0624" 
 	 z="-1.13686837721616e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_3-3"/>
        <position name="posArapuca3-Lat-3" unit="cm" 
-         x="60.02"
+         x="60.03"
 	 y="-732.8024" 
 	 z="-1.13686837721616e-13"/>
        <rotationref ref="rIdentity"/>
@@ -5478,14 +5483,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_3-3"/>
        <position name="posOpArapuca3-Lat-3" unit="cm" 
-         x="60.02"
+         x="60.03"
 	 y="-732.0624" 
 	 z="-1.13686837721616e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_3-4"/>
        <position name="posArapuca4-Lat-3" unit="cm" 
-         x="285.02"
+         x="285.03"
 	 y="732.8024" 
 	 z="-1.13686837721616e-13"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5493,14 +5498,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_3-4"/>
        <position name="posOpArapuca4-Lat-3" unit="cm" 
-         x="285.02"
+         x="285.03"
 	 y="732.0624" 
 	 z="-1.13686837721616e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_3-5"/>
        <position name="posArapuca5-Lat-3" unit="cm" 
-         x="210.02"
+         x="210.03"
 	 y="732.8024" 
 	 z="-1.13686837721616e-13"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5508,14 +5513,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_3-5"/>
        <position name="posOpArapuca5-Lat-3" unit="cm" 
-         x="210.02"
+         x="210.03"
 	 y="732.0624" 
 	 z="-1.13686837721616e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_3-6"/>
        <position name="posArapuca6-Lat-3" unit="cm" 
-         x="135.02"
+         x="135.03"
 	 y="732.8024" 
 	 z="-1.13686837721616e-13"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5523,14 +5528,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_3-6"/>
        <position name="posOpArapuca6-Lat-3" unit="cm" 
-         x="135.02"
+         x="135.03"
 	 y="732.0624" 
 	 z="-1.13686837721616e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_3-7"/>
        <position name="posArapuca7-Lat-3" unit="cm" 
-         x="60.02"
+         x="60.03"
 	 y="732.8024" 
 	 z="-1.13686837721616e-13"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5538,14 +5543,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_3-7"/>
        <position name="posOpArapuca7-Lat-3" unit="cm" 
-         x="60.02"
+         x="60.03"
 	 y="732.0624" 
 	 z="-1.13686837721616e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_4-0"/>
        <position name="posArapuca0-Lat-4" unit="cm" 
-         x="285.02"
+         x="285.03"
 	 y="-732.8024" 
 	 z="297.84"/>
        <rotationref ref="rIdentity"/>
@@ -5553,14 +5558,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_4-0"/>
        <position name="posOpArapuca0-Lat-4" unit="cm" 
-         x="285.02"
+         x="285.03"
 	 y="-732.0624" 
 	 z="297.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_4-1"/>
        <position name="posArapuca1-Lat-4" unit="cm" 
-         x="210.02"
+         x="210.03"
 	 y="-732.8024" 
 	 z="297.84"/>
        <rotationref ref="rIdentity"/>
@@ -5568,14 +5573,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_4-1"/>
        <position name="posOpArapuca1-Lat-4" unit="cm" 
-         x="210.02"
+         x="210.03"
 	 y="-732.0624" 
 	 z="297.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_4-2"/>
        <position name="posArapuca2-Lat-4" unit="cm" 
-         x="135.02"
+         x="135.03"
 	 y="-732.8024" 
 	 z="297.84"/>
        <rotationref ref="rIdentity"/>
@@ -5583,14 +5588,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_4-2"/>
        <position name="posOpArapuca2-Lat-4" unit="cm" 
-         x="135.02"
+         x="135.03"
 	 y="-732.0624" 
 	 z="297.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_4-3"/>
        <position name="posArapuca3-Lat-4" unit="cm" 
-         x="60.02"
+         x="60.03"
 	 y="-732.8024" 
 	 z="297.84"/>
        <rotationref ref="rIdentity"/>
@@ -5598,14 +5603,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_4-3"/>
        <position name="posOpArapuca3-Lat-4" unit="cm" 
-         x="60.02"
+         x="60.03"
 	 y="-732.0624" 
 	 z="297.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_4-4"/>
        <position name="posArapuca4-Lat-4" unit="cm" 
-         x="285.02"
+         x="285.03"
 	 y="732.8024" 
 	 z="297.84"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5613,14 +5618,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_4-4"/>
        <position name="posOpArapuca4-Lat-4" unit="cm" 
-         x="285.02"
+         x="285.03"
 	 y="732.0624" 
 	 z="297.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_4-5"/>
        <position name="posArapuca5-Lat-4" unit="cm" 
-         x="210.02"
+         x="210.03"
 	 y="732.8024" 
 	 z="297.84"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5628,14 +5633,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_4-5"/>
        <position name="posOpArapuca5-Lat-4" unit="cm" 
-         x="210.02"
+         x="210.03"
 	 y="732.0624" 
 	 z="297.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_4-6"/>
        <position name="posArapuca6-Lat-4" unit="cm" 
-         x="135.02"
+         x="135.03"
 	 y="732.8024" 
 	 z="297.84"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5643,14 +5648,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_4-6"/>
        <position name="posOpArapuca6-Lat-4" unit="cm" 
-         x="135.02"
+         x="135.03"
 	 y="732.0624" 
 	 z="297.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_4-7"/>
        <position name="posArapuca7-Lat-4" unit="cm" 
-         x="60.02"
+         x="60.03"
 	 y="732.8024" 
 	 z="297.84"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5658,14 +5663,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_4-7"/>
        <position name="posOpArapuca7-Lat-4" unit="cm" 
-         x="60.02"
+         x="60.03"
 	 y="732.0624" 
 	 z="297.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_5-0"/>
        <position name="posArapuca0-Lat-5" unit="cm" 
-         x="285.02"
+         x="285.03"
 	 y="-732.8024" 
 	 z="595.68"/>
        <rotationref ref="rIdentity"/>
@@ -5673,14 +5678,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_5-0"/>
        <position name="posOpArapuca0-Lat-5" unit="cm" 
-         x="285.02"
+         x="285.03"
 	 y="-732.0624" 
 	 z="595.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_5-1"/>
        <position name="posArapuca1-Lat-5" unit="cm" 
-         x="210.02"
+         x="210.03"
 	 y="-732.8024" 
 	 z="595.68"/>
        <rotationref ref="rIdentity"/>
@@ -5688,14 +5693,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_5-1"/>
        <position name="posOpArapuca1-Lat-5" unit="cm" 
-         x="210.02"
+         x="210.03"
 	 y="-732.0624" 
 	 z="595.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_5-2"/>
        <position name="posArapuca2-Lat-5" unit="cm" 
-         x="135.02"
+         x="135.03"
 	 y="-732.8024" 
 	 z="595.68"/>
        <rotationref ref="rIdentity"/>
@@ -5703,14 +5708,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_5-2"/>
        <position name="posOpArapuca2-Lat-5" unit="cm" 
-         x="135.02"
+         x="135.03"
 	 y="-732.0624" 
 	 z="595.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_5-3"/>
        <position name="posArapuca3-Lat-5" unit="cm" 
-         x="60.02"
+         x="60.03"
 	 y="-732.8024" 
 	 z="595.68"/>
        <rotationref ref="rIdentity"/>
@@ -5718,14 +5723,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_5-3"/>
        <position name="posOpArapuca3-Lat-5" unit="cm" 
-         x="60.02"
+         x="60.03"
 	 y="-732.0624" 
 	 z="595.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_5-4"/>
        <position name="posArapuca4-Lat-5" unit="cm" 
-         x="285.02"
+         x="285.03"
 	 y="732.8024" 
 	 z="595.68"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5733,14 +5738,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_5-4"/>
        <position name="posOpArapuca4-Lat-5" unit="cm" 
-         x="285.02"
+         x="285.03"
 	 y="732.0624" 
 	 z="595.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_5-5"/>
        <position name="posArapuca5-Lat-5" unit="cm" 
-         x="210.02"
+         x="210.03"
 	 y="732.8024" 
 	 z="595.68"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5748,14 +5753,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_5-5"/>
        <position name="posOpArapuca5-Lat-5" unit="cm" 
-         x="210.02"
+         x="210.03"
 	 y="732.0624" 
 	 z="595.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_5-6"/>
        <position name="posArapuca6-Lat-5" unit="cm" 
-         x="135.02"
+         x="135.03"
 	 y="732.8024" 
 	 z="595.68"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5763,14 +5768,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_5-6"/>
        <position name="posOpArapuca6-Lat-5" unit="cm" 
-         x="135.02"
+         x="135.03"
 	 y="732.0624" 
 	 z="595.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_5-7"/>
        <position name="posArapuca7-Lat-5" unit="cm" 
-         x="60.02"
+         x="60.03"
 	 y="732.8024" 
 	 z="595.68"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5778,14 +5783,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_5-7"/>
        <position name="posOpArapuca7-Lat-5" unit="cm" 
-         x="60.02"
+         x="60.03"
 	 y="732.0624" 
 	 z="595.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_6-0"/>
        <position name="posArapuca0-Lat-6" unit="cm" 
-         x="285.02"
+         x="285.03"
 	 y="-732.8024" 
 	 z="893.52"/>
        <rotationref ref="rIdentity"/>
@@ -5793,14 +5798,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_6-0"/>
        <position name="posOpArapuca0-Lat-6" unit="cm" 
-         x="285.02"
+         x="285.03"
 	 y="-732.0624" 
 	 z="893.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_6-1"/>
        <position name="posArapuca1-Lat-6" unit="cm" 
-         x="210.02"
+         x="210.03"
 	 y="-732.8024" 
 	 z="893.52"/>
        <rotationref ref="rIdentity"/>
@@ -5808,14 +5813,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_6-1"/>
        <position name="posOpArapuca1-Lat-6" unit="cm" 
-         x="210.02"
+         x="210.03"
 	 y="-732.0624" 
 	 z="893.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_6-2"/>
        <position name="posArapuca2-Lat-6" unit="cm" 
-         x="135.02"
+         x="135.03"
 	 y="-732.8024" 
 	 z="893.52"/>
        <rotationref ref="rIdentity"/>
@@ -5823,14 +5828,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_6-2"/>
        <position name="posOpArapuca2-Lat-6" unit="cm" 
-         x="135.02"
+         x="135.03"
 	 y="-732.0624" 
 	 z="893.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_6-3"/>
        <position name="posArapuca3-Lat-6" unit="cm" 
-         x="60.02"
+         x="60.03"
 	 y="-732.8024" 
 	 z="893.52"/>
        <rotationref ref="rIdentity"/>
@@ -5838,14 +5843,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_6-3"/>
        <position name="posOpArapuca3-Lat-6" unit="cm" 
-         x="60.02"
+         x="60.03"
 	 y="-732.0624" 
 	 z="893.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_6-4"/>
        <position name="posArapuca4-Lat-6" unit="cm" 
-         x="285.02"
+         x="285.03"
 	 y="732.8024" 
 	 z="893.52"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5853,14 +5858,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_6-4"/>
        <position name="posOpArapuca4-Lat-6" unit="cm" 
-         x="285.02"
+         x="285.03"
 	 y="732.0624" 
 	 z="893.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_6-5"/>
        <position name="posArapuca5-Lat-6" unit="cm" 
-         x="210.02"
+         x="210.03"
 	 y="732.8024" 
 	 z="893.52"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5868,14 +5873,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_6-5"/>
        <position name="posOpArapuca5-Lat-6" unit="cm" 
-         x="210.02"
+         x="210.03"
 	 y="732.0624" 
 	 z="893.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_6-6"/>
        <position name="posArapuca6-Lat-6" unit="cm" 
-         x="135.02"
+         x="135.03"
 	 y="732.8024" 
 	 z="893.52"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5883,14 +5888,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_6-6"/>
        <position name="posOpArapuca6-Lat-6" unit="cm" 
-         x="135.02"
+         x="135.03"
 	 y="732.0624" 
 	 z="893.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_6-7"/>
        <position name="posArapuca7-Lat-6" unit="cm" 
-         x="60.02"
+         x="60.03"
 	 y="732.8024" 
 	 z="893.52"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5898,7 +5903,7 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_6-7"/>
        <position name="posOpArapuca7-Lat-6" unit="cm" 
-         x="60.02"
+         x="60.03"
 	 y="732.0624" 
 	 z="893.52"/>
      </physvol>

--- a/dunecore/Geometry/gdml/dunevd10kt_3view_30deg_v3_refactored_1x8x14ref_nowires.gdml
+++ b/dunecore/Geometry/gdml/dunevd10kt_3view_30deg_v3_refactored_1x8x14ref_nowires.gdml
@@ -750,24 +750,35 @@
     <materialref ref="LAr"/>
     <solidref ref="CRMZPlane"/>
   </volume>
+     
+   <volume name="volAnodePlate">
+     <materialref ref="vm2000"/>
+     <solidref ref="CRMZPlane"/>
+  </volume>
    <volume name="volTPC">
      <materialref ref="LAr"/>
        <solidref ref="CRM"/>
        <physvol>
        <volumeref ref="volTPCPlaneU"/>
        <position name="posPlaneU" unit="cm" 
-         x="324.99" y="0" z="0"/>
+         x="324.97" y="0" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volTPCPlaneV"/>
        <position name="posPlaneY" unit="cm" 
-         x="325.01" y="0" z="0"/>
+         x="324.99" y="0" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volTPCPlaneZ"/>
        <position name="posPlaneZ" unit="cm" 
+         x="325.01" y="0" z="0"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate" unit="cm" 
          x="325.03" y="0" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -5054,7 +5065,7 @@
      <physvol>
        <volumeref ref="volArapucaLat_0-0"/>
        <position name="posArapuca0-Lat-0" unit="cm" 
-         x="285.03"
+         x="285.01"
 	 y="-732.8024" 
 	 z="-893.52"/>
        <rotationref ref="rIdentity"/>
@@ -5062,14 +5073,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-0"/>
        <position name="posOpArapuca0-Lat-0" unit="cm" 
-         x="285.03"
+         x="285.01"
 	 y="-732.0624" 
 	 z="-893.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-1"/>
        <position name="posArapuca1-Lat-0" unit="cm" 
-         x="210.03"
+         x="210.01"
 	 y="-732.8024" 
 	 z="-893.52"/>
        <rotationref ref="rIdentity"/>
@@ -5077,14 +5088,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-1"/>
        <position name="posOpArapuca1-Lat-0" unit="cm" 
-         x="210.03"
+         x="210.01"
 	 y="-732.0624" 
 	 z="-893.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-2"/>
        <position name="posArapuca2-Lat-0" unit="cm" 
-         x="135.03"
+         x="135.01"
 	 y="-732.8024" 
 	 z="-893.52"/>
        <rotationref ref="rIdentity"/>
@@ -5092,14 +5103,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-2"/>
        <position name="posOpArapuca2-Lat-0" unit="cm" 
-         x="135.03"
+         x="135.01"
 	 y="-732.0624" 
 	 z="-893.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-3"/>
        <position name="posArapuca3-Lat-0" unit="cm" 
-         x="60.03"
+         x="60.01"
 	 y="-732.8024" 
 	 z="-893.52"/>
        <rotationref ref="rIdentity"/>
@@ -5107,14 +5118,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-3"/>
        <position name="posOpArapuca3-Lat-0" unit="cm" 
-         x="60.03"
+         x="60.01"
 	 y="-732.0624" 
 	 z="-893.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-4"/>
        <position name="posArapuca4-Lat-0" unit="cm" 
-         x="285.03"
+         x="285.01"
 	 y="732.8024" 
 	 z="-893.52"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5122,14 +5133,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-4"/>
        <position name="posOpArapuca4-Lat-0" unit="cm" 
-         x="285.03"
+         x="285.01"
 	 y="732.0624" 
 	 z="-893.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-5"/>
        <position name="posArapuca5-Lat-0" unit="cm" 
-         x="210.03"
+         x="210.01"
 	 y="732.8024" 
 	 z="-893.52"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5137,14 +5148,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-5"/>
        <position name="posOpArapuca5-Lat-0" unit="cm" 
-         x="210.03"
+         x="210.01"
 	 y="732.0624" 
 	 z="-893.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-6"/>
        <position name="posArapuca6-Lat-0" unit="cm" 
-         x="135.03"
+         x="135.01"
 	 y="732.8024" 
 	 z="-893.52"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5152,14 +5163,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-6"/>
        <position name="posOpArapuca6-Lat-0" unit="cm" 
-         x="135.03"
+         x="135.01"
 	 y="732.0624" 
 	 z="-893.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-7"/>
        <position name="posArapuca7-Lat-0" unit="cm" 
-         x="60.03"
+         x="60.01"
 	 y="732.8024" 
 	 z="-893.52"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5167,14 +5178,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-7"/>
        <position name="posOpArapuca7-Lat-0" unit="cm" 
-         x="60.03"
+         x="60.01"
 	 y="732.0624" 
 	 z="-893.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-0"/>
        <position name="posArapuca0-Lat-1" unit="cm" 
-         x="285.03"
+         x="285.01"
 	 y="-732.8024" 
 	 z="-595.68"/>
        <rotationref ref="rIdentity"/>
@@ -5182,14 +5193,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-0"/>
        <position name="posOpArapuca0-Lat-1" unit="cm" 
-         x="285.03"
+         x="285.01"
 	 y="-732.0624" 
 	 z="-595.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-1"/>
        <position name="posArapuca1-Lat-1" unit="cm" 
-         x="210.03"
+         x="210.01"
 	 y="-732.8024" 
 	 z="-595.68"/>
        <rotationref ref="rIdentity"/>
@@ -5197,14 +5208,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-1"/>
        <position name="posOpArapuca1-Lat-1" unit="cm" 
-         x="210.03"
+         x="210.01"
 	 y="-732.0624" 
 	 z="-595.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-2"/>
        <position name="posArapuca2-Lat-1" unit="cm" 
-         x="135.03"
+         x="135.01"
 	 y="-732.8024" 
 	 z="-595.68"/>
        <rotationref ref="rIdentity"/>
@@ -5212,14 +5223,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-2"/>
        <position name="posOpArapuca2-Lat-1" unit="cm" 
-         x="135.03"
+         x="135.01"
 	 y="-732.0624" 
 	 z="-595.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-3"/>
        <position name="posArapuca3-Lat-1" unit="cm" 
-         x="60.03"
+         x="60.01"
 	 y="-732.8024" 
 	 z="-595.68"/>
        <rotationref ref="rIdentity"/>
@@ -5227,14 +5238,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-3"/>
        <position name="posOpArapuca3-Lat-1" unit="cm" 
-         x="60.03"
+         x="60.01"
 	 y="-732.0624" 
 	 z="-595.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-4"/>
        <position name="posArapuca4-Lat-1" unit="cm" 
-         x="285.03"
+         x="285.01"
 	 y="732.8024" 
 	 z="-595.68"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5242,14 +5253,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-4"/>
        <position name="posOpArapuca4-Lat-1" unit="cm" 
-         x="285.03"
+         x="285.01"
 	 y="732.0624" 
 	 z="-595.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-5"/>
        <position name="posArapuca5-Lat-1" unit="cm" 
-         x="210.03"
+         x="210.01"
 	 y="732.8024" 
 	 z="-595.68"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5257,14 +5268,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-5"/>
        <position name="posOpArapuca5-Lat-1" unit="cm" 
-         x="210.03"
+         x="210.01"
 	 y="732.0624" 
 	 z="-595.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-6"/>
        <position name="posArapuca6-Lat-1" unit="cm" 
-         x="135.03"
+         x="135.01"
 	 y="732.8024" 
 	 z="-595.68"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5272,14 +5283,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-6"/>
        <position name="posOpArapuca6-Lat-1" unit="cm" 
-         x="135.03"
+         x="135.01"
 	 y="732.0624" 
 	 z="-595.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-7"/>
        <position name="posArapuca7-Lat-1" unit="cm" 
-         x="60.03"
+         x="60.01"
 	 y="732.8024" 
 	 z="-595.68"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5287,14 +5298,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-7"/>
        <position name="posOpArapuca7-Lat-1" unit="cm" 
-         x="60.03"
+         x="60.01"
 	 y="732.0624" 
 	 z="-595.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-0"/>
        <position name="posArapuca0-Lat-2" unit="cm" 
-         x="285.03"
+         x="285.01"
 	 y="-732.8024" 
 	 z="-297.84"/>
        <rotationref ref="rIdentity"/>
@@ -5302,14 +5313,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-0"/>
        <position name="posOpArapuca0-Lat-2" unit="cm" 
-         x="285.03"
+         x="285.01"
 	 y="-732.0624" 
 	 z="-297.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-1"/>
        <position name="posArapuca1-Lat-2" unit="cm" 
-         x="210.03"
+         x="210.01"
 	 y="-732.8024" 
 	 z="-297.84"/>
        <rotationref ref="rIdentity"/>
@@ -5317,14 +5328,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-1"/>
        <position name="posOpArapuca1-Lat-2" unit="cm" 
-         x="210.03"
+         x="210.01"
 	 y="-732.0624" 
 	 z="-297.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-2"/>
        <position name="posArapuca2-Lat-2" unit="cm" 
-         x="135.03"
+         x="135.01"
 	 y="-732.8024" 
 	 z="-297.84"/>
        <rotationref ref="rIdentity"/>
@@ -5332,14 +5343,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-2"/>
        <position name="posOpArapuca2-Lat-2" unit="cm" 
-         x="135.03"
+         x="135.01"
 	 y="-732.0624" 
 	 z="-297.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-3"/>
        <position name="posArapuca3-Lat-2" unit="cm" 
-         x="60.03"
+         x="60.01"
 	 y="-732.8024" 
 	 z="-297.84"/>
        <rotationref ref="rIdentity"/>
@@ -5347,14 +5358,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-3"/>
        <position name="posOpArapuca3-Lat-2" unit="cm" 
-         x="60.03"
+         x="60.01"
 	 y="-732.0624" 
 	 z="-297.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-4"/>
        <position name="posArapuca4-Lat-2" unit="cm" 
-         x="285.03"
+         x="285.01"
 	 y="732.8024" 
 	 z="-297.84"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5362,14 +5373,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-4"/>
        <position name="posOpArapuca4-Lat-2" unit="cm" 
-         x="285.03"
+         x="285.01"
 	 y="732.0624" 
 	 z="-297.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-5"/>
        <position name="posArapuca5-Lat-2" unit="cm" 
-         x="210.03"
+         x="210.01"
 	 y="732.8024" 
 	 z="-297.84"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5377,14 +5388,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-5"/>
        <position name="posOpArapuca5-Lat-2" unit="cm" 
-         x="210.03"
+         x="210.01"
 	 y="732.0624" 
 	 z="-297.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-6"/>
        <position name="posArapuca6-Lat-2" unit="cm" 
-         x="135.03"
+         x="135.01"
 	 y="732.8024" 
 	 z="-297.84"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5392,14 +5403,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-6"/>
        <position name="posOpArapuca6-Lat-2" unit="cm" 
-         x="135.03"
+         x="135.01"
 	 y="732.0624" 
 	 z="-297.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-7"/>
        <position name="posArapuca7-Lat-2" unit="cm" 
-         x="60.03"
+         x="60.01"
 	 y="732.8024" 
 	 z="-297.84"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5407,14 +5418,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-7"/>
        <position name="posOpArapuca7-Lat-2" unit="cm" 
-         x="60.03"
+         x="60.01"
 	 y="732.0624" 
 	 z="-297.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_3-0"/>
        <position name="posArapuca0-Lat-3" unit="cm" 
-         x="285.03"
+         x="285.01"
 	 y="-732.8024" 
 	 z="-1.13686837721616e-13"/>
        <rotationref ref="rIdentity"/>
@@ -5422,14 +5433,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_3-0"/>
        <position name="posOpArapuca0-Lat-3" unit="cm" 
-         x="285.03"
+         x="285.01"
 	 y="-732.0624" 
 	 z="-1.13686837721616e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_3-1"/>
        <position name="posArapuca1-Lat-3" unit="cm" 
-         x="210.03"
+         x="210.01"
 	 y="-732.8024" 
 	 z="-1.13686837721616e-13"/>
        <rotationref ref="rIdentity"/>
@@ -5437,14 +5448,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_3-1"/>
        <position name="posOpArapuca1-Lat-3" unit="cm" 
-         x="210.03"
+         x="210.01"
 	 y="-732.0624" 
 	 z="-1.13686837721616e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_3-2"/>
        <position name="posArapuca2-Lat-3" unit="cm" 
-         x="135.03"
+         x="135.01"
 	 y="-732.8024" 
 	 z="-1.13686837721616e-13"/>
        <rotationref ref="rIdentity"/>
@@ -5452,14 +5463,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_3-2"/>
        <position name="posOpArapuca2-Lat-3" unit="cm" 
-         x="135.03"
+         x="135.01"
 	 y="-732.0624" 
 	 z="-1.13686837721616e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_3-3"/>
        <position name="posArapuca3-Lat-3" unit="cm" 
-         x="60.03"
+         x="60.01"
 	 y="-732.8024" 
 	 z="-1.13686837721616e-13"/>
        <rotationref ref="rIdentity"/>
@@ -5467,14 +5478,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_3-3"/>
        <position name="posOpArapuca3-Lat-3" unit="cm" 
-         x="60.03"
+         x="60.01"
 	 y="-732.0624" 
 	 z="-1.13686837721616e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_3-4"/>
        <position name="posArapuca4-Lat-3" unit="cm" 
-         x="285.03"
+         x="285.01"
 	 y="732.8024" 
 	 z="-1.13686837721616e-13"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5482,14 +5493,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_3-4"/>
        <position name="posOpArapuca4-Lat-3" unit="cm" 
-         x="285.03"
+         x="285.01"
 	 y="732.0624" 
 	 z="-1.13686837721616e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_3-5"/>
        <position name="posArapuca5-Lat-3" unit="cm" 
-         x="210.03"
+         x="210.01"
 	 y="732.8024" 
 	 z="-1.13686837721616e-13"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5497,14 +5508,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_3-5"/>
        <position name="posOpArapuca5-Lat-3" unit="cm" 
-         x="210.03"
+         x="210.01"
 	 y="732.0624" 
 	 z="-1.13686837721616e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_3-6"/>
        <position name="posArapuca6-Lat-3" unit="cm" 
-         x="135.03"
+         x="135.01"
 	 y="732.8024" 
 	 z="-1.13686837721616e-13"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5512,14 +5523,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_3-6"/>
        <position name="posOpArapuca6-Lat-3" unit="cm" 
-         x="135.03"
+         x="135.01"
 	 y="732.0624" 
 	 z="-1.13686837721616e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_3-7"/>
        <position name="posArapuca7-Lat-3" unit="cm" 
-         x="60.03"
+         x="60.01"
 	 y="732.8024" 
 	 z="-1.13686837721616e-13"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5527,14 +5538,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_3-7"/>
        <position name="posOpArapuca7-Lat-3" unit="cm" 
-         x="60.03"
+         x="60.01"
 	 y="732.0624" 
 	 z="-1.13686837721616e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_4-0"/>
        <position name="posArapuca0-Lat-4" unit="cm" 
-         x="285.03"
+         x="285.01"
 	 y="-732.8024" 
 	 z="297.84"/>
        <rotationref ref="rIdentity"/>
@@ -5542,14 +5553,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_4-0"/>
        <position name="posOpArapuca0-Lat-4" unit="cm" 
-         x="285.03"
+         x="285.01"
 	 y="-732.0624" 
 	 z="297.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_4-1"/>
        <position name="posArapuca1-Lat-4" unit="cm" 
-         x="210.03"
+         x="210.01"
 	 y="-732.8024" 
 	 z="297.84"/>
        <rotationref ref="rIdentity"/>
@@ -5557,14 +5568,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_4-1"/>
        <position name="posOpArapuca1-Lat-4" unit="cm" 
-         x="210.03"
+         x="210.01"
 	 y="-732.0624" 
 	 z="297.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_4-2"/>
        <position name="posArapuca2-Lat-4" unit="cm" 
-         x="135.03"
+         x="135.01"
 	 y="-732.8024" 
 	 z="297.84"/>
        <rotationref ref="rIdentity"/>
@@ -5572,14 +5583,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_4-2"/>
        <position name="posOpArapuca2-Lat-4" unit="cm" 
-         x="135.03"
+         x="135.01"
 	 y="-732.0624" 
 	 z="297.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_4-3"/>
        <position name="posArapuca3-Lat-4" unit="cm" 
-         x="60.03"
+         x="60.01"
 	 y="-732.8024" 
 	 z="297.84"/>
        <rotationref ref="rIdentity"/>
@@ -5587,14 +5598,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_4-3"/>
        <position name="posOpArapuca3-Lat-4" unit="cm" 
-         x="60.03"
+         x="60.01"
 	 y="-732.0624" 
 	 z="297.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_4-4"/>
        <position name="posArapuca4-Lat-4" unit="cm" 
-         x="285.03"
+         x="285.01"
 	 y="732.8024" 
 	 z="297.84"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5602,14 +5613,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_4-4"/>
        <position name="posOpArapuca4-Lat-4" unit="cm" 
-         x="285.03"
+         x="285.01"
 	 y="732.0624" 
 	 z="297.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_4-5"/>
        <position name="posArapuca5-Lat-4" unit="cm" 
-         x="210.03"
+         x="210.01"
 	 y="732.8024" 
 	 z="297.84"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5617,14 +5628,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_4-5"/>
        <position name="posOpArapuca5-Lat-4" unit="cm" 
-         x="210.03"
+         x="210.01"
 	 y="732.0624" 
 	 z="297.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_4-6"/>
        <position name="posArapuca6-Lat-4" unit="cm" 
-         x="135.03"
+         x="135.01"
 	 y="732.8024" 
 	 z="297.84"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5632,14 +5643,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_4-6"/>
        <position name="posOpArapuca6-Lat-4" unit="cm" 
-         x="135.03"
+         x="135.01"
 	 y="732.0624" 
 	 z="297.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_4-7"/>
        <position name="posArapuca7-Lat-4" unit="cm" 
-         x="60.03"
+         x="60.01"
 	 y="732.8024" 
 	 z="297.84"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5647,14 +5658,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_4-7"/>
        <position name="posOpArapuca7-Lat-4" unit="cm" 
-         x="60.03"
+         x="60.01"
 	 y="732.0624" 
 	 z="297.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_5-0"/>
        <position name="posArapuca0-Lat-5" unit="cm" 
-         x="285.03"
+         x="285.01"
 	 y="-732.8024" 
 	 z="595.68"/>
        <rotationref ref="rIdentity"/>
@@ -5662,14 +5673,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_5-0"/>
        <position name="posOpArapuca0-Lat-5" unit="cm" 
-         x="285.03"
+         x="285.01"
 	 y="-732.0624" 
 	 z="595.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_5-1"/>
        <position name="posArapuca1-Lat-5" unit="cm" 
-         x="210.03"
+         x="210.01"
 	 y="-732.8024" 
 	 z="595.68"/>
        <rotationref ref="rIdentity"/>
@@ -5677,14 +5688,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_5-1"/>
        <position name="posOpArapuca1-Lat-5" unit="cm" 
-         x="210.03"
+         x="210.01"
 	 y="-732.0624" 
 	 z="595.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_5-2"/>
        <position name="posArapuca2-Lat-5" unit="cm" 
-         x="135.03"
+         x="135.01"
 	 y="-732.8024" 
 	 z="595.68"/>
        <rotationref ref="rIdentity"/>
@@ -5692,14 +5703,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_5-2"/>
        <position name="posOpArapuca2-Lat-5" unit="cm" 
-         x="135.03"
+         x="135.01"
 	 y="-732.0624" 
 	 z="595.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_5-3"/>
        <position name="posArapuca3-Lat-5" unit="cm" 
-         x="60.03"
+         x="60.01"
 	 y="-732.8024" 
 	 z="595.68"/>
        <rotationref ref="rIdentity"/>
@@ -5707,14 +5718,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_5-3"/>
        <position name="posOpArapuca3-Lat-5" unit="cm" 
-         x="60.03"
+         x="60.01"
 	 y="-732.0624" 
 	 z="595.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_5-4"/>
        <position name="posArapuca4-Lat-5" unit="cm" 
-         x="285.03"
+         x="285.01"
 	 y="732.8024" 
 	 z="595.68"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5722,14 +5733,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_5-4"/>
        <position name="posOpArapuca4-Lat-5" unit="cm" 
-         x="285.03"
+         x="285.01"
 	 y="732.0624" 
 	 z="595.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_5-5"/>
        <position name="posArapuca5-Lat-5" unit="cm" 
-         x="210.03"
+         x="210.01"
 	 y="732.8024" 
 	 z="595.68"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5737,14 +5748,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_5-5"/>
        <position name="posOpArapuca5-Lat-5" unit="cm" 
-         x="210.03"
+         x="210.01"
 	 y="732.0624" 
 	 z="595.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_5-6"/>
        <position name="posArapuca6-Lat-5" unit="cm" 
-         x="135.03"
+         x="135.01"
 	 y="732.8024" 
 	 z="595.68"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5752,14 +5763,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_5-6"/>
        <position name="posOpArapuca6-Lat-5" unit="cm" 
-         x="135.03"
+         x="135.01"
 	 y="732.0624" 
 	 z="595.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_5-7"/>
        <position name="posArapuca7-Lat-5" unit="cm" 
-         x="60.03"
+         x="60.01"
 	 y="732.8024" 
 	 z="595.68"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5767,14 +5778,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_5-7"/>
        <position name="posOpArapuca7-Lat-5" unit="cm" 
-         x="60.03"
+         x="60.01"
 	 y="732.0624" 
 	 z="595.68"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_6-0"/>
        <position name="posArapuca0-Lat-6" unit="cm" 
-         x="285.03"
+         x="285.01"
 	 y="-732.8024" 
 	 z="893.52"/>
        <rotationref ref="rIdentity"/>
@@ -5782,14 +5793,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_6-0"/>
        <position name="posOpArapuca0-Lat-6" unit="cm" 
-         x="285.03"
+         x="285.01"
 	 y="-732.0624" 
 	 z="893.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_6-1"/>
        <position name="posArapuca1-Lat-6" unit="cm" 
-         x="210.03"
+         x="210.01"
 	 y="-732.8024" 
 	 z="893.52"/>
        <rotationref ref="rIdentity"/>
@@ -5797,14 +5808,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_6-1"/>
        <position name="posOpArapuca1-Lat-6" unit="cm" 
-         x="210.03"
+         x="210.01"
 	 y="-732.0624" 
 	 z="893.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_6-2"/>
        <position name="posArapuca2-Lat-6" unit="cm" 
-         x="135.03"
+         x="135.01"
 	 y="-732.8024" 
 	 z="893.52"/>
        <rotationref ref="rIdentity"/>
@@ -5812,14 +5823,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_6-2"/>
        <position name="posOpArapuca2-Lat-6" unit="cm" 
-         x="135.03"
+         x="135.01"
 	 y="-732.0624" 
 	 z="893.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_6-3"/>
        <position name="posArapuca3-Lat-6" unit="cm" 
-         x="60.03"
+         x="60.01"
 	 y="-732.8024" 
 	 z="893.52"/>
        <rotationref ref="rIdentity"/>
@@ -5827,14 +5838,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_6-3"/>
        <position name="posOpArapuca3-Lat-6" unit="cm" 
-         x="60.03"
+         x="60.01"
 	 y="-732.0624" 
 	 z="893.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_6-4"/>
        <position name="posArapuca4-Lat-6" unit="cm" 
-         x="285.03"
+         x="285.01"
 	 y="732.8024" 
 	 z="893.52"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5842,14 +5853,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_6-4"/>
        <position name="posOpArapuca4-Lat-6" unit="cm" 
-         x="285.03"
+         x="285.01"
 	 y="732.0624" 
 	 z="893.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_6-5"/>
        <position name="posArapuca5-Lat-6" unit="cm" 
-         x="210.03"
+         x="210.01"
 	 y="732.8024" 
 	 z="893.52"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5857,14 +5868,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_6-5"/>
        <position name="posOpArapuca5-Lat-6" unit="cm" 
-         x="210.03"
+         x="210.01"
 	 y="732.0624" 
 	 z="893.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_6-6"/>
        <position name="posArapuca6-Lat-6" unit="cm" 
-         x="135.03"
+         x="135.01"
 	 y="732.8024" 
 	 z="893.52"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5872,14 +5883,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_6-6"/>
        <position name="posOpArapuca6-Lat-6" unit="cm" 
-         x="135.03"
+         x="135.01"
 	 y="732.0624" 
 	 z="893.52"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_6-7"/>
        <position name="posArapuca7-Lat-6" unit="cm" 
-         x="60.03"
+         x="60.01"
 	 y="732.8024" 
 	 z="893.52"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5887,7 +5898,7 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_6-7"/>
        <position name="posOpArapuca7-Lat-6" unit="cm" 
-         x="60.03"
+         x="60.01"
 	 y="732.0624" 
 	 z="893.52"/>
      </physvol>

--- a/dunecore/Geometry/gdml/dunevd10kt_3view_30deg_v3_refactored_1x8x6ref.gdml
+++ b/dunecore/Geometry/gdml/dunevd10kt_3view_30deg_v3_refactored_1x8x6ref.gdml
@@ -490,7 +490,7 @@
     
 
    <box name="CRM"
-      x="650.08" 
+      x="650.1" 
       y="167.7006" 
       z="148.92"
       lunit="cm"/>
@@ -3424,12 +3424,12 @@
 
 
     <box name="Cryostat" lunit="cm" 
-      x="850.32" 
+      x="850.34" 
       y="1209.4436" 
       z="1096.76"/>
 
     <box name="ArgonInterior" lunit="cm" 
-      x="850.08"
+      x="850.1"
       y="1209.2036"
       z="1096.52"/>
 
@@ -3439,12 +3439,12 @@
       z="1096.52"/>
 
     <box name="ExternalAuxOut" lunit="cm" 
-      x="850.08 - 100"
+      x="850.1 - 100"
       y="1209.2036 - 2*2.5 - 2*40"
       z="1096.52"/>
 
     <box name="ExternalAuxIn" lunit="cm" 
-      x="850.08"
+      x="850.1"
       y="1020.3736"
       z="1096.52 + 1"/>
 
@@ -3552,7 +3552,7 @@
     </subtraction>
 
     <box name="FoamPadBlock" lunit="cm"
-      x="1010.32"
+      x="1010.34"
       y="1369.4436"
       z="1256.76" />
 
@@ -3563,7 +3563,7 @@
     </subtraction>
 
     <box name="SteelSupportBlock" lunit="cm"
-      x="1210.32"
+      x="1210.34"
       y="1569.4436"
       z="1456.76" />
 
@@ -3574,13 +3574,13 @@
     </subtraction>
 
     <box name="DetEnclosure" lunit="cm" 
-      x="1310.32"
+      x="1310.34"
       y="1769.4436"
       z="1656.76"/>
 
 
     <box name="World" lunit="cm" 
-      x="9310.32" 
+      x="9310.34" 
       y="9769.4436" 
       z="9656.76"/>
 </solids>
@@ -10238,31 +10238,31 @@
        <physvol>
        <volumeref ref="volTPCPlaneU"/>
        <position name="posPlaneU" unit="cm" 
-         x="324.97" y="0" z="0"/>
+         x="324.98" y="0" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volTPCPlaneV"/>
        <position name="posPlaneY" unit="cm" 
-         x="324.99" y="0" z="0"/>
+         x="325" y="0" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volTPCPlaneZ"/>
        <position name="posPlaneZ" unit="cm" 
-         x="325.01" y="0" z="0"/>
+         x="325.02" y="0" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volAnodePlate"/>
        <position name="posAnodePlate" unit="cm" 
-         x="325.03" y="0" z="0"/>
+         x="325.04" y="0" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volTPCActive"/>
        <position name="posActive" unit="cm" 
-        x="-0.04" y="" z="0"/>
+        x="-0.05" y="" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
    </volume>
@@ -10581,7 +10581,7 @@
       <solidref ref="Cryostat" />
       <physvol>
         <volumeref ref="volGaseousArgon"/>
-        <position name="posGaseousArgon" unit="cm" x="375.04" y="0" z="0"/>
+        <position name="posGaseousArgon" unit="cm" x="375.05" y="0" z="0"/>
       </physvol>
       <physvol>
         <volumeref ref="volSteelShell"/>
@@ -10773,584 +10773,584 @@
       </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper0" unit="cm"  x="-322.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper0" unit="cm"  x="-322.05" y="-506.9018" z="0" />
      <rotation name="rotFS0" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper1" unit="cm"  x="-316.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper1" unit="cm"  x="-316.05" y="-506.9018" z="0" />
      <rotation name="rotFS1" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper2" unit="cm"  x="-310.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper2" unit="cm"  x="-310.05" y="-506.9018" z="0" />
      <rotation name="rotFS2" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper3" unit="cm"  x="-304.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper3" unit="cm"  x="-304.05" y="-506.9018" z="0" />
      <rotation name="rotFS3" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper4" unit="cm"  x="-298.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper4" unit="cm"  x="-298.05" y="-506.9018" z="0" />
      <rotation name="rotFS4" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper5" unit="cm"  x="-292.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper5" unit="cm"  x="-292.05" y="-506.9018" z="0" />
      <rotation name="rotFS5" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper6" unit="cm"  x="-286.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper6" unit="cm"  x="-286.05" y="-506.9018" z="0" />
      <rotation name="rotFS6" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper7" unit="cm"  x="-280.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper7" unit="cm"  x="-280.05" y="-506.9018" z="0" />
      <rotation name="rotFS7" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper8" unit="cm"  x="-274.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper8" unit="cm"  x="-274.05" y="-506.9018" z="0" />
      <rotation name="rotFS8" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper9" unit="cm"  x="-268.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper9" unit="cm"  x="-268.05" y="-506.9018" z="0" />
      <rotation name="rotFS9" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper10" unit="cm"  x="-262.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper10" unit="cm"  x="-262.05" y="-506.9018" z="0" />
      <rotation name="rotFS10" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper11" unit="cm"  x="-256.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper11" unit="cm"  x="-256.05" y="-506.9018" z="0" />
      <rotation name="rotFS11" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper12" unit="cm"  x="-250.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper12" unit="cm"  x="-250.05" y="-506.9018" z="0" />
      <rotation name="rotFS12" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper13" unit="cm"  x="-244.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper13" unit="cm"  x="-244.05" y="-506.9018" z="0" />
      <rotation name="rotFS13" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper14" unit="cm"  x="-238.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper14" unit="cm"  x="-238.05" y="-506.9018" z="0" />
      <rotation name="rotFS14" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper15" unit="cm"  x="-232.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper15" unit="cm"  x="-232.05" y="-506.9018" z="0" />
      <rotation name="rotFS15" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper16" unit="cm"  x="-226.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper16" unit="cm"  x="-226.05" y="-506.9018" z="0" />
      <rotation name="rotFS16" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper17" unit="cm"  x="-220.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper17" unit="cm"  x="-220.05" y="-506.9018" z="0" />
      <rotation name="rotFS17" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper18" unit="cm"  x="-214.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper18" unit="cm"  x="-214.05" y="-506.9018" z="0" />
      <rotation name="rotFS18" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper19" unit="cm"  x="-208.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper19" unit="cm"  x="-208.05" y="-506.9018" z="0" />
      <rotation name="rotFS19" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper20" unit="cm"  x="-202.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper20" unit="cm"  x="-202.05" y="-506.9018" z="0" />
      <rotation name="rotFS20" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper21" unit="cm"  x="-196.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper21" unit="cm"  x="-196.05" y="-506.9018" z="0" />
      <rotation name="rotFS21" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper22" unit="cm"  x="-190.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper22" unit="cm"  x="-190.05" y="-506.9018" z="0" />
      <rotation name="rotFS22" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper23" unit="cm"  x="-184.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper23" unit="cm"  x="-184.05" y="-506.9018" z="0" />
      <rotation name="rotFS23" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper24" unit="cm"  x="-178.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper24" unit="cm"  x="-178.05" y="-506.9018" z="0" />
      <rotation name="rotFS24" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper25" unit="cm"  x="-172.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper25" unit="cm"  x="-172.05" y="-506.9018" z="0" />
      <rotation name="rotFS25" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper26" unit="cm"  x="-166.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper26" unit="cm"  x="-166.05" y="-506.9018" z="0" />
      <rotation name="rotFS26" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper27" unit="cm"  x="-160.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper27" unit="cm"  x="-160.05" y="-506.9018" z="0" />
      <rotation name="rotFS27" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper28" unit="cm"  x="-154.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper28" unit="cm"  x="-154.05" y="-506.9018" z="0" />
      <rotation name="rotFS28" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper29" unit="cm"  x="-148.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper29" unit="cm"  x="-148.05" y="-506.9018" z="0" />
      <rotation name="rotFS29" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper30" unit="cm"  x="-142.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper30" unit="cm"  x="-142.05" y="-506.9018" z="0" />
      <rotation name="rotFS30" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper31" unit="cm"  x="-136.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper31" unit="cm"  x="-136.05" y="-506.9018" z="0" />
      <rotation name="rotFS31" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper32" unit="cm"  x="-130.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper32" unit="cm"  x="-130.05" y="-506.9018" z="0" />
      <rotation name="rotFS32" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper33" unit="cm"  x="-124.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper33" unit="cm"  x="-124.05" y="-506.9018" z="0" />
      <rotation name="rotFS33" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper34" unit="cm"  x="-118.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper34" unit="cm"  x="-118.05" y="-506.9018" z="0" />
      <rotation name="rotFS34" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper35" unit="cm"  x="-112.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper35" unit="cm"  x="-112.05" y="-506.9018" z="0" />
      <rotation name="rotFS35" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper36" unit="cm"  x="-106.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper36" unit="cm"  x="-106.05" y="-506.9018" z="0" />
      <rotation name="rotFS36" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper37" unit="cm"  x="-100.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper37" unit="cm"  x="-100.05" y="-506.9018" z="0" />
      <rotation name="rotFS37" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper38" unit="cm"  x="-94.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper38" unit="cm"  x="-94.0500000000001" y="-506.9018" z="0" />
      <rotation name="rotFS38" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper39" unit="cm"  x="-88.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper39" unit="cm"  x="-88.0500000000001" y="-506.9018" z="0" />
      <rotation name="rotFS39" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper40" unit="cm"  x="-82.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper40" unit="cm"  x="-82.0500000000001" y="-506.9018" z="0" />
      <rotation name="rotFS40" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper41" unit="cm"  x="-76.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper41" unit="cm"  x="-76.0500000000001" y="-506.9018" z="0" />
      <rotation name="rotFS41" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper42" unit="cm"  x="-70.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper42" unit="cm"  x="-70.0500000000001" y="-506.9018" z="0" />
      <rotation name="rotFS42" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper43" unit="cm"  x="-64.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper43" unit="cm"  x="-64.0500000000001" y="-506.9018" z="0" />
      <rotation name="rotFS43" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper44" unit="cm"  x="-58.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper44" unit="cm"  x="-58.0500000000001" y="-506.9018" z="0" />
      <rotation name="rotFS44" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper45" unit="cm"  x="-52.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper45" unit="cm"  x="-52.0500000000001" y="-506.9018" z="0" />
      <rotation name="rotFS45" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper46" unit="cm"  x="-46.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper46" unit="cm"  x="-46.0500000000001" y="-506.9018" z="0" />
      <rotation name="rotFS46" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper47" unit="cm"  x="-40.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper47" unit="cm"  x="-40.0500000000001" y="-506.9018" z="0" />
      <rotation name="rotFS47" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper48" unit="cm"  x="-34.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper48" unit="cm"  x="-34.0500000000001" y="-506.9018" z="0" />
      <rotation name="rotFS48" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper49" unit="cm"  x="-28.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper49" unit="cm"  x="-28.0500000000001" y="-506.9018" z="0" />
      <rotation name="rotFS49" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper50" unit="cm"  x="-22.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper50" unit="cm"  x="-22.0500000000001" y="-506.9018" z="0" />
      <rotation name="rotFS50" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper51" unit="cm"  x="-16.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper51" unit="cm"  x="-16.0500000000001" y="-506.9018" z="0" />
      <rotation name="rotFS51" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper52" unit="cm"  x="-10.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper52" unit="cm"  x="-10.0500000000001" y="-506.9018" z="0" />
      <rotation name="rotFS52" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper53" unit="cm"  x="-4.04000000000001" y="-506.9018" z="0" />
+     <position name="posFieldShaper53" unit="cm"  x="-4.05000000000005" y="-506.9018" z="0" />
      <rotation name="rotFS53" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper54" unit="cm"  x="1.95999999999999" y="-506.9018" z="0" />
+     <position name="posFieldShaper54" unit="cm"  x="1.94999999999995" y="-506.9018" z="0" />
      <rotation name="rotFS54" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper55" unit="cm"  x="7.95999999999999" y="-506.9018" z="0" />
+     <position name="posFieldShaper55" unit="cm"  x="7.94999999999995" y="-506.9018" z="0" />
      <rotation name="rotFS55" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper56" unit="cm"  x="13.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper56" unit="cm"  x="13.9499999999999" y="-506.9018" z="0" />
      <rotation name="rotFS56" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper57" unit="cm"  x="19.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper57" unit="cm"  x="19.9499999999999" y="-506.9018" z="0" />
      <rotation name="rotFS57" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper58" unit="cm"  x="25.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper58" unit="cm"  x="25.9499999999999" y="-506.9018" z="0" />
      <rotation name="rotFS58" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper59" unit="cm"  x="31.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper59" unit="cm"  x="31.9499999999999" y="-506.9018" z="0" />
      <rotation name="rotFS59" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper60" unit="cm"  x="37.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper60" unit="cm"  x="37.9499999999999" y="-506.9018" z="0" />
      <rotation name="rotFS60" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper61" unit="cm"  x="43.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper61" unit="cm"  x="43.9499999999999" y="-506.9018" z="0" />
      <rotation name="rotFS61" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper62" unit="cm"  x="49.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper62" unit="cm"  x="49.9499999999999" y="-506.9018" z="0" />
      <rotation name="rotFS62" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper63" unit="cm"  x="55.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper63" unit="cm"  x="55.9499999999999" y="-506.9018" z="0" />
      <rotation name="rotFS63" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper64" unit="cm"  x="61.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper64" unit="cm"  x="61.9499999999999" y="-506.9018" z="0" />
      <rotation name="rotFS64" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper65" unit="cm"  x="67.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper65" unit="cm"  x="67.9499999999999" y="-506.9018" z="0" />
      <rotation name="rotFS65" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper66" unit="cm"  x="73.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper66" unit="cm"  x="73.9499999999999" y="-506.9018" z="0" />
      <rotation name="rotFS66" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper67" unit="cm"  x="79.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper67" unit="cm"  x="79.9499999999999" y="-506.9018" z="0" />
      <rotation name="rotFS67" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper68" unit="cm"  x="85.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper68" unit="cm"  x="85.9499999999999" y="-506.9018" z="0" />
      <rotation name="rotFS68" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper69" unit="cm"  x="91.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper69" unit="cm"  x="91.9499999999999" y="-506.9018" z="0" />
      <rotation name="rotFS69" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper70" unit="cm"  x="97.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper70" unit="cm"  x="97.9499999999999" y="-506.9018" z="0" />
      <rotation name="rotFS70" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper71" unit="cm"  x="103.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper71" unit="cm"  x="103.95" y="-506.9018" z="0" />
      <rotation name="rotFS71" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper72" unit="cm"  x="109.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper72" unit="cm"  x="109.95" y="-506.9018" z="0" />
      <rotation name="rotFS72" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper73" unit="cm"  x="115.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper73" unit="cm"  x="115.95" y="-506.9018" z="0" />
      <rotation name="rotFS73" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper74" unit="cm"  x="121.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper74" unit="cm"  x="121.95" y="-506.9018" z="0" />
      <rotation name="rotFS74" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper75" unit="cm"  x="127.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper75" unit="cm"  x="127.95" y="-506.9018" z="0" />
      <rotation name="rotFS75" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper76" unit="cm"  x="133.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper76" unit="cm"  x="133.95" y="-506.9018" z="0" />
      <rotation name="rotFS76" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper77" unit="cm"  x="139.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper77" unit="cm"  x="139.95" y="-506.9018" z="0" />
      <rotation name="rotFS77" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper78" unit="cm"  x="145.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper78" unit="cm"  x="145.95" y="-506.9018" z="0" />
      <rotation name="rotFS78" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper79" unit="cm"  x="151.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper79" unit="cm"  x="151.95" y="-506.9018" z="0" />
      <rotation name="rotFS79" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper80" unit="cm"  x="157.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper80" unit="cm"  x="157.95" y="-506.9018" z="0" />
      <rotation name="rotFS80" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper81" unit="cm"  x="163.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper81" unit="cm"  x="163.95" y="-506.9018" z="0" />
      <rotation name="rotFS81" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper82" unit="cm"  x="169.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper82" unit="cm"  x="169.95" y="-506.9018" z="0" />
      <rotation name="rotFS82" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper83" unit="cm"  x="175.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper83" unit="cm"  x="175.95" y="-506.9018" z="0" />
      <rotation name="rotFS83" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper84" unit="cm"  x="181.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper84" unit="cm"  x="181.95" y="-506.9018" z="0" />
      <rotation name="rotFS84" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper85" unit="cm"  x="187.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper85" unit="cm"  x="187.95" y="-506.9018" z="0" />
      <rotation name="rotFS85" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper86" unit="cm"  x="193.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper86" unit="cm"  x="193.95" y="-506.9018" z="0" />
      <rotation name="rotFS86" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper87" unit="cm"  x="199.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper87" unit="cm"  x="199.95" y="-506.9018" z="0" />
      <rotation name="rotFS87" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper88" unit="cm"  x="205.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper88" unit="cm"  x="205.95" y="-506.9018" z="0" />
      <rotation name="rotFS88" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper89" unit="cm"  x="211.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper89" unit="cm"  x="211.95" y="-506.9018" z="0" />
      <rotation name="rotFS89" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper90" unit="cm"  x="217.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper90" unit="cm"  x="217.95" y="-506.9018" z="0" />
      <rotation name="rotFS90" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper91" unit="cm"  x="223.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper91" unit="cm"  x="223.95" y="-506.9018" z="0" />
      <rotation name="rotFS91" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper92" unit="cm"  x="229.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper92" unit="cm"  x="229.95" y="-506.9018" z="0" />
      <rotation name="rotFS92" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper93" unit="cm"  x="235.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper93" unit="cm"  x="235.95" y="-506.9018" z="0" />
      <rotation name="rotFS93" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper94" unit="cm"  x="241.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper94" unit="cm"  x="241.95" y="-506.9018" z="0" />
      <rotation name="rotFS94" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper95" unit="cm"  x="247.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper95" unit="cm"  x="247.95" y="-506.9018" z="0" />
      <rotation name="rotFS95" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper96" unit="cm"  x="253.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper96" unit="cm"  x="253.95" y="-506.9018" z="0" />
      <rotation name="rotFS96" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper97" unit="cm"  x="259.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper97" unit="cm"  x="259.95" y="-506.9018" z="0" />
      <rotation name="rotFS97" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper98" unit="cm"  x="265.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper98" unit="cm"  x="265.95" y="-506.9018" z="0" />
      <rotation name="rotFS98" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper99" unit="cm"  x="271.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper99" unit="cm"  x="271.95" y="-506.9018" z="0" />
      <rotation name="rotFS99" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper100" unit="cm"  x="277.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper100" unit="cm"  x="277.95" y="-506.9018" z="0" />
      <rotation name="rotFS100" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper101" unit="cm"  x="283.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper101" unit="cm"  x="283.95" y="-506.9018" z="0" />
      <rotation name="rotFS101" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper102" unit="cm"  x="289.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper102" unit="cm"  x="289.95" y="-506.9018" z="0" />
      <rotation name="rotFS102" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper103" unit="cm"  x="295.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper103" unit="cm"  x="295.95" y="-506.9018" z="0" />
      <rotation name="rotFS103" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper104" unit="cm"  x="301.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper104" unit="cm"  x="301.95" y="-506.9018" z="0" />
      <rotation name="rotFS104" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper105" unit="cm"  x="307.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper105" unit="cm"  x="307.95" y="-506.9018" z="0" />
      <rotation name="rotFS105" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper106" unit="cm"  x="313.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper106" unit="cm"  x="313.95" y="-506.9018" z="0" />
      <rotation name="rotFS106" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper107" unit="cm"  x="319.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper107" unit="cm"  x="319.95" y="-506.9018" z="0" />
      <rotation name="rotFS107" unit="deg" x="0" y="0" z="90" />
   </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-0" unit="cm" x="-328.04" y="-336.9012" z="-299.34"/>
+   <position name="posGroundGrid-0" unit="cm" x="-328.05" y="-336.9012" z="-299.34"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-1" unit="cm" x="-328.04" y="-1.5" z="-299.34"/>
+   <position name="posGroundGrid-1" unit="cm" x="-328.05" y="-1.5" z="-299.34"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-2" unit="cm" x="-328.04" y="333.9012" z="-299.34"/>
+   <position name="posGroundGrid-2" unit="cm" x="-328.05" y="333.9012" z="-299.34"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-3" unit="cm" x="-328.04" y="-336.9012" z="-1.5"/>
+   <position name="posGroundGrid-3" unit="cm" x="-328.05" y="-336.9012" z="-1.5"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-4" unit="cm" x="-328.04" y="-1.5" z="-1.5"/>
+   <position name="posGroundGrid-4" unit="cm" x="-328.05" y="-1.5" z="-1.5"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-5" unit="cm" x="-328.04" y="333.9012" z="-1.5"/>
+   <position name="posGroundGrid-5" unit="cm" x="-328.05" y="333.9012" z="-1.5"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-6" unit="cm" x="-328.04" y="-336.9012" z="296.34"/>
+   <position name="posGroundGrid-6" unit="cm" x="-328.05" y="-336.9012" z="296.34"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-7" unit="cm" x="-328.04" y="-1.5" z="296.34"/>
+   <position name="posGroundGrid-7" unit="cm" x="-328.05" y="-1.5" z="296.34"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-8" unit="cm" x="-328.04" y="333.9012" z="296.34"/>
+   <position name="posGroundGrid-8" unit="cm" x="-328.05" y="333.9012" z="296.34"/>
       </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-0-0"/>
        <position name="posArapucaDouble0-Frame-0-0" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-464.6012" 
 	 z="-261.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11358,14 +11358,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-0"/>
        <position name="posOpArapucaDouble0-Frame-0-0" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-464.6012" 
 	 z="-261.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-0-1"/>
        <position name="posArapucaDouble1-Frame-0-0" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-373.9012" 
 	 z="-407.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11373,14 +11373,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-1"/>
        <position name="posOpArapucaDouble1-Frame-0-0" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-373.9012" 
 	 z="-407.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-0-2"/>
        <position name="posArapucaDouble2-Frame-0-0" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-299.9012" 
 	 z="-190.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11388,14 +11388,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-2"/>
        <position name="posOpArapucaDouble2-Frame-0-0" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-299.9012" 
 	 z="-190.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-0-3"/>
        <position name="posArapucaDouble3-Frame-0-0" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-209.2012" 
 	 z="-336.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11403,14 +11403,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-3"/>
        <position name="posOpArapucaDouble3-Frame-0-0" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-209.2012" 
 	 z="-336.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-1-0"/>
        <position name="posArapucaDouble0-Frame-0-1" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-464.6012" 
 	 z="36"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11418,14 +11418,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-0"/>
        <position name="posOpArapucaDouble0-Frame-0-1" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-464.6012" 
 	 z="36"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-1-1"/>
        <position name="posArapucaDouble1-Frame-0-1" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-373.9012" 
 	 z="-110"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11433,14 +11433,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-1"/>
        <position name="posOpArapucaDouble1-Frame-0-1" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-373.9012" 
 	 z="-110"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-1-2"/>
        <position name="posArapucaDouble2-Frame-0-1" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-299.9012" 
 	 z="107"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11448,14 +11448,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-2"/>
        <position name="posOpArapucaDouble2-Frame-0-1" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-299.9012" 
 	 z="107"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-1-3"/>
        <position name="posArapucaDouble3-Frame-0-1" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-209.2012" 
 	 z="-39"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11463,14 +11463,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-3"/>
        <position name="posOpArapucaDouble3-Frame-0-1" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-209.2012" 
 	 z="-39"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-2-0"/>
        <position name="posArapucaDouble0-Frame-0-2" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-464.6012" 
 	 z="333.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11478,14 +11478,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-0"/>
        <position name="posOpArapucaDouble0-Frame-0-2" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-464.6012" 
 	 z="333.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-2-1"/>
        <position name="posArapucaDouble1-Frame-0-2" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-373.9012" 
 	 z="187.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11493,14 +11493,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-1"/>
        <position name="posOpArapucaDouble1-Frame-0-2" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-373.9012" 
 	 z="187.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-2-2"/>
        <position name="posArapucaDouble2-Frame-0-2" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-299.9012" 
 	 z="404.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11508,14 +11508,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-2"/>
        <position name="posOpArapucaDouble2-Frame-0-2" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-299.9012" 
 	 z="404.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-2-3"/>
        <position name="posArapucaDouble3-Frame-0-2" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-209.2012" 
 	 z="258.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11523,14 +11523,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-3"/>
        <position name="posOpArapucaDouble3-Frame-0-2" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-209.2012" 
 	 z="258.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-0-0"/>
        <position name="posArapucaDouble0-Frame-1-0" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-129.2" 
 	 z="-261.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11538,14 +11538,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-0"/>
        <position name="posOpArapucaDouble0-Frame-1-0" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-129.2" 
 	 z="-261.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-0-1"/>
        <position name="posArapucaDouble1-Frame-1-0" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-38.5" 
 	 z="-407.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11553,14 +11553,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-1"/>
        <position name="posOpArapucaDouble1-Frame-1-0" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-38.5" 
 	 z="-407.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-0-2"/>
        <position name="posArapucaDouble2-Frame-1-0" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="35.5" 
 	 z="-190.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11568,14 +11568,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-2"/>
        <position name="posOpArapucaDouble2-Frame-1-0" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="35.5" 
 	 z="-190.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-0-3"/>
        <position name="posArapucaDouble3-Frame-1-0" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="126.2" 
 	 z="-336.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11583,14 +11583,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-3"/>
        <position name="posOpArapucaDouble3-Frame-1-0" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="126.2" 
 	 z="-336.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-1-0"/>
        <position name="posArapucaDouble0-Frame-1-1" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-129.2" 
 	 z="36"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11598,14 +11598,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-0"/>
        <position name="posOpArapucaDouble0-Frame-1-1" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-129.2" 
 	 z="36"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-1-1"/>
        <position name="posArapucaDouble1-Frame-1-1" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-38.5" 
 	 z="-110"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11613,14 +11613,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-1"/>
        <position name="posOpArapucaDouble1-Frame-1-1" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-38.5" 
 	 z="-110"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-1-2"/>
        <position name="posArapucaDouble2-Frame-1-1" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="35.5" 
 	 z="107"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11628,14 +11628,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-2"/>
        <position name="posOpArapucaDouble2-Frame-1-1" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="35.5" 
 	 z="107"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-1-3"/>
        <position name="posArapucaDouble3-Frame-1-1" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="126.2" 
 	 z="-39"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11643,14 +11643,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-3"/>
        <position name="posOpArapucaDouble3-Frame-1-1" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="126.2" 
 	 z="-39"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-2-0"/>
        <position name="posArapucaDouble0-Frame-1-2" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-129.2" 
 	 z="333.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11658,14 +11658,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-0"/>
        <position name="posOpArapucaDouble0-Frame-1-2" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-129.2" 
 	 z="333.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-2-1"/>
        <position name="posArapucaDouble1-Frame-1-2" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-38.5" 
 	 z="187.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11673,14 +11673,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-1"/>
        <position name="posOpArapucaDouble1-Frame-1-2" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-38.5" 
 	 z="187.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-2-2"/>
        <position name="posArapucaDouble2-Frame-1-2" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="35.5" 
 	 z="404.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11688,14 +11688,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-2"/>
        <position name="posOpArapucaDouble2-Frame-1-2" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="35.5" 
 	 z="404.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-2-3"/>
        <position name="posArapucaDouble3-Frame-1-2" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="126.2" 
 	 z="258.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11703,14 +11703,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-3"/>
        <position name="posOpArapucaDouble3-Frame-1-2" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="126.2" 
 	 z="258.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-0-0"/>
        <position name="posArapucaDouble0-Frame-2-0" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="206.2012" 
 	 z="-261.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11718,14 +11718,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-0"/>
        <position name="posOpArapucaDouble0-Frame-2-0" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="206.2012" 
 	 z="-261.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-0-1"/>
        <position name="posArapucaDouble1-Frame-2-0" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="296.9012" 
 	 z="-407.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11733,14 +11733,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-1"/>
        <position name="posOpArapucaDouble1-Frame-2-0" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="296.9012" 
 	 z="-407.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-0-2"/>
        <position name="posArapucaDouble2-Frame-2-0" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="370.9012" 
 	 z="-190.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11748,14 +11748,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-2"/>
        <position name="posOpArapucaDouble2-Frame-2-0" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="370.9012" 
 	 z="-190.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-0-3"/>
        <position name="posArapucaDouble3-Frame-2-0" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="461.6012" 
 	 z="-336.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11763,14 +11763,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-3"/>
        <position name="posOpArapucaDouble3-Frame-2-0" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="461.6012" 
 	 z="-336.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-1-0"/>
        <position name="posArapucaDouble0-Frame-2-1" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="206.2012" 
 	 z="36"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11778,14 +11778,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-0"/>
        <position name="posOpArapucaDouble0-Frame-2-1" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="206.2012" 
 	 z="36"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-1-1"/>
        <position name="posArapucaDouble1-Frame-2-1" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="296.9012" 
 	 z="-110"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11793,14 +11793,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-1"/>
        <position name="posOpArapucaDouble1-Frame-2-1" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="296.9012" 
 	 z="-110"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-1-2"/>
        <position name="posArapucaDouble2-Frame-2-1" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="370.9012" 
 	 z="107"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11808,14 +11808,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-2"/>
        <position name="posOpArapucaDouble2-Frame-2-1" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="370.9012" 
 	 z="107"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-1-3"/>
        <position name="posArapucaDouble3-Frame-2-1" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="461.6012" 
 	 z="-39"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11823,14 +11823,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-3"/>
        <position name="posOpArapucaDouble3-Frame-2-1" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="461.6012" 
 	 z="-39"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-2-0"/>
        <position name="posArapucaDouble0-Frame-2-2" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="206.2012" 
 	 z="333.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11838,14 +11838,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-0"/>
        <position name="posOpArapucaDouble0-Frame-2-2" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="206.2012" 
 	 z="333.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-2-1"/>
        <position name="posArapucaDouble1-Frame-2-2" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="296.9012" 
 	 z="187.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11853,14 +11853,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-1"/>
        <position name="posOpArapucaDouble1-Frame-2-2" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="296.9012" 
 	 z="187.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-2-2"/>
        <position name="posArapucaDouble2-Frame-2-2" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="370.9012" 
 	 z="404.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11868,14 +11868,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-2"/>
        <position name="posOpArapucaDouble2-Frame-2-2" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="370.9012" 
 	 z="404.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-2-3"/>
        <position name="posArapucaDouble3-Frame-2-2" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="461.6012" 
 	 z="258.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11883,7 +11883,7 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-3"/>
        <position name="posOpArapucaDouble3-Frame-2-2" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="461.6012" 
 	 z="258.84"/>
      </physvol>
@@ -11923,7 +11923,7 @@
 
       <physvol>
         <volumeref ref="volDetEnclosure"/>
-	<position name="posDetEnclosure" unit="cm" x="50.04" y="0" z="448.26"/>
+	<position name="posDetEnclosure" unit="cm" x="50.0500000000001" y="0" z="448.26"/>
       </physvol>
 
     </volume>

--- a/dunecore/Geometry/gdml/dunevd10kt_3view_30deg_v3_refactored_1x8x6ref.gdml
+++ b/dunecore/Geometry/gdml/dunevd10kt_3view_30deg_v3_refactored_1x8x6ref.gdml
@@ -390,7 +390,7 @@
      <torus name="FieldShaperCorner" rmin="0.5" rmax="2.285" rtor="2.3" deltaphi="90" startphi="0" aunit="deg" lunit="cm"/>
      <tube name="FieldShaperLongtube" rmin="0.5" rmax="2.285" z="896.52" deltaphi="360" startphi="0" aunit="deg" lunit="cm"/>
      <tube name="FieldShaperLongtubeSlim" rmin="0.5" rmax="0.75" z="896.52" deltaphi="360" startphi="0" aunit="deg" lunit="cm"/>
-     <tube name="FieldShaperShorttube" rmin="0.5" rmax="2.285" z="1345.6048" deltaphi="360" startphi="0" aunit="deg" lunit="cm"/>
+     <tube name="FieldShaperShorttube" rmin="0.5" rmax="2.285" z="1009.2036" deltaphi="360" startphi="0" aunit="deg" lunit="cm"/>
 
     <union name="FSunion1">
       <first ref="FieldShaperLongtube"/>
@@ -402,34 +402,34 @@
     <union name="FSunion2">
       <first ref="FSunion1"/>
       <second ref="FieldShaperShorttube"/>
-   		<position name="esquinapos2" unit="cm" x="-675.1024" y="0" z="450.56"/>
+   		<position name="esquinapos2" unit="cm" x="-506.9018" y="0" z="450.56"/>
    		<rotation name="rot2" unit="deg" x="0" y="90" z="0" />
     </union>
 
     <union name="FSunion3">
       <first ref="FSunion2"/>
       <second ref="FieldShaperCorner"/>
-   		<position name="esquinapos3" unit="cm" x="-1347.9048" y="0" z="448.26"/>
+   		<position name="esquinapos3" unit="cm" x="-1011.5036" y="0" z="448.26"/>
 		<rotation name="rot3" unit="deg" x="90" y="270" z="0" />
     </union>
 
     <union name="FSunion4">
       <first ref="FSunion3"/>
       <second ref="FieldShaperLongtube"/>
-   		<position name="esquinapos4" unit="cm" x="-1350.2048" y="0" z="0"/>
+   		<position name="esquinapos4" unit="cm" x="-1013.8036" y="0" z="0"/>
     </union>
 
     <union name="FSunion5">
       <first ref="FSunion4"/>
       <second ref="FieldShaperCorner"/>
-   		<position name="esquinapos5" unit="cm" x="-1347.9048" y="0" z="-448.26"/>
+   		<position name="esquinapos5" unit="cm" x="-1011.5036" y="0" z="-448.26"/>
 		<rotation name="rot5" unit="deg" x="90" y="180" z="0" />
     </union>
 
     <union name="FSunion6">
       <first ref="FSunion5"/>
       <second ref="FieldShaperShorttube"/>
-   		<position name="esquinapos6" unit="cm" x="-675.1024" y="0" z="-450.56"/>
+   		<position name="esquinapos6" unit="cm" x="-506.9018" y="0" z="-450.56"/>
 		<rotation name="rot6" unit="deg" x="0" y="90" z="0" />
     </union>
 
@@ -450,34 +450,34 @@
     <union name="FSunionSlim2">
       <first ref="FSunionSlim1"/>
       <second ref="FieldShaperShorttube"/>
-   		<position name="esquinapos2" unit="cm" x="-675.1024" y="0" z="450.56"/>
+   		<position name="esquinapos2" unit="cm" x="-506.9018" y="0" z="450.56"/>
    		<rotation name="rot2" unit="deg" x="0" y="90" z="0" />
     </union>
 
     <union name="FSunionSlim3">
       <first ref="FSunionSlim2"/>
       <second ref="FieldShaperCorner"/>
-   		<position name="esquinapos3" unit="cm" x="-1347.9048" y="0" z="448.26"/>
+   		<position name="esquinapos3" unit="cm" x="-1011.5036" y="0" z="448.26"/>
 		<rotation name="rot3" unit="deg" x="90" y="270" z="0" />
     </union>
 
     <union name="FSunionSlim4">
       <first ref="FSunionSlim3"/>
       <second ref="FieldShaperLongtubeSlim"/>
-   		<position name="esquinapos4" unit="cm" x="-1350.2048" y="0" z="0"/>
+   		<position name="esquinapos4" unit="cm" x="-1013.8036" y="0" z="0"/>
     </union>
 
     <union name="FSunionSlim5">
       <first ref="FSunionSlim4"/>
       <second ref="FieldShaperCorner"/>
-   		<position name="esquinapos5" unit="cm" x="-1347.9048" y="0" z="-448.26"/>
+   		<position name="esquinapos5" unit="cm" x="-1011.5036" y="0" z="-448.26"/>
 		<rotation name="rot5" unit="deg" x="90" y="180" z="0" />
     </union>
 
     <union name="FSunionSlim6">
       <first ref="FSunionSlim5"/>
       <second ref="FieldShaperShorttube"/>
-   		<position name="esquinapos6" unit="cm" x="-675.1024" y="0" z="-450.56"/>
+   		<position name="esquinapos6" unit="cm" x="-506.9018" y="0" z="-450.56"/>
 		<rotation name="rot6" unit="deg" x="0" y="90" z="0" />
     </union>
 
@@ -3425,27 +3425,27 @@
 
     <box name="Cryostat" lunit="cm" 
       x="850.32" 
-      y="1545.8448" 
+      y="1209.4436" 
       z="1096.76"/>
 
     <box name="ArgonInterior" lunit="cm" 
       x="850.08"
-      y="1545.6048"
+      y="1209.2036"
       z="1096.52"/>
 
     <box name="GaseousArgon" lunit="cm" 
       x="100"
-      y="1545.6048"
+      y="1209.2036"
       z="1096.52"/>
 
     <box name="ExternalAuxOut" lunit="cm" 
       x="850.08 - 100"
-      y="1545.6048 - 2*2.5 - 2*40"
+      y="1209.2036 - 2*2.5 - 2*40"
       z="1096.52"/>
 
     <box name="ExternalAuxIn" lunit="cm" 
       x="850.08"
-      y="1356.7748"
+      y="1020.3736"
       z="1096.52 + 1"/>
 
    <subtraction name="ExternalActive">
@@ -3553,7 +3553,7 @@
 
     <box name="FoamPadBlock" lunit="cm"
       x="1010.32"
-      y="1705.8448"
+      y="1369.4436"
       z="1256.76" />
 
     <subtraction name="FoamPadding">
@@ -3564,7 +3564,7 @@
 
     <box name="SteelSupportBlock" lunit="cm"
       x="1210.32"
-      y="1905.8448"
+      y="1569.4436"
       z="1456.76" />
 
     <subtraction name="SteelSupport">
@@ -3575,13 +3575,13 @@
 
     <box name="DetEnclosure" lunit="cm" 
       x="1310.32"
-      y="2105.8448"
+      y="1769.4436"
       z="1656.76"/>
 
 
     <box name="World" lunit="cm" 
       x="9310.32" 
-      y="10105.8448" 
+      y="9769.4436" 
       z="9656.76"/>
 </solids>
 <structure>
@@ -10227,24 +10227,35 @@
          <rotationref ref="rPlus90AboutX"/>
        </physvol>
   </volume>
+     
+   <volume name="volAnodePlate">
+     <materialref ref="vm2000"/>
+     <solidref ref="CRMZPlane"/>
+  </volume>
    <volume name="volTPC">
      <materialref ref="LAr"/>
        <solidref ref="CRM"/>
        <physvol>
        <volumeref ref="volTPCPlaneU"/>
        <position name="posPlaneU" unit="cm" 
-         x="324.99" y="0" z="0"/>
+         x="324.97" y="0" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volTPCPlaneV"/>
        <position name="posPlaneY" unit="cm" 
-         x="325.01" y="0" z="0"/>
+         x="324.99" y="0" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volTPCPlaneZ"/>
        <position name="posPlaneZ" unit="cm" 
+         x="325.01" y="0" z="0"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate" unit="cm" 
          x="325.03" y="0" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -10564,294 +10575,6 @@
       <materialref ref="LAr"/>
       <solidref ref="ArapucaCathodeAcceptanceWindow"/>
     </volume>
-    <volume name="volArapucaDouble_3-0-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-0-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-0-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-0-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-0-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-0-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-0-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-0-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-1-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-1-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-1-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-1-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-1-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-1-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-1-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-1-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-2-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-2-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-2-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-2-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-2-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-2-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-2-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-2-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_0-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_0-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_0-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_0-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_0-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_0-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_0-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_0-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_0-4">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_0-4">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_0-5">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_0-5">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_0-6">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_0-6">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_0-7">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_0-7">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_1-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_1-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_1-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_1-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_1-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_1-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_1-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_1-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_1-4">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_1-4">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_1-5">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_1-5">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_1-6">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_1-6">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_1-7">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_1-7">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_2-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_2-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_2-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_2-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_2-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_2-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_2-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_2-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_2-4">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_2-4">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_2-5">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_2-5">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_2-6">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_2-6">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_2-7">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_2-7">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
 
     <volume name="volCryostat">
       <materialref ref="LAr" />
@@ -10871,836 +10594,764 @@
       <physvol>
         <volumeref ref="volTPC"/>
 	<position name="posTPC-0" unit="cm"
-           x="0" y="-588.4521" z="-373.3"/>
+           x="0" y="-420.2515" z="-373.3"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC"/>
 	<position name="posTPC-1" unit="cm"
-           x="0" y="-420.7515" z="-373.3"/>
+           x="0" y="-252.5509" z="-373.3"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC"/>
 	<position name="posTPC-2" unit="cm"
-           x="0" y="-252.0509" z="-373.3"/>
+           x="0" y="-83.8503" z="-373.3"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC"/>
 	<position name="posTPC-3" unit="cm"
-           x="0" y="-84.3502999999999" z="-373.3"/>
+           x="0" y="83.8503" z="-373.3"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC"/>
 	<position name="posTPC-4" unit="cm"
-           x="0" y="84.3503000000001" z="-373.3"/>
+           x="0" y="252.5509" z="-373.3"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC"/>
 	<position name="posTPC-5" unit="cm"
-           x="0" y="252.0509" z="-373.3"/>
+           x="0" y="420.2515" z="-373.3"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC"/>
 	<position name="posTPC-6" unit="cm"
-           x="0" y="420.7515" z="-373.3"/>
+           x="0" y="-420.2515" z="-224.38"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC"/>
 	<position name="posTPC-7" unit="cm"
-           x="0" y="588.4521" z="-373.3"/>
+           x="0" y="-252.5509" z="-224.38"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC"/>
 	<position name="posTPC-8" unit="cm"
-           x="0" y="-588.4521" z="-224.38"/>
+           x="0" y="-83.8503" z="-224.38"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC"/>
 	<position name="posTPC-9" unit="cm"
-           x="0" y="-420.7515" z="-224.38"/>
+           x="0" y="83.8503" z="-224.38"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC"/>
 	<position name="posTPC-10" unit="cm"
-           x="0" y="-252.0509" z="-224.38"/>
+           x="0" y="252.5509" z="-224.38"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC"/>
 	<position name="posTPC-11" unit="cm"
-           x="0" y="-84.3502999999999" z="-224.38"/>
+           x="0" y="420.2515" z="-224.38"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC"/>
 	<position name="posTPC-12" unit="cm"
-           x="0" y="84.3503000000001" z="-224.38"/>
+           x="0" y="-420.2515" z="-74.46"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC"/>
 	<position name="posTPC-13" unit="cm"
-           x="0" y="252.0509" z="-224.38"/>
+           x="0" y="-252.5509" z="-74.46"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC"/>
 	<position name="posTPC-14" unit="cm"
-           x="0" y="420.7515" z="-224.38"/>
+           x="0" y="-83.8503" z="-74.46"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC"/>
 	<position name="posTPC-15" unit="cm"
-           x="0" y="588.4521" z="-224.38"/>
+           x="0" y="83.8503" z="-74.46"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC"/>
 	<position name="posTPC-16" unit="cm"
-           x="0" y="-588.4521" z="-74.46"/>
+           x="0" y="252.5509" z="-74.46"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC"/>
 	<position name="posTPC-17" unit="cm"
-           x="0" y="-420.7515" z="-74.46"/>
+           x="0" y="420.2515" z="-74.46"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC"/>
 	<position name="posTPC-18" unit="cm"
-           x="0" y="-252.0509" z="-74.46"/>
+           x="0" y="-420.2515" z="74.46"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC"/>
 	<position name="posTPC-19" unit="cm"
-           x="0" y="-84.3502999999999" z="-74.46"/>
+           x="0" y="-252.5509" z="74.46"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC"/>
 	<position name="posTPC-20" unit="cm"
-           x="0" y="84.3503000000001" z="-74.46"/>
+           x="0" y="-83.8503" z="74.46"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC"/>
 	<position name="posTPC-21" unit="cm"
-           x="0" y="252.0509" z="-74.46"/>
+           x="0" y="83.8503" z="74.46"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC"/>
 	<position name="posTPC-22" unit="cm"
-           x="0" y="420.7515" z="-74.46"/>
+           x="0" y="252.5509" z="74.46"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC"/>
 	<position name="posTPC-23" unit="cm"
-           x="0" y="588.4521" z="-74.46"/>
+           x="0" y="420.2515" z="74.46"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC"/>
 	<position name="posTPC-24" unit="cm"
-           x="0" y="-588.4521" z="74.46"/>
+           x="0" y="-420.2515" z="224.38"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC"/>
 	<position name="posTPC-25" unit="cm"
-           x="0" y="-420.7515" z="74.46"/>
+           x="0" y="-252.5509" z="224.38"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC"/>
 	<position name="posTPC-26" unit="cm"
-           x="0" y="-252.0509" z="74.46"/>
+           x="0" y="-83.8503" z="224.38"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC"/>
 	<position name="posTPC-27" unit="cm"
-           x="0" y="-84.3502999999999" z="74.46"/>
+           x="0" y="83.8503" z="224.38"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC"/>
 	<position name="posTPC-28" unit="cm"
-           x="0" y="84.3503000000001" z="74.46"/>
+           x="0" y="252.5509" z="224.38"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC"/>
 	<position name="posTPC-29" unit="cm"
-           x="0" y="252.0509" z="74.46"/>
+           x="0" y="420.2515" z="224.38"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC"/>
 	<position name="posTPC-30" unit="cm"
-           x="0" y="420.7515" z="74.46"/>
+           x="0" y="-420.2515" z="373.3"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC"/>
 	<position name="posTPC-31" unit="cm"
-           x="0" y="588.4521" z="74.46"/>
+           x="0" y="-252.5509" z="373.3"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC"/>
 	<position name="posTPC-32" unit="cm"
-           x="0" y="-588.4521" z="224.38"/>
+           x="0" y="-83.8503" z="373.3"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC"/>
 	<position name="posTPC-33" unit="cm"
-           x="0" y="-420.7515" z="224.38"/>
+           x="0" y="83.8503" z="373.3"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC"/>
 	<position name="posTPC-34" unit="cm"
-           x="0" y="-252.0509" z="224.38"/>
+           x="0" y="252.5509" z="373.3"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC"/>
 	<position name="posTPC-35" unit="cm"
-           x="0" y="-84.3502999999999" z="224.38"/>
-      </physvol>
-      <physvol>
-        <volumeref ref="volTPC"/>
-	<position name="posTPC-36" unit="cm"
-           x="0" y="84.3503000000001" z="224.38"/>
-      </physvol>
-      <physvol>
-        <volumeref ref="volTPC"/>
-	<position name="posTPC-37" unit="cm"
-           x="0" y="252.0509" z="224.38"/>
-      </physvol>
-      <physvol>
-        <volumeref ref="volTPC"/>
-	<position name="posTPC-38" unit="cm"
-           x="0" y="420.7515" z="224.38"/>
-      </physvol>
-      <physvol>
-        <volumeref ref="volTPC"/>
-	<position name="posTPC-39" unit="cm"
-           x="0" y="588.4521" z="224.38"/>
-      </physvol>
-      <physvol>
-        <volumeref ref="volTPC"/>
-	<position name="posTPC-40" unit="cm"
-           x="0" y="-588.4521" z="373.3"/>
-      </physvol>
-      <physvol>
-        <volumeref ref="volTPC"/>
-	<position name="posTPC-41" unit="cm"
-           x="0" y="-420.7515" z="373.3"/>
-      </physvol>
-      <physvol>
-        <volumeref ref="volTPC"/>
-	<position name="posTPC-42" unit="cm"
-           x="0" y="-252.0509" z="373.3"/>
-      </physvol>
-      <physvol>
-        <volumeref ref="volTPC"/>
-	<position name="posTPC-43" unit="cm"
-           x="0" y="-84.3502999999999" z="373.3"/>
-      </physvol>
-      <physvol>
-        <volumeref ref="volTPC"/>
-	<position name="posTPC-44" unit="cm"
-           x="0" y="84.3503000000001" z="373.3"/>
-      </physvol>
-      <physvol>
-        <volumeref ref="volTPC"/>
-	<position name="posTPC-45" unit="cm"
-           x="0" y="252.0509" z="373.3"/>
-      </physvol>
-      <physvol>
-        <volumeref ref="volTPC"/>
-	<position name="posTPC-46" unit="cm"
-           x="0" y="420.7515" z="373.3"/>
-      </physvol>
-      <physvol>
-        <volumeref ref="volTPC"/>
-	<position name="posTPC-47" unit="cm"
-           x="0" y="588.4521" z="373.3"/>
+           x="0" y="420.2515" z="373.3"/>
       </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper0" unit="cm"  x="-322.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper0" unit="cm"  x="-322.04" y="-506.9018" z="0" />
      <rotation name="rotFS0" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper1" unit="cm"  x="-316.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper1" unit="cm"  x="-316.04" y="-506.9018" z="0" />
      <rotation name="rotFS1" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper2" unit="cm"  x="-310.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper2" unit="cm"  x="-310.04" y="-506.9018" z="0" />
      <rotation name="rotFS2" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper3" unit="cm"  x="-304.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper3" unit="cm"  x="-304.04" y="-506.9018" z="0" />
      <rotation name="rotFS3" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper4" unit="cm"  x="-298.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper4" unit="cm"  x="-298.04" y="-506.9018" z="0" />
      <rotation name="rotFS4" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper5" unit="cm"  x="-292.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper5" unit="cm"  x="-292.04" y="-506.9018" z="0" />
      <rotation name="rotFS5" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper6" unit="cm"  x="-286.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper6" unit="cm"  x="-286.04" y="-506.9018" z="0" />
      <rotation name="rotFS6" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper7" unit="cm"  x="-280.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper7" unit="cm"  x="-280.04" y="-506.9018" z="0" />
      <rotation name="rotFS7" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper8" unit="cm"  x="-274.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper8" unit="cm"  x="-274.04" y="-506.9018" z="0" />
      <rotation name="rotFS8" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper9" unit="cm"  x="-268.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper9" unit="cm"  x="-268.04" y="-506.9018" z="0" />
      <rotation name="rotFS9" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper10" unit="cm"  x="-262.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper10" unit="cm"  x="-262.04" y="-506.9018" z="0" />
      <rotation name="rotFS10" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper11" unit="cm"  x="-256.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper11" unit="cm"  x="-256.04" y="-506.9018" z="0" />
      <rotation name="rotFS11" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper12" unit="cm"  x="-250.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper12" unit="cm"  x="-250.04" y="-506.9018" z="0" />
      <rotation name="rotFS12" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper13" unit="cm"  x="-244.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper13" unit="cm"  x="-244.04" y="-506.9018" z="0" />
      <rotation name="rotFS13" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper14" unit="cm"  x="-238.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper14" unit="cm"  x="-238.04" y="-506.9018" z="0" />
      <rotation name="rotFS14" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper15" unit="cm"  x="-232.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper15" unit="cm"  x="-232.04" y="-506.9018" z="0" />
      <rotation name="rotFS15" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper16" unit="cm"  x="-226.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper16" unit="cm"  x="-226.04" y="-506.9018" z="0" />
      <rotation name="rotFS16" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper17" unit="cm"  x="-220.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper17" unit="cm"  x="-220.04" y="-506.9018" z="0" />
      <rotation name="rotFS17" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper18" unit="cm"  x="-214.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper18" unit="cm"  x="-214.04" y="-506.9018" z="0" />
      <rotation name="rotFS18" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper19" unit="cm"  x="-208.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper19" unit="cm"  x="-208.04" y="-506.9018" z="0" />
      <rotation name="rotFS19" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper20" unit="cm"  x="-202.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper20" unit="cm"  x="-202.04" y="-506.9018" z="0" />
      <rotation name="rotFS20" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper21" unit="cm"  x="-196.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper21" unit="cm"  x="-196.04" y="-506.9018" z="0" />
      <rotation name="rotFS21" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper22" unit="cm"  x="-190.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper22" unit="cm"  x="-190.04" y="-506.9018" z="0" />
      <rotation name="rotFS22" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper23" unit="cm"  x="-184.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper23" unit="cm"  x="-184.04" y="-506.9018" z="0" />
      <rotation name="rotFS23" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper24" unit="cm"  x="-178.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper24" unit="cm"  x="-178.04" y="-506.9018" z="0" />
      <rotation name="rotFS24" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper25" unit="cm"  x="-172.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper25" unit="cm"  x="-172.04" y="-506.9018" z="0" />
      <rotation name="rotFS25" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper26" unit="cm"  x="-166.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper26" unit="cm"  x="-166.04" y="-506.9018" z="0" />
      <rotation name="rotFS26" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper27" unit="cm"  x="-160.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper27" unit="cm"  x="-160.04" y="-506.9018" z="0" />
      <rotation name="rotFS27" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper28" unit="cm"  x="-154.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper28" unit="cm"  x="-154.04" y="-506.9018" z="0" />
      <rotation name="rotFS28" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper29" unit="cm"  x="-148.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper29" unit="cm"  x="-148.04" y="-506.9018" z="0" />
      <rotation name="rotFS29" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper30" unit="cm"  x="-142.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper30" unit="cm"  x="-142.04" y="-506.9018" z="0" />
      <rotation name="rotFS30" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper31" unit="cm"  x="-136.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper31" unit="cm"  x="-136.04" y="-506.9018" z="0" />
      <rotation name="rotFS31" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper32" unit="cm"  x="-130.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper32" unit="cm"  x="-130.04" y="-506.9018" z="0" />
      <rotation name="rotFS32" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper33" unit="cm"  x="-124.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper33" unit="cm"  x="-124.04" y="-506.9018" z="0" />
      <rotation name="rotFS33" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper34" unit="cm"  x="-118.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper34" unit="cm"  x="-118.04" y="-506.9018" z="0" />
      <rotation name="rotFS34" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper35" unit="cm"  x="-112.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper35" unit="cm"  x="-112.04" y="-506.9018" z="0" />
      <rotation name="rotFS35" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper36" unit="cm"  x="-106.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper36" unit="cm"  x="-106.04" y="-506.9018" z="0" />
      <rotation name="rotFS36" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper37" unit="cm"  x="-100.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper37" unit="cm"  x="-100.04" y="-506.9018" z="0" />
      <rotation name="rotFS37" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper38" unit="cm"  x="-94.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper38" unit="cm"  x="-94.04" y="-506.9018" z="0" />
      <rotation name="rotFS38" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper39" unit="cm"  x="-88.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper39" unit="cm"  x="-88.04" y="-506.9018" z="0" />
      <rotation name="rotFS39" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper40" unit="cm"  x="-82.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper40" unit="cm"  x="-82.04" y="-506.9018" z="0" />
      <rotation name="rotFS40" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper41" unit="cm"  x="-76.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper41" unit="cm"  x="-76.04" y="-506.9018" z="0" />
      <rotation name="rotFS41" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper42" unit="cm"  x="-70.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper42" unit="cm"  x="-70.04" y="-506.9018" z="0" />
      <rotation name="rotFS42" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper43" unit="cm"  x="-64.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper43" unit="cm"  x="-64.04" y="-506.9018" z="0" />
      <rotation name="rotFS43" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper44" unit="cm"  x="-58.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper44" unit="cm"  x="-58.04" y="-506.9018" z="0" />
      <rotation name="rotFS44" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper45" unit="cm"  x="-52.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper45" unit="cm"  x="-52.04" y="-506.9018" z="0" />
      <rotation name="rotFS45" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper46" unit="cm"  x="-46.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper46" unit="cm"  x="-46.04" y="-506.9018" z="0" />
      <rotation name="rotFS46" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper47" unit="cm"  x="-40.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper47" unit="cm"  x="-40.04" y="-506.9018" z="0" />
      <rotation name="rotFS47" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper48" unit="cm"  x="-34.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper48" unit="cm"  x="-34.04" y="-506.9018" z="0" />
      <rotation name="rotFS48" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper49" unit="cm"  x="-28.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper49" unit="cm"  x="-28.04" y="-506.9018" z="0" />
      <rotation name="rotFS49" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper50" unit="cm"  x="-22.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper50" unit="cm"  x="-22.04" y="-506.9018" z="0" />
      <rotation name="rotFS50" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper51" unit="cm"  x="-16.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper51" unit="cm"  x="-16.04" y="-506.9018" z="0" />
      <rotation name="rotFS51" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper52" unit="cm"  x="-10.04" y="-675.1024" z="0" />
+     <position name="posFieldShaper52" unit="cm"  x="-10.04" y="-506.9018" z="0" />
      <rotation name="rotFS52" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper53" unit="cm"  x="-4.04000000000001" y="-675.1024" z="0" />
+     <position name="posFieldShaper53" unit="cm"  x="-4.04000000000001" y="-506.9018" z="0" />
      <rotation name="rotFS53" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper54" unit="cm"  x="1.95999999999999" y="-675.1024" z="0" />
+     <position name="posFieldShaper54" unit="cm"  x="1.95999999999999" y="-506.9018" z="0" />
      <rotation name="rotFS54" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper55" unit="cm"  x="7.95999999999999" y="-675.1024" z="0" />
+     <position name="posFieldShaper55" unit="cm"  x="7.95999999999999" y="-506.9018" z="0" />
      <rotation name="rotFS55" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper56" unit="cm"  x="13.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper56" unit="cm"  x="13.96" y="-506.9018" z="0" />
      <rotation name="rotFS56" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper57" unit="cm"  x="19.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper57" unit="cm"  x="19.96" y="-506.9018" z="0" />
      <rotation name="rotFS57" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper58" unit="cm"  x="25.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper58" unit="cm"  x="25.96" y="-506.9018" z="0" />
      <rotation name="rotFS58" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper59" unit="cm"  x="31.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper59" unit="cm"  x="31.96" y="-506.9018" z="0" />
      <rotation name="rotFS59" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper60" unit="cm"  x="37.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper60" unit="cm"  x="37.96" y="-506.9018" z="0" />
      <rotation name="rotFS60" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper61" unit="cm"  x="43.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper61" unit="cm"  x="43.96" y="-506.9018" z="0" />
      <rotation name="rotFS61" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper62" unit="cm"  x="49.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper62" unit="cm"  x="49.96" y="-506.9018" z="0" />
      <rotation name="rotFS62" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper63" unit="cm"  x="55.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper63" unit="cm"  x="55.96" y="-506.9018" z="0" />
      <rotation name="rotFS63" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper64" unit="cm"  x="61.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper64" unit="cm"  x="61.96" y="-506.9018" z="0" />
      <rotation name="rotFS64" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper65" unit="cm"  x="67.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper65" unit="cm"  x="67.96" y="-506.9018" z="0" />
      <rotation name="rotFS65" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper66" unit="cm"  x="73.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper66" unit="cm"  x="73.96" y="-506.9018" z="0" />
      <rotation name="rotFS66" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper67" unit="cm"  x="79.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper67" unit="cm"  x="79.96" y="-506.9018" z="0" />
      <rotation name="rotFS67" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper68" unit="cm"  x="85.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper68" unit="cm"  x="85.96" y="-506.9018" z="0" />
      <rotation name="rotFS68" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper69" unit="cm"  x="91.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper69" unit="cm"  x="91.96" y="-506.9018" z="0" />
      <rotation name="rotFS69" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper70" unit="cm"  x="97.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper70" unit="cm"  x="97.96" y="-506.9018" z="0" />
      <rotation name="rotFS70" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper71" unit="cm"  x="103.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper71" unit="cm"  x="103.96" y="-506.9018" z="0" />
      <rotation name="rotFS71" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper72" unit="cm"  x="109.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper72" unit="cm"  x="109.96" y="-506.9018" z="0" />
      <rotation name="rotFS72" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper73" unit="cm"  x="115.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper73" unit="cm"  x="115.96" y="-506.9018" z="0" />
      <rotation name="rotFS73" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper74" unit="cm"  x="121.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper74" unit="cm"  x="121.96" y="-506.9018" z="0" />
      <rotation name="rotFS74" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper75" unit="cm"  x="127.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper75" unit="cm"  x="127.96" y="-506.9018" z="0" />
      <rotation name="rotFS75" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper76" unit="cm"  x="133.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper76" unit="cm"  x="133.96" y="-506.9018" z="0" />
      <rotation name="rotFS76" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper77" unit="cm"  x="139.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper77" unit="cm"  x="139.96" y="-506.9018" z="0" />
      <rotation name="rotFS77" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper78" unit="cm"  x="145.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper78" unit="cm"  x="145.96" y="-506.9018" z="0" />
      <rotation name="rotFS78" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper79" unit="cm"  x="151.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper79" unit="cm"  x="151.96" y="-506.9018" z="0" />
      <rotation name="rotFS79" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper80" unit="cm"  x="157.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper80" unit="cm"  x="157.96" y="-506.9018" z="0" />
      <rotation name="rotFS80" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper81" unit="cm"  x="163.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper81" unit="cm"  x="163.96" y="-506.9018" z="0" />
      <rotation name="rotFS81" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper82" unit="cm"  x="169.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper82" unit="cm"  x="169.96" y="-506.9018" z="0" />
      <rotation name="rotFS82" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper83" unit="cm"  x="175.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper83" unit="cm"  x="175.96" y="-506.9018" z="0" />
      <rotation name="rotFS83" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper84" unit="cm"  x="181.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper84" unit="cm"  x="181.96" y="-506.9018" z="0" />
      <rotation name="rotFS84" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper85" unit="cm"  x="187.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper85" unit="cm"  x="187.96" y="-506.9018" z="0" />
      <rotation name="rotFS85" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper86" unit="cm"  x="193.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper86" unit="cm"  x="193.96" y="-506.9018" z="0" />
      <rotation name="rotFS86" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper87" unit="cm"  x="199.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper87" unit="cm"  x="199.96" y="-506.9018" z="0" />
      <rotation name="rotFS87" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper88" unit="cm"  x="205.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper88" unit="cm"  x="205.96" y="-506.9018" z="0" />
      <rotation name="rotFS88" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper89" unit="cm"  x="211.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper89" unit="cm"  x="211.96" y="-506.9018" z="0" />
      <rotation name="rotFS89" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper90" unit="cm"  x="217.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper90" unit="cm"  x="217.96" y="-506.9018" z="0" />
      <rotation name="rotFS90" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper91" unit="cm"  x="223.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper91" unit="cm"  x="223.96" y="-506.9018" z="0" />
      <rotation name="rotFS91" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper92" unit="cm"  x="229.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper92" unit="cm"  x="229.96" y="-506.9018" z="0" />
      <rotation name="rotFS92" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper93" unit="cm"  x="235.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper93" unit="cm"  x="235.96" y="-506.9018" z="0" />
      <rotation name="rotFS93" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper94" unit="cm"  x="241.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper94" unit="cm"  x="241.96" y="-506.9018" z="0" />
      <rotation name="rotFS94" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper95" unit="cm"  x="247.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper95" unit="cm"  x="247.96" y="-506.9018" z="0" />
      <rotation name="rotFS95" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper96" unit="cm"  x="253.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper96" unit="cm"  x="253.96" y="-506.9018" z="0" />
      <rotation name="rotFS96" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper97" unit="cm"  x="259.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper97" unit="cm"  x="259.96" y="-506.9018" z="0" />
      <rotation name="rotFS97" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper98" unit="cm"  x="265.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper98" unit="cm"  x="265.96" y="-506.9018" z="0" />
      <rotation name="rotFS98" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper99" unit="cm"  x="271.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper99" unit="cm"  x="271.96" y="-506.9018" z="0" />
      <rotation name="rotFS99" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper100" unit="cm"  x="277.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper100" unit="cm"  x="277.96" y="-506.9018" z="0" />
      <rotation name="rotFS100" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper101" unit="cm"  x="283.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper101" unit="cm"  x="283.96" y="-506.9018" z="0" />
      <rotation name="rotFS101" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper102" unit="cm"  x="289.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper102" unit="cm"  x="289.96" y="-506.9018" z="0" />
      <rotation name="rotFS102" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper103" unit="cm"  x="295.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper103" unit="cm"  x="295.96" y="-506.9018" z="0" />
      <rotation name="rotFS103" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper104" unit="cm"  x="301.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper104" unit="cm"  x="301.96" y="-506.9018" z="0" />
      <rotation name="rotFS104" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper105" unit="cm"  x="307.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper105" unit="cm"  x="307.96" y="-506.9018" z="0" />
      <rotation name="rotFS105" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper106" unit="cm"  x="313.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper106" unit="cm"  x="313.96" y="-506.9018" z="0" />
      <rotation name="rotFS106" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper107" unit="cm"  x="319.96" y="-675.1024" z="0" />
+     <position name="posFieldShaper107" unit="cm"  x="319.96" y="-506.9018" z="0" />
      <rotation name="rotFS107" unit="deg" x="0" y="0" z="90" />
   </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-0" unit="cm" x="-328.04" y="-505.1018" z="-299.34"/>
+   <position name="posGroundGrid-0" unit="cm" x="-328.04" y="-336.9012" z="-299.34"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-1" unit="cm" x="-328.04" y="-169.7006" z="-299.34"/>
+   <position name="posGroundGrid-1" unit="cm" x="-328.04" y="-1.5" z="-299.34"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-2" unit="cm" x="-328.04" y="165.7006" z="-299.34"/>
+   <position name="posGroundGrid-2" unit="cm" x="-328.04" y="333.9012" z="-299.34"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-3" unit="cm" x="-328.04" y="501.1018" z="-299.34"/>
+   <position name="posGroundGrid-3" unit="cm" x="-328.04" y="-336.9012" z="-1.5"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-4" unit="cm" x="-328.04" y="-505.1018" z="-1.5"/>
+   <position name="posGroundGrid-4" unit="cm" x="-328.04" y="-1.5" z="-1.5"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-5" unit="cm" x="-328.04" y="-169.7006" z="-1.5"/>
+   <position name="posGroundGrid-5" unit="cm" x="-328.04" y="333.9012" z="-1.5"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-6" unit="cm" x="-328.04" y="165.7006" z="-1.5"/>
+   <position name="posGroundGrid-6" unit="cm" x="-328.04" y="-336.9012" z="296.34"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-7" unit="cm" x="-328.04" y="501.1018" z="-1.5"/>
+   <position name="posGroundGrid-7" unit="cm" x="-328.04" y="-1.5" z="296.34"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-8" unit="cm" x="-328.04" y="-505.1018" z="296.34"/>
-      </physvol>
-      <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-9" unit="cm" x="-328.04" y="-169.7006" z="296.34"/>
-      </physvol>
-      <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-10" unit="cm" x="-328.04" y="165.7006" z="296.34"/>
-      </physvol>
-      <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-11" unit="cm" x="-328.04" y="501.1018" z="296.34"/>
+   <position name="posGroundGrid-8" unit="cm" x="-328.04" y="333.9012" z="296.34"/>
       </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-0-0"/>
        <position name="posArapucaDouble0-Frame-0-0" unit="cm" 
          x="-328.04"
-	 y="-632.8018" 
+	 y="-464.6012" 
 	 z="-261.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
@@ -11708,14 +11359,14 @@
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-0"/>
        <position name="posOpArapucaDouble0-Frame-0-0" unit="cm" 
          x="-327.3"
-	 y="-632.8018" 
+	 y="-464.6012" 
 	 z="-261.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-0-1"/>
        <position name="posArapucaDouble1-Frame-0-0" unit="cm" 
          x="-328.04"
-	 y="-542.1018" 
+	 y="-373.9012" 
 	 z="-407.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
@@ -11723,14 +11374,14 @@
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-1"/>
        <position name="posOpArapucaDouble1-Frame-0-0" unit="cm" 
          x="-327.3"
-	 y="-542.1018" 
+	 y="-373.9012" 
 	 z="-407.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-0-2"/>
        <position name="posArapucaDouble2-Frame-0-0" unit="cm" 
          x="-328.04"
-	 y="-468.1018" 
+	 y="-299.9012" 
 	 z="-190.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
@@ -11738,14 +11389,14 @@
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-2"/>
        <position name="posOpArapucaDouble2-Frame-0-0" unit="cm" 
          x="-327.3"
-	 y="-468.1018" 
+	 y="-299.9012" 
 	 z="-190.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-0-3"/>
        <position name="posArapucaDouble3-Frame-0-0" unit="cm" 
          x="-328.04"
-	 y="-377.4018" 
+	 y="-209.2012" 
 	 z="-336.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
@@ -11753,14 +11404,14 @@
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-3"/>
        <position name="posOpArapucaDouble3-Frame-0-0" unit="cm" 
          x="-327.3"
-	 y="-377.4018" 
+	 y="-209.2012" 
 	 z="-336.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-1-0"/>
        <position name="posArapucaDouble0-Frame-0-1" unit="cm" 
          x="-328.04"
-	 y="-632.8018" 
+	 y="-464.6012" 
 	 z="36"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
@@ -11768,14 +11419,14 @@
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-0"/>
        <position name="posOpArapucaDouble0-Frame-0-1" unit="cm" 
          x="-327.3"
-	 y="-632.8018" 
+	 y="-464.6012" 
 	 z="36"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-1-1"/>
        <position name="posArapucaDouble1-Frame-0-1" unit="cm" 
          x="-328.04"
-	 y="-542.1018" 
+	 y="-373.9012" 
 	 z="-110"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
@@ -11783,14 +11434,14 @@
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-1"/>
        <position name="posOpArapucaDouble1-Frame-0-1" unit="cm" 
          x="-327.3"
-	 y="-542.1018" 
+	 y="-373.9012" 
 	 z="-110"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-1-2"/>
        <position name="posArapucaDouble2-Frame-0-1" unit="cm" 
          x="-328.04"
-	 y="-468.1018" 
+	 y="-299.9012" 
 	 z="107"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
@@ -11798,14 +11449,14 @@
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-2"/>
        <position name="posOpArapucaDouble2-Frame-0-1" unit="cm" 
          x="-327.3"
-	 y="-468.1018" 
+	 y="-299.9012" 
 	 z="107"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-1-3"/>
        <position name="posArapucaDouble3-Frame-0-1" unit="cm" 
          x="-328.04"
-	 y="-377.4018" 
+	 y="-209.2012" 
 	 z="-39"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
@@ -11813,14 +11464,14 @@
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-3"/>
        <position name="posOpArapucaDouble3-Frame-0-1" unit="cm" 
          x="-327.3"
-	 y="-377.4018" 
+	 y="-209.2012" 
 	 z="-39"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-2-0"/>
        <position name="posArapucaDouble0-Frame-0-2" unit="cm" 
          x="-328.04"
-	 y="-632.8018" 
+	 y="-464.6012" 
 	 z="333.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
@@ -11828,14 +11479,14 @@
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-0"/>
        <position name="posOpArapucaDouble0-Frame-0-2" unit="cm" 
          x="-327.3"
-	 y="-632.8018" 
+	 y="-464.6012" 
 	 z="333.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-2-1"/>
        <position name="posArapucaDouble1-Frame-0-2" unit="cm" 
          x="-328.04"
-	 y="-542.1018" 
+	 y="-373.9012" 
 	 z="187.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
@@ -11843,14 +11494,14 @@
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-1"/>
        <position name="posOpArapucaDouble1-Frame-0-2" unit="cm" 
          x="-327.3"
-	 y="-542.1018" 
+	 y="-373.9012" 
 	 z="187.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-2-2"/>
        <position name="posArapucaDouble2-Frame-0-2" unit="cm" 
          x="-328.04"
-	 y="-468.1018" 
+	 y="-299.9012" 
 	 z="404.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
@@ -11858,14 +11509,14 @@
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-2"/>
        <position name="posOpArapucaDouble2-Frame-0-2" unit="cm" 
          x="-327.3"
-	 y="-468.1018" 
+	 y="-299.9012" 
 	 z="404.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-2-3"/>
        <position name="posArapucaDouble3-Frame-0-2" unit="cm" 
          x="-328.04"
-	 y="-377.4018" 
+	 y="-209.2012" 
 	 z="258.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
@@ -11873,14 +11524,14 @@
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-3"/>
        <position name="posOpArapucaDouble3-Frame-0-2" unit="cm" 
          x="-327.3"
-	 y="-377.4018" 
+	 y="-209.2012" 
 	 z="258.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-0-0"/>
        <position name="posArapucaDouble0-Frame-1-0" unit="cm" 
          x="-328.04"
-	 y="-297.4006" 
+	 y="-129.2" 
 	 z="-261.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
@@ -11888,14 +11539,14 @@
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-0"/>
        <position name="posOpArapucaDouble0-Frame-1-0" unit="cm" 
          x="-327.3"
-	 y="-297.4006" 
+	 y="-129.2" 
 	 z="-261.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-0-1"/>
        <position name="posArapucaDouble1-Frame-1-0" unit="cm" 
          x="-328.04"
-	 y="-206.7006" 
+	 y="-38.5" 
 	 z="-407.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
@@ -11903,14 +11554,14 @@
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-1"/>
        <position name="posOpArapucaDouble1-Frame-1-0" unit="cm" 
          x="-327.3"
-	 y="-206.7006" 
+	 y="-38.5" 
 	 z="-407.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-0-2"/>
        <position name="posArapucaDouble2-Frame-1-0" unit="cm" 
          x="-328.04"
-	 y="-132.7006" 
+	 y="35.5" 
 	 z="-190.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
@@ -11918,14 +11569,14 @@
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-2"/>
        <position name="posOpArapucaDouble2-Frame-1-0" unit="cm" 
          x="-327.3"
-	 y="-132.7006" 
+	 y="35.5" 
 	 z="-190.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-0-3"/>
        <position name="posArapucaDouble3-Frame-1-0" unit="cm" 
          x="-328.04"
-	 y="-42.0006" 
+	 y="126.2" 
 	 z="-336.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
@@ -11933,14 +11584,14 @@
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-3"/>
        <position name="posOpArapucaDouble3-Frame-1-0" unit="cm" 
          x="-327.3"
-	 y="-42.0006" 
+	 y="126.2" 
 	 z="-336.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-1-0"/>
        <position name="posArapucaDouble0-Frame-1-1" unit="cm" 
          x="-328.04"
-	 y="-297.4006" 
+	 y="-129.2" 
 	 z="36"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
@@ -11948,14 +11599,14 @@
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-0"/>
        <position name="posOpArapucaDouble0-Frame-1-1" unit="cm" 
          x="-327.3"
-	 y="-297.4006" 
+	 y="-129.2" 
 	 z="36"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-1-1"/>
        <position name="posArapucaDouble1-Frame-1-1" unit="cm" 
          x="-328.04"
-	 y="-206.7006" 
+	 y="-38.5" 
 	 z="-110"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
@@ -11963,14 +11614,14 @@
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-1"/>
        <position name="posOpArapucaDouble1-Frame-1-1" unit="cm" 
          x="-327.3"
-	 y="-206.7006" 
+	 y="-38.5" 
 	 z="-110"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-1-2"/>
        <position name="posArapucaDouble2-Frame-1-1" unit="cm" 
          x="-328.04"
-	 y="-132.7006" 
+	 y="35.5" 
 	 z="107"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
@@ -11978,14 +11629,14 @@
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-2"/>
        <position name="posOpArapucaDouble2-Frame-1-1" unit="cm" 
          x="-327.3"
-	 y="-132.7006" 
+	 y="35.5" 
 	 z="107"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-1-3"/>
        <position name="posArapucaDouble3-Frame-1-1" unit="cm" 
          x="-328.04"
-	 y="-42.0006" 
+	 y="126.2" 
 	 z="-39"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
@@ -11993,14 +11644,14 @@
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-3"/>
        <position name="posOpArapucaDouble3-Frame-1-1" unit="cm" 
          x="-327.3"
-	 y="-42.0006" 
+	 y="126.2" 
 	 z="-39"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-2-0"/>
        <position name="posArapucaDouble0-Frame-1-2" unit="cm" 
          x="-328.04"
-	 y="-297.4006" 
+	 y="-129.2" 
 	 z="333.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
@@ -12008,14 +11659,14 @@
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-0"/>
        <position name="posOpArapucaDouble0-Frame-1-2" unit="cm" 
          x="-327.3"
-	 y="-297.4006" 
+	 y="-129.2" 
 	 z="333.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-2-1"/>
        <position name="posArapucaDouble1-Frame-1-2" unit="cm" 
          x="-328.04"
-	 y="-206.7006" 
+	 y="-38.5" 
 	 z="187.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
@@ -12023,14 +11674,14 @@
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-1"/>
        <position name="posOpArapucaDouble1-Frame-1-2" unit="cm" 
          x="-327.3"
-	 y="-206.7006" 
+	 y="-38.5" 
 	 z="187.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-2-2"/>
        <position name="posArapucaDouble2-Frame-1-2" unit="cm" 
          x="-328.04"
-	 y="-132.7006" 
+	 y="35.5" 
 	 z="404.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
@@ -12038,14 +11689,14 @@
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-2"/>
        <position name="posOpArapucaDouble2-Frame-1-2" unit="cm" 
          x="-327.3"
-	 y="-132.7006" 
+	 y="35.5" 
 	 z="404.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-2-3"/>
        <position name="posArapucaDouble3-Frame-1-2" unit="cm" 
          x="-328.04"
-	 y="-42.0006" 
+	 y="126.2" 
 	 z="258.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
@@ -12053,14 +11704,14 @@
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-3"/>
        <position name="posOpArapucaDouble3-Frame-1-2" unit="cm" 
          x="-327.3"
-	 y="-42.0006" 
+	 y="126.2" 
 	 z="258.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-0-0"/>
        <position name="posArapucaDouble0-Frame-2-0" unit="cm" 
          x="-328.04"
-	 y="38.0006" 
+	 y="206.2012" 
 	 z="-261.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
@@ -12068,14 +11719,14 @@
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-0"/>
        <position name="posOpArapucaDouble0-Frame-2-0" unit="cm" 
          x="-327.3"
-	 y="38.0006" 
+	 y="206.2012" 
 	 z="-261.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-0-1"/>
        <position name="posArapucaDouble1-Frame-2-0" unit="cm" 
          x="-328.04"
-	 y="128.7006" 
+	 y="296.9012" 
 	 z="-407.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
@@ -12083,14 +11734,14 @@
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-1"/>
        <position name="posOpArapucaDouble1-Frame-2-0" unit="cm" 
          x="-327.3"
-	 y="128.7006" 
+	 y="296.9012" 
 	 z="-407.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-0-2"/>
        <position name="posArapucaDouble2-Frame-2-0" unit="cm" 
          x="-328.04"
-	 y="202.7006" 
+	 y="370.9012" 
 	 z="-190.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
@@ -12098,14 +11749,14 @@
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-2"/>
        <position name="posOpArapucaDouble2-Frame-2-0" unit="cm" 
          x="-327.3"
-	 y="202.7006" 
+	 y="370.9012" 
 	 z="-190.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-0-3"/>
        <position name="posArapucaDouble3-Frame-2-0" unit="cm" 
          x="-328.04"
-	 y="293.4006" 
+	 y="461.6012" 
 	 z="-336.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
@@ -12113,14 +11764,14 @@
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-3"/>
        <position name="posOpArapucaDouble3-Frame-2-0" unit="cm" 
          x="-327.3"
-	 y="293.4006" 
+	 y="461.6012" 
 	 z="-336.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-1-0"/>
        <position name="posArapucaDouble0-Frame-2-1" unit="cm" 
          x="-328.04"
-	 y="38.0006" 
+	 y="206.2012" 
 	 z="36"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
@@ -12128,14 +11779,14 @@
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-0"/>
        <position name="posOpArapucaDouble0-Frame-2-1" unit="cm" 
          x="-327.3"
-	 y="38.0006" 
+	 y="206.2012" 
 	 z="36"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-1-1"/>
        <position name="posArapucaDouble1-Frame-2-1" unit="cm" 
          x="-328.04"
-	 y="128.7006" 
+	 y="296.9012" 
 	 z="-110"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
@@ -12143,14 +11794,14 @@
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-1"/>
        <position name="posOpArapucaDouble1-Frame-2-1" unit="cm" 
          x="-327.3"
-	 y="128.7006" 
+	 y="296.9012" 
 	 z="-110"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-1-2"/>
        <position name="posArapucaDouble2-Frame-2-1" unit="cm" 
          x="-328.04"
-	 y="202.7006" 
+	 y="370.9012" 
 	 z="107"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
@@ -12158,14 +11809,14 @@
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-2"/>
        <position name="posOpArapucaDouble2-Frame-2-1" unit="cm" 
          x="-327.3"
-	 y="202.7006" 
+	 y="370.9012" 
 	 z="107"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-1-3"/>
        <position name="posArapucaDouble3-Frame-2-1" unit="cm" 
          x="-328.04"
-	 y="293.4006" 
+	 y="461.6012" 
 	 z="-39"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
@@ -12173,14 +11824,14 @@
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-3"/>
        <position name="posOpArapucaDouble3-Frame-2-1" unit="cm" 
          x="-327.3"
-	 y="293.4006" 
+	 y="461.6012" 
 	 z="-39"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-2-0"/>
        <position name="posArapucaDouble0-Frame-2-2" unit="cm" 
          x="-328.04"
-	 y="38.0006" 
+	 y="206.2012" 
 	 z="333.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
@@ -12188,14 +11839,14 @@
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-0"/>
        <position name="posOpArapucaDouble0-Frame-2-2" unit="cm" 
          x="-327.3"
-	 y="38.0006" 
+	 y="206.2012" 
 	 z="333.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-2-1"/>
        <position name="posArapucaDouble1-Frame-2-2" unit="cm" 
          x="-328.04"
-	 y="128.7006" 
+	 y="296.9012" 
 	 z="187.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
@@ -12203,14 +11854,14 @@
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-1"/>
        <position name="posOpArapucaDouble1-Frame-2-2" unit="cm" 
          x="-327.3"
-	 y="128.7006" 
+	 y="296.9012" 
 	 z="187.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-2-2"/>
        <position name="posArapucaDouble2-Frame-2-2" unit="cm" 
          x="-328.04"
-	 y="202.7006" 
+	 y="370.9012" 
 	 z="404.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
@@ -12218,14 +11869,14 @@
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-2"/>
        <position name="posOpArapucaDouble2-Frame-2-2" unit="cm" 
          x="-327.3"
-	 y="202.7006" 
+	 y="370.9012" 
 	 z="404.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-2-3"/>
        <position name="posArapucaDouble3-Frame-2-2" unit="cm" 
          x="-328.04"
-	 y="293.4006" 
+	 y="461.6012" 
 	 z="258.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
@@ -12233,548 +11884,8 @@
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-3"/>
        <position name="posOpArapucaDouble3-Frame-2-2" unit="cm" 
          x="-327.3"
-	 y="293.4006" 
+	 y="461.6012" 
 	 z="258.84"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-0-0"/>
-       <position name="posArapucaDouble0-Frame-3-0" unit="cm" 
-         x="-328.04"
-	 y="373.4018" 
-	 z="-261.84"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-0"/>
-       <position name="posOpArapucaDouble0-Frame-3-0" unit="cm" 
-         x="-327.3"
-	 y="373.4018" 
-	 z="-261.84"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-0-1"/>
-       <position name="posArapucaDouble1-Frame-3-0" unit="cm" 
-         x="-328.04"
-	 y="464.1018" 
-	 z="-407.84"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-1"/>
-       <position name="posOpArapucaDouble1-Frame-3-0" unit="cm" 
-         x="-327.3"
-	 y="464.1018" 
-	 z="-407.84"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-0-2"/>
-       <position name="posArapucaDouble2-Frame-3-0" unit="cm" 
-         x="-328.04"
-	 y="538.1018" 
-	 z="-190.84"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-2"/>
-       <position name="posOpArapucaDouble2-Frame-3-0" unit="cm" 
-         x="-327.3"
-	 y="538.1018" 
-	 z="-190.84"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-0-3"/>
-       <position name="posArapucaDouble3-Frame-3-0" unit="cm" 
-         x="-328.04"
-	 y="628.8018" 
-	 z="-336.84"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-3"/>
-       <position name="posOpArapucaDouble3-Frame-3-0" unit="cm" 
-         x="-327.3"
-	 y="628.8018" 
-	 z="-336.84"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-1-0"/>
-       <position name="posArapucaDouble0-Frame-3-1" unit="cm" 
-         x="-328.04"
-	 y="373.4018" 
-	 z="36"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-0"/>
-       <position name="posOpArapucaDouble0-Frame-3-1" unit="cm" 
-         x="-327.3"
-	 y="373.4018" 
-	 z="36"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-1-1"/>
-       <position name="posArapucaDouble1-Frame-3-1" unit="cm" 
-         x="-328.04"
-	 y="464.1018" 
-	 z="-110"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-1"/>
-       <position name="posOpArapucaDouble1-Frame-3-1" unit="cm" 
-         x="-327.3"
-	 y="464.1018" 
-	 z="-110"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-1-2"/>
-       <position name="posArapucaDouble2-Frame-3-1" unit="cm" 
-         x="-328.04"
-	 y="538.1018" 
-	 z="107"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-2"/>
-       <position name="posOpArapucaDouble2-Frame-3-1" unit="cm" 
-         x="-327.3"
-	 y="538.1018" 
-	 z="107"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-1-3"/>
-       <position name="posArapucaDouble3-Frame-3-1" unit="cm" 
-         x="-328.04"
-	 y="628.8018" 
-	 z="-39"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-3"/>
-       <position name="posOpArapucaDouble3-Frame-3-1" unit="cm" 
-         x="-327.3"
-	 y="628.8018" 
-	 z="-39"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-2-0"/>
-       <position name="posArapucaDouble0-Frame-3-2" unit="cm" 
-         x="-328.04"
-	 y="373.4018" 
-	 z="333.84"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-0"/>
-       <position name="posOpArapucaDouble0-Frame-3-2" unit="cm" 
-         x="-327.3"
-	 y="373.4018" 
-	 z="333.84"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-2-1"/>
-       <position name="posArapucaDouble1-Frame-3-2" unit="cm" 
-         x="-328.04"
-	 y="464.1018" 
-	 z="187.84"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-1"/>
-       <position name="posOpArapucaDouble1-Frame-3-2" unit="cm" 
-         x="-327.3"
-	 y="464.1018" 
-	 z="187.84"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-2-2"/>
-       <position name="posArapucaDouble2-Frame-3-2" unit="cm" 
-         x="-328.04"
-	 y="538.1018" 
-	 z="404.84"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-2"/>
-       <position name="posOpArapucaDouble2-Frame-3-2" unit="cm" 
-         x="-327.3"
-	 y="538.1018" 
-	 z="404.84"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-2-3"/>
-       <position name="posArapucaDouble3-Frame-3-2" unit="cm" 
-         x="-328.04"
-	 y="628.8018" 
-	 z="258.84"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-3"/>
-       <position name="posOpArapucaDouble3-Frame-3-2" unit="cm" 
-         x="-327.3"
-	 y="628.8018" 
-	 z="258.84"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_0-0"/>
-       <position name="posArapuca0-Lat-0" unit="cm" 
-         x="285.03"
-	 y="-732.8024" 
-	 z="-297.84"/>
-       <rotationref ref="rIdentity"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_0-0"/>
-       <position name="posOpArapuca0-Lat-0" unit="cm" 
-         x="285.03"
-	 y="-732.0624" 
-	 z="-297.84"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_0-1"/>
-       <position name="posArapuca1-Lat-0" unit="cm" 
-         x="210.03"
-	 y="-732.8024" 
-	 z="-297.84"/>
-       <rotationref ref="rIdentity"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_0-1"/>
-       <position name="posOpArapuca1-Lat-0" unit="cm" 
-         x="210.03"
-	 y="-732.0624" 
-	 z="-297.84"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_0-2"/>
-       <position name="posArapuca2-Lat-0" unit="cm" 
-         x="135.03"
-	 y="-732.8024" 
-	 z="-297.84"/>
-       <rotationref ref="rIdentity"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_0-2"/>
-       <position name="posOpArapuca2-Lat-0" unit="cm" 
-         x="135.03"
-	 y="-732.0624" 
-	 z="-297.84"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_0-3"/>
-       <position name="posArapuca3-Lat-0" unit="cm" 
-         x="60.03"
-	 y="-732.8024" 
-	 z="-297.84"/>
-       <rotationref ref="rIdentity"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_0-3"/>
-       <position name="posOpArapuca3-Lat-0" unit="cm" 
-         x="60.03"
-	 y="-732.0624" 
-	 z="-297.84"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_0-4"/>
-       <position name="posArapuca4-Lat-0" unit="cm" 
-         x="285.03"
-	 y="732.8024" 
-	 z="-297.84"/>
-       <rotationref ref="rPlus180AboutX"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_0-4"/>
-       <position name="posOpArapuca4-Lat-0" unit="cm" 
-         x="285.03"
-	 y="732.0624" 
-	 z="-297.84"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_0-5"/>
-       <position name="posArapuca5-Lat-0" unit="cm" 
-         x="210.03"
-	 y="732.8024" 
-	 z="-297.84"/>
-       <rotationref ref="rPlus180AboutX"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_0-5"/>
-       <position name="posOpArapuca5-Lat-0" unit="cm" 
-         x="210.03"
-	 y="732.0624" 
-	 z="-297.84"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_0-6"/>
-       <position name="posArapuca6-Lat-0" unit="cm" 
-         x="135.03"
-	 y="732.8024" 
-	 z="-297.84"/>
-       <rotationref ref="rPlus180AboutX"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_0-6"/>
-       <position name="posOpArapuca6-Lat-0" unit="cm" 
-         x="135.03"
-	 y="732.0624" 
-	 z="-297.84"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_0-7"/>
-       <position name="posArapuca7-Lat-0" unit="cm" 
-         x="60.03"
-	 y="732.8024" 
-	 z="-297.84"/>
-       <rotationref ref="rPlus180AboutX"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_0-7"/>
-       <position name="posOpArapuca7-Lat-0" unit="cm" 
-         x="60.03"
-	 y="732.0624" 
-	 z="-297.84"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_1-0"/>
-       <position name="posArapuca0-Lat-1" unit="cm" 
-         x="285.03"
-	 y="-732.8024" 
-	 z="-1.13686837721616e-13"/>
-       <rotationref ref="rIdentity"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_1-0"/>
-       <position name="posOpArapuca0-Lat-1" unit="cm" 
-         x="285.03"
-	 y="-732.0624" 
-	 z="-1.13686837721616e-13"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_1-1"/>
-       <position name="posArapuca1-Lat-1" unit="cm" 
-         x="210.03"
-	 y="-732.8024" 
-	 z="-1.13686837721616e-13"/>
-       <rotationref ref="rIdentity"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_1-1"/>
-       <position name="posOpArapuca1-Lat-1" unit="cm" 
-         x="210.03"
-	 y="-732.0624" 
-	 z="-1.13686837721616e-13"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_1-2"/>
-       <position name="posArapuca2-Lat-1" unit="cm" 
-         x="135.03"
-	 y="-732.8024" 
-	 z="-1.13686837721616e-13"/>
-       <rotationref ref="rIdentity"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_1-2"/>
-       <position name="posOpArapuca2-Lat-1" unit="cm" 
-         x="135.03"
-	 y="-732.0624" 
-	 z="-1.13686837721616e-13"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_1-3"/>
-       <position name="posArapuca3-Lat-1" unit="cm" 
-         x="60.03"
-	 y="-732.8024" 
-	 z="-1.13686837721616e-13"/>
-       <rotationref ref="rIdentity"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_1-3"/>
-       <position name="posOpArapuca3-Lat-1" unit="cm" 
-         x="60.03"
-	 y="-732.0624" 
-	 z="-1.13686837721616e-13"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_1-4"/>
-       <position name="posArapuca4-Lat-1" unit="cm" 
-         x="285.03"
-	 y="732.8024" 
-	 z="-1.13686837721616e-13"/>
-       <rotationref ref="rPlus180AboutX"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_1-4"/>
-       <position name="posOpArapuca4-Lat-1" unit="cm" 
-         x="285.03"
-	 y="732.0624" 
-	 z="-1.13686837721616e-13"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_1-5"/>
-       <position name="posArapuca5-Lat-1" unit="cm" 
-         x="210.03"
-	 y="732.8024" 
-	 z="-1.13686837721616e-13"/>
-       <rotationref ref="rPlus180AboutX"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_1-5"/>
-       <position name="posOpArapuca5-Lat-1" unit="cm" 
-         x="210.03"
-	 y="732.0624" 
-	 z="-1.13686837721616e-13"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_1-6"/>
-       <position name="posArapuca6-Lat-1" unit="cm" 
-         x="135.03"
-	 y="732.8024" 
-	 z="-1.13686837721616e-13"/>
-       <rotationref ref="rPlus180AboutX"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_1-6"/>
-       <position name="posOpArapuca6-Lat-1" unit="cm" 
-         x="135.03"
-	 y="732.0624" 
-	 z="-1.13686837721616e-13"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_1-7"/>
-       <position name="posArapuca7-Lat-1" unit="cm" 
-         x="60.03"
-	 y="732.8024" 
-	 z="-1.13686837721616e-13"/>
-       <rotationref ref="rPlus180AboutX"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_1-7"/>
-       <position name="posOpArapuca7-Lat-1" unit="cm" 
-         x="60.03"
-	 y="732.0624" 
-	 z="-1.13686837721616e-13"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_2-0"/>
-       <position name="posArapuca0-Lat-2" unit="cm" 
-         x="285.03"
-	 y="-732.8024" 
-	 z="297.84"/>
-       <rotationref ref="rIdentity"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_2-0"/>
-       <position name="posOpArapuca0-Lat-2" unit="cm" 
-         x="285.03"
-	 y="-732.0624" 
-	 z="297.84"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_2-1"/>
-       <position name="posArapuca1-Lat-2" unit="cm" 
-         x="210.03"
-	 y="-732.8024" 
-	 z="297.84"/>
-       <rotationref ref="rIdentity"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_2-1"/>
-       <position name="posOpArapuca1-Lat-2" unit="cm" 
-         x="210.03"
-	 y="-732.0624" 
-	 z="297.84"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_2-2"/>
-       <position name="posArapuca2-Lat-2" unit="cm" 
-         x="135.03"
-	 y="-732.8024" 
-	 z="297.84"/>
-       <rotationref ref="rIdentity"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_2-2"/>
-       <position name="posOpArapuca2-Lat-2" unit="cm" 
-         x="135.03"
-	 y="-732.0624" 
-	 z="297.84"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_2-3"/>
-       <position name="posArapuca3-Lat-2" unit="cm" 
-         x="60.03"
-	 y="-732.8024" 
-	 z="297.84"/>
-       <rotationref ref="rIdentity"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_2-3"/>
-       <position name="posOpArapuca3-Lat-2" unit="cm" 
-         x="60.03"
-	 y="-732.0624" 
-	 z="297.84"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_2-4"/>
-       <position name="posArapuca4-Lat-2" unit="cm" 
-         x="285.03"
-	 y="732.8024" 
-	 z="297.84"/>
-       <rotationref ref="rPlus180AboutX"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_2-4"/>
-       <position name="posOpArapuca4-Lat-2" unit="cm" 
-         x="285.03"
-	 y="732.0624" 
-	 z="297.84"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_2-5"/>
-       <position name="posArapuca5-Lat-2" unit="cm" 
-         x="210.03"
-	 y="732.8024" 
-	 z="297.84"/>
-       <rotationref ref="rPlus180AboutX"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_2-5"/>
-       <position name="posOpArapuca5-Lat-2" unit="cm" 
-         x="210.03"
-	 y="732.0624" 
-	 z="297.84"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_2-6"/>
-       <position name="posArapuca6-Lat-2" unit="cm" 
-         x="135.03"
-	 y="732.8024" 
-	 z="297.84"/>
-       <rotationref ref="rPlus180AboutX"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_2-6"/>
-       <position name="posOpArapuca6-Lat-2" unit="cm" 
-         x="135.03"
-	 y="732.0624" 
-	 z="297.84"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_2-7"/>
-       <position name="posArapuca7-Lat-2" unit="cm" 
-         x="60.03"
-	 y="732.8024" 
-	 z="297.84"/>
-       <rotationref ref="rPlus180AboutX"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_2-7"/>
-       <position name="posOpArapuca7-Lat-2" unit="cm" 
-         x="60.03"
-	 y="732.0624" 
-	 z="297.84"/>
      </physvol>
     </volume>
 
@@ -12812,7 +11923,7 @@
 
       <physvol>
         <volumeref ref="volDetEnclosure"/>
-	<position name="posDetEnclosure" unit="cm" x="50.04" y="-1.13686837721616e-13" z="448.26"/>
+	<position name="posDetEnclosure" unit="cm" x="50.04" y="0" z="448.26"/>
       </physvol>
 
     </volume>

--- a/dunecore/Geometry/gdml/dunevd10kt_3view_30deg_v3_refactored_1x8x6ref.gdml
+++ b/dunecore/Geometry/gdml/dunevd10kt_3view_30deg_v3_refactored_1x8x6ref.gdml
@@ -509,6 +509,11 @@
       y="167.7006"
       z="148.92"
       lunit="cm"/>
+   <box name="AnodePlate" 
+      x="0.02/2."
+      y="167.7006"
+      z="148.92"
+      lunit="cm"/>
    <box name="CRMActive" 
       x="650"
       y="167.7006"
@@ -10230,7 +10235,7 @@
      
    <volume name="volAnodePlate">
      <materialref ref="vm2000"/>
-     <solidref ref="CRMZPlane"/>
+     <solidref ref="AnodePlate"/>
   </volume>
    <volume name="volTPC">
      <materialref ref="LAr"/>
@@ -10238,25 +10243,25 @@
        <physvol>
        <volumeref ref="volTPCPlaneU"/>
        <position name="posPlaneU" unit="cm" 
-         x="324.98" y="0" z="0"/>
+         x="324.99" y="0" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volTPCPlaneV"/>
        <position name="posPlaneY" unit="cm" 
-         x="325" y="0" z="0"/>
+         x="325.01" y="0" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volTPCPlaneZ"/>
        <position name="posPlaneZ" unit="cm" 
-         x="325.02" y="0" z="0"/>
+         x="325.03" y="0" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volAnodePlate"/>
        <position name="posAnodePlate" unit="cm" 
-         x="325.04" y="0" z="0"/>
+         x="325.045" y="0" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
@@ -11313,44 +11318,44 @@
   </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-0" unit="cm" x="-328.05" y="-336.9012" z="-299.34"/>
+   <position name="posGroundGrid-0" unit="cm" x="-328.04" y="-336.9012" z="-299.34"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-1" unit="cm" x="-328.05" y="-1.5" z="-299.34"/>
+   <position name="posGroundGrid-1" unit="cm" x="-328.04" y="-1.5" z="-299.34"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-2" unit="cm" x="-328.05" y="333.9012" z="-299.34"/>
+   <position name="posGroundGrid-2" unit="cm" x="-328.04" y="333.9012" z="-299.34"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-3" unit="cm" x="-328.05" y="-336.9012" z="-1.5"/>
+   <position name="posGroundGrid-3" unit="cm" x="-328.04" y="-336.9012" z="-1.5"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-4" unit="cm" x="-328.05" y="-1.5" z="-1.5"/>
+   <position name="posGroundGrid-4" unit="cm" x="-328.04" y="-1.5" z="-1.5"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-5" unit="cm" x="-328.05" y="333.9012" z="-1.5"/>
+   <position name="posGroundGrid-5" unit="cm" x="-328.04" y="333.9012" z="-1.5"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-6" unit="cm" x="-328.05" y="-336.9012" z="296.34"/>
+   <position name="posGroundGrid-6" unit="cm" x="-328.04" y="-336.9012" z="296.34"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-7" unit="cm" x="-328.05" y="-1.5" z="296.34"/>
+   <position name="posGroundGrid-7" unit="cm" x="-328.04" y="-1.5" z="296.34"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-8" unit="cm" x="-328.05" y="333.9012" z="296.34"/>
+   <position name="posGroundGrid-8" unit="cm" x="-328.04" y="333.9012" z="296.34"/>
       </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-0-0"/>
        <position name="posArapucaDouble0-Frame-0-0" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-464.6012" 
 	 z="-261.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11358,14 +11363,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-0"/>
        <position name="posOpArapucaDouble0-Frame-0-0" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-464.6012" 
 	 z="-261.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-0-1"/>
        <position name="posArapucaDouble1-Frame-0-0" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-373.9012" 
 	 z="-407.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11373,14 +11378,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-1"/>
        <position name="posOpArapucaDouble1-Frame-0-0" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-373.9012" 
 	 z="-407.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-0-2"/>
        <position name="posArapucaDouble2-Frame-0-0" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-299.9012" 
 	 z="-190.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11388,14 +11393,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-2"/>
        <position name="posOpArapucaDouble2-Frame-0-0" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-299.9012" 
 	 z="-190.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-0-3"/>
        <position name="posArapucaDouble3-Frame-0-0" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-209.2012" 
 	 z="-336.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11403,14 +11408,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-3"/>
        <position name="posOpArapucaDouble3-Frame-0-0" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-209.2012" 
 	 z="-336.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-1-0"/>
        <position name="posArapucaDouble0-Frame-0-1" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-464.6012" 
 	 z="36"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11418,14 +11423,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-0"/>
        <position name="posOpArapucaDouble0-Frame-0-1" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-464.6012" 
 	 z="36"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-1-1"/>
        <position name="posArapucaDouble1-Frame-0-1" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-373.9012" 
 	 z="-110"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11433,14 +11438,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-1"/>
        <position name="posOpArapucaDouble1-Frame-0-1" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-373.9012" 
 	 z="-110"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-1-2"/>
        <position name="posArapucaDouble2-Frame-0-1" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-299.9012" 
 	 z="107"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11448,14 +11453,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-2"/>
        <position name="posOpArapucaDouble2-Frame-0-1" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-299.9012" 
 	 z="107"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-1-3"/>
        <position name="posArapucaDouble3-Frame-0-1" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-209.2012" 
 	 z="-39"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11463,14 +11468,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-3"/>
        <position name="posOpArapucaDouble3-Frame-0-1" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-209.2012" 
 	 z="-39"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-2-0"/>
        <position name="posArapucaDouble0-Frame-0-2" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-464.6012" 
 	 z="333.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11478,14 +11483,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-0"/>
        <position name="posOpArapucaDouble0-Frame-0-2" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-464.6012" 
 	 z="333.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-2-1"/>
        <position name="posArapucaDouble1-Frame-0-2" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-373.9012" 
 	 z="187.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11493,14 +11498,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-1"/>
        <position name="posOpArapucaDouble1-Frame-0-2" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-373.9012" 
 	 z="187.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-2-2"/>
        <position name="posArapucaDouble2-Frame-0-2" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-299.9012" 
 	 z="404.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11508,14 +11513,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-2"/>
        <position name="posOpArapucaDouble2-Frame-0-2" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-299.9012" 
 	 z="404.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-2-3"/>
        <position name="posArapucaDouble3-Frame-0-2" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-209.2012" 
 	 z="258.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11523,14 +11528,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-3"/>
        <position name="posOpArapucaDouble3-Frame-0-2" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-209.2012" 
 	 z="258.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-0-0"/>
        <position name="posArapucaDouble0-Frame-1-0" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-129.2" 
 	 z="-261.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11538,14 +11543,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-0"/>
        <position name="posOpArapucaDouble0-Frame-1-0" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-129.2" 
 	 z="-261.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-0-1"/>
        <position name="posArapucaDouble1-Frame-1-0" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-38.5" 
 	 z="-407.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11553,14 +11558,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-1"/>
        <position name="posOpArapucaDouble1-Frame-1-0" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-38.5" 
 	 z="-407.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-0-2"/>
        <position name="posArapucaDouble2-Frame-1-0" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="35.5" 
 	 z="-190.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11568,14 +11573,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-2"/>
        <position name="posOpArapucaDouble2-Frame-1-0" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="35.5" 
 	 z="-190.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-0-3"/>
        <position name="posArapucaDouble3-Frame-1-0" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="126.2" 
 	 z="-336.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11583,14 +11588,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-3"/>
        <position name="posOpArapucaDouble3-Frame-1-0" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="126.2" 
 	 z="-336.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-1-0"/>
        <position name="posArapucaDouble0-Frame-1-1" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-129.2" 
 	 z="36"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11598,14 +11603,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-0"/>
        <position name="posOpArapucaDouble0-Frame-1-1" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-129.2" 
 	 z="36"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-1-1"/>
        <position name="posArapucaDouble1-Frame-1-1" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-38.5" 
 	 z="-110"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11613,14 +11618,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-1"/>
        <position name="posOpArapucaDouble1-Frame-1-1" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-38.5" 
 	 z="-110"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-1-2"/>
        <position name="posArapucaDouble2-Frame-1-1" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="35.5" 
 	 z="107"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11628,14 +11633,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-2"/>
        <position name="posOpArapucaDouble2-Frame-1-1" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="35.5" 
 	 z="107"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-1-3"/>
        <position name="posArapucaDouble3-Frame-1-1" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="126.2" 
 	 z="-39"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11643,14 +11648,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-3"/>
        <position name="posOpArapucaDouble3-Frame-1-1" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="126.2" 
 	 z="-39"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-2-0"/>
        <position name="posArapucaDouble0-Frame-1-2" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-129.2" 
 	 z="333.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11658,14 +11663,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-0"/>
        <position name="posOpArapucaDouble0-Frame-1-2" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-129.2" 
 	 z="333.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-2-1"/>
        <position name="posArapucaDouble1-Frame-1-2" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-38.5" 
 	 z="187.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11673,14 +11678,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-1"/>
        <position name="posOpArapucaDouble1-Frame-1-2" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-38.5" 
 	 z="187.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-2-2"/>
        <position name="posArapucaDouble2-Frame-1-2" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="35.5" 
 	 z="404.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11688,14 +11693,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-2"/>
        <position name="posOpArapucaDouble2-Frame-1-2" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="35.5" 
 	 z="404.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-2-3"/>
        <position name="posArapucaDouble3-Frame-1-2" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="126.2" 
 	 z="258.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11703,14 +11708,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-3"/>
        <position name="posOpArapucaDouble3-Frame-1-2" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="126.2" 
 	 z="258.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-0-0"/>
        <position name="posArapucaDouble0-Frame-2-0" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="206.2012" 
 	 z="-261.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11718,14 +11723,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-0"/>
        <position name="posOpArapucaDouble0-Frame-2-0" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="206.2012" 
 	 z="-261.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-0-1"/>
        <position name="posArapucaDouble1-Frame-2-0" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="296.9012" 
 	 z="-407.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11733,14 +11738,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-1"/>
        <position name="posOpArapucaDouble1-Frame-2-0" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="296.9012" 
 	 z="-407.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-0-2"/>
        <position name="posArapucaDouble2-Frame-2-0" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="370.9012" 
 	 z="-190.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11748,14 +11753,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-2"/>
        <position name="posOpArapucaDouble2-Frame-2-0" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="370.9012" 
 	 z="-190.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-0-3"/>
        <position name="posArapucaDouble3-Frame-2-0" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="461.6012" 
 	 z="-336.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11763,14 +11768,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-3"/>
        <position name="posOpArapucaDouble3-Frame-2-0" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="461.6012" 
 	 z="-336.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-1-0"/>
        <position name="posArapucaDouble0-Frame-2-1" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="206.2012" 
 	 z="36"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11778,14 +11783,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-0"/>
        <position name="posOpArapucaDouble0-Frame-2-1" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="206.2012" 
 	 z="36"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-1-1"/>
        <position name="posArapucaDouble1-Frame-2-1" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="296.9012" 
 	 z="-110"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11793,14 +11798,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-1"/>
        <position name="posOpArapucaDouble1-Frame-2-1" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="296.9012" 
 	 z="-110"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-1-2"/>
        <position name="posArapucaDouble2-Frame-2-1" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="370.9012" 
 	 z="107"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11808,14 +11813,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-2"/>
        <position name="posOpArapucaDouble2-Frame-2-1" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="370.9012" 
 	 z="107"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-1-3"/>
        <position name="posArapucaDouble3-Frame-2-1" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="461.6012" 
 	 z="-39"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11823,14 +11828,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-3"/>
        <position name="posOpArapucaDouble3-Frame-2-1" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="461.6012" 
 	 z="-39"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-2-0"/>
        <position name="posArapucaDouble0-Frame-2-2" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="206.2012" 
 	 z="333.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11838,14 +11843,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-0"/>
        <position name="posOpArapucaDouble0-Frame-2-2" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="206.2012" 
 	 z="333.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-2-1"/>
        <position name="posArapucaDouble1-Frame-2-2" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="296.9012" 
 	 z="187.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11853,14 +11858,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-1"/>
        <position name="posOpArapucaDouble1-Frame-2-2" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="296.9012" 
 	 z="187.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-2-2"/>
        <position name="posArapucaDouble2-Frame-2-2" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="370.9012" 
 	 z="404.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11868,14 +11873,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-2"/>
        <position name="posOpArapucaDouble2-Frame-2-2" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="370.9012" 
 	 z="404.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-2-3"/>
        <position name="posArapucaDouble3-Frame-2-2" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="461.6012" 
 	 z="258.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11883,7 +11888,7 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-3"/>
        <position name="posOpArapucaDouble3-Frame-2-2" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="461.6012" 
 	 z="258.84"/>
      </physvol>

--- a/dunecore/Geometry/gdml/dunevd10kt_3view_30deg_v3_refactored_1x8x6ref_nowires.gdml
+++ b/dunecore/Geometry/gdml/dunevd10kt_3view_30deg_v3_refactored_1x8x6ref_nowires.gdml
@@ -509,6 +509,11 @@
       y="167.7006"
       z="148.92"
       lunit="cm"/>
+   <box name="AnodePlate" 
+      x="0.02/2."
+      y="167.7006"
+      z="148.92"
+      lunit="cm"/>
    <box name="CRMActive" 
       x="650"
       y="167.7006"
@@ -753,7 +758,7 @@
      
    <volume name="volAnodePlate">
      <materialref ref="vm2000"/>
-     <solidref ref="CRMZPlane"/>
+     <solidref ref="AnodePlate"/>
   </volume>
    <volume name="volTPC">
      <materialref ref="LAr"/>
@@ -761,25 +766,25 @@
        <physvol>
        <volumeref ref="volTPCPlaneU"/>
        <position name="posPlaneU" unit="cm" 
-         x="324.98" y="0" z="0"/>
+         x="324.99" y="0" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volTPCPlaneV"/>
        <position name="posPlaneY" unit="cm" 
-         x="325" y="0" z="0"/>
+         x="325.01" y="0" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volTPCPlaneZ"/>
        <position name="posPlaneZ" unit="cm" 
-         x="325.02" y="0" z="0"/>
+         x="325.03" y="0" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volAnodePlate"/>
        <position name="posAnodePlate" unit="cm" 
-         x="325.04" y="0" z="0"/>
+         x="325.045" y="0" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
@@ -1836,44 +1841,44 @@
   </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-0" unit="cm" x="-328.05" y="-336.9012" z="-299.34"/>
+   <position name="posGroundGrid-0" unit="cm" x="-328.04" y="-336.9012" z="-299.34"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-1" unit="cm" x="-328.05" y="-1.5" z="-299.34"/>
+   <position name="posGroundGrid-1" unit="cm" x="-328.04" y="-1.5" z="-299.34"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-2" unit="cm" x="-328.05" y="333.9012" z="-299.34"/>
+   <position name="posGroundGrid-2" unit="cm" x="-328.04" y="333.9012" z="-299.34"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-3" unit="cm" x="-328.05" y="-336.9012" z="-1.5"/>
+   <position name="posGroundGrid-3" unit="cm" x="-328.04" y="-336.9012" z="-1.5"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-4" unit="cm" x="-328.05" y="-1.5" z="-1.5"/>
+   <position name="posGroundGrid-4" unit="cm" x="-328.04" y="-1.5" z="-1.5"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-5" unit="cm" x="-328.05" y="333.9012" z="-1.5"/>
+   <position name="posGroundGrid-5" unit="cm" x="-328.04" y="333.9012" z="-1.5"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-6" unit="cm" x="-328.05" y="-336.9012" z="296.34"/>
+   <position name="posGroundGrid-6" unit="cm" x="-328.04" y="-336.9012" z="296.34"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-7" unit="cm" x="-328.05" y="-1.5" z="296.34"/>
+   <position name="posGroundGrid-7" unit="cm" x="-328.04" y="-1.5" z="296.34"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-8" unit="cm" x="-328.05" y="333.9012" z="296.34"/>
+   <position name="posGroundGrid-8" unit="cm" x="-328.04" y="333.9012" z="296.34"/>
       </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-0-0"/>
        <position name="posArapucaDouble0-Frame-0-0" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-464.6012" 
 	 z="-261.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -1881,14 +1886,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-0"/>
        <position name="posOpArapucaDouble0-Frame-0-0" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-464.6012" 
 	 z="-261.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-0-1"/>
        <position name="posArapucaDouble1-Frame-0-0" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-373.9012" 
 	 z="-407.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -1896,14 +1901,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-1"/>
        <position name="posOpArapucaDouble1-Frame-0-0" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-373.9012" 
 	 z="-407.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-0-2"/>
        <position name="posArapucaDouble2-Frame-0-0" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-299.9012" 
 	 z="-190.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -1911,14 +1916,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-2"/>
        <position name="posOpArapucaDouble2-Frame-0-0" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-299.9012" 
 	 z="-190.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-0-3"/>
        <position name="posArapucaDouble3-Frame-0-0" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-209.2012" 
 	 z="-336.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -1926,14 +1931,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-3"/>
        <position name="posOpArapucaDouble3-Frame-0-0" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-209.2012" 
 	 z="-336.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-1-0"/>
        <position name="posArapucaDouble0-Frame-0-1" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-464.6012" 
 	 z="36"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -1941,14 +1946,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-0"/>
        <position name="posOpArapucaDouble0-Frame-0-1" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-464.6012" 
 	 z="36"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-1-1"/>
        <position name="posArapucaDouble1-Frame-0-1" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-373.9012" 
 	 z="-110"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -1956,14 +1961,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-1"/>
        <position name="posOpArapucaDouble1-Frame-0-1" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-373.9012" 
 	 z="-110"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-1-2"/>
        <position name="posArapucaDouble2-Frame-0-1" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-299.9012" 
 	 z="107"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -1971,14 +1976,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-2"/>
        <position name="posOpArapucaDouble2-Frame-0-1" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-299.9012" 
 	 z="107"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-1-3"/>
        <position name="posArapucaDouble3-Frame-0-1" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-209.2012" 
 	 z="-39"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -1986,14 +1991,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-3"/>
        <position name="posOpArapucaDouble3-Frame-0-1" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-209.2012" 
 	 z="-39"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-2-0"/>
        <position name="posArapucaDouble0-Frame-0-2" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-464.6012" 
 	 z="333.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -2001,14 +2006,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-0"/>
        <position name="posOpArapucaDouble0-Frame-0-2" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-464.6012" 
 	 z="333.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-2-1"/>
        <position name="posArapucaDouble1-Frame-0-2" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-373.9012" 
 	 z="187.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -2016,14 +2021,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-1"/>
        <position name="posOpArapucaDouble1-Frame-0-2" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-373.9012" 
 	 z="187.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-2-2"/>
        <position name="posArapucaDouble2-Frame-0-2" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-299.9012" 
 	 z="404.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -2031,14 +2036,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-2"/>
        <position name="posOpArapucaDouble2-Frame-0-2" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-299.9012" 
 	 z="404.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-2-3"/>
        <position name="posArapucaDouble3-Frame-0-2" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-209.2012" 
 	 z="258.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -2046,14 +2051,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-3"/>
        <position name="posOpArapucaDouble3-Frame-0-2" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-209.2012" 
 	 z="258.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-0-0"/>
        <position name="posArapucaDouble0-Frame-1-0" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-129.2" 
 	 z="-261.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -2061,14 +2066,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-0"/>
        <position name="posOpArapucaDouble0-Frame-1-0" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-129.2" 
 	 z="-261.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-0-1"/>
        <position name="posArapucaDouble1-Frame-1-0" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-38.5" 
 	 z="-407.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -2076,14 +2081,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-1"/>
        <position name="posOpArapucaDouble1-Frame-1-0" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-38.5" 
 	 z="-407.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-0-2"/>
        <position name="posArapucaDouble2-Frame-1-0" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="35.5" 
 	 z="-190.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -2091,14 +2096,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-2"/>
        <position name="posOpArapucaDouble2-Frame-1-0" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="35.5" 
 	 z="-190.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-0-3"/>
        <position name="posArapucaDouble3-Frame-1-0" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="126.2" 
 	 z="-336.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -2106,14 +2111,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-3"/>
        <position name="posOpArapucaDouble3-Frame-1-0" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="126.2" 
 	 z="-336.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-1-0"/>
        <position name="posArapucaDouble0-Frame-1-1" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-129.2" 
 	 z="36"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -2121,14 +2126,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-0"/>
        <position name="posOpArapucaDouble0-Frame-1-1" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-129.2" 
 	 z="36"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-1-1"/>
        <position name="posArapucaDouble1-Frame-1-1" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-38.5" 
 	 z="-110"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -2136,14 +2141,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-1"/>
        <position name="posOpArapucaDouble1-Frame-1-1" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-38.5" 
 	 z="-110"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-1-2"/>
        <position name="posArapucaDouble2-Frame-1-1" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="35.5" 
 	 z="107"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -2151,14 +2156,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-2"/>
        <position name="posOpArapucaDouble2-Frame-1-1" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="35.5" 
 	 z="107"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-1-3"/>
        <position name="posArapucaDouble3-Frame-1-1" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="126.2" 
 	 z="-39"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -2166,14 +2171,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-3"/>
        <position name="posOpArapucaDouble3-Frame-1-1" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="126.2" 
 	 z="-39"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-2-0"/>
        <position name="posArapucaDouble0-Frame-1-2" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-129.2" 
 	 z="333.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -2181,14 +2186,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-0"/>
        <position name="posOpArapucaDouble0-Frame-1-2" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-129.2" 
 	 z="333.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-2-1"/>
        <position name="posArapucaDouble1-Frame-1-2" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-38.5" 
 	 z="187.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -2196,14 +2201,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-1"/>
        <position name="posOpArapucaDouble1-Frame-1-2" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-38.5" 
 	 z="187.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-2-2"/>
        <position name="posArapucaDouble2-Frame-1-2" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="35.5" 
 	 z="404.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -2211,14 +2216,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-2"/>
        <position name="posOpArapucaDouble2-Frame-1-2" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="35.5" 
 	 z="404.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-2-3"/>
        <position name="posArapucaDouble3-Frame-1-2" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="126.2" 
 	 z="258.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -2226,14 +2231,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-3"/>
        <position name="posOpArapucaDouble3-Frame-1-2" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="126.2" 
 	 z="258.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-0-0"/>
        <position name="posArapucaDouble0-Frame-2-0" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="206.2012" 
 	 z="-261.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -2241,14 +2246,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-0"/>
        <position name="posOpArapucaDouble0-Frame-2-0" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="206.2012" 
 	 z="-261.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-0-1"/>
        <position name="posArapucaDouble1-Frame-2-0" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="296.9012" 
 	 z="-407.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -2256,14 +2261,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-1"/>
        <position name="posOpArapucaDouble1-Frame-2-0" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="296.9012" 
 	 z="-407.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-0-2"/>
        <position name="posArapucaDouble2-Frame-2-0" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="370.9012" 
 	 z="-190.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -2271,14 +2276,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-2"/>
        <position name="posOpArapucaDouble2-Frame-2-0" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="370.9012" 
 	 z="-190.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-0-3"/>
        <position name="posArapucaDouble3-Frame-2-0" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="461.6012" 
 	 z="-336.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -2286,14 +2291,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-3"/>
        <position name="posOpArapucaDouble3-Frame-2-0" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="461.6012" 
 	 z="-336.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-1-0"/>
        <position name="posArapucaDouble0-Frame-2-1" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="206.2012" 
 	 z="36"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -2301,14 +2306,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-0"/>
        <position name="posOpArapucaDouble0-Frame-2-1" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="206.2012" 
 	 z="36"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-1-1"/>
        <position name="posArapucaDouble1-Frame-2-1" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="296.9012" 
 	 z="-110"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -2316,14 +2321,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-1"/>
        <position name="posOpArapucaDouble1-Frame-2-1" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="296.9012" 
 	 z="-110"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-1-2"/>
        <position name="posArapucaDouble2-Frame-2-1" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="370.9012" 
 	 z="107"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -2331,14 +2336,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-2"/>
        <position name="posOpArapucaDouble2-Frame-2-1" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="370.9012" 
 	 z="107"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-1-3"/>
        <position name="posArapucaDouble3-Frame-2-1" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="461.6012" 
 	 z="-39"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -2346,14 +2351,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-3"/>
        <position name="posOpArapucaDouble3-Frame-2-1" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="461.6012" 
 	 z="-39"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-2-0"/>
        <position name="posArapucaDouble0-Frame-2-2" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="206.2012" 
 	 z="333.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -2361,14 +2366,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-0"/>
        <position name="posOpArapucaDouble0-Frame-2-2" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="206.2012" 
 	 z="333.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-2-1"/>
        <position name="posArapucaDouble1-Frame-2-2" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="296.9012" 
 	 z="187.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -2376,14 +2381,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-1"/>
        <position name="posOpArapucaDouble1-Frame-2-2" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="296.9012" 
 	 z="187.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-2-2"/>
        <position name="posArapucaDouble2-Frame-2-2" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="370.9012" 
 	 z="404.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -2391,14 +2396,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-2"/>
        <position name="posOpArapucaDouble2-Frame-2-2" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="370.9012" 
 	 z="404.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-2-3"/>
        <position name="posArapucaDouble3-Frame-2-2" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="461.6012" 
 	 z="258.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -2406,7 +2411,7 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-3"/>
        <position name="posOpArapucaDouble3-Frame-2-2" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="461.6012" 
 	 z="258.84"/>
      </physvol>

--- a/dunecore/Geometry/gdml/dunevd10kt_3view_30deg_v3_refactored_1x8x6ref_nowires.gdml
+++ b/dunecore/Geometry/gdml/dunevd10kt_3view_30deg_v3_refactored_1x8x6ref_nowires.gdml
@@ -490,7 +490,7 @@
     
 
    <box name="CRM"
-      x="650.08" 
+      x="650.1" 
       y="167.7006" 
       z="148.92"
       lunit="cm"/>
@@ -559,12 +559,12 @@
 
 
     <box name="Cryostat" lunit="cm" 
-      x="850.32" 
+      x="850.34" 
       y="1209.4436" 
       z="1096.76"/>
 
     <box name="ArgonInterior" lunit="cm" 
-      x="850.08"
+      x="850.1"
       y="1209.2036"
       z="1096.52"/>
 
@@ -574,12 +574,12 @@
       z="1096.52"/>
 
     <box name="ExternalAuxOut" lunit="cm" 
-      x="850.08 - 100"
+      x="850.1 - 100"
       y="1209.2036 - 2*2.5 - 2*40"
       z="1096.52"/>
 
     <box name="ExternalAuxIn" lunit="cm" 
-      x="850.08"
+      x="850.1"
       y="1020.3736"
       z="1096.52 + 1"/>
 
@@ -687,7 +687,7 @@
     </subtraction>
 
     <box name="FoamPadBlock" lunit="cm"
-      x="1010.32"
+      x="1010.34"
       y="1369.4436"
       z="1256.76" />
 
@@ -698,7 +698,7 @@
     </subtraction>
 
     <box name="SteelSupportBlock" lunit="cm"
-      x="1210.32"
+      x="1210.34"
       y="1569.4436"
       z="1456.76" />
 
@@ -709,13 +709,13 @@
     </subtraction>
 
     <box name="DetEnclosure" lunit="cm" 
-      x="1310.32"
+      x="1310.34"
       y="1769.4436"
       z="1656.76"/>
 
 
     <box name="World" lunit="cm" 
-      x="9310.32" 
+      x="9310.34" 
       y="9769.4436" 
       z="9656.76"/>
 </solids>
@@ -761,31 +761,31 @@
        <physvol>
        <volumeref ref="volTPCPlaneU"/>
        <position name="posPlaneU" unit="cm" 
-         x="324.97" y="0" z="0"/>
+         x="324.98" y="0" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volTPCPlaneV"/>
        <position name="posPlaneY" unit="cm" 
-         x="324.99" y="0" z="0"/>
+         x="325" y="0" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volTPCPlaneZ"/>
        <position name="posPlaneZ" unit="cm" 
-         x="325.01" y="0" z="0"/>
+         x="325.02" y="0" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volAnodePlate"/>
        <position name="posAnodePlate" unit="cm" 
-         x="325.03" y="0" z="0"/>
+         x="325.04" y="0" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volTPCActive"/>
        <position name="posActive" unit="cm" 
-        x="-0.04" y="" z="0"/>
+        x="-0.05" y="" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
    </volume>
@@ -1104,7 +1104,7 @@
       <solidref ref="Cryostat" />
       <physvol>
         <volumeref ref="volGaseousArgon"/>
-        <position name="posGaseousArgon" unit="cm" x="375.04" y="0" z="0"/>
+        <position name="posGaseousArgon" unit="cm" x="375.05" y="0" z="0"/>
       </physvol>
       <physvol>
         <volumeref ref="volSteelShell"/>
@@ -1296,584 +1296,584 @@
       </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper0" unit="cm"  x="-322.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper0" unit="cm"  x="-322.05" y="-506.9018" z="0" />
      <rotation name="rotFS0" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper1" unit="cm"  x="-316.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper1" unit="cm"  x="-316.05" y="-506.9018" z="0" />
      <rotation name="rotFS1" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper2" unit="cm"  x="-310.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper2" unit="cm"  x="-310.05" y="-506.9018" z="0" />
      <rotation name="rotFS2" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper3" unit="cm"  x="-304.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper3" unit="cm"  x="-304.05" y="-506.9018" z="0" />
      <rotation name="rotFS3" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper4" unit="cm"  x="-298.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper4" unit="cm"  x="-298.05" y="-506.9018" z="0" />
      <rotation name="rotFS4" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper5" unit="cm"  x="-292.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper5" unit="cm"  x="-292.05" y="-506.9018" z="0" />
      <rotation name="rotFS5" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper6" unit="cm"  x="-286.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper6" unit="cm"  x="-286.05" y="-506.9018" z="0" />
      <rotation name="rotFS6" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper7" unit="cm"  x="-280.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper7" unit="cm"  x="-280.05" y="-506.9018" z="0" />
      <rotation name="rotFS7" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper8" unit="cm"  x="-274.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper8" unit="cm"  x="-274.05" y="-506.9018" z="0" />
      <rotation name="rotFS8" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper9" unit="cm"  x="-268.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper9" unit="cm"  x="-268.05" y="-506.9018" z="0" />
      <rotation name="rotFS9" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper10" unit="cm"  x="-262.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper10" unit="cm"  x="-262.05" y="-506.9018" z="0" />
      <rotation name="rotFS10" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper11" unit="cm"  x="-256.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper11" unit="cm"  x="-256.05" y="-506.9018" z="0" />
      <rotation name="rotFS11" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper12" unit="cm"  x="-250.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper12" unit="cm"  x="-250.05" y="-506.9018" z="0" />
      <rotation name="rotFS12" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper13" unit="cm"  x="-244.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper13" unit="cm"  x="-244.05" y="-506.9018" z="0" />
      <rotation name="rotFS13" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper14" unit="cm"  x="-238.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper14" unit="cm"  x="-238.05" y="-506.9018" z="0" />
      <rotation name="rotFS14" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper15" unit="cm"  x="-232.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper15" unit="cm"  x="-232.05" y="-506.9018" z="0" />
      <rotation name="rotFS15" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper16" unit="cm"  x="-226.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper16" unit="cm"  x="-226.05" y="-506.9018" z="0" />
      <rotation name="rotFS16" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper17" unit="cm"  x="-220.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper17" unit="cm"  x="-220.05" y="-506.9018" z="0" />
      <rotation name="rotFS17" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper18" unit="cm"  x="-214.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper18" unit="cm"  x="-214.05" y="-506.9018" z="0" />
      <rotation name="rotFS18" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper19" unit="cm"  x="-208.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper19" unit="cm"  x="-208.05" y="-506.9018" z="0" />
      <rotation name="rotFS19" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper20" unit="cm"  x="-202.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper20" unit="cm"  x="-202.05" y="-506.9018" z="0" />
      <rotation name="rotFS20" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper21" unit="cm"  x="-196.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper21" unit="cm"  x="-196.05" y="-506.9018" z="0" />
      <rotation name="rotFS21" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper22" unit="cm"  x="-190.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper22" unit="cm"  x="-190.05" y="-506.9018" z="0" />
      <rotation name="rotFS22" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper23" unit="cm"  x="-184.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper23" unit="cm"  x="-184.05" y="-506.9018" z="0" />
      <rotation name="rotFS23" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper24" unit="cm"  x="-178.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper24" unit="cm"  x="-178.05" y="-506.9018" z="0" />
      <rotation name="rotFS24" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper25" unit="cm"  x="-172.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper25" unit="cm"  x="-172.05" y="-506.9018" z="0" />
      <rotation name="rotFS25" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper26" unit="cm"  x="-166.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper26" unit="cm"  x="-166.05" y="-506.9018" z="0" />
      <rotation name="rotFS26" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper27" unit="cm"  x="-160.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper27" unit="cm"  x="-160.05" y="-506.9018" z="0" />
      <rotation name="rotFS27" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper28" unit="cm"  x="-154.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper28" unit="cm"  x="-154.05" y="-506.9018" z="0" />
      <rotation name="rotFS28" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper29" unit="cm"  x="-148.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper29" unit="cm"  x="-148.05" y="-506.9018" z="0" />
      <rotation name="rotFS29" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper30" unit="cm"  x="-142.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper30" unit="cm"  x="-142.05" y="-506.9018" z="0" />
      <rotation name="rotFS30" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper31" unit="cm"  x="-136.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper31" unit="cm"  x="-136.05" y="-506.9018" z="0" />
      <rotation name="rotFS31" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper32" unit="cm"  x="-130.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper32" unit="cm"  x="-130.05" y="-506.9018" z="0" />
      <rotation name="rotFS32" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper33" unit="cm"  x="-124.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper33" unit="cm"  x="-124.05" y="-506.9018" z="0" />
      <rotation name="rotFS33" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper34" unit="cm"  x="-118.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper34" unit="cm"  x="-118.05" y="-506.9018" z="0" />
      <rotation name="rotFS34" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper35" unit="cm"  x="-112.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper35" unit="cm"  x="-112.05" y="-506.9018" z="0" />
      <rotation name="rotFS35" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper36" unit="cm"  x="-106.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper36" unit="cm"  x="-106.05" y="-506.9018" z="0" />
      <rotation name="rotFS36" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper37" unit="cm"  x="-100.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper37" unit="cm"  x="-100.05" y="-506.9018" z="0" />
      <rotation name="rotFS37" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper38" unit="cm"  x="-94.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper38" unit="cm"  x="-94.0500000000001" y="-506.9018" z="0" />
      <rotation name="rotFS38" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper39" unit="cm"  x="-88.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper39" unit="cm"  x="-88.0500000000001" y="-506.9018" z="0" />
      <rotation name="rotFS39" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper40" unit="cm"  x="-82.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper40" unit="cm"  x="-82.0500000000001" y="-506.9018" z="0" />
      <rotation name="rotFS40" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper41" unit="cm"  x="-76.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper41" unit="cm"  x="-76.0500000000001" y="-506.9018" z="0" />
      <rotation name="rotFS41" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper42" unit="cm"  x="-70.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper42" unit="cm"  x="-70.0500000000001" y="-506.9018" z="0" />
      <rotation name="rotFS42" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper43" unit="cm"  x="-64.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper43" unit="cm"  x="-64.0500000000001" y="-506.9018" z="0" />
      <rotation name="rotFS43" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper44" unit="cm"  x="-58.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper44" unit="cm"  x="-58.0500000000001" y="-506.9018" z="0" />
      <rotation name="rotFS44" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper45" unit="cm"  x="-52.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper45" unit="cm"  x="-52.0500000000001" y="-506.9018" z="0" />
      <rotation name="rotFS45" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper46" unit="cm"  x="-46.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper46" unit="cm"  x="-46.0500000000001" y="-506.9018" z="0" />
      <rotation name="rotFS46" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper47" unit="cm"  x="-40.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper47" unit="cm"  x="-40.0500000000001" y="-506.9018" z="0" />
      <rotation name="rotFS47" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper48" unit="cm"  x="-34.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper48" unit="cm"  x="-34.0500000000001" y="-506.9018" z="0" />
      <rotation name="rotFS48" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper49" unit="cm"  x="-28.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper49" unit="cm"  x="-28.0500000000001" y="-506.9018" z="0" />
      <rotation name="rotFS49" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper50" unit="cm"  x="-22.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper50" unit="cm"  x="-22.0500000000001" y="-506.9018" z="0" />
      <rotation name="rotFS50" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper51" unit="cm"  x="-16.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper51" unit="cm"  x="-16.0500000000001" y="-506.9018" z="0" />
      <rotation name="rotFS51" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper52" unit="cm"  x="-10.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper52" unit="cm"  x="-10.0500000000001" y="-506.9018" z="0" />
      <rotation name="rotFS52" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper53" unit="cm"  x="-4.04000000000001" y="-506.9018" z="0" />
+     <position name="posFieldShaper53" unit="cm"  x="-4.05000000000005" y="-506.9018" z="0" />
      <rotation name="rotFS53" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper54" unit="cm"  x="1.95999999999999" y="-506.9018" z="0" />
+     <position name="posFieldShaper54" unit="cm"  x="1.94999999999995" y="-506.9018" z="0" />
      <rotation name="rotFS54" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper55" unit="cm"  x="7.95999999999999" y="-506.9018" z="0" />
+     <position name="posFieldShaper55" unit="cm"  x="7.94999999999995" y="-506.9018" z="0" />
      <rotation name="rotFS55" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper56" unit="cm"  x="13.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper56" unit="cm"  x="13.9499999999999" y="-506.9018" z="0" />
      <rotation name="rotFS56" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper57" unit="cm"  x="19.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper57" unit="cm"  x="19.9499999999999" y="-506.9018" z="0" />
      <rotation name="rotFS57" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper58" unit="cm"  x="25.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper58" unit="cm"  x="25.9499999999999" y="-506.9018" z="0" />
      <rotation name="rotFS58" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper59" unit="cm"  x="31.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper59" unit="cm"  x="31.9499999999999" y="-506.9018" z="0" />
      <rotation name="rotFS59" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper60" unit="cm"  x="37.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper60" unit="cm"  x="37.9499999999999" y="-506.9018" z="0" />
      <rotation name="rotFS60" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper61" unit="cm"  x="43.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper61" unit="cm"  x="43.9499999999999" y="-506.9018" z="0" />
      <rotation name="rotFS61" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper62" unit="cm"  x="49.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper62" unit="cm"  x="49.9499999999999" y="-506.9018" z="0" />
      <rotation name="rotFS62" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper63" unit="cm"  x="55.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper63" unit="cm"  x="55.9499999999999" y="-506.9018" z="0" />
      <rotation name="rotFS63" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper64" unit="cm"  x="61.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper64" unit="cm"  x="61.9499999999999" y="-506.9018" z="0" />
      <rotation name="rotFS64" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper65" unit="cm"  x="67.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper65" unit="cm"  x="67.9499999999999" y="-506.9018" z="0" />
      <rotation name="rotFS65" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper66" unit="cm"  x="73.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper66" unit="cm"  x="73.9499999999999" y="-506.9018" z="0" />
      <rotation name="rotFS66" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper67" unit="cm"  x="79.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper67" unit="cm"  x="79.9499999999999" y="-506.9018" z="0" />
      <rotation name="rotFS67" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper68" unit="cm"  x="85.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper68" unit="cm"  x="85.9499999999999" y="-506.9018" z="0" />
      <rotation name="rotFS68" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper69" unit="cm"  x="91.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper69" unit="cm"  x="91.9499999999999" y="-506.9018" z="0" />
      <rotation name="rotFS69" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper70" unit="cm"  x="97.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper70" unit="cm"  x="97.9499999999999" y="-506.9018" z="0" />
      <rotation name="rotFS70" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper71" unit="cm"  x="103.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper71" unit="cm"  x="103.95" y="-506.9018" z="0" />
      <rotation name="rotFS71" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper72" unit="cm"  x="109.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper72" unit="cm"  x="109.95" y="-506.9018" z="0" />
      <rotation name="rotFS72" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper73" unit="cm"  x="115.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper73" unit="cm"  x="115.95" y="-506.9018" z="0" />
      <rotation name="rotFS73" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper74" unit="cm"  x="121.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper74" unit="cm"  x="121.95" y="-506.9018" z="0" />
      <rotation name="rotFS74" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper75" unit="cm"  x="127.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper75" unit="cm"  x="127.95" y="-506.9018" z="0" />
      <rotation name="rotFS75" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper76" unit="cm"  x="133.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper76" unit="cm"  x="133.95" y="-506.9018" z="0" />
      <rotation name="rotFS76" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper77" unit="cm"  x="139.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper77" unit="cm"  x="139.95" y="-506.9018" z="0" />
      <rotation name="rotFS77" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper78" unit="cm"  x="145.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper78" unit="cm"  x="145.95" y="-506.9018" z="0" />
      <rotation name="rotFS78" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper79" unit="cm"  x="151.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper79" unit="cm"  x="151.95" y="-506.9018" z="0" />
      <rotation name="rotFS79" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper80" unit="cm"  x="157.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper80" unit="cm"  x="157.95" y="-506.9018" z="0" />
      <rotation name="rotFS80" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper81" unit="cm"  x="163.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper81" unit="cm"  x="163.95" y="-506.9018" z="0" />
      <rotation name="rotFS81" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper82" unit="cm"  x="169.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper82" unit="cm"  x="169.95" y="-506.9018" z="0" />
      <rotation name="rotFS82" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper83" unit="cm"  x="175.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper83" unit="cm"  x="175.95" y="-506.9018" z="0" />
      <rotation name="rotFS83" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper84" unit="cm"  x="181.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper84" unit="cm"  x="181.95" y="-506.9018" z="0" />
      <rotation name="rotFS84" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper85" unit="cm"  x="187.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper85" unit="cm"  x="187.95" y="-506.9018" z="0" />
      <rotation name="rotFS85" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper86" unit="cm"  x="193.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper86" unit="cm"  x="193.95" y="-506.9018" z="0" />
      <rotation name="rotFS86" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper87" unit="cm"  x="199.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper87" unit="cm"  x="199.95" y="-506.9018" z="0" />
      <rotation name="rotFS87" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper88" unit="cm"  x="205.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper88" unit="cm"  x="205.95" y="-506.9018" z="0" />
      <rotation name="rotFS88" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper89" unit="cm"  x="211.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper89" unit="cm"  x="211.95" y="-506.9018" z="0" />
      <rotation name="rotFS89" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper90" unit="cm"  x="217.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper90" unit="cm"  x="217.95" y="-506.9018" z="0" />
      <rotation name="rotFS90" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper91" unit="cm"  x="223.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper91" unit="cm"  x="223.95" y="-506.9018" z="0" />
      <rotation name="rotFS91" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper92" unit="cm"  x="229.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper92" unit="cm"  x="229.95" y="-506.9018" z="0" />
      <rotation name="rotFS92" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper93" unit="cm"  x="235.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper93" unit="cm"  x="235.95" y="-506.9018" z="0" />
      <rotation name="rotFS93" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper94" unit="cm"  x="241.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper94" unit="cm"  x="241.95" y="-506.9018" z="0" />
      <rotation name="rotFS94" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper95" unit="cm"  x="247.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper95" unit="cm"  x="247.95" y="-506.9018" z="0" />
      <rotation name="rotFS95" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper96" unit="cm"  x="253.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper96" unit="cm"  x="253.95" y="-506.9018" z="0" />
      <rotation name="rotFS96" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper97" unit="cm"  x="259.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper97" unit="cm"  x="259.95" y="-506.9018" z="0" />
      <rotation name="rotFS97" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper98" unit="cm"  x="265.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper98" unit="cm"  x="265.95" y="-506.9018" z="0" />
      <rotation name="rotFS98" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper99" unit="cm"  x="271.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper99" unit="cm"  x="271.95" y="-506.9018" z="0" />
      <rotation name="rotFS99" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper100" unit="cm"  x="277.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper100" unit="cm"  x="277.95" y="-506.9018" z="0" />
      <rotation name="rotFS100" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper101" unit="cm"  x="283.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper101" unit="cm"  x="283.95" y="-506.9018" z="0" />
      <rotation name="rotFS101" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper102" unit="cm"  x="289.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper102" unit="cm"  x="289.95" y="-506.9018" z="0" />
      <rotation name="rotFS102" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper103" unit="cm"  x="295.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper103" unit="cm"  x="295.95" y="-506.9018" z="0" />
      <rotation name="rotFS103" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper104" unit="cm"  x="301.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper104" unit="cm"  x="301.95" y="-506.9018" z="0" />
      <rotation name="rotFS104" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper105" unit="cm"  x="307.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper105" unit="cm"  x="307.95" y="-506.9018" z="0" />
      <rotation name="rotFS105" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper106" unit="cm"  x="313.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper106" unit="cm"  x="313.95" y="-506.9018" z="0" />
      <rotation name="rotFS106" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper107" unit="cm"  x="319.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper107" unit="cm"  x="319.95" y="-506.9018" z="0" />
      <rotation name="rotFS107" unit="deg" x="0" y="0" z="90" />
   </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-0" unit="cm" x="-328.04" y="-336.9012" z="-299.34"/>
+   <position name="posGroundGrid-0" unit="cm" x="-328.05" y="-336.9012" z="-299.34"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-1" unit="cm" x="-328.04" y="-1.5" z="-299.34"/>
+   <position name="posGroundGrid-1" unit="cm" x="-328.05" y="-1.5" z="-299.34"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-2" unit="cm" x="-328.04" y="333.9012" z="-299.34"/>
+   <position name="posGroundGrid-2" unit="cm" x="-328.05" y="333.9012" z="-299.34"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-3" unit="cm" x="-328.04" y="-336.9012" z="-1.5"/>
+   <position name="posGroundGrid-3" unit="cm" x="-328.05" y="-336.9012" z="-1.5"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-4" unit="cm" x="-328.04" y="-1.5" z="-1.5"/>
+   <position name="posGroundGrid-4" unit="cm" x="-328.05" y="-1.5" z="-1.5"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-5" unit="cm" x="-328.04" y="333.9012" z="-1.5"/>
+   <position name="posGroundGrid-5" unit="cm" x="-328.05" y="333.9012" z="-1.5"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-6" unit="cm" x="-328.04" y="-336.9012" z="296.34"/>
+   <position name="posGroundGrid-6" unit="cm" x="-328.05" y="-336.9012" z="296.34"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-7" unit="cm" x="-328.04" y="-1.5" z="296.34"/>
+   <position name="posGroundGrid-7" unit="cm" x="-328.05" y="-1.5" z="296.34"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-8" unit="cm" x="-328.04" y="333.9012" z="296.34"/>
+   <position name="posGroundGrid-8" unit="cm" x="-328.05" y="333.9012" z="296.34"/>
       </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-0-0"/>
        <position name="posArapucaDouble0-Frame-0-0" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-464.6012" 
 	 z="-261.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -1881,14 +1881,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-0"/>
        <position name="posOpArapucaDouble0-Frame-0-0" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-464.6012" 
 	 z="-261.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-0-1"/>
        <position name="posArapucaDouble1-Frame-0-0" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-373.9012" 
 	 z="-407.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -1896,14 +1896,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-1"/>
        <position name="posOpArapucaDouble1-Frame-0-0" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-373.9012" 
 	 z="-407.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-0-2"/>
        <position name="posArapucaDouble2-Frame-0-0" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-299.9012" 
 	 z="-190.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -1911,14 +1911,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-2"/>
        <position name="posOpArapucaDouble2-Frame-0-0" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-299.9012" 
 	 z="-190.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-0-3"/>
        <position name="posArapucaDouble3-Frame-0-0" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-209.2012" 
 	 z="-336.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -1926,14 +1926,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-3"/>
        <position name="posOpArapucaDouble3-Frame-0-0" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-209.2012" 
 	 z="-336.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-1-0"/>
        <position name="posArapucaDouble0-Frame-0-1" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-464.6012" 
 	 z="36"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -1941,14 +1941,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-0"/>
        <position name="posOpArapucaDouble0-Frame-0-1" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-464.6012" 
 	 z="36"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-1-1"/>
        <position name="posArapucaDouble1-Frame-0-1" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-373.9012" 
 	 z="-110"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -1956,14 +1956,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-1"/>
        <position name="posOpArapucaDouble1-Frame-0-1" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-373.9012" 
 	 z="-110"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-1-2"/>
        <position name="posArapucaDouble2-Frame-0-1" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-299.9012" 
 	 z="107"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -1971,14 +1971,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-2"/>
        <position name="posOpArapucaDouble2-Frame-0-1" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-299.9012" 
 	 z="107"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-1-3"/>
        <position name="posArapucaDouble3-Frame-0-1" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-209.2012" 
 	 z="-39"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -1986,14 +1986,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-3"/>
        <position name="posOpArapucaDouble3-Frame-0-1" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-209.2012" 
 	 z="-39"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-2-0"/>
        <position name="posArapucaDouble0-Frame-0-2" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-464.6012" 
 	 z="333.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -2001,14 +2001,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-0"/>
        <position name="posOpArapucaDouble0-Frame-0-2" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-464.6012" 
 	 z="333.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-2-1"/>
        <position name="posArapucaDouble1-Frame-0-2" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-373.9012" 
 	 z="187.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -2016,14 +2016,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-1"/>
        <position name="posOpArapucaDouble1-Frame-0-2" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-373.9012" 
 	 z="187.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-2-2"/>
        <position name="posArapucaDouble2-Frame-0-2" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-299.9012" 
 	 z="404.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -2031,14 +2031,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-2"/>
        <position name="posOpArapucaDouble2-Frame-0-2" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-299.9012" 
 	 z="404.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-2-3"/>
        <position name="posArapucaDouble3-Frame-0-2" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-209.2012" 
 	 z="258.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -2046,14 +2046,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-3"/>
        <position name="posOpArapucaDouble3-Frame-0-2" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-209.2012" 
 	 z="258.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-0-0"/>
        <position name="posArapucaDouble0-Frame-1-0" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-129.2" 
 	 z="-261.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -2061,14 +2061,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-0"/>
        <position name="posOpArapucaDouble0-Frame-1-0" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-129.2" 
 	 z="-261.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-0-1"/>
        <position name="posArapucaDouble1-Frame-1-0" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-38.5" 
 	 z="-407.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -2076,14 +2076,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-1"/>
        <position name="posOpArapucaDouble1-Frame-1-0" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-38.5" 
 	 z="-407.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-0-2"/>
        <position name="posArapucaDouble2-Frame-1-0" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="35.5" 
 	 z="-190.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -2091,14 +2091,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-2"/>
        <position name="posOpArapucaDouble2-Frame-1-0" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="35.5" 
 	 z="-190.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-0-3"/>
        <position name="posArapucaDouble3-Frame-1-0" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="126.2" 
 	 z="-336.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -2106,14 +2106,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-3"/>
        <position name="posOpArapucaDouble3-Frame-1-0" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="126.2" 
 	 z="-336.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-1-0"/>
        <position name="posArapucaDouble0-Frame-1-1" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-129.2" 
 	 z="36"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -2121,14 +2121,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-0"/>
        <position name="posOpArapucaDouble0-Frame-1-1" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-129.2" 
 	 z="36"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-1-1"/>
        <position name="posArapucaDouble1-Frame-1-1" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-38.5" 
 	 z="-110"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -2136,14 +2136,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-1"/>
        <position name="posOpArapucaDouble1-Frame-1-1" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-38.5" 
 	 z="-110"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-1-2"/>
        <position name="posArapucaDouble2-Frame-1-1" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="35.5" 
 	 z="107"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -2151,14 +2151,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-2"/>
        <position name="posOpArapucaDouble2-Frame-1-1" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="35.5" 
 	 z="107"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-1-3"/>
        <position name="posArapucaDouble3-Frame-1-1" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="126.2" 
 	 z="-39"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -2166,14 +2166,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-3"/>
        <position name="posOpArapucaDouble3-Frame-1-1" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="126.2" 
 	 z="-39"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-2-0"/>
        <position name="posArapucaDouble0-Frame-1-2" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-129.2" 
 	 z="333.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -2181,14 +2181,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-0"/>
        <position name="posOpArapucaDouble0-Frame-1-2" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-129.2" 
 	 z="333.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-2-1"/>
        <position name="posArapucaDouble1-Frame-1-2" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-38.5" 
 	 z="187.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -2196,14 +2196,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-1"/>
        <position name="posOpArapucaDouble1-Frame-1-2" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-38.5" 
 	 z="187.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-2-2"/>
        <position name="posArapucaDouble2-Frame-1-2" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="35.5" 
 	 z="404.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -2211,14 +2211,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-2"/>
        <position name="posOpArapucaDouble2-Frame-1-2" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="35.5" 
 	 z="404.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-2-3"/>
        <position name="posArapucaDouble3-Frame-1-2" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="126.2" 
 	 z="258.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -2226,14 +2226,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-3"/>
        <position name="posOpArapucaDouble3-Frame-1-2" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="126.2" 
 	 z="258.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-0-0"/>
        <position name="posArapucaDouble0-Frame-2-0" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="206.2012" 
 	 z="-261.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -2241,14 +2241,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-0"/>
        <position name="posOpArapucaDouble0-Frame-2-0" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="206.2012" 
 	 z="-261.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-0-1"/>
        <position name="posArapucaDouble1-Frame-2-0" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="296.9012" 
 	 z="-407.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -2256,14 +2256,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-1"/>
        <position name="posOpArapucaDouble1-Frame-2-0" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="296.9012" 
 	 z="-407.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-0-2"/>
        <position name="posArapucaDouble2-Frame-2-0" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="370.9012" 
 	 z="-190.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -2271,14 +2271,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-2"/>
        <position name="posOpArapucaDouble2-Frame-2-0" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="370.9012" 
 	 z="-190.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-0-3"/>
        <position name="posArapucaDouble3-Frame-2-0" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="461.6012" 
 	 z="-336.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -2286,14 +2286,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-3"/>
        <position name="posOpArapucaDouble3-Frame-2-0" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="461.6012" 
 	 z="-336.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-1-0"/>
        <position name="posArapucaDouble0-Frame-2-1" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="206.2012" 
 	 z="36"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -2301,14 +2301,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-0"/>
        <position name="posOpArapucaDouble0-Frame-2-1" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="206.2012" 
 	 z="36"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-1-1"/>
        <position name="posArapucaDouble1-Frame-2-1" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="296.9012" 
 	 z="-110"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -2316,14 +2316,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-1"/>
        <position name="posOpArapucaDouble1-Frame-2-1" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="296.9012" 
 	 z="-110"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-1-2"/>
        <position name="posArapucaDouble2-Frame-2-1" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="370.9012" 
 	 z="107"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -2331,14 +2331,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-2"/>
        <position name="posOpArapucaDouble2-Frame-2-1" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="370.9012" 
 	 z="107"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-1-3"/>
        <position name="posArapucaDouble3-Frame-2-1" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="461.6012" 
 	 z="-39"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -2346,14 +2346,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-3"/>
        <position name="posOpArapucaDouble3-Frame-2-1" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="461.6012" 
 	 z="-39"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-2-0"/>
        <position name="posArapucaDouble0-Frame-2-2" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="206.2012" 
 	 z="333.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -2361,14 +2361,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-0"/>
        <position name="posOpArapucaDouble0-Frame-2-2" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="206.2012" 
 	 z="333.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-2-1"/>
        <position name="posArapucaDouble1-Frame-2-2" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="296.9012" 
 	 z="187.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -2376,14 +2376,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-1"/>
        <position name="posOpArapucaDouble1-Frame-2-2" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="296.9012" 
 	 z="187.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-2-2"/>
        <position name="posArapucaDouble2-Frame-2-2" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="370.9012" 
 	 z="404.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -2391,14 +2391,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-2"/>
        <position name="posOpArapucaDouble2-Frame-2-2" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="370.9012" 
 	 z="404.84"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-2-3"/>
        <position name="posArapucaDouble3-Frame-2-2" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="461.6012" 
 	 z="258.84"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -2406,7 +2406,7 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-3"/>
        <position name="posOpArapucaDouble3-Frame-2-2" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="461.6012" 
 	 z="258.84"/>
      </physvol>
@@ -2446,7 +2446,7 @@
 
       <physvol>
         <volumeref ref="volDetEnclosure"/>
-	<position name="posDetEnclosure" unit="cm" x="50.04" y="0" z="448.26"/>
+	<position name="posDetEnclosure" unit="cm" x="50.0500000000001" y="0" z="448.26"/>
       </physvol>
 
     </volume>

--- a/dunecore/Geometry/gdml/dunevd10kt_3view_v3_refactored_1x8x14ref.gdml
+++ b/dunecore/Geometry/gdml/dunevd10kt_3view_v3_refactored_1x8x14ref.gdml
@@ -508,6 +508,11 @@
       y="168"
       z="148.9009"
       lunit="cm"/>
+   <box name="AnodePlate" 
+      x="0.02/2."
+      y="168"
+      z="148.9009"
+      lunit="cm"/>
    <box name="CRMActive" 
       x="650"
       y="168"
@@ -7394,7 +7399,7 @@
      
    <volume name="volAnodePlate">
      <materialref ref="vm2000"/>
-     <solidref ref="CRMZPlane"/>
+     <solidref ref="AnodePlate"/>
   </volume>
    <volume name="volTPC">
      <materialref ref="LAr"/>
@@ -7402,25 +7407,25 @@
        <physvol>
        <volumeref ref="volTPCPlaneU"/>
        <position name="posPlaneU" unit="cm" 
-         x="324.98" y="0" z="0"/>
+         x="324.99" y="0" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volTPCPlaneY"/>
        <position name="posPlaneY" unit="cm" 
-         x="325" y="0" z="0"/>
+         x="325.01" y="0" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volTPCPlaneZ"/>
        <position name="posPlaneZ" unit="cm" 
-         x="325.02" y="0" z="0"/>
+         x="325.03" y="0" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volAnodePlate"/>
        <position name="posAnodePlate" unit="cm" 
-         x="325.04" y="0" z="0"/>
+         x="325.045" y="0" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>    
      <physvol>
@@ -9913,120 +9918,120 @@
   </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-0" unit="cm" x="-328.05" y="-506" z="-896.9054"/>
+   <position name="posGroundGrid-0" unit="cm" x="-328.04" y="-506" z="-896.9054"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-1" unit="cm" x="-328.05" y="-170" z="-896.9054"/>
+   <position name="posGroundGrid-1" unit="cm" x="-328.04" y="-170" z="-896.9054"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-2" unit="cm" x="-328.05" y="166" z="-896.9054"/>
+   <position name="posGroundGrid-2" unit="cm" x="-328.04" y="166" z="-896.9054"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-3" unit="cm" x="-328.05" y="502" z="-896.9054"/>
+   <position name="posGroundGrid-3" unit="cm" x="-328.04" y="502" z="-896.9054"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-4" unit="cm" x="-328.05" y="-506" z="-599.1036"/>
+   <position name="posGroundGrid-4" unit="cm" x="-328.04" y="-506" z="-599.1036"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-5" unit="cm" x="-328.05" y="-170" z="-599.1036"/>
+   <position name="posGroundGrid-5" unit="cm" x="-328.04" y="-170" z="-599.1036"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-6" unit="cm" x="-328.05" y="166" z="-599.1036"/>
+   <position name="posGroundGrid-6" unit="cm" x="-328.04" y="166" z="-599.1036"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-7" unit="cm" x="-328.05" y="502" z="-599.1036"/>
+   <position name="posGroundGrid-7" unit="cm" x="-328.04" y="502" z="-599.1036"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-8" unit="cm" x="-328.05" y="-506" z="-301.3018"/>
+   <position name="posGroundGrid-8" unit="cm" x="-328.04" y="-506" z="-301.3018"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-9" unit="cm" x="-328.05" y="-170" z="-301.3018"/>
+   <position name="posGroundGrid-9" unit="cm" x="-328.04" y="-170" z="-301.3018"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-10" unit="cm" x="-328.05" y="166" z="-301.3018"/>
+   <position name="posGroundGrid-10" unit="cm" x="-328.04" y="166" z="-301.3018"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-11" unit="cm" x="-328.05" y="502" z="-301.3018"/>
+   <position name="posGroundGrid-11" unit="cm" x="-328.04" y="502" z="-301.3018"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-12" unit="cm" x="-328.05" y="-506" z="-3.49999999999989"/>
+   <position name="posGroundGrid-12" unit="cm" x="-328.04" y="-506" z="-3.49999999999989"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-13" unit="cm" x="-328.05" y="-170" z="-3.49999999999989"/>
+   <position name="posGroundGrid-13" unit="cm" x="-328.04" y="-170" z="-3.49999999999989"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-14" unit="cm" x="-328.05" y="166" z="-3.49999999999989"/>
+   <position name="posGroundGrid-14" unit="cm" x="-328.04" y="166" z="-3.49999999999989"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-15" unit="cm" x="-328.05" y="502" z="-3.49999999999989"/>
+   <position name="posGroundGrid-15" unit="cm" x="-328.04" y="502" z="-3.49999999999989"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-16" unit="cm" x="-328.05" y="-506" z="294.3018"/>
+   <position name="posGroundGrid-16" unit="cm" x="-328.04" y="-506" z="294.3018"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-17" unit="cm" x="-328.05" y="-170" z="294.3018"/>
+   <position name="posGroundGrid-17" unit="cm" x="-328.04" y="-170" z="294.3018"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-18" unit="cm" x="-328.05" y="166" z="294.3018"/>
+   <position name="posGroundGrid-18" unit="cm" x="-328.04" y="166" z="294.3018"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-19" unit="cm" x="-328.05" y="502" z="294.3018"/>
+   <position name="posGroundGrid-19" unit="cm" x="-328.04" y="502" z="294.3018"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-20" unit="cm" x="-328.05" y="-506" z="592.1036"/>
+   <position name="posGroundGrid-20" unit="cm" x="-328.04" y="-506" z="592.1036"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-21" unit="cm" x="-328.05" y="-170" z="592.1036"/>
+   <position name="posGroundGrid-21" unit="cm" x="-328.04" y="-170" z="592.1036"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-22" unit="cm" x="-328.05" y="166" z="592.1036"/>
+   <position name="posGroundGrid-22" unit="cm" x="-328.04" y="166" z="592.1036"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-23" unit="cm" x="-328.05" y="502" z="592.1036"/>
+   <position name="posGroundGrid-23" unit="cm" x="-328.04" y="502" z="592.1036"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-24" unit="cm" x="-328.05" y="-506" z="889.9054"/>
+   <position name="posGroundGrid-24" unit="cm" x="-328.04" y="-506" z="889.9054"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-25" unit="cm" x="-328.05" y="-170" z="889.9054"/>
+   <position name="posGroundGrid-25" unit="cm" x="-328.04" y="-170" z="889.9054"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-26" unit="cm" x="-328.05" y="166" z="889.9054"/>
+   <position name="posGroundGrid-26" unit="cm" x="-328.04" y="166" z="889.9054"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-27" unit="cm" x="-328.05" y="502" z="889.9054"/>
+   <position name="posGroundGrid-27" unit="cm" x="-328.04" y="502" z="889.9054"/>
       </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-0-0"/>
        <position name="posArapucaDouble0-Frame-0-0" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-633.7" 
 	 z="-859.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10034,14 +10039,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-0"/>
        <position name="posOpArapucaDouble0-Frame-0-0" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-633.7" 
 	 z="-859.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-0-1"/>
        <position name="posArapucaDouble1-Frame-0-0" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-543" 
 	 z="-1005.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10049,14 +10054,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-1"/>
        <position name="posOpArapucaDouble1-Frame-0-0" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-543" 
 	 z="-1005.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-0-2"/>
        <position name="posArapucaDouble2-Frame-0-0" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-469" 
 	 z="-788.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10064,14 +10069,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-2"/>
        <position name="posOpArapucaDouble2-Frame-0-0" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-469" 
 	 z="-788.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-0-3"/>
        <position name="posArapucaDouble3-Frame-0-0" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-378.3" 
 	 z="-934.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10079,14 +10084,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-3"/>
        <position name="posOpArapucaDouble3-Frame-0-0" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-378.3" 
 	 z="-934.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-1-0"/>
        <position name="posArapucaDouble0-Frame-0-1" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-633.7" 
 	 z="-561.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10094,14 +10099,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-0"/>
        <position name="posOpArapucaDouble0-Frame-0-1" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-633.7" 
 	 z="-561.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-1-1"/>
        <position name="posArapucaDouble1-Frame-0-1" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-543" 
 	 z="-707.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10109,14 +10114,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-1"/>
        <position name="posOpArapucaDouble1-Frame-0-1" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-543" 
 	 z="-707.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-1-2"/>
        <position name="posArapucaDouble2-Frame-0-1" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-469" 
 	 z="-490.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10124,14 +10129,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-2"/>
        <position name="posOpArapucaDouble2-Frame-0-1" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-469" 
 	 z="-490.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-1-3"/>
        <position name="posArapucaDouble3-Frame-0-1" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-378.3" 
 	 z="-636.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10139,14 +10144,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-3"/>
        <position name="posOpArapucaDouble3-Frame-0-1" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-378.3" 
 	 z="-636.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-2-0"/>
        <position name="posArapucaDouble0-Frame-0-2" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-633.7" 
 	 z="-263.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10154,14 +10159,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-0"/>
        <position name="posOpArapucaDouble0-Frame-0-2" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-633.7" 
 	 z="-263.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-2-1"/>
        <position name="posArapucaDouble1-Frame-0-2" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-543" 
 	 z="-409.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10169,14 +10174,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-1"/>
        <position name="posOpArapucaDouble1-Frame-0-2" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-543" 
 	 z="-409.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-2-2"/>
        <position name="posArapucaDouble2-Frame-0-2" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-469" 
 	 z="-192.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10184,14 +10189,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-2"/>
        <position name="posOpArapucaDouble2-Frame-0-2" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-469" 
 	 z="-192.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-2-3"/>
        <position name="posArapucaDouble3-Frame-0-2" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-378.3" 
 	 z="-338.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10199,14 +10204,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-3"/>
        <position name="posOpArapucaDouble3-Frame-0-2" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-378.3" 
 	 z="-338.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-3-0"/>
        <position name="posArapucaDouble0-Frame-0-3" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-633.7" 
 	 z="34.0000000000001"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10214,14 +10219,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-3-0"/>
        <position name="posOpArapucaDouble0-Frame-0-3" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-633.7" 
 	 z="34.0000000000001"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-3-1"/>
        <position name="posArapucaDouble1-Frame-0-3" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-543" 
 	 z="-112"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10229,14 +10234,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-3-1"/>
        <position name="posOpArapucaDouble1-Frame-0-3" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-543" 
 	 z="-112"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-3-2"/>
        <position name="posArapucaDouble2-Frame-0-3" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-469" 
 	 z="105"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10244,14 +10249,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-3-2"/>
        <position name="posOpArapucaDouble2-Frame-0-3" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-469" 
 	 z="105"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-3-3"/>
        <position name="posArapucaDouble3-Frame-0-3" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-378.3" 
 	 z="-40.9999999999999"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10259,14 +10264,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-3-3"/>
        <position name="posOpArapucaDouble3-Frame-0-3" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-378.3" 
 	 z="-40.9999999999999"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-4-0"/>
        <position name="posArapucaDouble0-Frame-0-4" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-633.7" 
 	 z="331.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10274,14 +10279,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-4-0"/>
        <position name="posOpArapucaDouble0-Frame-0-4" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-633.7" 
 	 z="331.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-4-1"/>
        <position name="posArapucaDouble1-Frame-0-4" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-543" 
 	 z="185.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10289,14 +10294,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-4-1"/>
        <position name="posOpArapucaDouble1-Frame-0-4" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-543" 
 	 z="185.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-4-2"/>
        <position name="posArapucaDouble2-Frame-0-4" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-469" 
 	 z="402.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10304,14 +10309,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-4-2"/>
        <position name="posOpArapucaDouble2-Frame-0-4" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-469" 
 	 z="402.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-4-3"/>
        <position name="posArapucaDouble3-Frame-0-4" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-378.3" 
 	 z="256.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10319,14 +10324,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-4-3"/>
        <position name="posOpArapucaDouble3-Frame-0-4" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-378.3" 
 	 z="256.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-5-0"/>
        <position name="posArapucaDouble0-Frame-0-5" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-633.7" 
 	 z="629.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10334,14 +10339,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-5-0"/>
        <position name="posOpArapucaDouble0-Frame-0-5" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-633.7" 
 	 z="629.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-5-1"/>
        <position name="posArapucaDouble1-Frame-0-5" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-543" 
 	 z="483.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10349,14 +10354,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-5-1"/>
        <position name="posOpArapucaDouble1-Frame-0-5" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-543" 
 	 z="483.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-5-2"/>
        <position name="posArapucaDouble2-Frame-0-5" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-469" 
 	 z="700.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10364,14 +10369,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-5-2"/>
        <position name="posOpArapucaDouble2-Frame-0-5" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-469" 
 	 z="700.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-5-3"/>
        <position name="posArapucaDouble3-Frame-0-5" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-378.3" 
 	 z="554.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10379,14 +10384,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-5-3"/>
        <position name="posOpArapucaDouble3-Frame-0-5" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-378.3" 
 	 z="554.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-6-0"/>
        <position name="posArapucaDouble0-Frame-0-6" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-633.7" 
 	 z="927.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10394,14 +10399,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-6-0"/>
        <position name="posOpArapucaDouble0-Frame-0-6" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-633.7" 
 	 z="927.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-6-1"/>
        <position name="posArapucaDouble1-Frame-0-6" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-543" 
 	 z="781.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10409,14 +10414,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-6-1"/>
        <position name="posOpArapucaDouble1-Frame-0-6" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-543" 
 	 z="781.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-6-2"/>
        <position name="posArapucaDouble2-Frame-0-6" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-469" 
 	 z="998.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10424,14 +10429,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-6-2"/>
        <position name="posOpArapucaDouble2-Frame-0-6" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-469" 
 	 z="998.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-6-3"/>
        <position name="posArapucaDouble3-Frame-0-6" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-378.3" 
 	 z="852.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10439,14 +10444,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-6-3"/>
        <position name="posOpArapucaDouble3-Frame-0-6" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-378.3" 
 	 z="852.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-0-0"/>
        <position name="posArapucaDouble0-Frame-1-0" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-297.7" 
 	 z="-859.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10454,14 +10459,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-0"/>
        <position name="posOpArapucaDouble0-Frame-1-0" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-297.7" 
 	 z="-859.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-0-1"/>
        <position name="posArapucaDouble1-Frame-1-0" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-207" 
 	 z="-1005.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10469,14 +10474,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-1"/>
        <position name="posOpArapucaDouble1-Frame-1-0" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-207" 
 	 z="-1005.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-0-2"/>
        <position name="posArapucaDouble2-Frame-1-0" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-133" 
 	 z="-788.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10484,14 +10489,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-2"/>
        <position name="posOpArapucaDouble2-Frame-1-0" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-133" 
 	 z="-788.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-0-3"/>
        <position name="posArapucaDouble3-Frame-1-0" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-42.3" 
 	 z="-934.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10499,14 +10504,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-3"/>
        <position name="posOpArapucaDouble3-Frame-1-0" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-42.3" 
 	 z="-934.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-1-0"/>
        <position name="posArapucaDouble0-Frame-1-1" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-297.7" 
 	 z="-561.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10514,14 +10519,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-0"/>
        <position name="posOpArapucaDouble0-Frame-1-1" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-297.7" 
 	 z="-561.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-1-1"/>
        <position name="posArapucaDouble1-Frame-1-1" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-207" 
 	 z="-707.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10529,14 +10534,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-1"/>
        <position name="posOpArapucaDouble1-Frame-1-1" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-207" 
 	 z="-707.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-1-2"/>
        <position name="posArapucaDouble2-Frame-1-1" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-133" 
 	 z="-490.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10544,14 +10549,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-2"/>
        <position name="posOpArapucaDouble2-Frame-1-1" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-133" 
 	 z="-490.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-1-3"/>
        <position name="posArapucaDouble3-Frame-1-1" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-42.3" 
 	 z="-636.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10559,14 +10564,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-3"/>
        <position name="posOpArapucaDouble3-Frame-1-1" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-42.3" 
 	 z="-636.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-2-0"/>
        <position name="posArapucaDouble0-Frame-1-2" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-297.7" 
 	 z="-263.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10574,14 +10579,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-0"/>
        <position name="posOpArapucaDouble0-Frame-1-2" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-297.7" 
 	 z="-263.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-2-1"/>
        <position name="posArapucaDouble1-Frame-1-2" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-207" 
 	 z="-409.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10589,14 +10594,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-1"/>
        <position name="posOpArapucaDouble1-Frame-1-2" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-207" 
 	 z="-409.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-2-2"/>
        <position name="posArapucaDouble2-Frame-1-2" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-133" 
 	 z="-192.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10604,14 +10609,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-2"/>
        <position name="posOpArapucaDouble2-Frame-1-2" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-133" 
 	 z="-192.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-2-3"/>
        <position name="posArapucaDouble3-Frame-1-2" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-42.3" 
 	 z="-338.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10619,14 +10624,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-3"/>
        <position name="posOpArapucaDouble3-Frame-1-2" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-42.3" 
 	 z="-338.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-3-0"/>
        <position name="posArapucaDouble0-Frame-1-3" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-297.7" 
 	 z="34.0000000000001"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10634,14 +10639,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-3-0"/>
        <position name="posOpArapucaDouble0-Frame-1-3" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-297.7" 
 	 z="34.0000000000001"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-3-1"/>
        <position name="posArapucaDouble1-Frame-1-3" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-207" 
 	 z="-112"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10649,14 +10654,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-3-1"/>
        <position name="posOpArapucaDouble1-Frame-1-3" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-207" 
 	 z="-112"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-3-2"/>
        <position name="posArapucaDouble2-Frame-1-3" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-133" 
 	 z="105"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10664,14 +10669,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-3-2"/>
        <position name="posOpArapucaDouble2-Frame-1-3" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-133" 
 	 z="105"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-3-3"/>
        <position name="posArapucaDouble3-Frame-1-3" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-42.3" 
 	 z="-40.9999999999999"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10679,14 +10684,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-3-3"/>
        <position name="posOpArapucaDouble3-Frame-1-3" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-42.3" 
 	 z="-40.9999999999999"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-4-0"/>
        <position name="posArapucaDouble0-Frame-1-4" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-297.7" 
 	 z="331.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10694,14 +10699,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-4-0"/>
        <position name="posOpArapucaDouble0-Frame-1-4" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-297.7" 
 	 z="331.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-4-1"/>
        <position name="posArapucaDouble1-Frame-1-4" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-207" 
 	 z="185.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10709,14 +10714,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-4-1"/>
        <position name="posOpArapucaDouble1-Frame-1-4" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-207" 
 	 z="185.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-4-2"/>
        <position name="posArapucaDouble2-Frame-1-4" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-133" 
 	 z="402.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10724,14 +10729,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-4-2"/>
        <position name="posOpArapucaDouble2-Frame-1-4" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-133" 
 	 z="402.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-4-3"/>
        <position name="posArapucaDouble3-Frame-1-4" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-42.3" 
 	 z="256.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10739,14 +10744,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-4-3"/>
        <position name="posOpArapucaDouble3-Frame-1-4" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-42.3" 
 	 z="256.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-5-0"/>
        <position name="posArapucaDouble0-Frame-1-5" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-297.7" 
 	 z="629.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10754,14 +10759,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-5-0"/>
        <position name="posOpArapucaDouble0-Frame-1-5" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-297.7" 
 	 z="629.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-5-1"/>
        <position name="posArapucaDouble1-Frame-1-5" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-207" 
 	 z="483.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10769,14 +10774,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-5-1"/>
        <position name="posOpArapucaDouble1-Frame-1-5" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-207" 
 	 z="483.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-5-2"/>
        <position name="posArapucaDouble2-Frame-1-5" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-133" 
 	 z="700.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10784,14 +10789,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-5-2"/>
        <position name="posOpArapucaDouble2-Frame-1-5" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-133" 
 	 z="700.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-5-3"/>
        <position name="posArapucaDouble3-Frame-1-5" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-42.3" 
 	 z="554.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10799,14 +10804,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-5-3"/>
        <position name="posOpArapucaDouble3-Frame-1-5" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-42.3" 
 	 z="554.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-6-0"/>
        <position name="posArapucaDouble0-Frame-1-6" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-297.7" 
 	 z="927.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10814,14 +10819,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-6-0"/>
        <position name="posOpArapucaDouble0-Frame-1-6" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-297.7" 
 	 z="927.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-6-1"/>
        <position name="posArapucaDouble1-Frame-1-6" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-207" 
 	 z="781.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10829,14 +10834,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-6-1"/>
        <position name="posOpArapucaDouble1-Frame-1-6" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-207" 
 	 z="781.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-6-2"/>
        <position name="posArapucaDouble2-Frame-1-6" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-133" 
 	 z="998.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10844,14 +10849,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-6-2"/>
        <position name="posOpArapucaDouble2-Frame-1-6" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-133" 
 	 z="998.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-6-3"/>
        <position name="posArapucaDouble3-Frame-1-6" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-42.3" 
 	 z="852.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10859,14 +10864,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-6-3"/>
        <position name="posOpArapucaDouble3-Frame-1-6" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-42.3" 
 	 z="852.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-0-0"/>
        <position name="posArapucaDouble0-Frame-2-0" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="38.3" 
 	 z="-859.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10874,14 +10879,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-0"/>
        <position name="posOpArapucaDouble0-Frame-2-0" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="38.3" 
 	 z="-859.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-0-1"/>
        <position name="posArapucaDouble1-Frame-2-0" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="129" 
 	 z="-1005.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10889,14 +10894,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-1"/>
        <position name="posOpArapucaDouble1-Frame-2-0" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="129" 
 	 z="-1005.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-0-2"/>
        <position name="posArapucaDouble2-Frame-2-0" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="203" 
 	 z="-788.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10904,14 +10909,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-2"/>
        <position name="posOpArapucaDouble2-Frame-2-0" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="203" 
 	 z="-788.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-0-3"/>
        <position name="posArapucaDouble3-Frame-2-0" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="293.7" 
 	 z="-934.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10919,14 +10924,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-3"/>
        <position name="posOpArapucaDouble3-Frame-2-0" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="293.7" 
 	 z="-934.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-1-0"/>
        <position name="posArapucaDouble0-Frame-2-1" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="38.3" 
 	 z="-561.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10934,14 +10939,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-0"/>
        <position name="posOpArapucaDouble0-Frame-2-1" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="38.3" 
 	 z="-561.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-1-1"/>
        <position name="posArapucaDouble1-Frame-2-1" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="129" 
 	 z="-707.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10949,14 +10954,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-1"/>
        <position name="posOpArapucaDouble1-Frame-2-1" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="129" 
 	 z="-707.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-1-2"/>
        <position name="posArapucaDouble2-Frame-2-1" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="203" 
 	 z="-490.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10964,14 +10969,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-2"/>
        <position name="posOpArapucaDouble2-Frame-2-1" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="203" 
 	 z="-490.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-1-3"/>
        <position name="posArapucaDouble3-Frame-2-1" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="293.7" 
 	 z="-636.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10979,14 +10984,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-3"/>
        <position name="posOpArapucaDouble3-Frame-2-1" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="293.7" 
 	 z="-636.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-2-0"/>
        <position name="posArapucaDouble0-Frame-2-2" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="38.3" 
 	 z="-263.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10994,14 +10999,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-0"/>
        <position name="posOpArapucaDouble0-Frame-2-2" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="38.3" 
 	 z="-263.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-2-1"/>
        <position name="posArapucaDouble1-Frame-2-2" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="129" 
 	 z="-409.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11009,14 +11014,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-1"/>
        <position name="posOpArapucaDouble1-Frame-2-2" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="129" 
 	 z="-409.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-2-2"/>
        <position name="posArapucaDouble2-Frame-2-2" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="203" 
 	 z="-192.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11024,14 +11029,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-2"/>
        <position name="posOpArapucaDouble2-Frame-2-2" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="203" 
 	 z="-192.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-2-3"/>
        <position name="posArapucaDouble3-Frame-2-2" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="293.7" 
 	 z="-338.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11039,14 +11044,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-3"/>
        <position name="posOpArapucaDouble3-Frame-2-2" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="293.7" 
 	 z="-338.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-3-0"/>
        <position name="posArapucaDouble0-Frame-2-3" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="38.3" 
 	 z="34.0000000000001"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11054,14 +11059,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-3-0"/>
        <position name="posOpArapucaDouble0-Frame-2-3" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="38.3" 
 	 z="34.0000000000001"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-3-1"/>
        <position name="posArapucaDouble1-Frame-2-3" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="129" 
 	 z="-112"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11069,14 +11074,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-3-1"/>
        <position name="posOpArapucaDouble1-Frame-2-3" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="129" 
 	 z="-112"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-3-2"/>
        <position name="posArapucaDouble2-Frame-2-3" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="203" 
 	 z="105"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11084,14 +11089,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-3-2"/>
        <position name="posOpArapucaDouble2-Frame-2-3" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="203" 
 	 z="105"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-3-3"/>
        <position name="posArapucaDouble3-Frame-2-3" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="293.7" 
 	 z="-40.9999999999999"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11099,14 +11104,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-3-3"/>
        <position name="posOpArapucaDouble3-Frame-2-3" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="293.7" 
 	 z="-40.9999999999999"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-4-0"/>
        <position name="posArapucaDouble0-Frame-2-4" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="38.3" 
 	 z="331.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11114,14 +11119,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-4-0"/>
        <position name="posOpArapucaDouble0-Frame-2-4" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="38.3" 
 	 z="331.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-4-1"/>
        <position name="posArapucaDouble1-Frame-2-4" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="129" 
 	 z="185.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11129,14 +11134,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-4-1"/>
        <position name="posOpArapucaDouble1-Frame-2-4" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="129" 
 	 z="185.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-4-2"/>
        <position name="posArapucaDouble2-Frame-2-4" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="203" 
 	 z="402.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11144,14 +11149,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-4-2"/>
        <position name="posOpArapucaDouble2-Frame-2-4" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="203" 
 	 z="402.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-4-3"/>
        <position name="posArapucaDouble3-Frame-2-4" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="293.7" 
 	 z="256.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11159,14 +11164,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-4-3"/>
        <position name="posOpArapucaDouble3-Frame-2-4" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="293.7" 
 	 z="256.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-5-0"/>
        <position name="posArapucaDouble0-Frame-2-5" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="38.3" 
 	 z="629.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11174,14 +11179,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-5-0"/>
        <position name="posOpArapucaDouble0-Frame-2-5" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="38.3" 
 	 z="629.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-5-1"/>
        <position name="posArapucaDouble1-Frame-2-5" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="129" 
 	 z="483.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11189,14 +11194,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-5-1"/>
        <position name="posOpArapucaDouble1-Frame-2-5" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="129" 
 	 z="483.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-5-2"/>
        <position name="posArapucaDouble2-Frame-2-5" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="203" 
 	 z="700.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11204,14 +11209,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-5-2"/>
        <position name="posOpArapucaDouble2-Frame-2-5" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="203" 
 	 z="700.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-5-3"/>
        <position name="posArapucaDouble3-Frame-2-5" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="293.7" 
 	 z="554.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11219,14 +11224,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-5-3"/>
        <position name="posOpArapucaDouble3-Frame-2-5" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="293.7" 
 	 z="554.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-6-0"/>
        <position name="posArapucaDouble0-Frame-2-6" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="38.3" 
 	 z="927.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11234,14 +11239,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-6-0"/>
        <position name="posOpArapucaDouble0-Frame-2-6" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="38.3" 
 	 z="927.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-6-1"/>
        <position name="posArapucaDouble1-Frame-2-6" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="129" 
 	 z="781.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11249,14 +11254,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-6-1"/>
        <position name="posOpArapucaDouble1-Frame-2-6" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="129" 
 	 z="781.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-6-2"/>
        <position name="posArapucaDouble2-Frame-2-6" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="203" 
 	 z="998.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11264,14 +11269,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-6-2"/>
        <position name="posOpArapucaDouble2-Frame-2-6" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="203" 
 	 z="998.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-6-3"/>
        <position name="posArapucaDouble3-Frame-2-6" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="293.7" 
 	 z="852.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11279,14 +11284,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-6-3"/>
        <position name="posOpArapucaDouble3-Frame-2-6" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="293.7" 
 	 z="852.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-0-0"/>
        <position name="posArapucaDouble0-Frame-3-0" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="374.3" 
 	 z="-859.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11294,14 +11299,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-0"/>
        <position name="posOpArapucaDouble0-Frame-3-0" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="374.3" 
 	 z="-859.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-0-1"/>
        <position name="posArapucaDouble1-Frame-3-0" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="465" 
 	 z="-1005.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11309,14 +11314,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-1"/>
        <position name="posOpArapucaDouble1-Frame-3-0" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="465" 
 	 z="-1005.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-0-2"/>
        <position name="posArapucaDouble2-Frame-3-0" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="539" 
 	 z="-788.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11324,14 +11329,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-2"/>
        <position name="posOpArapucaDouble2-Frame-3-0" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="539" 
 	 z="-788.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-0-3"/>
        <position name="posArapucaDouble3-Frame-3-0" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="629.7" 
 	 z="-934.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11339,14 +11344,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-3"/>
        <position name="posOpArapucaDouble3-Frame-3-0" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="629.7" 
 	 z="-934.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-1-0"/>
        <position name="posArapucaDouble0-Frame-3-1" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="374.3" 
 	 z="-561.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11354,14 +11359,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-0"/>
        <position name="posOpArapucaDouble0-Frame-3-1" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="374.3" 
 	 z="-561.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-1-1"/>
        <position name="posArapucaDouble1-Frame-3-1" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="465" 
 	 z="-707.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11369,14 +11374,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-1"/>
        <position name="posOpArapucaDouble1-Frame-3-1" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="465" 
 	 z="-707.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-1-2"/>
        <position name="posArapucaDouble2-Frame-3-1" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="539" 
 	 z="-490.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11384,14 +11389,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-2"/>
        <position name="posOpArapucaDouble2-Frame-3-1" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="539" 
 	 z="-490.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-1-3"/>
        <position name="posArapucaDouble3-Frame-3-1" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="629.7" 
 	 z="-636.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11399,14 +11404,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-3"/>
        <position name="posOpArapucaDouble3-Frame-3-1" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="629.7" 
 	 z="-636.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-2-0"/>
        <position name="posArapucaDouble0-Frame-3-2" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="374.3" 
 	 z="-263.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11414,14 +11419,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-0"/>
        <position name="posOpArapucaDouble0-Frame-3-2" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="374.3" 
 	 z="-263.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-2-1"/>
        <position name="posArapucaDouble1-Frame-3-2" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="465" 
 	 z="-409.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11429,14 +11434,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-1"/>
        <position name="posOpArapucaDouble1-Frame-3-2" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="465" 
 	 z="-409.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-2-2"/>
        <position name="posArapucaDouble2-Frame-3-2" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="539" 
 	 z="-192.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11444,14 +11449,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-2"/>
        <position name="posOpArapucaDouble2-Frame-3-2" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="539" 
 	 z="-192.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-2-3"/>
        <position name="posArapucaDouble3-Frame-3-2" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="629.7" 
 	 z="-338.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11459,14 +11464,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-3"/>
        <position name="posOpArapucaDouble3-Frame-3-2" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="629.7" 
 	 z="-338.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-3-0"/>
        <position name="posArapucaDouble0-Frame-3-3" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="374.3" 
 	 z="34.0000000000001"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11474,14 +11479,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-3-0"/>
        <position name="posOpArapucaDouble0-Frame-3-3" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="374.3" 
 	 z="34.0000000000001"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-3-1"/>
        <position name="posArapucaDouble1-Frame-3-3" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="465" 
 	 z="-112"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11489,14 +11494,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-3-1"/>
        <position name="posOpArapucaDouble1-Frame-3-3" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="465" 
 	 z="-112"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-3-2"/>
        <position name="posArapucaDouble2-Frame-3-3" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="539" 
 	 z="105"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11504,14 +11509,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-3-2"/>
        <position name="posOpArapucaDouble2-Frame-3-3" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="539" 
 	 z="105"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-3-3"/>
        <position name="posArapucaDouble3-Frame-3-3" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="629.7" 
 	 z="-40.9999999999999"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11519,14 +11524,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-3-3"/>
        <position name="posOpArapucaDouble3-Frame-3-3" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="629.7" 
 	 z="-40.9999999999999"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-4-0"/>
        <position name="posArapucaDouble0-Frame-3-4" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="374.3" 
 	 z="331.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11534,14 +11539,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-4-0"/>
        <position name="posOpArapucaDouble0-Frame-3-4" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="374.3" 
 	 z="331.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-4-1"/>
        <position name="posArapucaDouble1-Frame-3-4" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="465" 
 	 z="185.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11549,14 +11554,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-4-1"/>
        <position name="posOpArapucaDouble1-Frame-3-4" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="465" 
 	 z="185.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-4-2"/>
        <position name="posArapucaDouble2-Frame-3-4" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="539" 
 	 z="402.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11564,14 +11569,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-4-2"/>
        <position name="posOpArapucaDouble2-Frame-3-4" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="539" 
 	 z="402.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-4-3"/>
        <position name="posArapucaDouble3-Frame-3-4" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="629.7" 
 	 z="256.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11579,14 +11584,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-4-3"/>
        <position name="posOpArapucaDouble3-Frame-3-4" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="629.7" 
 	 z="256.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-5-0"/>
        <position name="posArapucaDouble0-Frame-3-5" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="374.3" 
 	 z="629.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11594,14 +11599,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-5-0"/>
        <position name="posOpArapucaDouble0-Frame-3-5" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="374.3" 
 	 z="629.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-5-1"/>
        <position name="posArapucaDouble1-Frame-3-5" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="465" 
 	 z="483.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11609,14 +11614,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-5-1"/>
        <position name="posOpArapucaDouble1-Frame-3-5" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="465" 
 	 z="483.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-5-2"/>
        <position name="posArapucaDouble2-Frame-3-5" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="539" 
 	 z="700.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11624,14 +11629,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-5-2"/>
        <position name="posOpArapucaDouble2-Frame-3-5" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="539" 
 	 z="700.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-5-3"/>
        <position name="posArapucaDouble3-Frame-3-5" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="629.7" 
 	 z="554.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11639,14 +11644,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-5-3"/>
        <position name="posOpArapucaDouble3-Frame-3-5" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="629.7" 
 	 z="554.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-6-0"/>
        <position name="posArapucaDouble0-Frame-3-6" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="374.3" 
 	 z="927.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11654,14 +11659,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-6-0"/>
        <position name="posOpArapucaDouble0-Frame-3-6" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="374.3" 
 	 z="927.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-6-1"/>
        <position name="posArapucaDouble1-Frame-3-6" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="465" 
 	 z="781.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11669,14 +11674,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-6-1"/>
        <position name="posOpArapucaDouble1-Frame-3-6" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="465" 
 	 z="781.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-6-2"/>
        <position name="posArapucaDouble2-Frame-3-6" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="539" 
 	 z="998.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11684,14 +11689,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-6-2"/>
        <position name="posOpArapucaDouble2-Frame-3-6" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="539" 
 	 z="998.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-6-3"/>
        <position name="posArapucaDouble3-Frame-3-6" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="629.7" 
 	 z="852.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11699,14 +11704,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-6-3"/>
        <position name="posOpArapucaDouble3-Frame-3-6" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="629.7" 
 	 z="852.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-0"/>
        <position name="posArapuca0-Lat-0" unit="cm" 
-         x="285.02"
+         x="285.03"
 	 y="-734" 
 	 z="-893.4054"/>
        <rotationref ref="rIdentity"/>
@@ -11714,14 +11719,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-0"/>
        <position name="posOpArapuca0-Lat-0" unit="cm" 
-         x="285.02"
+         x="285.03"
 	 y="-733.26" 
 	 z="-893.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-1"/>
        <position name="posArapuca1-Lat-0" unit="cm" 
-         x="210.02"
+         x="210.03"
 	 y="-734" 
 	 z="-893.4054"/>
        <rotationref ref="rIdentity"/>
@@ -11729,14 +11734,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-1"/>
        <position name="posOpArapuca1-Lat-0" unit="cm" 
-         x="210.02"
+         x="210.03"
 	 y="-733.26" 
 	 z="-893.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-2"/>
        <position name="posArapuca2-Lat-0" unit="cm" 
-         x="135.02"
+         x="135.03"
 	 y="-734" 
 	 z="-893.4054"/>
        <rotationref ref="rIdentity"/>
@@ -11744,14 +11749,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-2"/>
        <position name="posOpArapuca2-Lat-0" unit="cm" 
-         x="135.02"
+         x="135.03"
 	 y="-733.26" 
 	 z="-893.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-3"/>
        <position name="posArapuca3-Lat-0" unit="cm" 
-         x="60.02"
+         x="60.03"
 	 y="-734" 
 	 z="-893.4054"/>
        <rotationref ref="rIdentity"/>
@@ -11759,14 +11764,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-3"/>
        <position name="posOpArapuca3-Lat-0" unit="cm" 
-         x="60.02"
+         x="60.03"
 	 y="-733.26" 
 	 z="-893.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-4"/>
        <position name="posArapuca4-Lat-0" unit="cm" 
-         x="285.02"
+         x="285.03"
 	 y="734" 
 	 z="-893.4054"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -11774,14 +11779,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-4"/>
        <position name="posOpArapuca4-Lat-0" unit="cm" 
-         x="285.02"
+         x="285.03"
 	 y="733.26" 
 	 z="-893.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-5"/>
        <position name="posArapuca5-Lat-0" unit="cm" 
-         x="210.02"
+         x="210.03"
 	 y="734" 
 	 z="-893.4054"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -11789,14 +11794,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-5"/>
        <position name="posOpArapuca5-Lat-0" unit="cm" 
-         x="210.02"
+         x="210.03"
 	 y="733.26" 
 	 z="-893.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-6"/>
        <position name="posArapuca6-Lat-0" unit="cm" 
-         x="135.02"
+         x="135.03"
 	 y="734" 
 	 z="-893.4054"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -11804,14 +11809,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-6"/>
        <position name="posOpArapuca6-Lat-0" unit="cm" 
-         x="135.02"
+         x="135.03"
 	 y="733.26" 
 	 z="-893.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-7"/>
        <position name="posArapuca7-Lat-0" unit="cm" 
-         x="60.02"
+         x="60.03"
 	 y="734" 
 	 z="-893.4054"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -11819,14 +11824,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-7"/>
        <position name="posOpArapuca7-Lat-0" unit="cm" 
-         x="60.02"
+         x="60.03"
 	 y="733.26" 
 	 z="-893.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-0"/>
        <position name="posArapuca0-Lat-1" unit="cm" 
-         x="285.02"
+         x="285.03"
 	 y="-734" 
 	 z="-595.6036"/>
        <rotationref ref="rIdentity"/>
@@ -11834,14 +11839,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-0"/>
        <position name="posOpArapuca0-Lat-1" unit="cm" 
-         x="285.02"
+         x="285.03"
 	 y="-733.26" 
 	 z="-595.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-1"/>
        <position name="posArapuca1-Lat-1" unit="cm" 
-         x="210.02"
+         x="210.03"
 	 y="-734" 
 	 z="-595.6036"/>
        <rotationref ref="rIdentity"/>
@@ -11849,14 +11854,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-1"/>
        <position name="posOpArapuca1-Lat-1" unit="cm" 
-         x="210.02"
+         x="210.03"
 	 y="-733.26" 
 	 z="-595.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-2"/>
        <position name="posArapuca2-Lat-1" unit="cm" 
-         x="135.02"
+         x="135.03"
 	 y="-734" 
 	 z="-595.6036"/>
        <rotationref ref="rIdentity"/>
@@ -11864,14 +11869,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-2"/>
        <position name="posOpArapuca2-Lat-1" unit="cm" 
-         x="135.02"
+         x="135.03"
 	 y="-733.26" 
 	 z="-595.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-3"/>
        <position name="posArapuca3-Lat-1" unit="cm" 
-         x="60.02"
+         x="60.03"
 	 y="-734" 
 	 z="-595.6036"/>
        <rotationref ref="rIdentity"/>
@@ -11879,14 +11884,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-3"/>
        <position name="posOpArapuca3-Lat-1" unit="cm" 
-         x="60.02"
+         x="60.03"
 	 y="-733.26" 
 	 z="-595.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-4"/>
        <position name="posArapuca4-Lat-1" unit="cm" 
-         x="285.02"
+         x="285.03"
 	 y="734" 
 	 z="-595.6036"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -11894,14 +11899,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-4"/>
        <position name="posOpArapuca4-Lat-1" unit="cm" 
-         x="285.02"
+         x="285.03"
 	 y="733.26" 
 	 z="-595.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-5"/>
        <position name="posArapuca5-Lat-1" unit="cm" 
-         x="210.02"
+         x="210.03"
 	 y="734" 
 	 z="-595.6036"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -11909,14 +11914,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-5"/>
        <position name="posOpArapuca5-Lat-1" unit="cm" 
-         x="210.02"
+         x="210.03"
 	 y="733.26" 
 	 z="-595.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-6"/>
        <position name="posArapuca6-Lat-1" unit="cm" 
-         x="135.02"
+         x="135.03"
 	 y="734" 
 	 z="-595.6036"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -11924,14 +11929,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-6"/>
        <position name="posOpArapuca6-Lat-1" unit="cm" 
-         x="135.02"
+         x="135.03"
 	 y="733.26" 
 	 z="-595.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-7"/>
        <position name="posArapuca7-Lat-1" unit="cm" 
-         x="60.02"
+         x="60.03"
 	 y="734" 
 	 z="-595.6036"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -11939,14 +11944,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-7"/>
        <position name="posOpArapuca7-Lat-1" unit="cm" 
-         x="60.02"
+         x="60.03"
 	 y="733.26" 
 	 z="-595.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-0"/>
        <position name="posArapuca0-Lat-2" unit="cm" 
-         x="285.02"
+         x="285.03"
 	 y="-734" 
 	 z="-297.8018"/>
        <rotationref ref="rIdentity"/>
@@ -11954,14 +11959,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-0"/>
        <position name="posOpArapuca0-Lat-2" unit="cm" 
-         x="285.02"
+         x="285.03"
 	 y="-733.26" 
 	 z="-297.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-1"/>
        <position name="posArapuca1-Lat-2" unit="cm" 
-         x="210.02"
+         x="210.03"
 	 y="-734" 
 	 z="-297.8018"/>
        <rotationref ref="rIdentity"/>
@@ -11969,14 +11974,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-1"/>
        <position name="posOpArapuca1-Lat-2" unit="cm" 
-         x="210.02"
+         x="210.03"
 	 y="-733.26" 
 	 z="-297.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-2"/>
        <position name="posArapuca2-Lat-2" unit="cm" 
-         x="135.02"
+         x="135.03"
 	 y="-734" 
 	 z="-297.8018"/>
        <rotationref ref="rIdentity"/>
@@ -11984,14 +11989,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-2"/>
        <position name="posOpArapuca2-Lat-2" unit="cm" 
-         x="135.02"
+         x="135.03"
 	 y="-733.26" 
 	 z="-297.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-3"/>
        <position name="posArapuca3-Lat-2" unit="cm" 
-         x="60.02"
+         x="60.03"
 	 y="-734" 
 	 z="-297.8018"/>
        <rotationref ref="rIdentity"/>
@@ -11999,14 +12004,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-3"/>
        <position name="posOpArapuca3-Lat-2" unit="cm" 
-         x="60.02"
+         x="60.03"
 	 y="-733.26" 
 	 z="-297.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-4"/>
        <position name="posArapuca4-Lat-2" unit="cm" 
-         x="285.02"
+         x="285.03"
 	 y="734" 
 	 z="-297.8018"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -12014,14 +12019,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-4"/>
        <position name="posOpArapuca4-Lat-2" unit="cm" 
-         x="285.02"
+         x="285.03"
 	 y="733.26" 
 	 z="-297.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-5"/>
        <position name="posArapuca5-Lat-2" unit="cm" 
-         x="210.02"
+         x="210.03"
 	 y="734" 
 	 z="-297.8018"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -12029,14 +12034,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-5"/>
        <position name="posOpArapuca5-Lat-2" unit="cm" 
-         x="210.02"
+         x="210.03"
 	 y="733.26" 
 	 z="-297.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-6"/>
        <position name="posArapuca6-Lat-2" unit="cm" 
-         x="135.02"
+         x="135.03"
 	 y="734" 
 	 z="-297.8018"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -12044,14 +12049,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-6"/>
        <position name="posOpArapuca6-Lat-2" unit="cm" 
-         x="135.02"
+         x="135.03"
 	 y="733.26" 
 	 z="-297.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-7"/>
        <position name="posArapuca7-Lat-2" unit="cm" 
-         x="60.02"
+         x="60.03"
 	 y="734" 
 	 z="-297.8018"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -12059,14 +12064,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-7"/>
        <position name="posOpArapuca7-Lat-2" unit="cm" 
-         x="60.02"
+         x="60.03"
 	 y="733.26" 
 	 z="-297.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_3-0"/>
        <position name="posArapuca0-Lat-3" unit="cm" 
-         x="285.02"
+         x="285.03"
 	 y="-734" 
 	 z="1.13686837721616e-13"/>
        <rotationref ref="rIdentity"/>
@@ -12074,14 +12079,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_3-0"/>
        <position name="posOpArapuca0-Lat-3" unit="cm" 
-         x="285.02"
+         x="285.03"
 	 y="-733.26" 
 	 z="1.13686837721616e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_3-1"/>
        <position name="posArapuca1-Lat-3" unit="cm" 
-         x="210.02"
+         x="210.03"
 	 y="-734" 
 	 z="1.13686837721616e-13"/>
        <rotationref ref="rIdentity"/>
@@ -12089,14 +12094,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_3-1"/>
        <position name="posOpArapuca1-Lat-3" unit="cm" 
-         x="210.02"
+         x="210.03"
 	 y="-733.26" 
 	 z="1.13686837721616e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_3-2"/>
        <position name="posArapuca2-Lat-3" unit="cm" 
-         x="135.02"
+         x="135.03"
 	 y="-734" 
 	 z="1.13686837721616e-13"/>
        <rotationref ref="rIdentity"/>
@@ -12104,14 +12109,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_3-2"/>
        <position name="posOpArapuca2-Lat-3" unit="cm" 
-         x="135.02"
+         x="135.03"
 	 y="-733.26" 
 	 z="1.13686837721616e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_3-3"/>
        <position name="posArapuca3-Lat-3" unit="cm" 
-         x="60.02"
+         x="60.03"
 	 y="-734" 
 	 z="1.13686837721616e-13"/>
        <rotationref ref="rIdentity"/>
@@ -12119,14 +12124,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_3-3"/>
        <position name="posOpArapuca3-Lat-3" unit="cm" 
-         x="60.02"
+         x="60.03"
 	 y="-733.26" 
 	 z="1.13686837721616e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_3-4"/>
        <position name="posArapuca4-Lat-3" unit="cm" 
-         x="285.02"
+         x="285.03"
 	 y="734" 
 	 z="1.13686837721616e-13"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -12134,14 +12139,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_3-4"/>
        <position name="posOpArapuca4-Lat-3" unit="cm" 
-         x="285.02"
+         x="285.03"
 	 y="733.26" 
 	 z="1.13686837721616e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_3-5"/>
        <position name="posArapuca5-Lat-3" unit="cm" 
-         x="210.02"
+         x="210.03"
 	 y="734" 
 	 z="1.13686837721616e-13"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -12149,14 +12154,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_3-5"/>
        <position name="posOpArapuca5-Lat-3" unit="cm" 
-         x="210.02"
+         x="210.03"
 	 y="733.26" 
 	 z="1.13686837721616e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_3-6"/>
        <position name="posArapuca6-Lat-3" unit="cm" 
-         x="135.02"
+         x="135.03"
 	 y="734" 
 	 z="1.13686837721616e-13"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -12164,14 +12169,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_3-6"/>
        <position name="posOpArapuca6-Lat-3" unit="cm" 
-         x="135.02"
+         x="135.03"
 	 y="733.26" 
 	 z="1.13686837721616e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_3-7"/>
        <position name="posArapuca7-Lat-3" unit="cm" 
-         x="60.02"
+         x="60.03"
 	 y="734" 
 	 z="1.13686837721616e-13"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -12179,14 +12184,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_3-7"/>
        <position name="posOpArapuca7-Lat-3" unit="cm" 
-         x="60.02"
+         x="60.03"
 	 y="733.26" 
 	 z="1.13686837721616e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_4-0"/>
        <position name="posArapuca0-Lat-4" unit="cm" 
-         x="285.02"
+         x="285.03"
 	 y="-734" 
 	 z="297.8018"/>
        <rotationref ref="rIdentity"/>
@@ -12194,14 +12199,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_4-0"/>
        <position name="posOpArapuca0-Lat-4" unit="cm" 
-         x="285.02"
+         x="285.03"
 	 y="-733.26" 
 	 z="297.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_4-1"/>
        <position name="posArapuca1-Lat-4" unit="cm" 
-         x="210.02"
+         x="210.03"
 	 y="-734" 
 	 z="297.8018"/>
        <rotationref ref="rIdentity"/>
@@ -12209,14 +12214,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_4-1"/>
        <position name="posOpArapuca1-Lat-4" unit="cm" 
-         x="210.02"
+         x="210.03"
 	 y="-733.26" 
 	 z="297.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_4-2"/>
        <position name="posArapuca2-Lat-4" unit="cm" 
-         x="135.02"
+         x="135.03"
 	 y="-734" 
 	 z="297.8018"/>
        <rotationref ref="rIdentity"/>
@@ -12224,14 +12229,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_4-2"/>
        <position name="posOpArapuca2-Lat-4" unit="cm" 
-         x="135.02"
+         x="135.03"
 	 y="-733.26" 
 	 z="297.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_4-3"/>
        <position name="posArapuca3-Lat-4" unit="cm" 
-         x="60.02"
+         x="60.03"
 	 y="-734" 
 	 z="297.8018"/>
        <rotationref ref="rIdentity"/>
@@ -12239,14 +12244,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_4-3"/>
        <position name="posOpArapuca3-Lat-4" unit="cm" 
-         x="60.02"
+         x="60.03"
 	 y="-733.26" 
 	 z="297.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_4-4"/>
        <position name="posArapuca4-Lat-4" unit="cm" 
-         x="285.02"
+         x="285.03"
 	 y="734" 
 	 z="297.8018"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -12254,14 +12259,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_4-4"/>
        <position name="posOpArapuca4-Lat-4" unit="cm" 
-         x="285.02"
+         x="285.03"
 	 y="733.26" 
 	 z="297.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_4-5"/>
        <position name="posArapuca5-Lat-4" unit="cm" 
-         x="210.02"
+         x="210.03"
 	 y="734" 
 	 z="297.8018"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -12269,14 +12274,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_4-5"/>
        <position name="posOpArapuca5-Lat-4" unit="cm" 
-         x="210.02"
+         x="210.03"
 	 y="733.26" 
 	 z="297.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_4-6"/>
        <position name="posArapuca6-Lat-4" unit="cm" 
-         x="135.02"
+         x="135.03"
 	 y="734" 
 	 z="297.8018"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -12284,14 +12289,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_4-6"/>
        <position name="posOpArapuca6-Lat-4" unit="cm" 
-         x="135.02"
+         x="135.03"
 	 y="733.26" 
 	 z="297.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_4-7"/>
        <position name="posArapuca7-Lat-4" unit="cm" 
-         x="60.02"
+         x="60.03"
 	 y="734" 
 	 z="297.8018"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -12299,14 +12304,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_4-7"/>
        <position name="posOpArapuca7-Lat-4" unit="cm" 
-         x="60.02"
+         x="60.03"
 	 y="733.26" 
 	 z="297.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_5-0"/>
        <position name="posArapuca0-Lat-5" unit="cm" 
-         x="285.02"
+         x="285.03"
 	 y="-734" 
 	 z="595.6036"/>
        <rotationref ref="rIdentity"/>
@@ -12314,14 +12319,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_5-0"/>
        <position name="posOpArapuca0-Lat-5" unit="cm" 
-         x="285.02"
+         x="285.03"
 	 y="-733.26" 
 	 z="595.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_5-1"/>
        <position name="posArapuca1-Lat-5" unit="cm" 
-         x="210.02"
+         x="210.03"
 	 y="-734" 
 	 z="595.6036"/>
        <rotationref ref="rIdentity"/>
@@ -12329,14 +12334,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_5-1"/>
        <position name="posOpArapuca1-Lat-5" unit="cm" 
-         x="210.02"
+         x="210.03"
 	 y="-733.26" 
 	 z="595.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_5-2"/>
        <position name="posArapuca2-Lat-5" unit="cm" 
-         x="135.02"
+         x="135.03"
 	 y="-734" 
 	 z="595.6036"/>
        <rotationref ref="rIdentity"/>
@@ -12344,14 +12349,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_5-2"/>
        <position name="posOpArapuca2-Lat-5" unit="cm" 
-         x="135.02"
+         x="135.03"
 	 y="-733.26" 
 	 z="595.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_5-3"/>
        <position name="posArapuca3-Lat-5" unit="cm" 
-         x="60.02"
+         x="60.03"
 	 y="-734" 
 	 z="595.6036"/>
        <rotationref ref="rIdentity"/>
@@ -12359,14 +12364,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_5-3"/>
        <position name="posOpArapuca3-Lat-5" unit="cm" 
-         x="60.02"
+         x="60.03"
 	 y="-733.26" 
 	 z="595.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_5-4"/>
        <position name="posArapuca4-Lat-5" unit="cm" 
-         x="285.02"
+         x="285.03"
 	 y="734" 
 	 z="595.6036"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -12374,14 +12379,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_5-4"/>
        <position name="posOpArapuca4-Lat-5" unit="cm" 
-         x="285.02"
+         x="285.03"
 	 y="733.26" 
 	 z="595.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_5-5"/>
        <position name="posArapuca5-Lat-5" unit="cm" 
-         x="210.02"
+         x="210.03"
 	 y="734" 
 	 z="595.6036"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -12389,14 +12394,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_5-5"/>
        <position name="posOpArapuca5-Lat-5" unit="cm" 
-         x="210.02"
+         x="210.03"
 	 y="733.26" 
 	 z="595.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_5-6"/>
        <position name="posArapuca6-Lat-5" unit="cm" 
-         x="135.02"
+         x="135.03"
 	 y="734" 
 	 z="595.6036"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -12404,14 +12409,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_5-6"/>
        <position name="posOpArapuca6-Lat-5" unit="cm" 
-         x="135.02"
+         x="135.03"
 	 y="733.26" 
 	 z="595.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_5-7"/>
        <position name="posArapuca7-Lat-5" unit="cm" 
-         x="60.02"
+         x="60.03"
 	 y="734" 
 	 z="595.6036"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -12419,14 +12424,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_5-7"/>
        <position name="posOpArapuca7-Lat-5" unit="cm" 
-         x="60.02"
+         x="60.03"
 	 y="733.26" 
 	 z="595.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_6-0"/>
        <position name="posArapuca0-Lat-6" unit="cm" 
-         x="285.02"
+         x="285.03"
 	 y="-734" 
 	 z="893.4054"/>
        <rotationref ref="rIdentity"/>
@@ -12434,14 +12439,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_6-0"/>
        <position name="posOpArapuca0-Lat-6" unit="cm" 
-         x="285.02"
+         x="285.03"
 	 y="-733.26" 
 	 z="893.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_6-1"/>
        <position name="posArapuca1-Lat-6" unit="cm" 
-         x="210.02"
+         x="210.03"
 	 y="-734" 
 	 z="893.4054"/>
        <rotationref ref="rIdentity"/>
@@ -12449,14 +12454,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_6-1"/>
        <position name="posOpArapuca1-Lat-6" unit="cm" 
-         x="210.02"
+         x="210.03"
 	 y="-733.26" 
 	 z="893.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_6-2"/>
        <position name="posArapuca2-Lat-6" unit="cm" 
-         x="135.02"
+         x="135.03"
 	 y="-734" 
 	 z="893.4054"/>
        <rotationref ref="rIdentity"/>
@@ -12464,14 +12469,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_6-2"/>
        <position name="posOpArapuca2-Lat-6" unit="cm" 
-         x="135.02"
+         x="135.03"
 	 y="-733.26" 
 	 z="893.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_6-3"/>
        <position name="posArapuca3-Lat-6" unit="cm" 
-         x="60.02"
+         x="60.03"
 	 y="-734" 
 	 z="893.4054"/>
        <rotationref ref="rIdentity"/>
@@ -12479,14 +12484,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_6-3"/>
        <position name="posOpArapuca3-Lat-6" unit="cm" 
-         x="60.02"
+         x="60.03"
 	 y="-733.26" 
 	 z="893.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_6-4"/>
        <position name="posArapuca4-Lat-6" unit="cm" 
-         x="285.02"
+         x="285.03"
 	 y="734" 
 	 z="893.4054"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -12494,14 +12499,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_6-4"/>
        <position name="posOpArapuca4-Lat-6" unit="cm" 
-         x="285.02"
+         x="285.03"
 	 y="733.26" 
 	 z="893.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_6-5"/>
        <position name="posArapuca5-Lat-6" unit="cm" 
-         x="210.02"
+         x="210.03"
 	 y="734" 
 	 z="893.4054"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -12509,14 +12514,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_6-5"/>
        <position name="posOpArapuca5-Lat-6" unit="cm" 
-         x="210.02"
+         x="210.03"
 	 y="733.26" 
 	 z="893.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_6-6"/>
        <position name="posArapuca6-Lat-6" unit="cm" 
-         x="135.02"
+         x="135.03"
 	 y="734" 
 	 z="893.4054"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -12524,14 +12529,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_6-6"/>
        <position name="posOpArapuca6-Lat-6" unit="cm" 
-         x="135.02"
+         x="135.03"
 	 y="733.26" 
 	 z="893.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_6-7"/>
        <position name="posArapuca7-Lat-6" unit="cm" 
-         x="60.02"
+         x="60.03"
 	 y="734" 
 	 z="893.4054"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -12539,7 +12544,7 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_6-7"/>
        <position name="posOpArapuca7-Lat-6" unit="cm" 
-         x="60.02"
+         x="60.03"
 	 y="733.26" 
 	 z="893.4054"/>
      </physvol>

--- a/dunecore/Geometry/gdml/dunevd10kt_3view_v3_refactored_1x8x14ref.gdml
+++ b/dunecore/Geometry/gdml/dunevd10kt_3view_v3_refactored_1x8x14ref.gdml
@@ -1862,12 +1862,118 @@
       y="1548"
       z="2291.6126"/>
 
+    <box name="ExternalAuxOut" lunit="cm" 
+      x="850.08 - 100"
+      y="1548 - 2*2.5 - 2*40"
+      z="2291.6126"/>
+
+    <box name="ExternalAuxIn" lunit="cm" 
+      x="850.08"
+      y="1359.17"
+      z="2291.6126 + 1"/>
+
+   <subtraction name="ExternalActive">
+      <first ref="ExternalAuxOut"/>
+      <second ref="ExternalAuxIn"/>
+    </subtraction>
+
     <subtraction name="SteelShell">
       <first ref="Cryostat"/>
       <second ref="ArgonInterior"/>
     </subtraction>
 
 
+
+    <box name="CathodeBlock" lunit="cm"
+      x="4"
+      y="336"
+      z="297.8018" />
+
+    <box name="CathodeVoid" lunit="cm"
+      x="5"
+      y="76.35"
+      z="67" />
+
+    <subtraction name="Cathode1">
+      <first ref="CathodeBlock"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub1" x="0" y="-122.525" z="-108.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode2">
+      <first ref="Cathode1"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub2" x="0" y="-122.525" z="-37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode3">
+      <first ref="Cathode2"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub3" x="0" y="-122.525" z="37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode4">
+      <first ref="Cathode3"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub4" x="0" y="-122.525" z="108.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode5">
+      <first ref="Cathode4"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub5" x="0" y="-42.175" z="-108.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode6">
+      <first ref="Cathode5"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub6" x="0" y="-42.175" z="-37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode7">
+      <first ref="Cathode6"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub7" x="0" y="-42.175" z="37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode8">
+      <first ref="Cathode7"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub8" x="0" y="-42.175" z="108.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode9">
+      <first ref="Cathode8"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub9" x="0" y="42.175" z="-108.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode10">
+      <first ref="Cathode9"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub10" x="0" y="42.175" z="-37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode11">
+      <first ref="Cathode10"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub11" x="0" y="42.175" z="37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode12">
+      <first ref="Cathode11"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub12" x="0" y="42.175" z="108.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode13">
+      <first ref="Cathode12"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub13" x="0" y="122.525" z="-108.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode14">
+      <first ref="Cathode13"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub14" x="0" y="122.525" z="-37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode15">
+      <first ref="Cathode14"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub15" x="0" y="122.525" z="37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="CathodeGrid">
+      <first ref="Cathode15"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub16" x="0" y="122.525" z="108.5" unit="cm"/>
+    </subtraction>
 
     <box name="FoamPadBlock" lunit="cm"
       x="1010.32"
@@ -7285,36 +7391,36 @@
          <rotationref ref="rPlus90AboutX"/>
        </physvol>
   </volume>
-   
-   <volume name="volReflectiveAnode">
+     
+   <volume name="volAnodePlate">
      <materialref ref="vm2000"/>
      <solidref ref="CRMZPlane"/>
-   </volume>
+  </volume>
    <volume name="volTPC">
      <materialref ref="LAr"/>
        <solidref ref="CRM"/>
        <physvol>
        <volumeref ref="volTPCPlaneU"/>
        <position name="posPlaneU" unit="cm" 
-         x="324.99" y="0" z="0"/>
+         x="324.97" y="0" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volTPCPlaneY"/>
        <position name="posPlaneY" unit="cm" 
-         x="325.01" y="0" z="0"/>
+         x="324.99" y="0" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volTPCPlaneZ"/>
        <position name="posPlaneZ" unit="cm" 
-         x="325.03" y="0" z="0"/>
+         x="325.01" y="0" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volReflectiveAnode"/>
-       <position name="posReflectiveAnode" unit="cm" 
-         x="324.97" y="0" z="0"/>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate" unit="cm" 
+         x="325.03" y="0" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>    
      <physvol>
@@ -7329,9 +7435,21 @@
       <materialref ref="STEEL_STAINLESS_Fe7Cr2Ni" />
       <solidref ref="SteelShell" />
     </volume>
+    <volume name="volGroundGrid">
+      <materialref ref="STEEL_STAINLESS_Fe7Cr2Ni" />
+      <solidref ref="CathodeGrid" />
+    </volume>    
     <volume name="volGaseousArgon">
       <materialref ref="ArGas"/>
       <solidref ref="GaseousArgon"/>
+    </volume>
+    <volume name="volExternalActive">
+      <materialref ref="LAr"/>
+      <solidref ref="ExternalActive"/>
+      <auxiliary auxtype="SensDet" auxvalue="SimEnergyDeposit"/>
+      <auxiliary auxtype="StepLimit" auxunit="cm" auxvalue="0.5208*cm"/>
+      <auxiliary auxtype="Efield" auxunit="V/cm" auxvalue="0*V/cm"/>
+      <colorref ref="green"/>
     </volume>
     <volume name="volArapucaDouble_0-0-0">
       <materialref ref="G10" />
@@ -8678,7 +8796,6 @@
       <solidref ref="ArapucaAcceptanceWindow"/>
     </volume>
 
-
     <volume name="volCryostat">
       <materialref ref="LAr" />
       <solidref ref="Cryostat" />
@@ -8689,6 +8806,10 @@
       <physvol>
         <volumeref ref="volSteelShell"/>
         <position name="posSteelShell" unit="cm" x="0" y="0" z="0"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volExternalActive"/>
+        <position name="posExternalActive" unit="cm" x="-100/2" y="0" z="0"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC"/>
@@ -9790,1690 +9911,1802 @@
      <position name="posFieldShaper107" unit="cm"  x="319.96" y="-676.3" z="0" />
      <rotation name="rotFS107" unit="deg" x="0" y="0" z="90" />
   </physvol>
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-0" unit="cm" x="-328.04" y="-506" z="-896.9054"/>
+      </physvol>
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-1" unit="cm" x="-328.04" y="-170" z="-896.9054"/>
+      </physvol>
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-2" unit="cm" x="-328.04" y="166" z="-896.9054"/>
+      </physvol>
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-3" unit="cm" x="-328.04" y="502" z="-896.9054"/>
+      </physvol>
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-4" unit="cm" x="-328.04" y="-506" z="-599.1036"/>
+      </physvol>
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-5" unit="cm" x="-328.04" y="-170" z="-599.1036"/>
+      </physvol>
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-6" unit="cm" x="-328.04" y="166" z="-599.1036"/>
+      </physvol>
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-7" unit="cm" x="-328.04" y="502" z="-599.1036"/>
+      </physvol>
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-8" unit="cm" x="-328.04" y="-506" z="-301.3018"/>
+      </physvol>
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-9" unit="cm" x="-328.04" y="-170" z="-301.3018"/>
+      </physvol>
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-10" unit="cm" x="-328.04" y="166" z="-301.3018"/>
+      </physvol>
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-11" unit="cm" x="-328.04" y="502" z="-301.3018"/>
+      </physvol>
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-12" unit="cm" x="-328.04" y="-506" z="-3.49999999999989"/>
+      </physvol>
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-13" unit="cm" x="-328.04" y="-170" z="-3.49999999999989"/>
+      </physvol>
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-14" unit="cm" x="-328.04" y="166" z="-3.49999999999989"/>
+      </physvol>
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-15" unit="cm" x="-328.04" y="502" z="-3.49999999999989"/>
+      </physvol>
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-16" unit="cm" x="-328.04" y="-506" z="294.3018"/>
+      </physvol>
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-17" unit="cm" x="-328.04" y="-170" z="294.3018"/>
+      </physvol>
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-18" unit="cm" x="-328.04" y="166" z="294.3018"/>
+      </physvol>
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-19" unit="cm" x="-328.04" y="502" z="294.3018"/>
+      </physvol>
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-20" unit="cm" x="-328.04" y="-506" z="592.1036"/>
+      </physvol>
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-21" unit="cm" x="-328.04" y="-170" z="592.1036"/>
+      </physvol>
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-22" unit="cm" x="-328.04" y="166" z="592.1036"/>
+      </physvol>
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-23" unit="cm" x="-328.04" y="502" z="592.1036"/>
+      </physvol>
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-24" unit="cm" x="-328.04" y="-506" z="889.9054"/>
+      </physvol>
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-25" unit="cm" x="-328.04" y="-170" z="889.9054"/>
+      </physvol>
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-26" unit="cm" x="-328.04" y="166" z="889.9054"/>
+      </physvol>
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-27" unit="cm" x="-328.04" y="502" z="889.9054"/>
+      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-0-0"/>
        <position name="posArapucaDouble0-Frame-0-0" unit="cm" 
-         x="-327.04"
-	 y="-627.55" 
-	 z="-858.805175"/>
+         x="-328.04"
+	 y="-633.7" 
+	 z="-859.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-0"/>
        <position name="posOpArapucaDouble0-Frame-0-0" unit="cm" 
-         x="-326.3"
-	 y="-627.55" 
-	 z="-858.805175"/>
+         x="-327.3"
+	 y="-633.7" 
+	 z="-859.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-0-1"/>
        <position name="posArapucaDouble1-Frame-0-0" unit="cm" 
-         x="-327.04"
-	 y="-537" 
-	 z="-996.456075"/>
+         x="-328.04"
+	 y="-543" 
+	 z="-1005.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-1"/>
        <position name="posOpArapucaDouble1-Frame-0-0" unit="cm" 
-         x="-326.3"
-	 y="-537" 
-	 z="-996.456075"/>
+         x="-327.3"
+	 y="-543" 
+	 z="-1005.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-0-2"/>
        <position name="posArapucaDouble2-Frame-0-0" unit="cm" 
-         x="-327.04"
-	 y="-471" 
-	 z="-790.354725"/>
+         x="-328.04"
+	 y="-469" 
+	 z="-788.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-2"/>
        <position name="posOpArapucaDouble2-Frame-0-0" unit="cm" 
-         x="-326.3"
-	 y="-471" 
-	 z="-790.354725"/>
+         x="-327.3"
+	 y="-469" 
+	 z="-788.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-0-3"/>
        <position name="posArapucaDouble3-Frame-0-0" unit="cm" 
-         x="-327.04"
-	 y="-380.45" 
-	 z="-928.005625"/>
+         x="-328.04"
+	 y="-378.3" 
+	 z="-934.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-3"/>
        <position name="posOpArapucaDouble3-Frame-0-0" unit="cm" 
-         x="-326.3"
-	 y="-380.45" 
-	 z="-928.005625"/>
+         x="-327.3"
+	 y="-378.3" 
+	 z="-934.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-1-0"/>
        <position name="posArapucaDouble0-Frame-0-1" unit="cm" 
-         x="-327.04"
-	 y="-627.55" 
-	 z="-561.003375"/>
+         x="-328.04"
+	 y="-633.7" 
+	 z="-561.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-0"/>
        <position name="posOpArapucaDouble0-Frame-0-1" unit="cm" 
-         x="-326.3"
-	 y="-627.55" 
-	 z="-561.003375"/>
+         x="-327.3"
+	 y="-633.7" 
+	 z="-561.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-1-1"/>
        <position name="posArapucaDouble1-Frame-0-1" unit="cm" 
-         x="-327.04"
-	 y="-537" 
-	 z="-698.654275"/>
+         x="-328.04"
+	 y="-543" 
+	 z="-707.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-1"/>
        <position name="posOpArapucaDouble1-Frame-0-1" unit="cm" 
-         x="-326.3"
-	 y="-537" 
-	 z="-698.654275"/>
+         x="-327.3"
+	 y="-543" 
+	 z="-707.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-1-2"/>
        <position name="posArapucaDouble2-Frame-0-1" unit="cm" 
-         x="-327.04"
-	 y="-471" 
-	 z="-492.552925"/>
+         x="-328.04"
+	 y="-469" 
+	 z="-490.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-2"/>
        <position name="posOpArapucaDouble2-Frame-0-1" unit="cm" 
-         x="-326.3"
-	 y="-471" 
-	 z="-492.552925"/>
+         x="-327.3"
+	 y="-469" 
+	 z="-490.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-1-3"/>
        <position name="posArapucaDouble3-Frame-0-1" unit="cm" 
-         x="-327.04"
-	 y="-380.45" 
-	 z="-630.203825"/>
+         x="-328.04"
+	 y="-378.3" 
+	 z="-636.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-3"/>
        <position name="posOpArapucaDouble3-Frame-0-1" unit="cm" 
-         x="-326.3"
-	 y="-380.45" 
-	 z="-630.203825"/>
+         x="-327.3"
+	 y="-378.3" 
+	 z="-636.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-2-0"/>
        <position name="posArapucaDouble0-Frame-0-2" unit="cm" 
-         x="-327.04"
-	 y="-627.55" 
-	 z="-263.201575"/>
+         x="-328.04"
+	 y="-633.7" 
+	 z="-263.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-0"/>
        <position name="posOpArapucaDouble0-Frame-0-2" unit="cm" 
-         x="-326.3"
-	 y="-627.55" 
-	 z="-263.201575"/>
+         x="-327.3"
+	 y="-633.7" 
+	 z="-263.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-2-1"/>
        <position name="posArapucaDouble1-Frame-0-2" unit="cm" 
-         x="-327.04"
-	 y="-537" 
-	 z="-400.852475"/>
+         x="-328.04"
+	 y="-543" 
+	 z="-409.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-1"/>
        <position name="posOpArapucaDouble1-Frame-0-2" unit="cm" 
-         x="-326.3"
-	 y="-537" 
-	 z="-400.852475"/>
+         x="-327.3"
+	 y="-543" 
+	 z="-409.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-2-2"/>
        <position name="posArapucaDouble2-Frame-0-2" unit="cm" 
-         x="-327.04"
-	 y="-471" 
-	 z="-194.751125"/>
+         x="-328.04"
+	 y="-469" 
+	 z="-192.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-2"/>
        <position name="posOpArapucaDouble2-Frame-0-2" unit="cm" 
-         x="-326.3"
-	 y="-471" 
-	 z="-194.751125"/>
+         x="-327.3"
+	 y="-469" 
+	 z="-192.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-2-3"/>
        <position name="posArapucaDouble3-Frame-0-2" unit="cm" 
-         x="-327.04"
-	 y="-380.45" 
-	 z="-332.402025"/>
+         x="-328.04"
+	 y="-378.3" 
+	 z="-338.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-3"/>
        <position name="posOpArapucaDouble3-Frame-0-2" unit="cm" 
-         x="-326.3"
-	 y="-380.45" 
-	 z="-332.402025"/>
+         x="-327.3"
+	 y="-378.3" 
+	 z="-338.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-3-0"/>
        <position name="posArapucaDouble0-Frame-0-3" unit="cm" 
-         x="-327.04"
-	 y="-627.55" 
-	 z="34.6002250000001"/>
+         x="-328.04"
+	 y="-633.7" 
+	 z="34.0000000000001"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-3-0"/>
        <position name="posOpArapucaDouble0-Frame-0-3" unit="cm" 
-         x="-326.3"
-	 y="-627.55" 
-	 z="34.6002250000001"/>
+         x="-327.3"
+	 y="-633.7" 
+	 z="34.0000000000001"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-3-1"/>
        <position name="posArapucaDouble1-Frame-0-3" unit="cm" 
-         x="-327.04"
-	 y="-537" 
-	 z="-103.050675"/>
+         x="-328.04"
+	 y="-543" 
+	 z="-112"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-3-1"/>
        <position name="posOpArapucaDouble1-Frame-0-3" unit="cm" 
-         x="-326.3"
-	 y="-537" 
-	 z="-103.050675"/>
+         x="-327.3"
+	 y="-543" 
+	 z="-112"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-3-2"/>
        <position name="posArapucaDouble2-Frame-0-3" unit="cm" 
-         x="-327.04"
-	 y="-471" 
-	 z="103.050675"/>
+         x="-328.04"
+	 y="-469" 
+	 z="105"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-3-2"/>
        <position name="posOpArapucaDouble2-Frame-0-3" unit="cm" 
-         x="-326.3"
-	 y="-471" 
-	 z="103.050675"/>
+         x="-327.3"
+	 y="-469" 
+	 z="105"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-3-3"/>
        <position name="posArapucaDouble3-Frame-0-3" unit="cm" 
-         x="-327.04"
-	 y="-380.45" 
-	 z="-34.6002249999999"/>
+         x="-328.04"
+	 y="-378.3" 
+	 z="-40.9999999999999"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-3-3"/>
        <position name="posOpArapucaDouble3-Frame-0-3" unit="cm" 
-         x="-326.3"
-	 y="-380.45" 
-	 z="-34.6002249999999"/>
+         x="-327.3"
+	 y="-378.3" 
+	 z="-40.9999999999999"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-4-0"/>
        <position name="posArapucaDouble0-Frame-0-4" unit="cm" 
-         x="-327.04"
-	 y="-627.55" 
-	 z="332.402025"/>
+         x="-328.04"
+	 y="-633.7" 
+	 z="331.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-4-0"/>
        <position name="posOpArapucaDouble0-Frame-0-4" unit="cm" 
-         x="-326.3"
-	 y="-627.55" 
-	 z="332.402025"/>
+         x="-327.3"
+	 y="-633.7" 
+	 z="331.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-4-1"/>
        <position name="posArapucaDouble1-Frame-0-4" unit="cm" 
-         x="-327.04"
-	 y="-537" 
-	 z="194.751125"/>
+         x="-328.04"
+	 y="-543" 
+	 z="185.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-4-1"/>
        <position name="posOpArapucaDouble1-Frame-0-4" unit="cm" 
-         x="-326.3"
-	 y="-537" 
-	 z="194.751125"/>
+         x="-327.3"
+	 y="-543" 
+	 z="185.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-4-2"/>
        <position name="posArapucaDouble2-Frame-0-4" unit="cm" 
-         x="-327.04"
-	 y="-471" 
-	 z="400.852475"/>
+         x="-328.04"
+	 y="-469" 
+	 z="402.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-4-2"/>
        <position name="posOpArapucaDouble2-Frame-0-4" unit="cm" 
-         x="-326.3"
-	 y="-471" 
-	 z="400.852475"/>
+         x="-327.3"
+	 y="-469" 
+	 z="402.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-4-3"/>
        <position name="posArapucaDouble3-Frame-0-4" unit="cm" 
-         x="-327.04"
-	 y="-380.45" 
-	 z="263.201575"/>
+         x="-328.04"
+	 y="-378.3" 
+	 z="256.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-4-3"/>
        <position name="posOpArapucaDouble3-Frame-0-4" unit="cm" 
-         x="-326.3"
-	 y="-380.45" 
-	 z="263.201575"/>
+         x="-327.3"
+	 y="-378.3" 
+	 z="256.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-5-0"/>
        <position name="posArapucaDouble0-Frame-0-5" unit="cm" 
-         x="-327.04"
-	 y="-627.55" 
-	 z="630.203825"/>
+         x="-328.04"
+	 y="-633.7" 
+	 z="629.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-5-0"/>
        <position name="posOpArapucaDouble0-Frame-0-5" unit="cm" 
-         x="-326.3"
-	 y="-627.55" 
-	 z="630.203825"/>
+         x="-327.3"
+	 y="-633.7" 
+	 z="629.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-5-1"/>
        <position name="posArapucaDouble1-Frame-0-5" unit="cm" 
-         x="-327.04"
-	 y="-537" 
-	 z="492.552925"/>
+         x="-328.04"
+	 y="-543" 
+	 z="483.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-5-1"/>
        <position name="posOpArapucaDouble1-Frame-0-5" unit="cm" 
-         x="-326.3"
-	 y="-537" 
-	 z="492.552925"/>
+         x="-327.3"
+	 y="-543" 
+	 z="483.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-5-2"/>
        <position name="posArapucaDouble2-Frame-0-5" unit="cm" 
-         x="-327.04"
-	 y="-471" 
-	 z="698.654275"/>
+         x="-328.04"
+	 y="-469" 
+	 z="700.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-5-2"/>
        <position name="posOpArapucaDouble2-Frame-0-5" unit="cm" 
-         x="-326.3"
-	 y="-471" 
-	 z="698.654275"/>
+         x="-327.3"
+	 y="-469" 
+	 z="700.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-5-3"/>
        <position name="posArapucaDouble3-Frame-0-5" unit="cm" 
-         x="-327.04"
-	 y="-380.45" 
-	 z="561.003375"/>
+         x="-328.04"
+	 y="-378.3" 
+	 z="554.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-5-3"/>
        <position name="posOpArapucaDouble3-Frame-0-5" unit="cm" 
-         x="-326.3"
-	 y="-380.45" 
-	 z="561.003375"/>
+         x="-327.3"
+	 y="-378.3" 
+	 z="554.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-6-0"/>
        <position name="posArapucaDouble0-Frame-0-6" unit="cm" 
-         x="-327.04"
-	 y="-627.55" 
-	 z="928.005625"/>
+         x="-328.04"
+	 y="-633.7" 
+	 z="927.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-6-0"/>
        <position name="posOpArapucaDouble0-Frame-0-6" unit="cm" 
-         x="-326.3"
-	 y="-627.55" 
-	 z="928.005625"/>
+         x="-327.3"
+	 y="-633.7" 
+	 z="927.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-6-1"/>
        <position name="posArapucaDouble1-Frame-0-6" unit="cm" 
-         x="-327.04"
-	 y="-537" 
-	 z="790.354725"/>
+         x="-328.04"
+	 y="-543" 
+	 z="781.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-6-1"/>
        <position name="posOpArapucaDouble1-Frame-0-6" unit="cm" 
-         x="-326.3"
-	 y="-537" 
-	 z="790.354725"/>
+         x="-327.3"
+	 y="-543" 
+	 z="781.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-6-2"/>
        <position name="posArapucaDouble2-Frame-0-6" unit="cm" 
-         x="-327.04"
-	 y="-471" 
-	 z="996.456075"/>
+         x="-328.04"
+	 y="-469" 
+	 z="998.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-6-2"/>
        <position name="posOpArapucaDouble2-Frame-0-6" unit="cm" 
-         x="-326.3"
-	 y="-471" 
-	 z="996.456075"/>
+         x="-327.3"
+	 y="-469" 
+	 z="998.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-6-3"/>
        <position name="posArapucaDouble3-Frame-0-6" unit="cm" 
-         x="-327.04"
-	 y="-380.45" 
-	 z="858.805175"/>
+         x="-328.04"
+	 y="-378.3" 
+	 z="852.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-6-3"/>
        <position name="posOpArapucaDouble3-Frame-0-6" unit="cm" 
-         x="-326.3"
-	 y="-380.45" 
-	 z="858.805175"/>
+         x="-327.3"
+	 y="-378.3" 
+	 z="852.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-0-0"/>
        <position name="posArapucaDouble0-Frame-1-0" unit="cm" 
-         x="-327.04"
-	 y="-291.55" 
-	 z="-858.805175"/>
+         x="-328.04"
+	 y="-297.7" 
+	 z="-859.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-0"/>
        <position name="posOpArapucaDouble0-Frame-1-0" unit="cm" 
-         x="-326.3"
-	 y="-291.55" 
-	 z="-858.805175"/>
+         x="-327.3"
+	 y="-297.7" 
+	 z="-859.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-0-1"/>
        <position name="posArapucaDouble1-Frame-1-0" unit="cm" 
-         x="-327.04"
-	 y="-201" 
-	 z="-996.456075"/>
+         x="-328.04"
+	 y="-207" 
+	 z="-1005.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-1"/>
        <position name="posOpArapucaDouble1-Frame-1-0" unit="cm" 
-         x="-326.3"
-	 y="-201" 
-	 z="-996.456075"/>
+         x="-327.3"
+	 y="-207" 
+	 z="-1005.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-0-2"/>
        <position name="posArapucaDouble2-Frame-1-0" unit="cm" 
-         x="-327.04"
-	 y="-135" 
-	 z="-790.354725"/>
+         x="-328.04"
+	 y="-133" 
+	 z="-788.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-2"/>
        <position name="posOpArapucaDouble2-Frame-1-0" unit="cm" 
-         x="-326.3"
-	 y="-135" 
-	 z="-790.354725"/>
+         x="-327.3"
+	 y="-133" 
+	 z="-788.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-0-3"/>
        <position name="posArapucaDouble3-Frame-1-0" unit="cm" 
-         x="-327.04"
-	 y="-44.45" 
-	 z="-928.005625"/>
+         x="-328.04"
+	 y="-42.3" 
+	 z="-934.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-3"/>
        <position name="posOpArapucaDouble3-Frame-1-0" unit="cm" 
-         x="-326.3"
-	 y="-44.45" 
-	 z="-928.005625"/>
+         x="-327.3"
+	 y="-42.3" 
+	 z="-934.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-1-0"/>
        <position name="posArapucaDouble0-Frame-1-1" unit="cm" 
-         x="-327.04"
-	 y="-291.55" 
-	 z="-561.003375"/>
+         x="-328.04"
+	 y="-297.7" 
+	 z="-561.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-0"/>
        <position name="posOpArapucaDouble0-Frame-1-1" unit="cm" 
-         x="-326.3"
-	 y="-291.55" 
-	 z="-561.003375"/>
+         x="-327.3"
+	 y="-297.7" 
+	 z="-561.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-1-1"/>
        <position name="posArapucaDouble1-Frame-1-1" unit="cm" 
-         x="-327.04"
-	 y="-201" 
-	 z="-698.654275"/>
+         x="-328.04"
+	 y="-207" 
+	 z="-707.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-1"/>
        <position name="posOpArapucaDouble1-Frame-1-1" unit="cm" 
-         x="-326.3"
-	 y="-201" 
-	 z="-698.654275"/>
+         x="-327.3"
+	 y="-207" 
+	 z="-707.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-1-2"/>
        <position name="posArapucaDouble2-Frame-1-1" unit="cm" 
-         x="-327.04"
-	 y="-135" 
-	 z="-492.552925"/>
+         x="-328.04"
+	 y="-133" 
+	 z="-490.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-2"/>
        <position name="posOpArapucaDouble2-Frame-1-1" unit="cm" 
-         x="-326.3"
-	 y="-135" 
-	 z="-492.552925"/>
+         x="-327.3"
+	 y="-133" 
+	 z="-490.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-1-3"/>
        <position name="posArapucaDouble3-Frame-1-1" unit="cm" 
-         x="-327.04"
-	 y="-44.45" 
-	 z="-630.203825"/>
+         x="-328.04"
+	 y="-42.3" 
+	 z="-636.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-3"/>
        <position name="posOpArapucaDouble3-Frame-1-1" unit="cm" 
-         x="-326.3"
-	 y="-44.45" 
-	 z="-630.203825"/>
+         x="-327.3"
+	 y="-42.3" 
+	 z="-636.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-2-0"/>
        <position name="posArapucaDouble0-Frame-1-2" unit="cm" 
-         x="-327.04"
-	 y="-291.55" 
-	 z="-263.201575"/>
+         x="-328.04"
+	 y="-297.7" 
+	 z="-263.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-0"/>
        <position name="posOpArapucaDouble0-Frame-1-2" unit="cm" 
-         x="-326.3"
-	 y="-291.55" 
-	 z="-263.201575"/>
+         x="-327.3"
+	 y="-297.7" 
+	 z="-263.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-2-1"/>
        <position name="posArapucaDouble1-Frame-1-2" unit="cm" 
-         x="-327.04"
-	 y="-201" 
-	 z="-400.852475"/>
+         x="-328.04"
+	 y="-207" 
+	 z="-409.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-1"/>
        <position name="posOpArapucaDouble1-Frame-1-2" unit="cm" 
-         x="-326.3"
-	 y="-201" 
-	 z="-400.852475"/>
+         x="-327.3"
+	 y="-207" 
+	 z="-409.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-2-2"/>
        <position name="posArapucaDouble2-Frame-1-2" unit="cm" 
-         x="-327.04"
-	 y="-135" 
-	 z="-194.751125"/>
+         x="-328.04"
+	 y="-133" 
+	 z="-192.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-2"/>
        <position name="posOpArapucaDouble2-Frame-1-2" unit="cm" 
-         x="-326.3"
-	 y="-135" 
-	 z="-194.751125"/>
+         x="-327.3"
+	 y="-133" 
+	 z="-192.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-2-3"/>
        <position name="posArapucaDouble3-Frame-1-2" unit="cm" 
-         x="-327.04"
-	 y="-44.45" 
-	 z="-332.402025"/>
+         x="-328.04"
+	 y="-42.3" 
+	 z="-338.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-3"/>
        <position name="posOpArapucaDouble3-Frame-1-2" unit="cm" 
-         x="-326.3"
-	 y="-44.45" 
-	 z="-332.402025"/>
+         x="-327.3"
+	 y="-42.3" 
+	 z="-338.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-3-0"/>
        <position name="posArapucaDouble0-Frame-1-3" unit="cm" 
-         x="-327.04"
-	 y="-291.55" 
-	 z="34.6002250000001"/>
+         x="-328.04"
+	 y="-297.7" 
+	 z="34.0000000000001"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-3-0"/>
        <position name="posOpArapucaDouble0-Frame-1-3" unit="cm" 
-         x="-326.3"
-	 y="-291.55" 
-	 z="34.6002250000001"/>
+         x="-327.3"
+	 y="-297.7" 
+	 z="34.0000000000001"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-3-1"/>
        <position name="posArapucaDouble1-Frame-1-3" unit="cm" 
-         x="-327.04"
-	 y="-201" 
-	 z="-103.050675"/>
+         x="-328.04"
+	 y="-207" 
+	 z="-112"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-3-1"/>
        <position name="posOpArapucaDouble1-Frame-1-3" unit="cm" 
-         x="-326.3"
-	 y="-201" 
-	 z="-103.050675"/>
+         x="-327.3"
+	 y="-207" 
+	 z="-112"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-3-2"/>
        <position name="posArapucaDouble2-Frame-1-3" unit="cm" 
-         x="-327.04"
-	 y="-135" 
-	 z="103.050675"/>
+         x="-328.04"
+	 y="-133" 
+	 z="105"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-3-2"/>
        <position name="posOpArapucaDouble2-Frame-1-3" unit="cm" 
-         x="-326.3"
-	 y="-135" 
-	 z="103.050675"/>
+         x="-327.3"
+	 y="-133" 
+	 z="105"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-3-3"/>
        <position name="posArapucaDouble3-Frame-1-3" unit="cm" 
-         x="-327.04"
-	 y="-44.45" 
-	 z="-34.6002249999999"/>
+         x="-328.04"
+	 y="-42.3" 
+	 z="-40.9999999999999"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-3-3"/>
        <position name="posOpArapucaDouble3-Frame-1-3" unit="cm" 
-         x="-326.3"
-	 y="-44.45" 
-	 z="-34.6002249999999"/>
+         x="-327.3"
+	 y="-42.3" 
+	 z="-40.9999999999999"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-4-0"/>
        <position name="posArapucaDouble0-Frame-1-4" unit="cm" 
-         x="-327.04"
-	 y="-291.55" 
-	 z="332.402025"/>
+         x="-328.04"
+	 y="-297.7" 
+	 z="331.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-4-0"/>
        <position name="posOpArapucaDouble0-Frame-1-4" unit="cm" 
-         x="-326.3"
-	 y="-291.55" 
-	 z="332.402025"/>
+         x="-327.3"
+	 y="-297.7" 
+	 z="331.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-4-1"/>
        <position name="posArapucaDouble1-Frame-1-4" unit="cm" 
-         x="-327.04"
-	 y="-201" 
-	 z="194.751125"/>
+         x="-328.04"
+	 y="-207" 
+	 z="185.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-4-1"/>
        <position name="posOpArapucaDouble1-Frame-1-4" unit="cm" 
-         x="-326.3"
-	 y="-201" 
-	 z="194.751125"/>
+         x="-327.3"
+	 y="-207" 
+	 z="185.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-4-2"/>
        <position name="posArapucaDouble2-Frame-1-4" unit="cm" 
-         x="-327.04"
-	 y="-135" 
-	 z="400.852475"/>
+         x="-328.04"
+	 y="-133" 
+	 z="402.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-4-2"/>
        <position name="posOpArapucaDouble2-Frame-1-4" unit="cm" 
-         x="-326.3"
-	 y="-135" 
-	 z="400.852475"/>
+         x="-327.3"
+	 y="-133" 
+	 z="402.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-4-3"/>
        <position name="posArapucaDouble3-Frame-1-4" unit="cm" 
-         x="-327.04"
-	 y="-44.45" 
-	 z="263.201575"/>
+         x="-328.04"
+	 y="-42.3" 
+	 z="256.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-4-3"/>
        <position name="posOpArapucaDouble3-Frame-1-4" unit="cm" 
-         x="-326.3"
-	 y="-44.45" 
-	 z="263.201575"/>
+         x="-327.3"
+	 y="-42.3" 
+	 z="256.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-5-0"/>
        <position name="posArapucaDouble0-Frame-1-5" unit="cm" 
-         x="-327.04"
-	 y="-291.55" 
-	 z="630.203825"/>
+         x="-328.04"
+	 y="-297.7" 
+	 z="629.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-5-0"/>
        <position name="posOpArapucaDouble0-Frame-1-5" unit="cm" 
-         x="-326.3"
-	 y="-291.55" 
-	 z="630.203825"/>
+         x="-327.3"
+	 y="-297.7" 
+	 z="629.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-5-1"/>
        <position name="posArapucaDouble1-Frame-1-5" unit="cm" 
-         x="-327.04"
-	 y="-201" 
-	 z="492.552925"/>
+         x="-328.04"
+	 y="-207" 
+	 z="483.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-5-1"/>
        <position name="posOpArapucaDouble1-Frame-1-5" unit="cm" 
-         x="-326.3"
-	 y="-201" 
-	 z="492.552925"/>
+         x="-327.3"
+	 y="-207" 
+	 z="483.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-5-2"/>
        <position name="posArapucaDouble2-Frame-1-5" unit="cm" 
-         x="-327.04"
-	 y="-135" 
-	 z="698.654275"/>
+         x="-328.04"
+	 y="-133" 
+	 z="700.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-5-2"/>
        <position name="posOpArapucaDouble2-Frame-1-5" unit="cm" 
-         x="-326.3"
-	 y="-135" 
-	 z="698.654275"/>
+         x="-327.3"
+	 y="-133" 
+	 z="700.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-5-3"/>
        <position name="posArapucaDouble3-Frame-1-5" unit="cm" 
-         x="-327.04"
-	 y="-44.45" 
-	 z="561.003375"/>
+         x="-328.04"
+	 y="-42.3" 
+	 z="554.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-5-3"/>
        <position name="posOpArapucaDouble3-Frame-1-5" unit="cm" 
-         x="-326.3"
-	 y="-44.45" 
-	 z="561.003375"/>
+         x="-327.3"
+	 y="-42.3" 
+	 z="554.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-6-0"/>
        <position name="posArapucaDouble0-Frame-1-6" unit="cm" 
-         x="-327.04"
-	 y="-291.55" 
-	 z="928.005625"/>
+         x="-328.04"
+	 y="-297.7" 
+	 z="927.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-6-0"/>
        <position name="posOpArapucaDouble0-Frame-1-6" unit="cm" 
-         x="-326.3"
-	 y="-291.55" 
-	 z="928.005625"/>
+         x="-327.3"
+	 y="-297.7" 
+	 z="927.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-6-1"/>
        <position name="posArapucaDouble1-Frame-1-6" unit="cm" 
-         x="-327.04"
-	 y="-201" 
-	 z="790.354725"/>
+         x="-328.04"
+	 y="-207" 
+	 z="781.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-6-1"/>
        <position name="posOpArapucaDouble1-Frame-1-6" unit="cm" 
-         x="-326.3"
-	 y="-201" 
-	 z="790.354725"/>
+         x="-327.3"
+	 y="-207" 
+	 z="781.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-6-2"/>
        <position name="posArapucaDouble2-Frame-1-6" unit="cm" 
-         x="-327.04"
-	 y="-135" 
-	 z="996.456075"/>
+         x="-328.04"
+	 y="-133" 
+	 z="998.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-6-2"/>
        <position name="posOpArapucaDouble2-Frame-1-6" unit="cm" 
-         x="-326.3"
-	 y="-135" 
-	 z="996.456075"/>
+         x="-327.3"
+	 y="-133" 
+	 z="998.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-6-3"/>
        <position name="posArapucaDouble3-Frame-1-6" unit="cm" 
-         x="-327.04"
-	 y="-44.45" 
-	 z="858.805175"/>
+         x="-328.04"
+	 y="-42.3" 
+	 z="852.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-6-3"/>
        <position name="posOpArapucaDouble3-Frame-1-6" unit="cm" 
-         x="-326.3"
-	 y="-44.45" 
-	 z="858.805175"/>
+         x="-327.3"
+	 y="-42.3" 
+	 z="852.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-0-0"/>
        <position name="posArapucaDouble0-Frame-2-0" unit="cm" 
-         x="-327.04"
-	 y="44.45" 
-	 z="-858.805175"/>
+         x="-328.04"
+	 y="38.3" 
+	 z="-859.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-0"/>
        <position name="posOpArapucaDouble0-Frame-2-0" unit="cm" 
-         x="-326.3"
-	 y="44.45" 
-	 z="-858.805175"/>
+         x="-327.3"
+	 y="38.3" 
+	 z="-859.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-0-1"/>
        <position name="posArapucaDouble1-Frame-2-0" unit="cm" 
-         x="-327.04"
-	 y="135" 
-	 z="-996.456075"/>
+         x="-328.04"
+	 y="129" 
+	 z="-1005.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-1"/>
        <position name="posOpArapucaDouble1-Frame-2-0" unit="cm" 
-         x="-326.3"
-	 y="135" 
-	 z="-996.456075"/>
+         x="-327.3"
+	 y="129" 
+	 z="-1005.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-0-2"/>
        <position name="posArapucaDouble2-Frame-2-0" unit="cm" 
-         x="-327.04"
-	 y="201" 
-	 z="-790.354725"/>
+         x="-328.04"
+	 y="203" 
+	 z="-788.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-2"/>
        <position name="posOpArapucaDouble2-Frame-2-0" unit="cm" 
-         x="-326.3"
-	 y="201" 
-	 z="-790.354725"/>
+         x="-327.3"
+	 y="203" 
+	 z="-788.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-0-3"/>
        <position name="posArapucaDouble3-Frame-2-0" unit="cm" 
-         x="-327.04"
-	 y="291.55" 
-	 z="-928.005625"/>
+         x="-328.04"
+	 y="293.7" 
+	 z="-934.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-3"/>
        <position name="posOpArapucaDouble3-Frame-2-0" unit="cm" 
-         x="-326.3"
-	 y="291.55" 
-	 z="-928.005625"/>
+         x="-327.3"
+	 y="293.7" 
+	 z="-934.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-1-0"/>
        <position name="posArapucaDouble0-Frame-2-1" unit="cm" 
-         x="-327.04"
-	 y="44.45" 
-	 z="-561.003375"/>
+         x="-328.04"
+	 y="38.3" 
+	 z="-561.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-0"/>
        <position name="posOpArapucaDouble0-Frame-2-1" unit="cm" 
-         x="-326.3"
-	 y="44.45" 
-	 z="-561.003375"/>
+         x="-327.3"
+	 y="38.3" 
+	 z="-561.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-1-1"/>
        <position name="posArapucaDouble1-Frame-2-1" unit="cm" 
-         x="-327.04"
-	 y="135" 
-	 z="-698.654275"/>
+         x="-328.04"
+	 y="129" 
+	 z="-707.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-1"/>
        <position name="posOpArapucaDouble1-Frame-2-1" unit="cm" 
-         x="-326.3"
-	 y="135" 
-	 z="-698.654275"/>
+         x="-327.3"
+	 y="129" 
+	 z="-707.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-1-2"/>
        <position name="posArapucaDouble2-Frame-2-1" unit="cm" 
-         x="-327.04"
-	 y="201" 
-	 z="-492.552925"/>
+         x="-328.04"
+	 y="203" 
+	 z="-490.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-2"/>
        <position name="posOpArapucaDouble2-Frame-2-1" unit="cm" 
-         x="-326.3"
-	 y="201" 
-	 z="-492.552925"/>
+         x="-327.3"
+	 y="203" 
+	 z="-490.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-1-3"/>
        <position name="posArapucaDouble3-Frame-2-1" unit="cm" 
-         x="-327.04"
-	 y="291.55" 
-	 z="-630.203825"/>
+         x="-328.04"
+	 y="293.7" 
+	 z="-636.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-3"/>
        <position name="posOpArapucaDouble3-Frame-2-1" unit="cm" 
-         x="-326.3"
-	 y="291.55" 
-	 z="-630.203825"/>
+         x="-327.3"
+	 y="293.7" 
+	 z="-636.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-2-0"/>
        <position name="posArapucaDouble0-Frame-2-2" unit="cm" 
-         x="-327.04"
-	 y="44.45" 
-	 z="-263.201575"/>
+         x="-328.04"
+	 y="38.3" 
+	 z="-263.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-0"/>
        <position name="posOpArapucaDouble0-Frame-2-2" unit="cm" 
-         x="-326.3"
-	 y="44.45" 
-	 z="-263.201575"/>
+         x="-327.3"
+	 y="38.3" 
+	 z="-263.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-2-1"/>
        <position name="posArapucaDouble1-Frame-2-2" unit="cm" 
-         x="-327.04"
-	 y="135" 
-	 z="-400.852475"/>
+         x="-328.04"
+	 y="129" 
+	 z="-409.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-1"/>
        <position name="posOpArapucaDouble1-Frame-2-2" unit="cm" 
-         x="-326.3"
-	 y="135" 
-	 z="-400.852475"/>
+         x="-327.3"
+	 y="129" 
+	 z="-409.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-2-2"/>
        <position name="posArapucaDouble2-Frame-2-2" unit="cm" 
-         x="-327.04"
-	 y="201" 
-	 z="-194.751125"/>
+         x="-328.04"
+	 y="203" 
+	 z="-192.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-2"/>
        <position name="posOpArapucaDouble2-Frame-2-2" unit="cm" 
-         x="-326.3"
-	 y="201" 
-	 z="-194.751125"/>
+         x="-327.3"
+	 y="203" 
+	 z="-192.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-2-3"/>
        <position name="posArapucaDouble3-Frame-2-2" unit="cm" 
-         x="-327.04"
-	 y="291.55" 
-	 z="-332.402025"/>
+         x="-328.04"
+	 y="293.7" 
+	 z="-338.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-3"/>
        <position name="posOpArapucaDouble3-Frame-2-2" unit="cm" 
-         x="-326.3"
-	 y="291.55" 
-	 z="-332.402025"/>
+         x="-327.3"
+	 y="293.7" 
+	 z="-338.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-3-0"/>
        <position name="posArapucaDouble0-Frame-2-3" unit="cm" 
-         x="-327.04"
-	 y="44.45" 
-	 z="34.6002250000001"/>
+         x="-328.04"
+	 y="38.3" 
+	 z="34.0000000000001"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-3-0"/>
        <position name="posOpArapucaDouble0-Frame-2-3" unit="cm" 
-         x="-326.3"
-	 y="44.45" 
-	 z="34.6002250000001"/>
+         x="-327.3"
+	 y="38.3" 
+	 z="34.0000000000001"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-3-1"/>
        <position name="posArapucaDouble1-Frame-2-3" unit="cm" 
-         x="-327.04"
-	 y="135" 
-	 z="-103.050675"/>
+         x="-328.04"
+	 y="129" 
+	 z="-112"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-3-1"/>
        <position name="posOpArapucaDouble1-Frame-2-3" unit="cm" 
-         x="-326.3"
-	 y="135" 
-	 z="-103.050675"/>
+         x="-327.3"
+	 y="129" 
+	 z="-112"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-3-2"/>
        <position name="posArapucaDouble2-Frame-2-3" unit="cm" 
-         x="-327.04"
-	 y="201" 
-	 z="103.050675"/>
+         x="-328.04"
+	 y="203" 
+	 z="105"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-3-2"/>
        <position name="posOpArapucaDouble2-Frame-2-3" unit="cm" 
-         x="-326.3"
-	 y="201" 
-	 z="103.050675"/>
+         x="-327.3"
+	 y="203" 
+	 z="105"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-3-3"/>
        <position name="posArapucaDouble3-Frame-2-3" unit="cm" 
-         x="-327.04"
-	 y="291.55" 
-	 z="-34.6002249999999"/>
+         x="-328.04"
+	 y="293.7" 
+	 z="-40.9999999999999"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-3-3"/>
        <position name="posOpArapucaDouble3-Frame-2-3" unit="cm" 
-         x="-326.3"
-	 y="291.55" 
-	 z="-34.6002249999999"/>
+         x="-327.3"
+	 y="293.7" 
+	 z="-40.9999999999999"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-4-0"/>
        <position name="posArapucaDouble0-Frame-2-4" unit="cm" 
-         x="-327.04"
-	 y="44.45" 
-	 z="332.402025"/>
+         x="-328.04"
+	 y="38.3" 
+	 z="331.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-4-0"/>
        <position name="posOpArapucaDouble0-Frame-2-4" unit="cm" 
-         x="-326.3"
-	 y="44.45" 
-	 z="332.402025"/>
+         x="-327.3"
+	 y="38.3" 
+	 z="331.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-4-1"/>
        <position name="posArapucaDouble1-Frame-2-4" unit="cm" 
-         x="-327.04"
-	 y="135" 
-	 z="194.751125"/>
+         x="-328.04"
+	 y="129" 
+	 z="185.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-4-1"/>
        <position name="posOpArapucaDouble1-Frame-2-4" unit="cm" 
-         x="-326.3"
-	 y="135" 
-	 z="194.751125"/>
+         x="-327.3"
+	 y="129" 
+	 z="185.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-4-2"/>
        <position name="posArapucaDouble2-Frame-2-4" unit="cm" 
-         x="-327.04"
-	 y="201" 
-	 z="400.852475"/>
+         x="-328.04"
+	 y="203" 
+	 z="402.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-4-2"/>
        <position name="posOpArapucaDouble2-Frame-2-4" unit="cm" 
-         x="-326.3"
-	 y="201" 
-	 z="400.852475"/>
+         x="-327.3"
+	 y="203" 
+	 z="402.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-4-3"/>
        <position name="posArapucaDouble3-Frame-2-4" unit="cm" 
-         x="-327.04"
-	 y="291.55" 
-	 z="263.201575"/>
+         x="-328.04"
+	 y="293.7" 
+	 z="256.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-4-3"/>
        <position name="posOpArapucaDouble3-Frame-2-4" unit="cm" 
-         x="-326.3"
-	 y="291.55" 
-	 z="263.201575"/>
+         x="-327.3"
+	 y="293.7" 
+	 z="256.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-5-0"/>
        <position name="posArapucaDouble0-Frame-2-5" unit="cm" 
-         x="-327.04"
-	 y="44.45" 
-	 z="630.203825"/>
+         x="-328.04"
+	 y="38.3" 
+	 z="629.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-5-0"/>
        <position name="posOpArapucaDouble0-Frame-2-5" unit="cm" 
-         x="-326.3"
-	 y="44.45" 
-	 z="630.203825"/>
+         x="-327.3"
+	 y="38.3" 
+	 z="629.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-5-1"/>
        <position name="posArapucaDouble1-Frame-2-5" unit="cm" 
-         x="-327.04"
-	 y="135" 
-	 z="492.552925"/>
+         x="-328.04"
+	 y="129" 
+	 z="483.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-5-1"/>
        <position name="posOpArapucaDouble1-Frame-2-5" unit="cm" 
-         x="-326.3"
-	 y="135" 
-	 z="492.552925"/>
+         x="-327.3"
+	 y="129" 
+	 z="483.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-5-2"/>
        <position name="posArapucaDouble2-Frame-2-5" unit="cm" 
-         x="-327.04"
-	 y="201" 
-	 z="698.654275"/>
+         x="-328.04"
+	 y="203" 
+	 z="700.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-5-2"/>
        <position name="posOpArapucaDouble2-Frame-2-5" unit="cm" 
-         x="-326.3"
-	 y="201" 
-	 z="698.654275"/>
+         x="-327.3"
+	 y="203" 
+	 z="700.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-5-3"/>
        <position name="posArapucaDouble3-Frame-2-5" unit="cm" 
-         x="-327.04"
-	 y="291.55" 
-	 z="561.003375"/>
+         x="-328.04"
+	 y="293.7" 
+	 z="554.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-5-3"/>
        <position name="posOpArapucaDouble3-Frame-2-5" unit="cm" 
-         x="-326.3"
-	 y="291.55" 
-	 z="561.003375"/>
+         x="-327.3"
+	 y="293.7" 
+	 z="554.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-6-0"/>
        <position name="posArapucaDouble0-Frame-2-6" unit="cm" 
-         x="-327.04"
-	 y="44.45" 
-	 z="928.005625"/>
+         x="-328.04"
+	 y="38.3" 
+	 z="927.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-6-0"/>
        <position name="posOpArapucaDouble0-Frame-2-6" unit="cm" 
-         x="-326.3"
-	 y="44.45" 
-	 z="928.005625"/>
+         x="-327.3"
+	 y="38.3" 
+	 z="927.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-6-1"/>
        <position name="posArapucaDouble1-Frame-2-6" unit="cm" 
-         x="-327.04"
-	 y="135" 
-	 z="790.354725"/>
+         x="-328.04"
+	 y="129" 
+	 z="781.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-6-1"/>
        <position name="posOpArapucaDouble1-Frame-2-6" unit="cm" 
-         x="-326.3"
-	 y="135" 
-	 z="790.354725"/>
+         x="-327.3"
+	 y="129" 
+	 z="781.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-6-2"/>
        <position name="posArapucaDouble2-Frame-2-6" unit="cm" 
-         x="-327.04"
-	 y="201" 
-	 z="996.456075"/>
+         x="-328.04"
+	 y="203" 
+	 z="998.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-6-2"/>
        <position name="posOpArapucaDouble2-Frame-2-6" unit="cm" 
-         x="-326.3"
-	 y="201" 
-	 z="996.456075"/>
+         x="-327.3"
+	 y="203" 
+	 z="998.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-6-3"/>
        <position name="posArapucaDouble3-Frame-2-6" unit="cm" 
-         x="-327.04"
-	 y="291.55" 
-	 z="858.805175"/>
+         x="-328.04"
+	 y="293.7" 
+	 z="852.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-6-3"/>
        <position name="posOpArapucaDouble3-Frame-2-6" unit="cm" 
-         x="-326.3"
-	 y="291.55" 
-	 z="858.805175"/>
+         x="-327.3"
+	 y="293.7" 
+	 z="852.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-0-0"/>
        <position name="posArapucaDouble0-Frame-3-0" unit="cm" 
-         x="-327.04"
-	 y="380.45" 
-	 z="-858.805175"/>
+         x="-328.04"
+	 y="374.3" 
+	 z="-859.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-0"/>
        <position name="posOpArapucaDouble0-Frame-3-0" unit="cm" 
-         x="-326.3"
-	 y="380.45" 
-	 z="-858.805175"/>
+         x="-327.3"
+	 y="374.3" 
+	 z="-859.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-0-1"/>
        <position name="posArapucaDouble1-Frame-3-0" unit="cm" 
-         x="-327.04"
-	 y="471" 
-	 z="-996.456075"/>
+         x="-328.04"
+	 y="465" 
+	 z="-1005.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-1"/>
        <position name="posOpArapucaDouble1-Frame-3-0" unit="cm" 
-         x="-326.3"
-	 y="471" 
-	 z="-996.456075"/>
+         x="-327.3"
+	 y="465" 
+	 z="-1005.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-0-2"/>
        <position name="posArapucaDouble2-Frame-3-0" unit="cm" 
-         x="-327.04"
-	 y="537" 
-	 z="-790.354725"/>
+         x="-328.04"
+	 y="539" 
+	 z="-788.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-2"/>
        <position name="posOpArapucaDouble2-Frame-3-0" unit="cm" 
-         x="-326.3"
-	 y="537" 
-	 z="-790.354725"/>
+         x="-327.3"
+	 y="539" 
+	 z="-788.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-0-3"/>
        <position name="posArapucaDouble3-Frame-3-0" unit="cm" 
-         x="-327.04"
-	 y="627.55" 
-	 z="-928.005625"/>
+         x="-328.04"
+	 y="629.7" 
+	 z="-934.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-3"/>
        <position name="posOpArapucaDouble3-Frame-3-0" unit="cm" 
-         x="-326.3"
-	 y="627.55" 
-	 z="-928.005625"/>
+         x="-327.3"
+	 y="629.7" 
+	 z="-934.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-1-0"/>
        <position name="posArapucaDouble0-Frame-3-1" unit="cm" 
-         x="-327.04"
-	 y="380.45" 
-	 z="-561.003375"/>
+         x="-328.04"
+	 y="374.3" 
+	 z="-561.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-0"/>
        <position name="posOpArapucaDouble0-Frame-3-1" unit="cm" 
-         x="-326.3"
-	 y="380.45" 
-	 z="-561.003375"/>
+         x="-327.3"
+	 y="374.3" 
+	 z="-561.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-1-1"/>
        <position name="posArapucaDouble1-Frame-3-1" unit="cm" 
-         x="-327.04"
-	 y="471" 
-	 z="-698.654275"/>
+         x="-328.04"
+	 y="465" 
+	 z="-707.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-1"/>
        <position name="posOpArapucaDouble1-Frame-3-1" unit="cm" 
-         x="-326.3"
-	 y="471" 
-	 z="-698.654275"/>
+         x="-327.3"
+	 y="465" 
+	 z="-707.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-1-2"/>
        <position name="posArapucaDouble2-Frame-3-1" unit="cm" 
-         x="-327.04"
-	 y="537" 
-	 z="-492.552925"/>
+         x="-328.04"
+	 y="539" 
+	 z="-490.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-2"/>
        <position name="posOpArapucaDouble2-Frame-3-1" unit="cm" 
-         x="-326.3"
-	 y="537" 
-	 z="-492.552925"/>
+         x="-327.3"
+	 y="539" 
+	 z="-490.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-1-3"/>
        <position name="posArapucaDouble3-Frame-3-1" unit="cm" 
-         x="-327.04"
-	 y="627.55" 
-	 z="-630.203825"/>
+         x="-328.04"
+	 y="629.7" 
+	 z="-636.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-3"/>
        <position name="posOpArapucaDouble3-Frame-3-1" unit="cm" 
-         x="-326.3"
-	 y="627.55" 
-	 z="-630.203825"/>
+         x="-327.3"
+	 y="629.7" 
+	 z="-636.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-2-0"/>
        <position name="posArapucaDouble0-Frame-3-2" unit="cm" 
-         x="-327.04"
-	 y="380.45" 
-	 z="-263.201575"/>
+         x="-328.04"
+	 y="374.3" 
+	 z="-263.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-0"/>
        <position name="posOpArapucaDouble0-Frame-3-2" unit="cm" 
-         x="-326.3"
-	 y="380.45" 
-	 z="-263.201575"/>
+         x="-327.3"
+	 y="374.3" 
+	 z="-263.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-2-1"/>
        <position name="posArapucaDouble1-Frame-3-2" unit="cm" 
-         x="-327.04"
-	 y="471" 
-	 z="-400.852475"/>
+         x="-328.04"
+	 y="465" 
+	 z="-409.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-1"/>
        <position name="posOpArapucaDouble1-Frame-3-2" unit="cm" 
-         x="-326.3"
-	 y="471" 
-	 z="-400.852475"/>
+         x="-327.3"
+	 y="465" 
+	 z="-409.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-2-2"/>
        <position name="posArapucaDouble2-Frame-3-2" unit="cm" 
-         x="-327.04"
-	 y="537" 
-	 z="-194.751125"/>
+         x="-328.04"
+	 y="539" 
+	 z="-192.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-2"/>
        <position name="posOpArapucaDouble2-Frame-3-2" unit="cm" 
-         x="-326.3"
-	 y="537" 
-	 z="-194.751125"/>
+         x="-327.3"
+	 y="539" 
+	 z="-192.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-2-3"/>
        <position name="posArapucaDouble3-Frame-3-2" unit="cm" 
-         x="-327.04"
-	 y="627.55" 
-	 z="-332.402025"/>
+         x="-328.04"
+	 y="629.7" 
+	 z="-338.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-3"/>
        <position name="posOpArapucaDouble3-Frame-3-2" unit="cm" 
-         x="-326.3"
-	 y="627.55" 
-	 z="-332.402025"/>
+         x="-327.3"
+	 y="629.7" 
+	 z="-338.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-3-0"/>
        <position name="posArapucaDouble0-Frame-3-3" unit="cm" 
-         x="-327.04"
-	 y="380.45" 
-	 z="34.6002250000001"/>
+         x="-328.04"
+	 y="374.3" 
+	 z="34.0000000000001"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-3-0"/>
        <position name="posOpArapucaDouble0-Frame-3-3" unit="cm" 
-         x="-326.3"
-	 y="380.45" 
-	 z="34.6002250000001"/>
+         x="-327.3"
+	 y="374.3" 
+	 z="34.0000000000001"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-3-1"/>
        <position name="posArapucaDouble1-Frame-3-3" unit="cm" 
-         x="-327.04"
-	 y="471" 
-	 z="-103.050675"/>
+         x="-328.04"
+	 y="465" 
+	 z="-112"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-3-1"/>
        <position name="posOpArapucaDouble1-Frame-3-3" unit="cm" 
-         x="-326.3"
-	 y="471" 
-	 z="-103.050675"/>
+         x="-327.3"
+	 y="465" 
+	 z="-112"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-3-2"/>
        <position name="posArapucaDouble2-Frame-3-3" unit="cm" 
-         x="-327.04"
-	 y="537" 
-	 z="103.050675"/>
+         x="-328.04"
+	 y="539" 
+	 z="105"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-3-2"/>
        <position name="posOpArapucaDouble2-Frame-3-3" unit="cm" 
-         x="-326.3"
-	 y="537" 
-	 z="103.050675"/>
+         x="-327.3"
+	 y="539" 
+	 z="105"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-3-3"/>
        <position name="posArapucaDouble3-Frame-3-3" unit="cm" 
-         x="-327.04"
-	 y="627.55" 
-	 z="-34.6002249999999"/>
+         x="-328.04"
+	 y="629.7" 
+	 z="-40.9999999999999"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-3-3"/>
        <position name="posOpArapucaDouble3-Frame-3-3" unit="cm" 
-         x="-326.3"
-	 y="627.55" 
-	 z="-34.6002249999999"/>
+         x="-327.3"
+	 y="629.7" 
+	 z="-40.9999999999999"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-4-0"/>
        <position name="posArapucaDouble0-Frame-3-4" unit="cm" 
-         x="-327.04"
-	 y="380.45" 
-	 z="332.402025"/>
+         x="-328.04"
+	 y="374.3" 
+	 z="331.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-4-0"/>
        <position name="posOpArapucaDouble0-Frame-3-4" unit="cm" 
-         x="-326.3"
-	 y="380.45" 
-	 z="332.402025"/>
+         x="-327.3"
+	 y="374.3" 
+	 z="331.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-4-1"/>
        <position name="posArapucaDouble1-Frame-3-4" unit="cm" 
-         x="-327.04"
-	 y="471" 
-	 z="194.751125"/>
+         x="-328.04"
+	 y="465" 
+	 z="185.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-4-1"/>
        <position name="posOpArapucaDouble1-Frame-3-4" unit="cm" 
-         x="-326.3"
-	 y="471" 
-	 z="194.751125"/>
+         x="-327.3"
+	 y="465" 
+	 z="185.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-4-2"/>
        <position name="posArapucaDouble2-Frame-3-4" unit="cm" 
-         x="-327.04"
-	 y="537" 
-	 z="400.852475"/>
+         x="-328.04"
+	 y="539" 
+	 z="402.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-4-2"/>
        <position name="posOpArapucaDouble2-Frame-3-4" unit="cm" 
-         x="-326.3"
-	 y="537" 
-	 z="400.852475"/>
+         x="-327.3"
+	 y="539" 
+	 z="402.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-4-3"/>
        <position name="posArapucaDouble3-Frame-3-4" unit="cm" 
-         x="-327.04"
-	 y="627.55" 
-	 z="263.201575"/>
+         x="-328.04"
+	 y="629.7" 
+	 z="256.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-4-3"/>
        <position name="posOpArapucaDouble3-Frame-3-4" unit="cm" 
-         x="-326.3"
-	 y="627.55" 
-	 z="263.201575"/>
+         x="-327.3"
+	 y="629.7" 
+	 z="256.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-5-0"/>
        <position name="posArapucaDouble0-Frame-3-5" unit="cm" 
-         x="-327.04"
-	 y="380.45" 
-	 z="630.203825"/>
+         x="-328.04"
+	 y="374.3" 
+	 z="629.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-5-0"/>
        <position name="posOpArapucaDouble0-Frame-3-5" unit="cm" 
-         x="-326.3"
-	 y="380.45" 
-	 z="630.203825"/>
+         x="-327.3"
+	 y="374.3" 
+	 z="629.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-5-1"/>
        <position name="posArapucaDouble1-Frame-3-5" unit="cm" 
-         x="-327.04"
-	 y="471" 
-	 z="492.552925"/>
+         x="-328.04"
+	 y="465" 
+	 z="483.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-5-1"/>
        <position name="posOpArapucaDouble1-Frame-3-5" unit="cm" 
-         x="-326.3"
-	 y="471" 
-	 z="492.552925"/>
+         x="-327.3"
+	 y="465" 
+	 z="483.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-5-2"/>
        <position name="posArapucaDouble2-Frame-3-5" unit="cm" 
-         x="-327.04"
-	 y="537" 
-	 z="698.654275"/>
+         x="-328.04"
+	 y="539" 
+	 z="700.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-5-2"/>
        <position name="posOpArapucaDouble2-Frame-3-5" unit="cm" 
-         x="-326.3"
-	 y="537" 
-	 z="698.654275"/>
+         x="-327.3"
+	 y="539" 
+	 z="700.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-5-3"/>
        <position name="posArapucaDouble3-Frame-3-5" unit="cm" 
-         x="-327.04"
-	 y="627.55" 
-	 z="561.003375"/>
+         x="-328.04"
+	 y="629.7" 
+	 z="554.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-5-3"/>
        <position name="posOpArapucaDouble3-Frame-3-5" unit="cm" 
-         x="-326.3"
-	 y="627.55" 
-	 z="561.003375"/>
+         x="-327.3"
+	 y="629.7" 
+	 z="554.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-6-0"/>
        <position name="posArapucaDouble0-Frame-3-6" unit="cm" 
-         x="-327.04"
-	 y="380.45" 
-	 z="928.005625"/>
+         x="-328.04"
+	 y="374.3" 
+	 z="927.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-6-0"/>
        <position name="posOpArapucaDouble0-Frame-3-6" unit="cm" 
-         x="-326.3"
-	 y="380.45" 
-	 z="928.005625"/>
+         x="-327.3"
+	 y="374.3" 
+	 z="927.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-6-1"/>
        <position name="posArapucaDouble1-Frame-3-6" unit="cm" 
-         x="-327.04"
-	 y="471" 
-	 z="790.354725"/>
+         x="-328.04"
+	 y="465" 
+	 z="781.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-6-1"/>
        <position name="posOpArapucaDouble1-Frame-3-6" unit="cm" 
-         x="-326.3"
-	 y="471" 
-	 z="790.354725"/>
+         x="-327.3"
+	 y="465" 
+	 z="781.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-6-2"/>
        <position name="posArapucaDouble2-Frame-3-6" unit="cm" 
-         x="-327.04"
-	 y="537" 
-	 z="996.456075"/>
+         x="-328.04"
+	 y="539" 
+	 z="998.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-6-2"/>
        <position name="posOpArapucaDouble2-Frame-3-6" unit="cm" 
-         x="-326.3"
-	 y="537" 
-	 z="996.456075"/>
+         x="-327.3"
+	 y="539" 
+	 z="998.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-6-3"/>
        <position name="posArapucaDouble3-Frame-3-6" unit="cm" 
-         x="-327.04"
-	 y="627.55" 
-	 z="858.805175"/>
+         x="-328.04"
+	 y="629.7" 
+	 z="852.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-6-3"/>
        <position name="posOpArapucaDouble3-Frame-3-6" unit="cm" 
-         x="-326.3"
-	 y="627.55" 
-	 z="858.805175"/>
+         x="-327.3"
+	 y="629.7" 
+	 z="852.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-0"/>
        <position name="posArapuca0-Lat-0" unit="cm" 
-         x="285.03"
+         x="285.01"
 	 y="-734" 
 	 z="-893.4054"/>
        <rotationref ref="rIdentity"/>
@@ -11481,14 +11714,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-0"/>
        <position name="posOpArapuca0-Lat-0" unit="cm" 
-         x="285.03"
+         x="285.01"
 	 y="-733.26" 
 	 z="-893.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-1"/>
        <position name="posArapuca1-Lat-0" unit="cm" 
-         x="210.03"
+         x="210.01"
 	 y="-734" 
 	 z="-893.4054"/>
        <rotationref ref="rIdentity"/>
@@ -11496,14 +11729,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-1"/>
        <position name="posOpArapuca1-Lat-0" unit="cm" 
-         x="210.03"
+         x="210.01"
 	 y="-733.26" 
 	 z="-893.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-2"/>
        <position name="posArapuca2-Lat-0" unit="cm" 
-         x="135.03"
+         x="135.01"
 	 y="-734" 
 	 z="-893.4054"/>
        <rotationref ref="rIdentity"/>
@@ -11511,14 +11744,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-2"/>
        <position name="posOpArapuca2-Lat-0" unit="cm" 
-         x="135.03"
+         x="135.01"
 	 y="-733.26" 
 	 z="-893.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-3"/>
        <position name="posArapuca3-Lat-0" unit="cm" 
-         x="60.03"
+         x="60.01"
 	 y="-734" 
 	 z="-893.4054"/>
        <rotationref ref="rIdentity"/>
@@ -11526,14 +11759,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-3"/>
        <position name="posOpArapuca3-Lat-0" unit="cm" 
-         x="60.03"
+         x="60.01"
 	 y="-733.26" 
 	 z="-893.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-4"/>
        <position name="posArapuca4-Lat-0" unit="cm" 
-         x="285.03"
+         x="285.01"
 	 y="734" 
 	 z="-893.4054"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -11541,14 +11774,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-4"/>
        <position name="posOpArapuca4-Lat-0" unit="cm" 
-         x="285.03"
+         x="285.01"
 	 y="733.26" 
 	 z="-893.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-5"/>
        <position name="posArapuca5-Lat-0" unit="cm" 
-         x="210.03"
+         x="210.01"
 	 y="734" 
 	 z="-893.4054"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -11556,14 +11789,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-5"/>
        <position name="posOpArapuca5-Lat-0" unit="cm" 
-         x="210.03"
+         x="210.01"
 	 y="733.26" 
 	 z="-893.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-6"/>
        <position name="posArapuca6-Lat-0" unit="cm" 
-         x="135.03"
+         x="135.01"
 	 y="734" 
 	 z="-893.4054"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -11571,14 +11804,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-6"/>
        <position name="posOpArapuca6-Lat-0" unit="cm" 
-         x="135.03"
+         x="135.01"
 	 y="733.26" 
 	 z="-893.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-7"/>
        <position name="posArapuca7-Lat-0" unit="cm" 
-         x="60.03"
+         x="60.01"
 	 y="734" 
 	 z="-893.4054"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -11586,14 +11819,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-7"/>
        <position name="posOpArapuca7-Lat-0" unit="cm" 
-         x="60.03"
+         x="60.01"
 	 y="733.26" 
 	 z="-893.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-0"/>
        <position name="posArapuca0-Lat-1" unit="cm" 
-         x="285.03"
+         x="285.01"
 	 y="-734" 
 	 z="-595.6036"/>
        <rotationref ref="rIdentity"/>
@@ -11601,14 +11834,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-0"/>
        <position name="posOpArapuca0-Lat-1" unit="cm" 
-         x="285.03"
+         x="285.01"
 	 y="-733.26" 
 	 z="-595.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-1"/>
        <position name="posArapuca1-Lat-1" unit="cm" 
-         x="210.03"
+         x="210.01"
 	 y="-734" 
 	 z="-595.6036"/>
        <rotationref ref="rIdentity"/>
@@ -11616,14 +11849,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-1"/>
        <position name="posOpArapuca1-Lat-1" unit="cm" 
-         x="210.03"
+         x="210.01"
 	 y="-733.26" 
 	 z="-595.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-2"/>
        <position name="posArapuca2-Lat-1" unit="cm" 
-         x="135.03"
+         x="135.01"
 	 y="-734" 
 	 z="-595.6036"/>
        <rotationref ref="rIdentity"/>
@@ -11631,14 +11864,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-2"/>
        <position name="posOpArapuca2-Lat-1" unit="cm" 
-         x="135.03"
+         x="135.01"
 	 y="-733.26" 
 	 z="-595.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-3"/>
        <position name="posArapuca3-Lat-1" unit="cm" 
-         x="60.03"
+         x="60.01"
 	 y="-734" 
 	 z="-595.6036"/>
        <rotationref ref="rIdentity"/>
@@ -11646,14 +11879,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-3"/>
        <position name="posOpArapuca3-Lat-1" unit="cm" 
-         x="60.03"
+         x="60.01"
 	 y="-733.26" 
 	 z="-595.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-4"/>
        <position name="posArapuca4-Lat-1" unit="cm" 
-         x="285.03"
+         x="285.01"
 	 y="734" 
 	 z="-595.6036"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -11661,14 +11894,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-4"/>
        <position name="posOpArapuca4-Lat-1" unit="cm" 
-         x="285.03"
+         x="285.01"
 	 y="733.26" 
 	 z="-595.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-5"/>
        <position name="posArapuca5-Lat-1" unit="cm" 
-         x="210.03"
+         x="210.01"
 	 y="734" 
 	 z="-595.6036"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -11676,14 +11909,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-5"/>
        <position name="posOpArapuca5-Lat-1" unit="cm" 
-         x="210.03"
+         x="210.01"
 	 y="733.26" 
 	 z="-595.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-6"/>
        <position name="posArapuca6-Lat-1" unit="cm" 
-         x="135.03"
+         x="135.01"
 	 y="734" 
 	 z="-595.6036"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -11691,14 +11924,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-6"/>
        <position name="posOpArapuca6-Lat-1" unit="cm" 
-         x="135.03"
+         x="135.01"
 	 y="733.26" 
 	 z="-595.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-7"/>
        <position name="posArapuca7-Lat-1" unit="cm" 
-         x="60.03"
+         x="60.01"
 	 y="734" 
 	 z="-595.6036"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -11706,14 +11939,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-7"/>
        <position name="posOpArapuca7-Lat-1" unit="cm" 
-         x="60.03"
+         x="60.01"
 	 y="733.26" 
 	 z="-595.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-0"/>
        <position name="posArapuca0-Lat-2" unit="cm" 
-         x="285.03"
+         x="285.01"
 	 y="-734" 
 	 z="-297.8018"/>
        <rotationref ref="rIdentity"/>
@@ -11721,14 +11954,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-0"/>
        <position name="posOpArapuca0-Lat-2" unit="cm" 
-         x="285.03"
+         x="285.01"
 	 y="-733.26" 
 	 z="-297.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-1"/>
        <position name="posArapuca1-Lat-2" unit="cm" 
-         x="210.03"
+         x="210.01"
 	 y="-734" 
 	 z="-297.8018"/>
        <rotationref ref="rIdentity"/>
@@ -11736,14 +11969,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-1"/>
        <position name="posOpArapuca1-Lat-2" unit="cm" 
-         x="210.03"
+         x="210.01"
 	 y="-733.26" 
 	 z="-297.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-2"/>
        <position name="posArapuca2-Lat-2" unit="cm" 
-         x="135.03"
+         x="135.01"
 	 y="-734" 
 	 z="-297.8018"/>
        <rotationref ref="rIdentity"/>
@@ -11751,14 +11984,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-2"/>
        <position name="posOpArapuca2-Lat-2" unit="cm" 
-         x="135.03"
+         x="135.01"
 	 y="-733.26" 
 	 z="-297.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-3"/>
        <position name="posArapuca3-Lat-2" unit="cm" 
-         x="60.03"
+         x="60.01"
 	 y="-734" 
 	 z="-297.8018"/>
        <rotationref ref="rIdentity"/>
@@ -11766,14 +11999,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-3"/>
        <position name="posOpArapuca3-Lat-2" unit="cm" 
-         x="60.03"
+         x="60.01"
 	 y="-733.26" 
 	 z="-297.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-4"/>
        <position name="posArapuca4-Lat-2" unit="cm" 
-         x="285.03"
+         x="285.01"
 	 y="734" 
 	 z="-297.8018"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -11781,14 +12014,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-4"/>
        <position name="posOpArapuca4-Lat-2" unit="cm" 
-         x="285.03"
+         x="285.01"
 	 y="733.26" 
 	 z="-297.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-5"/>
        <position name="posArapuca5-Lat-2" unit="cm" 
-         x="210.03"
+         x="210.01"
 	 y="734" 
 	 z="-297.8018"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -11796,14 +12029,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-5"/>
        <position name="posOpArapuca5-Lat-2" unit="cm" 
-         x="210.03"
+         x="210.01"
 	 y="733.26" 
 	 z="-297.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-6"/>
        <position name="posArapuca6-Lat-2" unit="cm" 
-         x="135.03"
+         x="135.01"
 	 y="734" 
 	 z="-297.8018"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -11811,14 +12044,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-6"/>
        <position name="posOpArapuca6-Lat-2" unit="cm" 
-         x="135.03"
+         x="135.01"
 	 y="733.26" 
 	 z="-297.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-7"/>
        <position name="posArapuca7-Lat-2" unit="cm" 
-         x="60.03"
+         x="60.01"
 	 y="734" 
 	 z="-297.8018"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -11826,14 +12059,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-7"/>
        <position name="posOpArapuca7-Lat-2" unit="cm" 
-         x="60.03"
+         x="60.01"
 	 y="733.26" 
 	 z="-297.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_3-0"/>
        <position name="posArapuca0-Lat-3" unit="cm" 
-         x="285.03"
+         x="285.01"
 	 y="-734" 
 	 z="1.13686837721616e-13"/>
        <rotationref ref="rIdentity"/>
@@ -11841,14 +12074,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_3-0"/>
        <position name="posOpArapuca0-Lat-3" unit="cm" 
-         x="285.03"
+         x="285.01"
 	 y="-733.26" 
 	 z="1.13686837721616e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_3-1"/>
        <position name="posArapuca1-Lat-3" unit="cm" 
-         x="210.03"
+         x="210.01"
 	 y="-734" 
 	 z="1.13686837721616e-13"/>
        <rotationref ref="rIdentity"/>
@@ -11856,14 +12089,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_3-1"/>
        <position name="posOpArapuca1-Lat-3" unit="cm" 
-         x="210.03"
+         x="210.01"
 	 y="-733.26" 
 	 z="1.13686837721616e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_3-2"/>
        <position name="posArapuca2-Lat-3" unit="cm" 
-         x="135.03"
+         x="135.01"
 	 y="-734" 
 	 z="1.13686837721616e-13"/>
        <rotationref ref="rIdentity"/>
@@ -11871,14 +12104,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_3-2"/>
        <position name="posOpArapuca2-Lat-3" unit="cm" 
-         x="135.03"
+         x="135.01"
 	 y="-733.26" 
 	 z="1.13686837721616e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_3-3"/>
        <position name="posArapuca3-Lat-3" unit="cm" 
-         x="60.03"
+         x="60.01"
 	 y="-734" 
 	 z="1.13686837721616e-13"/>
        <rotationref ref="rIdentity"/>
@@ -11886,14 +12119,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_3-3"/>
        <position name="posOpArapuca3-Lat-3" unit="cm" 
-         x="60.03"
+         x="60.01"
 	 y="-733.26" 
 	 z="1.13686837721616e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_3-4"/>
        <position name="posArapuca4-Lat-3" unit="cm" 
-         x="285.03"
+         x="285.01"
 	 y="734" 
 	 z="1.13686837721616e-13"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -11901,14 +12134,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_3-4"/>
        <position name="posOpArapuca4-Lat-3" unit="cm" 
-         x="285.03"
+         x="285.01"
 	 y="733.26" 
 	 z="1.13686837721616e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_3-5"/>
        <position name="posArapuca5-Lat-3" unit="cm" 
-         x="210.03"
+         x="210.01"
 	 y="734" 
 	 z="1.13686837721616e-13"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -11916,14 +12149,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_3-5"/>
        <position name="posOpArapuca5-Lat-3" unit="cm" 
-         x="210.03"
+         x="210.01"
 	 y="733.26" 
 	 z="1.13686837721616e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_3-6"/>
        <position name="posArapuca6-Lat-3" unit="cm" 
-         x="135.03"
+         x="135.01"
 	 y="734" 
 	 z="1.13686837721616e-13"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -11931,14 +12164,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_3-6"/>
        <position name="posOpArapuca6-Lat-3" unit="cm" 
-         x="135.03"
+         x="135.01"
 	 y="733.26" 
 	 z="1.13686837721616e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_3-7"/>
        <position name="posArapuca7-Lat-3" unit="cm" 
-         x="60.03"
+         x="60.01"
 	 y="734" 
 	 z="1.13686837721616e-13"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -11946,14 +12179,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_3-7"/>
        <position name="posOpArapuca7-Lat-3" unit="cm" 
-         x="60.03"
+         x="60.01"
 	 y="733.26" 
 	 z="1.13686837721616e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_4-0"/>
        <position name="posArapuca0-Lat-4" unit="cm" 
-         x="285.03"
+         x="285.01"
 	 y="-734" 
 	 z="297.8018"/>
        <rotationref ref="rIdentity"/>
@@ -11961,14 +12194,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_4-0"/>
        <position name="posOpArapuca0-Lat-4" unit="cm" 
-         x="285.03"
+         x="285.01"
 	 y="-733.26" 
 	 z="297.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_4-1"/>
        <position name="posArapuca1-Lat-4" unit="cm" 
-         x="210.03"
+         x="210.01"
 	 y="-734" 
 	 z="297.8018"/>
        <rotationref ref="rIdentity"/>
@@ -11976,14 +12209,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_4-1"/>
        <position name="posOpArapuca1-Lat-4" unit="cm" 
-         x="210.03"
+         x="210.01"
 	 y="-733.26" 
 	 z="297.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_4-2"/>
        <position name="posArapuca2-Lat-4" unit="cm" 
-         x="135.03"
+         x="135.01"
 	 y="-734" 
 	 z="297.8018"/>
        <rotationref ref="rIdentity"/>
@@ -11991,14 +12224,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_4-2"/>
        <position name="posOpArapuca2-Lat-4" unit="cm" 
-         x="135.03"
+         x="135.01"
 	 y="-733.26" 
 	 z="297.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_4-3"/>
        <position name="posArapuca3-Lat-4" unit="cm" 
-         x="60.03"
+         x="60.01"
 	 y="-734" 
 	 z="297.8018"/>
        <rotationref ref="rIdentity"/>
@@ -12006,14 +12239,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_4-3"/>
        <position name="posOpArapuca3-Lat-4" unit="cm" 
-         x="60.03"
+         x="60.01"
 	 y="-733.26" 
 	 z="297.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_4-4"/>
        <position name="posArapuca4-Lat-4" unit="cm" 
-         x="285.03"
+         x="285.01"
 	 y="734" 
 	 z="297.8018"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -12021,14 +12254,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_4-4"/>
        <position name="posOpArapuca4-Lat-4" unit="cm" 
-         x="285.03"
+         x="285.01"
 	 y="733.26" 
 	 z="297.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_4-5"/>
        <position name="posArapuca5-Lat-4" unit="cm" 
-         x="210.03"
+         x="210.01"
 	 y="734" 
 	 z="297.8018"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -12036,14 +12269,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_4-5"/>
        <position name="posOpArapuca5-Lat-4" unit="cm" 
-         x="210.03"
+         x="210.01"
 	 y="733.26" 
 	 z="297.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_4-6"/>
        <position name="posArapuca6-Lat-4" unit="cm" 
-         x="135.03"
+         x="135.01"
 	 y="734" 
 	 z="297.8018"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -12051,14 +12284,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_4-6"/>
        <position name="posOpArapuca6-Lat-4" unit="cm" 
-         x="135.03"
+         x="135.01"
 	 y="733.26" 
 	 z="297.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_4-7"/>
        <position name="posArapuca7-Lat-4" unit="cm" 
-         x="60.03"
+         x="60.01"
 	 y="734" 
 	 z="297.8018"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -12066,14 +12299,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_4-7"/>
        <position name="posOpArapuca7-Lat-4" unit="cm" 
-         x="60.03"
+         x="60.01"
 	 y="733.26" 
 	 z="297.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_5-0"/>
        <position name="posArapuca0-Lat-5" unit="cm" 
-         x="285.03"
+         x="285.01"
 	 y="-734" 
 	 z="595.6036"/>
        <rotationref ref="rIdentity"/>
@@ -12081,14 +12314,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_5-0"/>
        <position name="posOpArapuca0-Lat-5" unit="cm" 
-         x="285.03"
+         x="285.01"
 	 y="-733.26" 
 	 z="595.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_5-1"/>
        <position name="posArapuca1-Lat-5" unit="cm" 
-         x="210.03"
+         x="210.01"
 	 y="-734" 
 	 z="595.6036"/>
        <rotationref ref="rIdentity"/>
@@ -12096,14 +12329,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_5-1"/>
        <position name="posOpArapuca1-Lat-5" unit="cm" 
-         x="210.03"
+         x="210.01"
 	 y="-733.26" 
 	 z="595.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_5-2"/>
        <position name="posArapuca2-Lat-5" unit="cm" 
-         x="135.03"
+         x="135.01"
 	 y="-734" 
 	 z="595.6036"/>
        <rotationref ref="rIdentity"/>
@@ -12111,14 +12344,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_5-2"/>
        <position name="posOpArapuca2-Lat-5" unit="cm" 
-         x="135.03"
+         x="135.01"
 	 y="-733.26" 
 	 z="595.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_5-3"/>
        <position name="posArapuca3-Lat-5" unit="cm" 
-         x="60.03"
+         x="60.01"
 	 y="-734" 
 	 z="595.6036"/>
        <rotationref ref="rIdentity"/>
@@ -12126,14 +12359,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_5-3"/>
        <position name="posOpArapuca3-Lat-5" unit="cm" 
-         x="60.03"
+         x="60.01"
 	 y="-733.26" 
 	 z="595.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_5-4"/>
        <position name="posArapuca4-Lat-5" unit="cm" 
-         x="285.03"
+         x="285.01"
 	 y="734" 
 	 z="595.6036"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -12141,14 +12374,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_5-4"/>
        <position name="posOpArapuca4-Lat-5" unit="cm" 
-         x="285.03"
+         x="285.01"
 	 y="733.26" 
 	 z="595.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_5-5"/>
        <position name="posArapuca5-Lat-5" unit="cm" 
-         x="210.03"
+         x="210.01"
 	 y="734" 
 	 z="595.6036"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -12156,14 +12389,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_5-5"/>
        <position name="posOpArapuca5-Lat-5" unit="cm" 
-         x="210.03"
+         x="210.01"
 	 y="733.26" 
 	 z="595.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_5-6"/>
        <position name="posArapuca6-Lat-5" unit="cm" 
-         x="135.03"
+         x="135.01"
 	 y="734" 
 	 z="595.6036"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -12171,14 +12404,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_5-6"/>
        <position name="posOpArapuca6-Lat-5" unit="cm" 
-         x="135.03"
+         x="135.01"
 	 y="733.26" 
 	 z="595.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_5-7"/>
        <position name="posArapuca7-Lat-5" unit="cm" 
-         x="60.03"
+         x="60.01"
 	 y="734" 
 	 z="595.6036"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -12186,14 +12419,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_5-7"/>
        <position name="posOpArapuca7-Lat-5" unit="cm" 
-         x="60.03"
+         x="60.01"
 	 y="733.26" 
 	 z="595.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_6-0"/>
        <position name="posArapuca0-Lat-6" unit="cm" 
-         x="285.03"
+         x="285.01"
 	 y="-734" 
 	 z="893.4054"/>
        <rotationref ref="rIdentity"/>
@@ -12201,14 +12434,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_6-0"/>
        <position name="posOpArapuca0-Lat-6" unit="cm" 
-         x="285.03"
+         x="285.01"
 	 y="-733.26" 
 	 z="893.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_6-1"/>
        <position name="posArapuca1-Lat-6" unit="cm" 
-         x="210.03"
+         x="210.01"
 	 y="-734" 
 	 z="893.4054"/>
        <rotationref ref="rIdentity"/>
@@ -12216,14 +12449,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_6-1"/>
        <position name="posOpArapuca1-Lat-6" unit="cm" 
-         x="210.03"
+         x="210.01"
 	 y="-733.26" 
 	 z="893.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_6-2"/>
        <position name="posArapuca2-Lat-6" unit="cm" 
-         x="135.03"
+         x="135.01"
 	 y="-734" 
 	 z="893.4054"/>
        <rotationref ref="rIdentity"/>
@@ -12231,14 +12464,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_6-2"/>
        <position name="posOpArapuca2-Lat-6" unit="cm" 
-         x="135.03"
+         x="135.01"
 	 y="-733.26" 
 	 z="893.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_6-3"/>
        <position name="posArapuca3-Lat-6" unit="cm" 
-         x="60.03"
+         x="60.01"
 	 y="-734" 
 	 z="893.4054"/>
        <rotationref ref="rIdentity"/>
@@ -12246,14 +12479,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_6-3"/>
        <position name="posOpArapuca3-Lat-6" unit="cm" 
-         x="60.03"
+         x="60.01"
 	 y="-733.26" 
 	 z="893.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_6-4"/>
        <position name="posArapuca4-Lat-6" unit="cm" 
-         x="285.03"
+         x="285.01"
 	 y="734" 
 	 z="893.4054"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -12261,14 +12494,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_6-4"/>
        <position name="posOpArapuca4-Lat-6" unit="cm" 
-         x="285.03"
+         x="285.01"
 	 y="733.26" 
 	 z="893.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_6-5"/>
        <position name="posArapuca5-Lat-6" unit="cm" 
-         x="210.03"
+         x="210.01"
 	 y="734" 
 	 z="893.4054"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -12276,14 +12509,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_6-5"/>
        <position name="posOpArapuca5-Lat-6" unit="cm" 
-         x="210.03"
+         x="210.01"
 	 y="733.26" 
 	 z="893.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_6-6"/>
        <position name="posArapuca6-Lat-6" unit="cm" 
-         x="135.03"
+         x="135.01"
 	 y="734" 
 	 z="893.4054"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -12291,14 +12524,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_6-6"/>
        <position name="posOpArapuca6-Lat-6" unit="cm" 
-         x="135.03"
+         x="135.01"
 	 y="733.26" 
 	 z="893.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_6-7"/>
        <position name="posArapuca7-Lat-6" unit="cm" 
-         x="60.03"
+         x="60.01"
 	 y="734" 
 	 z="893.4054"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -12306,7 +12539,7 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_6-7"/>
        <position name="posOpArapuca7-Lat-6" unit="cm" 
-         x="60.03"
+         x="60.01"
 	 y="733.26" 
 	 z="893.4054"/>
      </physvol>

--- a/dunecore/Geometry/gdml/dunevd10kt_3view_v3_refactored_1x8x14ref.gdml
+++ b/dunecore/Geometry/gdml/dunevd10kt_3view_v3_refactored_1x8x14ref.gdml
@@ -489,7 +489,7 @@
     
 
    <box name="CRM"
-      x="650.08" 
+      x="650.1" 
       y="168" 
       z="148.9009"
       lunit="cm"/>
@@ -1848,12 +1848,12 @@
 
 
     <box name="Cryostat" lunit="cm" 
-      x="850.32" 
+      x="850.34" 
       y="1548.24" 
       z="2291.8526"/>
 
     <box name="ArgonInterior" lunit="cm" 
-      x="850.08"
+      x="850.1"
       y="1548"
       z="2291.6126"/>
 
@@ -1863,12 +1863,12 @@
       z="2291.6126"/>
 
     <box name="ExternalAuxOut" lunit="cm" 
-      x="850.08 - 100"
+      x="850.1 - 100"
       y="1548 - 2*2.5 - 2*40"
       z="2291.6126"/>
 
     <box name="ExternalAuxIn" lunit="cm" 
-      x="850.08"
+      x="850.1"
       y="1359.17"
       z="2291.6126 + 1"/>
 
@@ -1976,7 +1976,7 @@
     </subtraction>
 
     <box name="FoamPadBlock" lunit="cm"
-      x="1010.32"
+      x="1010.34"
       y="1708.24"
       z="2451.8526" />
 
@@ -1987,7 +1987,7 @@
     </subtraction>
 
     <box name="SteelSupportBlock" lunit="cm"
-      x="1210.32"
+      x="1210.34"
       y="1908.24"
       z="2651.8526" />
 
@@ -1998,13 +1998,13 @@
     </subtraction>
 
     <box name="DetEnclosure" lunit="cm" 
-      x="1310.32"
+      x="1310.34"
       y="2108.24"
       z="2851.8526"/>
 
 
     <box name="World" lunit="cm" 
-      x="9310.32" 
+      x="9310.34" 
       y="10108.24" 
       z="10851.8526"/>
 </solids>
@@ -7402,31 +7402,31 @@
        <physvol>
        <volumeref ref="volTPCPlaneU"/>
        <position name="posPlaneU" unit="cm" 
-         x="324.97" y="0" z="0"/>
+         x="324.98" y="0" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volTPCPlaneY"/>
        <position name="posPlaneY" unit="cm" 
-         x="324.99" y="0" z="0"/>
+         x="325" y="0" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volTPCPlaneZ"/>
        <position name="posPlaneZ" unit="cm" 
-         x="325.01" y="0" z="0"/>
+         x="325.02" y="0" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volAnodePlate"/>
        <position name="posAnodePlate" unit="cm" 
-         x="325.03" y="0" z="0"/>
+         x="325.04" y="0" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>    
      <physvol>
        <volumeref ref="volTPCActive"/>
        <position name="posActive" unit="cm" 
-        x="-0.04" y="" z="0"/>
+        x="-0.05" y="" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
    </volume>
@@ -8801,7 +8801,7 @@
       <solidref ref="Cryostat" />
       <physvol>
         <volumeref ref="volGaseousArgon"/>
-        <position name="posGaseousArgon" unit="cm" x="375.04" y="0" z="0"/>
+        <position name="posGaseousArgon" unit="cm" x="375.05" y="0" z="0"/>
       </physvol>
       <physvol>
         <volumeref ref="volSteelShell"/>
@@ -9373,660 +9373,660 @@
       </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper0" unit="cm"  x="-322.04" y="-676.3" z="0" />
+     <position name="posFieldShaper0" unit="cm"  x="-322.05" y="-676.3" z="0" />
      <rotation name="rotFS0" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper1" unit="cm"  x="-316.04" y="-676.3" z="0" />
+     <position name="posFieldShaper1" unit="cm"  x="-316.05" y="-676.3" z="0" />
      <rotation name="rotFS1" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper2" unit="cm"  x="-310.04" y="-676.3" z="0" />
+     <position name="posFieldShaper2" unit="cm"  x="-310.05" y="-676.3" z="0" />
      <rotation name="rotFS2" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper3" unit="cm"  x="-304.04" y="-676.3" z="0" />
+     <position name="posFieldShaper3" unit="cm"  x="-304.05" y="-676.3" z="0" />
      <rotation name="rotFS3" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper4" unit="cm"  x="-298.04" y="-676.3" z="0" />
+     <position name="posFieldShaper4" unit="cm"  x="-298.05" y="-676.3" z="0" />
      <rotation name="rotFS4" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper5" unit="cm"  x="-292.04" y="-676.3" z="0" />
+     <position name="posFieldShaper5" unit="cm"  x="-292.05" y="-676.3" z="0" />
      <rotation name="rotFS5" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper6" unit="cm"  x="-286.04" y="-676.3" z="0" />
+     <position name="posFieldShaper6" unit="cm"  x="-286.05" y="-676.3" z="0" />
      <rotation name="rotFS6" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper7" unit="cm"  x="-280.04" y="-676.3" z="0" />
+     <position name="posFieldShaper7" unit="cm"  x="-280.05" y="-676.3" z="0" />
      <rotation name="rotFS7" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper8" unit="cm"  x="-274.04" y="-676.3" z="0" />
+     <position name="posFieldShaper8" unit="cm"  x="-274.05" y="-676.3" z="0" />
      <rotation name="rotFS8" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper9" unit="cm"  x="-268.04" y="-676.3" z="0" />
+     <position name="posFieldShaper9" unit="cm"  x="-268.05" y="-676.3" z="0" />
      <rotation name="rotFS9" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper10" unit="cm"  x="-262.04" y="-676.3" z="0" />
+     <position name="posFieldShaper10" unit="cm"  x="-262.05" y="-676.3" z="0" />
      <rotation name="rotFS10" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper11" unit="cm"  x="-256.04" y="-676.3" z="0" />
+     <position name="posFieldShaper11" unit="cm"  x="-256.05" y="-676.3" z="0" />
      <rotation name="rotFS11" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper12" unit="cm"  x="-250.04" y="-676.3" z="0" />
+     <position name="posFieldShaper12" unit="cm"  x="-250.05" y="-676.3" z="0" />
      <rotation name="rotFS12" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper13" unit="cm"  x="-244.04" y="-676.3" z="0" />
+     <position name="posFieldShaper13" unit="cm"  x="-244.05" y="-676.3" z="0" />
      <rotation name="rotFS13" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper14" unit="cm"  x="-238.04" y="-676.3" z="0" />
+     <position name="posFieldShaper14" unit="cm"  x="-238.05" y="-676.3" z="0" />
      <rotation name="rotFS14" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper15" unit="cm"  x="-232.04" y="-676.3" z="0" />
+     <position name="posFieldShaper15" unit="cm"  x="-232.05" y="-676.3" z="0" />
      <rotation name="rotFS15" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper16" unit="cm"  x="-226.04" y="-676.3" z="0" />
+     <position name="posFieldShaper16" unit="cm"  x="-226.05" y="-676.3" z="0" />
      <rotation name="rotFS16" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper17" unit="cm"  x="-220.04" y="-676.3" z="0" />
+     <position name="posFieldShaper17" unit="cm"  x="-220.05" y="-676.3" z="0" />
      <rotation name="rotFS17" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper18" unit="cm"  x="-214.04" y="-676.3" z="0" />
+     <position name="posFieldShaper18" unit="cm"  x="-214.05" y="-676.3" z="0" />
      <rotation name="rotFS18" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper19" unit="cm"  x="-208.04" y="-676.3" z="0" />
+     <position name="posFieldShaper19" unit="cm"  x="-208.05" y="-676.3" z="0" />
      <rotation name="rotFS19" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper20" unit="cm"  x="-202.04" y="-676.3" z="0" />
+     <position name="posFieldShaper20" unit="cm"  x="-202.05" y="-676.3" z="0" />
      <rotation name="rotFS20" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper21" unit="cm"  x="-196.04" y="-676.3" z="0" />
+     <position name="posFieldShaper21" unit="cm"  x="-196.05" y="-676.3" z="0" />
      <rotation name="rotFS21" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper22" unit="cm"  x="-190.04" y="-676.3" z="0" />
+     <position name="posFieldShaper22" unit="cm"  x="-190.05" y="-676.3" z="0" />
      <rotation name="rotFS22" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper23" unit="cm"  x="-184.04" y="-676.3" z="0" />
+     <position name="posFieldShaper23" unit="cm"  x="-184.05" y="-676.3" z="0" />
      <rotation name="rotFS23" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper24" unit="cm"  x="-178.04" y="-676.3" z="0" />
+     <position name="posFieldShaper24" unit="cm"  x="-178.05" y="-676.3" z="0" />
      <rotation name="rotFS24" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper25" unit="cm"  x="-172.04" y="-676.3" z="0" />
+     <position name="posFieldShaper25" unit="cm"  x="-172.05" y="-676.3" z="0" />
      <rotation name="rotFS25" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper26" unit="cm"  x="-166.04" y="-676.3" z="0" />
+     <position name="posFieldShaper26" unit="cm"  x="-166.05" y="-676.3" z="0" />
      <rotation name="rotFS26" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper27" unit="cm"  x="-160.04" y="-676.3" z="0" />
+     <position name="posFieldShaper27" unit="cm"  x="-160.05" y="-676.3" z="0" />
      <rotation name="rotFS27" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper28" unit="cm"  x="-154.04" y="-676.3" z="0" />
+     <position name="posFieldShaper28" unit="cm"  x="-154.05" y="-676.3" z="0" />
      <rotation name="rotFS28" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper29" unit="cm"  x="-148.04" y="-676.3" z="0" />
+     <position name="posFieldShaper29" unit="cm"  x="-148.05" y="-676.3" z="0" />
      <rotation name="rotFS29" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper30" unit="cm"  x="-142.04" y="-676.3" z="0" />
+     <position name="posFieldShaper30" unit="cm"  x="-142.05" y="-676.3" z="0" />
      <rotation name="rotFS30" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper31" unit="cm"  x="-136.04" y="-676.3" z="0" />
+     <position name="posFieldShaper31" unit="cm"  x="-136.05" y="-676.3" z="0" />
      <rotation name="rotFS31" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper32" unit="cm"  x="-130.04" y="-676.3" z="0" />
+     <position name="posFieldShaper32" unit="cm"  x="-130.05" y="-676.3" z="0" />
      <rotation name="rotFS32" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper33" unit="cm"  x="-124.04" y="-676.3" z="0" />
+     <position name="posFieldShaper33" unit="cm"  x="-124.05" y="-676.3" z="0" />
      <rotation name="rotFS33" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper34" unit="cm"  x="-118.04" y="-676.3" z="0" />
+     <position name="posFieldShaper34" unit="cm"  x="-118.05" y="-676.3" z="0" />
      <rotation name="rotFS34" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper35" unit="cm"  x="-112.04" y="-676.3" z="0" />
+     <position name="posFieldShaper35" unit="cm"  x="-112.05" y="-676.3" z="0" />
      <rotation name="rotFS35" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper36" unit="cm"  x="-106.04" y="-676.3" z="0" />
+     <position name="posFieldShaper36" unit="cm"  x="-106.05" y="-676.3" z="0" />
      <rotation name="rotFS36" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper37" unit="cm"  x="-100.04" y="-676.3" z="0" />
+     <position name="posFieldShaper37" unit="cm"  x="-100.05" y="-676.3" z="0" />
      <rotation name="rotFS37" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper38" unit="cm"  x="-94.04" y="-676.3" z="0" />
+     <position name="posFieldShaper38" unit="cm"  x="-94.0500000000001" y="-676.3" z="0" />
      <rotation name="rotFS38" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper39" unit="cm"  x="-88.04" y="-676.3" z="0" />
+     <position name="posFieldShaper39" unit="cm"  x="-88.0500000000001" y="-676.3" z="0" />
      <rotation name="rotFS39" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper40" unit="cm"  x="-82.04" y="-676.3" z="0" />
+     <position name="posFieldShaper40" unit="cm"  x="-82.0500000000001" y="-676.3" z="0" />
      <rotation name="rotFS40" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper41" unit="cm"  x="-76.04" y="-676.3" z="0" />
+     <position name="posFieldShaper41" unit="cm"  x="-76.0500000000001" y="-676.3" z="0" />
      <rotation name="rotFS41" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper42" unit="cm"  x="-70.04" y="-676.3" z="0" />
+     <position name="posFieldShaper42" unit="cm"  x="-70.0500000000001" y="-676.3" z="0" />
      <rotation name="rotFS42" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper43" unit="cm"  x="-64.04" y="-676.3" z="0" />
+     <position name="posFieldShaper43" unit="cm"  x="-64.0500000000001" y="-676.3" z="0" />
      <rotation name="rotFS43" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper44" unit="cm"  x="-58.04" y="-676.3" z="0" />
+     <position name="posFieldShaper44" unit="cm"  x="-58.0500000000001" y="-676.3" z="0" />
      <rotation name="rotFS44" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper45" unit="cm"  x="-52.04" y="-676.3" z="0" />
+     <position name="posFieldShaper45" unit="cm"  x="-52.0500000000001" y="-676.3" z="0" />
      <rotation name="rotFS45" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper46" unit="cm"  x="-46.04" y="-676.3" z="0" />
+     <position name="posFieldShaper46" unit="cm"  x="-46.0500000000001" y="-676.3" z="0" />
      <rotation name="rotFS46" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper47" unit="cm"  x="-40.04" y="-676.3" z="0" />
+     <position name="posFieldShaper47" unit="cm"  x="-40.0500000000001" y="-676.3" z="0" />
      <rotation name="rotFS47" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper48" unit="cm"  x="-34.04" y="-676.3" z="0" />
+     <position name="posFieldShaper48" unit="cm"  x="-34.0500000000001" y="-676.3" z="0" />
      <rotation name="rotFS48" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper49" unit="cm"  x="-28.04" y="-676.3" z="0" />
+     <position name="posFieldShaper49" unit="cm"  x="-28.0500000000001" y="-676.3" z="0" />
      <rotation name="rotFS49" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper50" unit="cm"  x="-22.04" y="-676.3" z="0" />
+     <position name="posFieldShaper50" unit="cm"  x="-22.0500000000001" y="-676.3" z="0" />
      <rotation name="rotFS50" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper51" unit="cm"  x="-16.04" y="-676.3" z="0" />
+     <position name="posFieldShaper51" unit="cm"  x="-16.0500000000001" y="-676.3" z="0" />
      <rotation name="rotFS51" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper52" unit="cm"  x="-10.04" y="-676.3" z="0" />
+     <position name="posFieldShaper52" unit="cm"  x="-10.0500000000001" y="-676.3" z="0" />
      <rotation name="rotFS52" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper53" unit="cm"  x="-4.04000000000001" y="-676.3" z="0" />
+     <position name="posFieldShaper53" unit="cm"  x="-4.05000000000005" y="-676.3" z="0" />
      <rotation name="rotFS53" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper54" unit="cm"  x="1.95999999999999" y="-676.3" z="0" />
+     <position name="posFieldShaper54" unit="cm"  x="1.94999999999995" y="-676.3" z="0" />
      <rotation name="rotFS54" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper55" unit="cm"  x="7.95999999999999" y="-676.3" z="0" />
+     <position name="posFieldShaper55" unit="cm"  x="7.94999999999995" y="-676.3" z="0" />
      <rotation name="rotFS55" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper56" unit="cm"  x="13.96" y="-676.3" z="0" />
+     <position name="posFieldShaper56" unit="cm"  x="13.9499999999999" y="-676.3" z="0" />
      <rotation name="rotFS56" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper57" unit="cm"  x="19.96" y="-676.3" z="0" />
+     <position name="posFieldShaper57" unit="cm"  x="19.9499999999999" y="-676.3" z="0" />
      <rotation name="rotFS57" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper58" unit="cm"  x="25.96" y="-676.3" z="0" />
+     <position name="posFieldShaper58" unit="cm"  x="25.9499999999999" y="-676.3" z="0" />
      <rotation name="rotFS58" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper59" unit="cm"  x="31.96" y="-676.3" z="0" />
+     <position name="posFieldShaper59" unit="cm"  x="31.9499999999999" y="-676.3" z="0" />
      <rotation name="rotFS59" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper60" unit="cm"  x="37.96" y="-676.3" z="0" />
+     <position name="posFieldShaper60" unit="cm"  x="37.9499999999999" y="-676.3" z="0" />
      <rotation name="rotFS60" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper61" unit="cm"  x="43.96" y="-676.3" z="0" />
+     <position name="posFieldShaper61" unit="cm"  x="43.9499999999999" y="-676.3" z="0" />
      <rotation name="rotFS61" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper62" unit="cm"  x="49.96" y="-676.3" z="0" />
+     <position name="posFieldShaper62" unit="cm"  x="49.9499999999999" y="-676.3" z="0" />
      <rotation name="rotFS62" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper63" unit="cm"  x="55.96" y="-676.3" z="0" />
+     <position name="posFieldShaper63" unit="cm"  x="55.9499999999999" y="-676.3" z="0" />
      <rotation name="rotFS63" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper64" unit="cm"  x="61.96" y="-676.3" z="0" />
+     <position name="posFieldShaper64" unit="cm"  x="61.9499999999999" y="-676.3" z="0" />
      <rotation name="rotFS64" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper65" unit="cm"  x="67.96" y="-676.3" z="0" />
+     <position name="posFieldShaper65" unit="cm"  x="67.9499999999999" y="-676.3" z="0" />
      <rotation name="rotFS65" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper66" unit="cm"  x="73.96" y="-676.3" z="0" />
+     <position name="posFieldShaper66" unit="cm"  x="73.9499999999999" y="-676.3" z="0" />
      <rotation name="rotFS66" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper67" unit="cm"  x="79.96" y="-676.3" z="0" />
+     <position name="posFieldShaper67" unit="cm"  x="79.9499999999999" y="-676.3" z="0" />
      <rotation name="rotFS67" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper68" unit="cm"  x="85.96" y="-676.3" z="0" />
+     <position name="posFieldShaper68" unit="cm"  x="85.9499999999999" y="-676.3" z="0" />
      <rotation name="rotFS68" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper69" unit="cm"  x="91.96" y="-676.3" z="0" />
+     <position name="posFieldShaper69" unit="cm"  x="91.9499999999999" y="-676.3" z="0" />
      <rotation name="rotFS69" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper70" unit="cm"  x="97.96" y="-676.3" z="0" />
+     <position name="posFieldShaper70" unit="cm"  x="97.9499999999999" y="-676.3" z="0" />
      <rotation name="rotFS70" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper71" unit="cm"  x="103.96" y="-676.3" z="0" />
+     <position name="posFieldShaper71" unit="cm"  x="103.95" y="-676.3" z="0" />
      <rotation name="rotFS71" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper72" unit="cm"  x="109.96" y="-676.3" z="0" />
+     <position name="posFieldShaper72" unit="cm"  x="109.95" y="-676.3" z="0" />
      <rotation name="rotFS72" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper73" unit="cm"  x="115.96" y="-676.3" z="0" />
+     <position name="posFieldShaper73" unit="cm"  x="115.95" y="-676.3" z="0" />
      <rotation name="rotFS73" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper74" unit="cm"  x="121.96" y="-676.3" z="0" />
+     <position name="posFieldShaper74" unit="cm"  x="121.95" y="-676.3" z="0" />
      <rotation name="rotFS74" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper75" unit="cm"  x="127.96" y="-676.3" z="0" />
+     <position name="posFieldShaper75" unit="cm"  x="127.95" y="-676.3" z="0" />
      <rotation name="rotFS75" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper76" unit="cm"  x="133.96" y="-676.3" z="0" />
+     <position name="posFieldShaper76" unit="cm"  x="133.95" y="-676.3" z="0" />
      <rotation name="rotFS76" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper77" unit="cm"  x="139.96" y="-676.3" z="0" />
+     <position name="posFieldShaper77" unit="cm"  x="139.95" y="-676.3" z="0" />
      <rotation name="rotFS77" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper78" unit="cm"  x="145.96" y="-676.3" z="0" />
+     <position name="posFieldShaper78" unit="cm"  x="145.95" y="-676.3" z="0" />
      <rotation name="rotFS78" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper79" unit="cm"  x="151.96" y="-676.3" z="0" />
+     <position name="posFieldShaper79" unit="cm"  x="151.95" y="-676.3" z="0" />
      <rotation name="rotFS79" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper80" unit="cm"  x="157.96" y="-676.3" z="0" />
+     <position name="posFieldShaper80" unit="cm"  x="157.95" y="-676.3" z="0" />
      <rotation name="rotFS80" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper81" unit="cm"  x="163.96" y="-676.3" z="0" />
+     <position name="posFieldShaper81" unit="cm"  x="163.95" y="-676.3" z="0" />
      <rotation name="rotFS81" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper82" unit="cm"  x="169.96" y="-676.3" z="0" />
+     <position name="posFieldShaper82" unit="cm"  x="169.95" y="-676.3" z="0" />
      <rotation name="rotFS82" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper83" unit="cm"  x="175.96" y="-676.3" z="0" />
+     <position name="posFieldShaper83" unit="cm"  x="175.95" y="-676.3" z="0" />
      <rotation name="rotFS83" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper84" unit="cm"  x="181.96" y="-676.3" z="0" />
+     <position name="posFieldShaper84" unit="cm"  x="181.95" y="-676.3" z="0" />
      <rotation name="rotFS84" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper85" unit="cm"  x="187.96" y="-676.3" z="0" />
+     <position name="posFieldShaper85" unit="cm"  x="187.95" y="-676.3" z="0" />
      <rotation name="rotFS85" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper86" unit="cm"  x="193.96" y="-676.3" z="0" />
+     <position name="posFieldShaper86" unit="cm"  x="193.95" y="-676.3" z="0" />
      <rotation name="rotFS86" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper87" unit="cm"  x="199.96" y="-676.3" z="0" />
+     <position name="posFieldShaper87" unit="cm"  x="199.95" y="-676.3" z="0" />
      <rotation name="rotFS87" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper88" unit="cm"  x="205.96" y="-676.3" z="0" />
+     <position name="posFieldShaper88" unit="cm"  x="205.95" y="-676.3" z="0" />
      <rotation name="rotFS88" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper89" unit="cm"  x="211.96" y="-676.3" z="0" />
+     <position name="posFieldShaper89" unit="cm"  x="211.95" y="-676.3" z="0" />
      <rotation name="rotFS89" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper90" unit="cm"  x="217.96" y="-676.3" z="0" />
+     <position name="posFieldShaper90" unit="cm"  x="217.95" y="-676.3" z="0" />
      <rotation name="rotFS90" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper91" unit="cm"  x="223.96" y="-676.3" z="0" />
+     <position name="posFieldShaper91" unit="cm"  x="223.95" y="-676.3" z="0" />
      <rotation name="rotFS91" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper92" unit="cm"  x="229.96" y="-676.3" z="0" />
+     <position name="posFieldShaper92" unit="cm"  x="229.95" y="-676.3" z="0" />
      <rotation name="rotFS92" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper93" unit="cm"  x="235.96" y="-676.3" z="0" />
+     <position name="posFieldShaper93" unit="cm"  x="235.95" y="-676.3" z="0" />
      <rotation name="rotFS93" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper94" unit="cm"  x="241.96" y="-676.3" z="0" />
+     <position name="posFieldShaper94" unit="cm"  x="241.95" y="-676.3" z="0" />
      <rotation name="rotFS94" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper95" unit="cm"  x="247.96" y="-676.3" z="0" />
+     <position name="posFieldShaper95" unit="cm"  x="247.95" y="-676.3" z="0" />
      <rotation name="rotFS95" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper96" unit="cm"  x="253.96" y="-676.3" z="0" />
+     <position name="posFieldShaper96" unit="cm"  x="253.95" y="-676.3" z="0" />
      <rotation name="rotFS96" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper97" unit="cm"  x="259.96" y="-676.3" z="0" />
+     <position name="posFieldShaper97" unit="cm"  x="259.95" y="-676.3" z="0" />
      <rotation name="rotFS97" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper98" unit="cm"  x="265.96" y="-676.3" z="0" />
+     <position name="posFieldShaper98" unit="cm"  x="265.95" y="-676.3" z="0" />
      <rotation name="rotFS98" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper99" unit="cm"  x="271.96" y="-676.3" z="0" />
+     <position name="posFieldShaper99" unit="cm"  x="271.95" y="-676.3" z="0" />
      <rotation name="rotFS99" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper100" unit="cm"  x="277.96" y="-676.3" z="0" />
+     <position name="posFieldShaper100" unit="cm"  x="277.95" y="-676.3" z="0" />
      <rotation name="rotFS100" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper101" unit="cm"  x="283.96" y="-676.3" z="0" />
+     <position name="posFieldShaper101" unit="cm"  x="283.95" y="-676.3" z="0" />
      <rotation name="rotFS101" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper102" unit="cm"  x="289.96" y="-676.3" z="0" />
+     <position name="posFieldShaper102" unit="cm"  x="289.95" y="-676.3" z="0" />
      <rotation name="rotFS102" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper103" unit="cm"  x="295.96" y="-676.3" z="0" />
+     <position name="posFieldShaper103" unit="cm"  x="295.95" y="-676.3" z="0" />
      <rotation name="rotFS103" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper104" unit="cm"  x="301.96" y="-676.3" z="0" />
+     <position name="posFieldShaper104" unit="cm"  x="301.95" y="-676.3" z="0" />
      <rotation name="rotFS104" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper105" unit="cm"  x="307.96" y="-676.3" z="0" />
+     <position name="posFieldShaper105" unit="cm"  x="307.95" y="-676.3" z="0" />
      <rotation name="rotFS105" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper106" unit="cm"  x="313.96" y="-676.3" z="0" />
+     <position name="posFieldShaper106" unit="cm"  x="313.95" y="-676.3" z="0" />
      <rotation name="rotFS106" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper107" unit="cm"  x="319.96" y="-676.3" z="0" />
+     <position name="posFieldShaper107" unit="cm"  x="319.95" y="-676.3" z="0" />
      <rotation name="rotFS107" unit="deg" x="0" y="0" z="90" />
   </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-0" unit="cm" x="-328.04" y="-506" z="-896.9054"/>
+   <position name="posGroundGrid-0" unit="cm" x="-328.05" y="-506" z="-896.9054"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-1" unit="cm" x="-328.04" y="-170" z="-896.9054"/>
+   <position name="posGroundGrid-1" unit="cm" x="-328.05" y="-170" z="-896.9054"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-2" unit="cm" x="-328.04" y="166" z="-896.9054"/>
+   <position name="posGroundGrid-2" unit="cm" x="-328.05" y="166" z="-896.9054"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-3" unit="cm" x="-328.04" y="502" z="-896.9054"/>
+   <position name="posGroundGrid-3" unit="cm" x="-328.05" y="502" z="-896.9054"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-4" unit="cm" x="-328.04" y="-506" z="-599.1036"/>
+   <position name="posGroundGrid-4" unit="cm" x="-328.05" y="-506" z="-599.1036"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-5" unit="cm" x="-328.04" y="-170" z="-599.1036"/>
+   <position name="posGroundGrid-5" unit="cm" x="-328.05" y="-170" z="-599.1036"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-6" unit="cm" x="-328.04" y="166" z="-599.1036"/>
+   <position name="posGroundGrid-6" unit="cm" x="-328.05" y="166" z="-599.1036"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-7" unit="cm" x="-328.04" y="502" z="-599.1036"/>
+   <position name="posGroundGrid-7" unit="cm" x="-328.05" y="502" z="-599.1036"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-8" unit="cm" x="-328.04" y="-506" z="-301.3018"/>
+   <position name="posGroundGrid-8" unit="cm" x="-328.05" y="-506" z="-301.3018"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-9" unit="cm" x="-328.04" y="-170" z="-301.3018"/>
+   <position name="posGroundGrid-9" unit="cm" x="-328.05" y="-170" z="-301.3018"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-10" unit="cm" x="-328.04" y="166" z="-301.3018"/>
+   <position name="posGroundGrid-10" unit="cm" x="-328.05" y="166" z="-301.3018"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-11" unit="cm" x="-328.04" y="502" z="-301.3018"/>
+   <position name="posGroundGrid-11" unit="cm" x="-328.05" y="502" z="-301.3018"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-12" unit="cm" x="-328.04" y="-506" z="-3.49999999999989"/>
+   <position name="posGroundGrid-12" unit="cm" x="-328.05" y="-506" z="-3.49999999999989"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-13" unit="cm" x="-328.04" y="-170" z="-3.49999999999989"/>
+   <position name="posGroundGrid-13" unit="cm" x="-328.05" y="-170" z="-3.49999999999989"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-14" unit="cm" x="-328.04" y="166" z="-3.49999999999989"/>
+   <position name="posGroundGrid-14" unit="cm" x="-328.05" y="166" z="-3.49999999999989"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-15" unit="cm" x="-328.04" y="502" z="-3.49999999999989"/>
+   <position name="posGroundGrid-15" unit="cm" x="-328.05" y="502" z="-3.49999999999989"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-16" unit="cm" x="-328.04" y="-506" z="294.3018"/>
+   <position name="posGroundGrid-16" unit="cm" x="-328.05" y="-506" z="294.3018"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-17" unit="cm" x="-328.04" y="-170" z="294.3018"/>
+   <position name="posGroundGrid-17" unit="cm" x="-328.05" y="-170" z="294.3018"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-18" unit="cm" x="-328.04" y="166" z="294.3018"/>
+   <position name="posGroundGrid-18" unit="cm" x="-328.05" y="166" z="294.3018"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-19" unit="cm" x="-328.04" y="502" z="294.3018"/>
+   <position name="posGroundGrid-19" unit="cm" x="-328.05" y="502" z="294.3018"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-20" unit="cm" x="-328.04" y="-506" z="592.1036"/>
+   <position name="posGroundGrid-20" unit="cm" x="-328.05" y="-506" z="592.1036"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-21" unit="cm" x="-328.04" y="-170" z="592.1036"/>
+   <position name="posGroundGrid-21" unit="cm" x="-328.05" y="-170" z="592.1036"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-22" unit="cm" x="-328.04" y="166" z="592.1036"/>
+   <position name="posGroundGrid-22" unit="cm" x="-328.05" y="166" z="592.1036"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-23" unit="cm" x="-328.04" y="502" z="592.1036"/>
+   <position name="posGroundGrid-23" unit="cm" x="-328.05" y="502" z="592.1036"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-24" unit="cm" x="-328.04" y="-506" z="889.9054"/>
+   <position name="posGroundGrid-24" unit="cm" x="-328.05" y="-506" z="889.9054"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-25" unit="cm" x="-328.04" y="-170" z="889.9054"/>
+   <position name="posGroundGrid-25" unit="cm" x="-328.05" y="-170" z="889.9054"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-26" unit="cm" x="-328.04" y="166" z="889.9054"/>
+   <position name="posGroundGrid-26" unit="cm" x="-328.05" y="166" z="889.9054"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-27" unit="cm" x="-328.04" y="502" z="889.9054"/>
+   <position name="posGroundGrid-27" unit="cm" x="-328.05" y="502" z="889.9054"/>
       </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-0-0"/>
        <position name="posArapucaDouble0-Frame-0-0" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-633.7" 
 	 z="-859.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10034,14 +10034,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-0"/>
        <position name="posOpArapucaDouble0-Frame-0-0" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-633.7" 
 	 z="-859.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-0-1"/>
        <position name="posArapucaDouble1-Frame-0-0" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-543" 
 	 z="-1005.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10049,14 +10049,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-1"/>
        <position name="posOpArapucaDouble1-Frame-0-0" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-543" 
 	 z="-1005.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-0-2"/>
        <position name="posArapucaDouble2-Frame-0-0" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-469" 
 	 z="-788.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10064,14 +10064,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-2"/>
        <position name="posOpArapucaDouble2-Frame-0-0" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-469" 
 	 z="-788.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-0-3"/>
        <position name="posArapucaDouble3-Frame-0-0" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-378.3" 
 	 z="-934.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10079,14 +10079,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-3"/>
        <position name="posOpArapucaDouble3-Frame-0-0" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-378.3" 
 	 z="-934.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-1-0"/>
        <position name="posArapucaDouble0-Frame-0-1" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-633.7" 
 	 z="-561.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10094,14 +10094,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-0"/>
        <position name="posOpArapucaDouble0-Frame-0-1" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-633.7" 
 	 z="-561.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-1-1"/>
        <position name="posArapucaDouble1-Frame-0-1" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-543" 
 	 z="-707.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10109,14 +10109,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-1"/>
        <position name="posOpArapucaDouble1-Frame-0-1" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-543" 
 	 z="-707.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-1-2"/>
        <position name="posArapucaDouble2-Frame-0-1" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-469" 
 	 z="-490.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10124,14 +10124,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-2"/>
        <position name="posOpArapucaDouble2-Frame-0-1" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-469" 
 	 z="-490.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-1-3"/>
        <position name="posArapucaDouble3-Frame-0-1" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-378.3" 
 	 z="-636.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10139,14 +10139,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-3"/>
        <position name="posOpArapucaDouble3-Frame-0-1" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-378.3" 
 	 z="-636.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-2-0"/>
        <position name="posArapucaDouble0-Frame-0-2" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-633.7" 
 	 z="-263.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10154,14 +10154,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-0"/>
        <position name="posOpArapucaDouble0-Frame-0-2" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-633.7" 
 	 z="-263.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-2-1"/>
        <position name="posArapucaDouble1-Frame-0-2" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-543" 
 	 z="-409.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10169,14 +10169,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-1"/>
        <position name="posOpArapucaDouble1-Frame-0-2" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-543" 
 	 z="-409.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-2-2"/>
        <position name="posArapucaDouble2-Frame-0-2" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-469" 
 	 z="-192.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10184,14 +10184,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-2"/>
        <position name="posOpArapucaDouble2-Frame-0-2" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-469" 
 	 z="-192.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-2-3"/>
        <position name="posArapucaDouble3-Frame-0-2" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-378.3" 
 	 z="-338.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10199,14 +10199,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-3"/>
        <position name="posOpArapucaDouble3-Frame-0-2" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-378.3" 
 	 z="-338.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-3-0"/>
        <position name="posArapucaDouble0-Frame-0-3" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-633.7" 
 	 z="34.0000000000001"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10214,14 +10214,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-3-0"/>
        <position name="posOpArapucaDouble0-Frame-0-3" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-633.7" 
 	 z="34.0000000000001"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-3-1"/>
        <position name="posArapucaDouble1-Frame-0-3" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-543" 
 	 z="-112"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10229,14 +10229,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-3-1"/>
        <position name="posOpArapucaDouble1-Frame-0-3" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-543" 
 	 z="-112"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-3-2"/>
        <position name="posArapucaDouble2-Frame-0-3" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-469" 
 	 z="105"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10244,14 +10244,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-3-2"/>
        <position name="posOpArapucaDouble2-Frame-0-3" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-469" 
 	 z="105"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-3-3"/>
        <position name="posArapucaDouble3-Frame-0-3" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-378.3" 
 	 z="-40.9999999999999"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10259,14 +10259,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-3-3"/>
        <position name="posOpArapucaDouble3-Frame-0-3" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-378.3" 
 	 z="-40.9999999999999"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-4-0"/>
        <position name="posArapucaDouble0-Frame-0-4" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-633.7" 
 	 z="331.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10274,14 +10274,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-4-0"/>
        <position name="posOpArapucaDouble0-Frame-0-4" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-633.7" 
 	 z="331.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-4-1"/>
        <position name="posArapucaDouble1-Frame-0-4" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-543" 
 	 z="185.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10289,14 +10289,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-4-1"/>
        <position name="posOpArapucaDouble1-Frame-0-4" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-543" 
 	 z="185.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-4-2"/>
        <position name="posArapucaDouble2-Frame-0-4" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-469" 
 	 z="402.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10304,14 +10304,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-4-2"/>
        <position name="posOpArapucaDouble2-Frame-0-4" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-469" 
 	 z="402.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-4-3"/>
        <position name="posArapucaDouble3-Frame-0-4" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-378.3" 
 	 z="256.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10319,14 +10319,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-4-3"/>
        <position name="posOpArapucaDouble3-Frame-0-4" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-378.3" 
 	 z="256.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-5-0"/>
        <position name="posArapucaDouble0-Frame-0-5" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-633.7" 
 	 z="629.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10334,14 +10334,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-5-0"/>
        <position name="posOpArapucaDouble0-Frame-0-5" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-633.7" 
 	 z="629.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-5-1"/>
        <position name="posArapucaDouble1-Frame-0-5" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-543" 
 	 z="483.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10349,14 +10349,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-5-1"/>
        <position name="posOpArapucaDouble1-Frame-0-5" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-543" 
 	 z="483.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-5-2"/>
        <position name="posArapucaDouble2-Frame-0-5" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-469" 
 	 z="700.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10364,14 +10364,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-5-2"/>
        <position name="posOpArapucaDouble2-Frame-0-5" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-469" 
 	 z="700.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-5-3"/>
        <position name="posArapucaDouble3-Frame-0-5" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-378.3" 
 	 z="554.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10379,14 +10379,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-5-3"/>
        <position name="posOpArapucaDouble3-Frame-0-5" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-378.3" 
 	 z="554.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-6-0"/>
        <position name="posArapucaDouble0-Frame-0-6" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-633.7" 
 	 z="927.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10394,14 +10394,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-6-0"/>
        <position name="posOpArapucaDouble0-Frame-0-6" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-633.7" 
 	 z="927.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-6-1"/>
        <position name="posArapucaDouble1-Frame-0-6" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-543" 
 	 z="781.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10409,14 +10409,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-6-1"/>
        <position name="posOpArapucaDouble1-Frame-0-6" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-543" 
 	 z="781.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-6-2"/>
        <position name="posArapucaDouble2-Frame-0-6" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-469" 
 	 z="998.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10424,14 +10424,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-6-2"/>
        <position name="posOpArapucaDouble2-Frame-0-6" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-469" 
 	 z="998.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-6-3"/>
        <position name="posArapucaDouble3-Frame-0-6" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-378.3" 
 	 z="852.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10439,14 +10439,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-6-3"/>
        <position name="posOpArapucaDouble3-Frame-0-6" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-378.3" 
 	 z="852.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-0-0"/>
        <position name="posArapucaDouble0-Frame-1-0" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-297.7" 
 	 z="-859.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10454,14 +10454,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-0"/>
        <position name="posOpArapucaDouble0-Frame-1-0" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-297.7" 
 	 z="-859.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-0-1"/>
        <position name="posArapucaDouble1-Frame-1-0" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-207" 
 	 z="-1005.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10469,14 +10469,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-1"/>
        <position name="posOpArapucaDouble1-Frame-1-0" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-207" 
 	 z="-1005.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-0-2"/>
        <position name="posArapucaDouble2-Frame-1-0" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-133" 
 	 z="-788.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10484,14 +10484,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-2"/>
        <position name="posOpArapucaDouble2-Frame-1-0" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-133" 
 	 z="-788.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-0-3"/>
        <position name="posArapucaDouble3-Frame-1-0" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-42.3" 
 	 z="-934.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10499,14 +10499,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-3"/>
        <position name="posOpArapucaDouble3-Frame-1-0" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-42.3" 
 	 z="-934.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-1-0"/>
        <position name="posArapucaDouble0-Frame-1-1" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-297.7" 
 	 z="-561.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10514,14 +10514,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-0"/>
        <position name="posOpArapucaDouble0-Frame-1-1" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-297.7" 
 	 z="-561.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-1-1"/>
        <position name="posArapucaDouble1-Frame-1-1" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-207" 
 	 z="-707.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10529,14 +10529,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-1"/>
        <position name="posOpArapucaDouble1-Frame-1-1" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-207" 
 	 z="-707.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-1-2"/>
        <position name="posArapucaDouble2-Frame-1-1" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-133" 
 	 z="-490.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10544,14 +10544,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-2"/>
        <position name="posOpArapucaDouble2-Frame-1-1" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-133" 
 	 z="-490.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-1-3"/>
        <position name="posArapucaDouble3-Frame-1-1" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-42.3" 
 	 z="-636.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10559,14 +10559,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-3"/>
        <position name="posOpArapucaDouble3-Frame-1-1" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-42.3" 
 	 z="-636.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-2-0"/>
        <position name="posArapucaDouble0-Frame-1-2" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-297.7" 
 	 z="-263.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10574,14 +10574,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-0"/>
        <position name="posOpArapucaDouble0-Frame-1-2" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-297.7" 
 	 z="-263.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-2-1"/>
        <position name="posArapucaDouble1-Frame-1-2" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-207" 
 	 z="-409.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10589,14 +10589,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-1"/>
        <position name="posOpArapucaDouble1-Frame-1-2" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-207" 
 	 z="-409.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-2-2"/>
        <position name="posArapucaDouble2-Frame-1-2" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-133" 
 	 z="-192.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10604,14 +10604,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-2"/>
        <position name="posOpArapucaDouble2-Frame-1-2" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-133" 
 	 z="-192.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-2-3"/>
        <position name="posArapucaDouble3-Frame-1-2" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-42.3" 
 	 z="-338.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10619,14 +10619,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-3"/>
        <position name="posOpArapucaDouble3-Frame-1-2" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-42.3" 
 	 z="-338.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-3-0"/>
        <position name="posArapucaDouble0-Frame-1-3" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-297.7" 
 	 z="34.0000000000001"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10634,14 +10634,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-3-0"/>
        <position name="posOpArapucaDouble0-Frame-1-3" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-297.7" 
 	 z="34.0000000000001"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-3-1"/>
        <position name="posArapucaDouble1-Frame-1-3" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-207" 
 	 z="-112"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10649,14 +10649,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-3-1"/>
        <position name="posOpArapucaDouble1-Frame-1-3" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-207" 
 	 z="-112"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-3-2"/>
        <position name="posArapucaDouble2-Frame-1-3" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-133" 
 	 z="105"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10664,14 +10664,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-3-2"/>
        <position name="posOpArapucaDouble2-Frame-1-3" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-133" 
 	 z="105"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-3-3"/>
        <position name="posArapucaDouble3-Frame-1-3" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-42.3" 
 	 z="-40.9999999999999"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10679,14 +10679,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-3-3"/>
        <position name="posOpArapucaDouble3-Frame-1-3" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-42.3" 
 	 z="-40.9999999999999"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-4-0"/>
        <position name="posArapucaDouble0-Frame-1-4" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-297.7" 
 	 z="331.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10694,14 +10694,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-4-0"/>
        <position name="posOpArapucaDouble0-Frame-1-4" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-297.7" 
 	 z="331.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-4-1"/>
        <position name="posArapucaDouble1-Frame-1-4" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-207" 
 	 z="185.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10709,14 +10709,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-4-1"/>
        <position name="posOpArapucaDouble1-Frame-1-4" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-207" 
 	 z="185.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-4-2"/>
        <position name="posArapucaDouble2-Frame-1-4" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-133" 
 	 z="402.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10724,14 +10724,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-4-2"/>
        <position name="posOpArapucaDouble2-Frame-1-4" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-133" 
 	 z="402.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-4-3"/>
        <position name="posArapucaDouble3-Frame-1-4" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-42.3" 
 	 z="256.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10739,14 +10739,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-4-3"/>
        <position name="posOpArapucaDouble3-Frame-1-4" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-42.3" 
 	 z="256.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-5-0"/>
        <position name="posArapucaDouble0-Frame-1-5" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-297.7" 
 	 z="629.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10754,14 +10754,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-5-0"/>
        <position name="posOpArapucaDouble0-Frame-1-5" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-297.7" 
 	 z="629.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-5-1"/>
        <position name="posArapucaDouble1-Frame-1-5" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-207" 
 	 z="483.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10769,14 +10769,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-5-1"/>
        <position name="posOpArapucaDouble1-Frame-1-5" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-207" 
 	 z="483.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-5-2"/>
        <position name="posArapucaDouble2-Frame-1-5" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-133" 
 	 z="700.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10784,14 +10784,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-5-2"/>
        <position name="posOpArapucaDouble2-Frame-1-5" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-133" 
 	 z="700.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-5-3"/>
        <position name="posArapucaDouble3-Frame-1-5" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-42.3" 
 	 z="554.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10799,14 +10799,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-5-3"/>
        <position name="posOpArapucaDouble3-Frame-1-5" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-42.3" 
 	 z="554.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-6-0"/>
        <position name="posArapucaDouble0-Frame-1-6" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-297.7" 
 	 z="927.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10814,14 +10814,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-6-0"/>
        <position name="posOpArapucaDouble0-Frame-1-6" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-297.7" 
 	 z="927.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-6-1"/>
        <position name="posArapucaDouble1-Frame-1-6" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-207" 
 	 z="781.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10829,14 +10829,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-6-1"/>
        <position name="posOpArapucaDouble1-Frame-1-6" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-207" 
 	 z="781.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-6-2"/>
        <position name="posArapucaDouble2-Frame-1-6" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-133" 
 	 z="998.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10844,14 +10844,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-6-2"/>
        <position name="posOpArapucaDouble2-Frame-1-6" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-133" 
 	 z="998.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-6-3"/>
        <position name="posArapucaDouble3-Frame-1-6" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-42.3" 
 	 z="852.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10859,14 +10859,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-6-3"/>
        <position name="posOpArapucaDouble3-Frame-1-6" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-42.3" 
 	 z="852.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-0-0"/>
        <position name="posArapucaDouble0-Frame-2-0" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="38.3" 
 	 z="-859.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10874,14 +10874,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-0"/>
        <position name="posOpArapucaDouble0-Frame-2-0" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="38.3" 
 	 z="-859.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-0-1"/>
        <position name="posArapucaDouble1-Frame-2-0" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="129" 
 	 z="-1005.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10889,14 +10889,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-1"/>
        <position name="posOpArapucaDouble1-Frame-2-0" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="129" 
 	 z="-1005.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-0-2"/>
        <position name="posArapucaDouble2-Frame-2-0" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="203" 
 	 z="-788.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10904,14 +10904,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-2"/>
        <position name="posOpArapucaDouble2-Frame-2-0" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="203" 
 	 z="-788.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-0-3"/>
        <position name="posArapucaDouble3-Frame-2-0" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="293.7" 
 	 z="-934.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10919,14 +10919,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-3"/>
        <position name="posOpArapucaDouble3-Frame-2-0" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="293.7" 
 	 z="-934.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-1-0"/>
        <position name="posArapucaDouble0-Frame-2-1" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="38.3" 
 	 z="-561.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10934,14 +10934,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-0"/>
        <position name="posOpArapucaDouble0-Frame-2-1" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="38.3" 
 	 z="-561.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-1-1"/>
        <position name="posArapucaDouble1-Frame-2-1" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="129" 
 	 z="-707.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10949,14 +10949,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-1"/>
        <position name="posOpArapucaDouble1-Frame-2-1" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="129" 
 	 z="-707.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-1-2"/>
        <position name="posArapucaDouble2-Frame-2-1" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="203" 
 	 z="-490.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10964,14 +10964,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-2"/>
        <position name="posOpArapucaDouble2-Frame-2-1" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="203" 
 	 z="-490.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-1-3"/>
        <position name="posArapucaDouble3-Frame-2-1" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="293.7" 
 	 z="-636.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10979,14 +10979,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-3"/>
        <position name="posOpArapucaDouble3-Frame-2-1" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="293.7" 
 	 z="-636.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-2-0"/>
        <position name="posArapucaDouble0-Frame-2-2" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="38.3" 
 	 z="-263.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -10994,14 +10994,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-0"/>
        <position name="posOpArapucaDouble0-Frame-2-2" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="38.3" 
 	 z="-263.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-2-1"/>
        <position name="posArapucaDouble1-Frame-2-2" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="129" 
 	 z="-409.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11009,14 +11009,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-1"/>
        <position name="posOpArapucaDouble1-Frame-2-2" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="129" 
 	 z="-409.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-2-2"/>
        <position name="posArapucaDouble2-Frame-2-2" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="203" 
 	 z="-192.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11024,14 +11024,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-2"/>
        <position name="posOpArapucaDouble2-Frame-2-2" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="203" 
 	 z="-192.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-2-3"/>
        <position name="posArapucaDouble3-Frame-2-2" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="293.7" 
 	 z="-338.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11039,14 +11039,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-3"/>
        <position name="posOpArapucaDouble3-Frame-2-2" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="293.7" 
 	 z="-338.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-3-0"/>
        <position name="posArapucaDouble0-Frame-2-3" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="38.3" 
 	 z="34.0000000000001"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11054,14 +11054,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-3-0"/>
        <position name="posOpArapucaDouble0-Frame-2-3" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="38.3" 
 	 z="34.0000000000001"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-3-1"/>
        <position name="posArapucaDouble1-Frame-2-3" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="129" 
 	 z="-112"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11069,14 +11069,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-3-1"/>
        <position name="posOpArapucaDouble1-Frame-2-3" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="129" 
 	 z="-112"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-3-2"/>
        <position name="posArapucaDouble2-Frame-2-3" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="203" 
 	 z="105"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11084,14 +11084,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-3-2"/>
        <position name="posOpArapucaDouble2-Frame-2-3" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="203" 
 	 z="105"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-3-3"/>
        <position name="posArapucaDouble3-Frame-2-3" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="293.7" 
 	 z="-40.9999999999999"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11099,14 +11099,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-3-3"/>
        <position name="posOpArapucaDouble3-Frame-2-3" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="293.7" 
 	 z="-40.9999999999999"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-4-0"/>
        <position name="posArapucaDouble0-Frame-2-4" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="38.3" 
 	 z="331.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11114,14 +11114,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-4-0"/>
        <position name="posOpArapucaDouble0-Frame-2-4" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="38.3" 
 	 z="331.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-4-1"/>
        <position name="posArapucaDouble1-Frame-2-4" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="129" 
 	 z="185.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11129,14 +11129,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-4-1"/>
        <position name="posOpArapucaDouble1-Frame-2-4" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="129" 
 	 z="185.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-4-2"/>
        <position name="posArapucaDouble2-Frame-2-4" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="203" 
 	 z="402.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11144,14 +11144,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-4-2"/>
        <position name="posOpArapucaDouble2-Frame-2-4" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="203" 
 	 z="402.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-4-3"/>
        <position name="posArapucaDouble3-Frame-2-4" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="293.7" 
 	 z="256.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11159,14 +11159,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-4-3"/>
        <position name="posOpArapucaDouble3-Frame-2-4" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="293.7" 
 	 z="256.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-5-0"/>
        <position name="posArapucaDouble0-Frame-2-5" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="38.3" 
 	 z="629.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11174,14 +11174,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-5-0"/>
        <position name="posOpArapucaDouble0-Frame-2-5" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="38.3" 
 	 z="629.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-5-1"/>
        <position name="posArapucaDouble1-Frame-2-5" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="129" 
 	 z="483.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11189,14 +11189,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-5-1"/>
        <position name="posOpArapucaDouble1-Frame-2-5" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="129" 
 	 z="483.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-5-2"/>
        <position name="posArapucaDouble2-Frame-2-5" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="203" 
 	 z="700.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11204,14 +11204,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-5-2"/>
        <position name="posOpArapucaDouble2-Frame-2-5" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="203" 
 	 z="700.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-5-3"/>
        <position name="posArapucaDouble3-Frame-2-5" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="293.7" 
 	 z="554.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11219,14 +11219,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-5-3"/>
        <position name="posOpArapucaDouble3-Frame-2-5" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="293.7" 
 	 z="554.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-6-0"/>
        <position name="posArapucaDouble0-Frame-2-6" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="38.3" 
 	 z="927.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11234,14 +11234,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-6-0"/>
        <position name="posOpArapucaDouble0-Frame-2-6" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="38.3" 
 	 z="927.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-6-1"/>
        <position name="posArapucaDouble1-Frame-2-6" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="129" 
 	 z="781.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11249,14 +11249,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-6-1"/>
        <position name="posOpArapucaDouble1-Frame-2-6" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="129" 
 	 z="781.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-6-2"/>
        <position name="posArapucaDouble2-Frame-2-6" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="203" 
 	 z="998.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11264,14 +11264,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-6-2"/>
        <position name="posOpArapucaDouble2-Frame-2-6" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="203" 
 	 z="998.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-6-3"/>
        <position name="posArapucaDouble3-Frame-2-6" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="293.7" 
 	 z="852.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11279,14 +11279,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-6-3"/>
        <position name="posOpArapucaDouble3-Frame-2-6" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="293.7" 
 	 z="852.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-0-0"/>
        <position name="posArapucaDouble0-Frame-3-0" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="374.3" 
 	 z="-859.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11294,14 +11294,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-0"/>
        <position name="posOpArapucaDouble0-Frame-3-0" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="374.3" 
 	 z="-859.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-0-1"/>
        <position name="posArapucaDouble1-Frame-3-0" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="465" 
 	 z="-1005.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11309,14 +11309,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-1"/>
        <position name="posOpArapucaDouble1-Frame-3-0" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="465" 
 	 z="-1005.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-0-2"/>
        <position name="posArapucaDouble2-Frame-3-0" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="539" 
 	 z="-788.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11324,14 +11324,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-2"/>
        <position name="posOpArapucaDouble2-Frame-3-0" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="539" 
 	 z="-788.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-0-3"/>
        <position name="posArapucaDouble3-Frame-3-0" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="629.7" 
 	 z="-934.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11339,14 +11339,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-3"/>
        <position name="posOpArapucaDouble3-Frame-3-0" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="629.7" 
 	 z="-934.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-1-0"/>
        <position name="posArapucaDouble0-Frame-3-1" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="374.3" 
 	 z="-561.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11354,14 +11354,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-0"/>
        <position name="posOpArapucaDouble0-Frame-3-1" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="374.3" 
 	 z="-561.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-1-1"/>
        <position name="posArapucaDouble1-Frame-3-1" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="465" 
 	 z="-707.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11369,14 +11369,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-1"/>
        <position name="posOpArapucaDouble1-Frame-3-1" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="465" 
 	 z="-707.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-1-2"/>
        <position name="posArapucaDouble2-Frame-3-1" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="539" 
 	 z="-490.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11384,14 +11384,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-2"/>
        <position name="posOpArapucaDouble2-Frame-3-1" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="539" 
 	 z="-490.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-1-3"/>
        <position name="posArapucaDouble3-Frame-3-1" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="629.7" 
 	 z="-636.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11399,14 +11399,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-3"/>
        <position name="posOpArapucaDouble3-Frame-3-1" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="629.7" 
 	 z="-636.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-2-0"/>
        <position name="posArapucaDouble0-Frame-3-2" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="374.3" 
 	 z="-263.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11414,14 +11414,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-0"/>
        <position name="posOpArapucaDouble0-Frame-3-2" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="374.3" 
 	 z="-263.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-2-1"/>
        <position name="posArapucaDouble1-Frame-3-2" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="465" 
 	 z="-409.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11429,14 +11429,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-1"/>
        <position name="posOpArapucaDouble1-Frame-3-2" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="465" 
 	 z="-409.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-2-2"/>
        <position name="posArapucaDouble2-Frame-3-2" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="539" 
 	 z="-192.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11444,14 +11444,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-2"/>
        <position name="posOpArapucaDouble2-Frame-3-2" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="539" 
 	 z="-192.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-2-3"/>
        <position name="posArapucaDouble3-Frame-3-2" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="629.7" 
 	 z="-338.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11459,14 +11459,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-3"/>
        <position name="posOpArapucaDouble3-Frame-3-2" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="629.7" 
 	 z="-338.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-3-0"/>
        <position name="posArapucaDouble0-Frame-3-3" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="374.3" 
 	 z="34.0000000000001"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11474,14 +11474,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-3-0"/>
        <position name="posOpArapucaDouble0-Frame-3-3" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="374.3" 
 	 z="34.0000000000001"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-3-1"/>
        <position name="posArapucaDouble1-Frame-3-3" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="465" 
 	 z="-112"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11489,14 +11489,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-3-1"/>
        <position name="posOpArapucaDouble1-Frame-3-3" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="465" 
 	 z="-112"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-3-2"/>
        <position name="posArapucaDouble2-Frame-3-3" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="539" 
 	 z="105"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11504,14 +11504,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-3-2"/>
        <position name="posOpArapucaDouble2-Frame-3-3" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="539" 
 	 z="105"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-3-3"/>
        <position name="posArapucaDouble3-Frame-3-3" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="629.7" 
 	 z="-40.9999999999999"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11519,14 +11519,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-3-3"/>
        <position name="posOpArapucaDouble3-Frame-3-3" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="629.7" 
 	 z="-40.9999999999999"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-4-0"/>
        <position name="posArapucaDouble0-Frame-3-4" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="374.3" 
 	 z="331.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11534,14 +11534,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-4-0"/>
        <position name="posOpArapucaDouble0-Frame-3-4" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="374.3" 
 	 z="331.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-4-1"/>
        <position name="posArapucaDouble1-Frame-3-4" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="465" 
 	 z="185.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11549,14 +11549,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-4-1"/>
        <position name="posOpArapucaDouble1-Frame-3-4" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="465" 
 	 z="185.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-4-2"/>
        <position name="posArapucaDouble2-Frame-3-4" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="539" 
 	 z="402.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11564,14 +11564,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-4-2"/>
        <position name="posOpArapucaDouble2-Frame-3-4" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="539" 
 	 z="402.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-4-3"/>
        <position name="posArapucaDouble3-Frame-3-4" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="629.7" 
 	 z="256.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11579,14 +11579,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-4-3"/>
        <position name="posOpArapucaDouble3-Frame-3-4" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="629.7" 
 	 z="256.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-5-0"/>
        <position name="posArapucaDouble0-Frame-3-5" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="374.3" 
 	 z="629.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11594,14 +11594,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-5-0"/>
        <position name="posOpArapucaDouble0-Frame-3-5" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="374.3" 
 	 z="629.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-5-1"/>
        <position name="posArapucaDouble1-Frame-3-5" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="465" 
 	 z="483.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11609,14 +11609,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-5-1"/>
        <position name="posOpArapucaDouble1-Frame-3-5" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="465" 
 	 z="483.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-5-2"/>
        <position name="posArapucaDouble2-Frame-3-5" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="539" 
 	 z="700.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11624,14 +11624,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-5-2"/>
        <position name="posOpArapucaDouble2-Frame-3-5" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="539" 
 	 z="700.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-5-3"/>
        <position name="posArapucaDouble3-Frame-3-5" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="629.7" 
 	 z="554.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11639,14 +11639,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-5-3"/>
        <position name="posOpArapucaDouble3-Frame-3-5" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="629.7" 
 	 z="554.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-6-0"/>
        <position name="posArapucaDouble0-Frame-3-6" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="374.3" 
 	 z="927.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11654,14 +11654,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-6-0"/>
        <position name="posOpArapucaDouble0-Frame-3-6" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="374.3" 
 	 z="927.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-6-1"/>
        <position name="posArapucaDouble1-Frame-3-6" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="465" 
 	 z="781.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11669,14 +11669,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-6-1"/>
        <position name="posOpArapucaDouble1-Frame-3-6" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="465" 
 	 z="781.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-6-2"/>
        <position name="posArapucaDouble2-Frame-3-6" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="539" 
 	 z="998.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11684,14 +11684,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-6-2"/>
        <position name="posOpArapucaDouble2-Frame-3-6" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="539" 
 	 z="998.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-6-3"/>
        <position name="posArapucaDouble3-Frame-3-6" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="629.7" 
 	 z="852.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -11699,14 +11699,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-6-3"/>
        <position name="posOpArapucaDouble3-Frame-3-6" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="629.7" 
 	 z="852.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-0"/>
        <position name="posArapuca0-Lat-0" unit="cm" 
-         x="285.01"
+         x="285.02"
 	 y="-734" 
 	 z="-893.4054"/>
        <rotationref ref="rIdentity"/>
@@ -11714,14 +11714,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-0"/>
        <position name="posOpArapuca0-Lat-0" unit="cm" 
-         x="285.01"
+         x="285.02"
 	 y="-733.26" 
 	 z="-893.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-1"/>
        <position name="posArapuca1-Lat-0" unit="cm" 
-         x="210.01"
+         x="210.02"
 	 y="-734" 
 	 z="-893.4054"/>
        <rotationref ref="rIdentity"/>
@@ -11729,14 +11729,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-1"/>
        <position name="posOpArapuca1-Lat-0" unit="cm" 
-         x="210.01"
+         x="210.02"
 	 y="-733.26" 
 	 z="-893.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-2"/>
        <position name="posArapuca2-Lat-0" unit="cm" 
-         x="135.01"
+         x="135.02"
 	 y="-734" 
 	 z="-893.4054"/>
        <rotationref ref="rIdentity"/>
@@ -11744,14 +11744,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-2"/>
        <position name="posOpArapuca2-Lat-0" unit="cm" 
-         x="135.01"
+         x="135.02"
 	 y="-733.26" 
 	 z="-893.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-3"/>
        <position name="posArapuca3-Lat-0" unit="cm" 
-         x="60.01"
+         x="60.02"
 	 y="-734" 
 	 z="-893.4054"/>
        <rotationref ref="rIdentity"/>
@@ -11759,14 +11759,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-3"/>
        <position name="posOpArapuca3-Lat-0" unit="cm" 
-         x="60.01"
+         x="60.02"
 	 y="-733.26" 
 	 z="-893.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-4"/>
        <position name="posArapuca4-Lat-0" unit="cm" 
-         x="285.01"
+         x="285.02"
 	 y="734" 
 	 z="-893.4054"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -11774,14 +11774,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-4"/>
        <position name="posOpArapuca4-Lat-0" unit="cm" 
-         x="285.01"
+         x="285.02"
 	 y="733.26" 
 	 z="-893.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-5"/>
        <position name="posArapuca5-Lat-0" unit="cm" 
-         x="210.01"
+         x="210.02"
 	 y="734" 
 	 z="-893.4054"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -11789,14 +11789,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-5"/>
        <position name="posOpArapuca5-Lat-0" unit="cm" 
-         x="210.01"
+         x="210.02"
 	 y="733.26" 
 	 z="-893.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-6"/>
        <position name="posArapuca6-Lat-0" unit="cm" 
-         x="135.01"
+         x="135.02"
 	 y="734" 
 	 z="-893.4054"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -11804,14 +11804,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-6"/>
        <position name="posOpArapuca6-Lat-0" unit="cm" 
-         x="135.01"
+         x="135.02"
 	 y="733.26" 
 	 z="-893.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-7"/>
        <position name="posArapuca7-Lat-0" unit="cm" 
-         x="60.01"
+         x="60.02"
 	 y="734" 
 	 z="-893.4054"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -11819,14 +11819,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-7"/>
        <position name="posOpArapuca7-Lat-0" unit="cm" 
-         x="60.01"
+         x="60.02"
 	 y="733.26" 
 	 z="-893.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-0"/>
        <position name="posArapuca0-Lat-1" unit="cm" 
-         x="285.01"
+         x="285.02"
 	 y="-734" 
 	 z="-595.6036"/>
        <rotationref ref="rIdentity"/>
@@ -11834,14 +11834,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-0"/>
        <position name="posOpArapuca0-Lat-1" unit="cm" 
-         x="285.01"
+         x="285.02"
 	 y="-733.26" 
 	 z="-595.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-1"/>
        <position name="posArapuca1-Lat-1" unit="cm" 
-         x="210.01"
+         x="210.02"
 	 y="-734" 
 	 z="-595.6036"/>
        <rotationref ref="rIdentity"/>
@@ -11849,14 +11849,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-1"/>
        <position name="posOpArapuca1-Lat-1" unit="cm" 
-         x="210.01"
+         x="210.02"
 	 y="-733.26" 
 	 z="-595.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-2"/>
        <position name="posArapuca2-Lat-1" unit="cm" 
-         x="135.01"
+         x="135.02"
 	 y="-734" 
 	 z="-595.6036"/>
        <rotationref ref="rIdentity"/>
@@ -11864,14 +11864,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-2"/>
        <position name="posOpArapuca2-Lat-1" unit="cm" 
-         x="135.01"
+         x="135.02"
 	 y="-733.26" 
 	 z="-595.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-3"/>
        <position name="posArapuca3-Lat-1" unit="cm" 
-         x="60.01"
+         x="60.02"
 	 y="-734" 
 	 z="-595.6036"/>
        <rotationref ref="rIdentity"/>
@@ -11879,14 +11879,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-3"/>
        <position name="posOpArapuca3-Lat-1" unit="cm" 
-         x="60.01"
+         x="60.02"
 	 y="-733.26" 
 	 z="-595.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-4"/>
        <position name="posArapuca4-Lat-1" unit="cm" 
-         x="285.01"
+         x="285.02"
 	 y="734" 
 	 z="-595.6036"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -11894,14 +11894,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-4"/>
        <position name="posOpArapuca4-Lat-1" unit="cm" 
-         x="285.01"
+         x="285.02"
 	 y="733.26" 
 	 z="-595.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-5"/>
        <position name="posArapuca5-Lat-1" unit="cm" 
-         x="210.01"
+         x="210.02"
 	 y="734" 
 	 z="-595.6036"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -11909,14 +11909,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-5"/>
        <position name="posOpArapuca5-Lat-1" unit="cm" 
-         x="210.01"
+         x="210.02"
 	 y="733.26" 
 	 z="-595.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-6"/>
        <position name="posArapuca6-Lat-1" unit="cm" 
-         x="135.01"
+         x="135.02"
 	 y="734" 
 	 z="-595.6036"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -11924,14 +11924,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-6"/>
        <position name="posOpArapuca6-Lat-1" unit="cm" 
-         x="135.01"
+         x="135.02"
 	 y="733.26" 
 	 z="-595.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-7"/>
        <position name="posArapuca7-Lat-1" unit="cm" 
-         x="60.01"
+         x="60.02"
 	 y="734" 
 	 z="-595.6036"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -11939,14 +11939,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-7"/>
        <position name="posOpArapuca7-Lat-1" unit="cm" 
-         x="60.01"
+         x="60.02"
 	 y="733.26" 
 	 z="-595.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-0"/>
        <position name="posArapuca0-Lat-2" unit="cm" 
-         x="285.01"
+         x="285.02"
 	 y="-734" 
 	 z="-297.8018"/>
        <rotationref ref="rIdentity"/>
@@ -11954,14 +11954,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-0"/>
        <position name="posOpArapuca0-Lat-2" unit="cm" 
-         x="285.01"
+         x="285.02"
 	 y="-733.26" 
 	 z="-297.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-1"/>
        <position name="posArapuca1-Lat-2" unit="cm" 
-         x="210.01"
+         x="210.02"
 	 y="-734" 
 	 z="-297.8018"/>
        <rotationref ref="rIdentity"/>
@@ -11969,14 +11969,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-1"/>
        <position name="posOpArapuca1-Lat-2" unit="cm" 
-         x="210.01"
+         x="210.02"
 	 y="-733.26" 
 	 z="-297.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-2"/>
        <position name="posArapuca2-Lat-2" unit="cm" 
-         x="135.01"
+         x="135.02"
 	 y="-734" 
 	 z="-297.8018"/>
        <rotationref ref="rIdentity"/>
@@ -11984,14 +11984,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-2"/>
        <position name="posOpArapuca2-Lat-2" unit="cm" 
-         x="135.01"
+         x="135.02"
 	 y="-733.26" 
 	 z="-297.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-3"/>
        <position name="posArapuca3-Lat-2" unit="cm" 
-         x="60.01"
+         x="60.02"
 	 y="-734" 
 	 z="-297.8018"/>
        <rotationref ref="rIdentity"/>
@@ -11999,14 +11999,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-3"/>
        <position name="posOpArapuca3-Lat-2" unit="cm" 
-         x="60.01"
+         x="60.02"
 	 y="-733.26" 
 	 z="-297.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-4"/>
        <position name="posArapuca4-Lat-2" unit="cm" 
-         x="285.01"
+         x="285.02"
 	 y="734" 
 	 z="-297.8018"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -12014,14 +12014,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-4"/>
        <position name="posOpArapuca4-Lat-2" unit="cm" 
-         x="285.01"
+         x="285.02"
 	 y="733.26" 
 	 z="-297.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-5"/>
        <position name="posArapuca5-Lat-2" unit="cm" 
-         x="210.01"
+         x="210.02"
 	 y="734" 
 	 z="-297.8018"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -12029,14 +12029,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-5"/>
        <position name="posOpArapuca5-Lat-2" unit="cm" 
-         x="210.01"
+         x="210.02"
 	 y="733.26" 
 	 z="-297.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-6"/>
        <position name="posArapuca6-Lat-2" unit="cm" 
-         x="135.01"
+         x="135.02"
 	 y="734" 
 	 z="-297.8018"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -12044,14 +12044,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-6"/>
        <position name="posOpArapuca6-Lat-2" unit="cm" 
-         x="135.01"
+         x="135.02"
 	 y="733.26" 
 	 z="-297.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-7"/>
        <position name="posArapuca7-Lat-2" unit="cm" 
-         x="60.01"
+         x="60.02"
 	 y="734" 
 	 z="-297.8018"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -12059,14 +12059,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-7"/>
        <position name="posOpArapuca7-Lat-2" unit="cm" 
-         x="60.01"
+         x="60.02"
 	 y="733.26" 
 	 z="-297.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_3-0"/>
        <position name="posArapuca0-Lat-3" unit="cm" 
-         x="285.01"
+         x="285.02"
 	 y="-734" 
 	 z="1.13686837721616e-13"/>
        <rotationref ref="rIdentity"/>
@@ -12074,14 +12074,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_3-0"/>
        <position name="posOpArapuca0-Lat-3" unit="cm" 
-         x="285.01"
+         x="285.02"
 	 y="-733.26" 
 	 z="1.13686837721616e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_3-1"/>
        <position name="posArapuca1-Lat-3" unit="cm" 
-         x="210.01"
+         x="210.02"
 	 y="-734" 
 	 z="1.13686837721616e-13"/>
        <rotationref ref="rIdentity"/>
@@ -12089,14 +12089,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_3-1"/>
        <position name="posOpArapuca1-Lat-3" unit="cm" 
-         x="210.01"
+         x="210.02"
 	 y="-733.26" 
 	 z="1.13686837721616e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_3-2"/>
        <position name="posArapuca2-Lat-3" unit="cm" 
-         x="135.01"
+         x="135.02"
 	 y="-734" 
 	 z="1.13686837721616e-13"/>
        <rotationref ref="rIdentity"/>
@@ -12104,14 +12104,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_3-2"/>
        <position name="posOpArapuca2-Lat-3" unit="cm" 
-         x="135.01"
+         x="135.02"
 	 y="-733.26" 
 	 z="1.13686837721616e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_3-3"/>
        <position name="posArapuca3-Lat-3" unit="cm" 
-         x="60.01"
+         x="60.02"
 	 y="-734" 
 	 z="1.13686837721616e-13"/>
        <rotationref ref="rIdentity"/>
@@ -12119,14 +12119,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_3-3"/>
        <position name="posOpArapuca3-Lat-3" unit="cm" 
-         x="60.01"
+         x="60.02"
 	 y="-733.26" 
 	 z="1.13686837721616e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_3-4"/>
        <position name="posArapuca4-Lat-3" unit="cm" 
-         x="285.01"
+         x="285.02"
 	 y="734" 
 	 z="1.13686837721616e-13"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -12134,14 +12134,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_3-4"/>
        <position name="posOpArapuca4-Lat-3" unit="cm" 
-         x="285.01"
+         x="285.02"
 	 y="733.26" 
 	 z="1.13686837721616e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_3-5"/>
        <position name="posArapuca5-Lat-3" unit="cm" 
-         x="210.01"
+         x="210.02"
 	 y="734" 
 	 z="1.13686837721616e-13"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -12149,14 +12149,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_3-5"/>
        <position name="posOpArapuca5-Lat-3" unit="cm" 
-         x="210.01"
+         x="210.02"
 	 y="733.26" 
 	 z="1.13686837721616e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_3-6"/>
        <position name="posArapuca6-Lat-3" unit="cm" 
-         x="135.01"
+         x="135.02"
 	 y="734" 
 	 z="1.13686837721616e-13"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -12164,14 +12164,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_3-6"/>
        <position name="posOpArapuca6-Lat-3" unit="cm" 
-         x="135.01"
+         x="135.02"
 	 y="733.26" 
 	 z="1.13686837721616e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_3-7"/>
        <position name="posArapuca7-Lat-3" unit="cm" 
-         x="60.01"
+         x="60.02"
 	 y="734" 
 	 z="1.13686837721616e-13"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -12179,14 +12179,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_3-7"/>
        <position name="posOpArapuca7-Lat-3" unit="cm" 
-         x="60.01"
+         x="60.02"
 	 y="733.26" 
 	 z="1.13686837721616e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_4-0"/>
        <position name="posArapuca0-Lat-4" unit="cm" 
-         x="285.01"
+         x="285.02"
 	 y="-734" 
 	 z="297.8018"/>
        <rotationref ref="rIdentity"/>
@@ -12194,14 +12194,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_4-0"/>
        <position name="posOpArapuca0-Lat-4" unit="cm" 
-         x="285.01"
+         x="285.02"
 	 y="-733.26" 
 	 z="297.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_4-1"/>
        <position name="posArapuca1-Lat-4" unit="cm" 
-         x="210.01"
+         x="210.02"
 	 y="-734" 
 	 z="297.8018"/>
        <rotationref ref="rIdentity"/>
@@ -12209,14 +12209,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_4-1"/>
        <position name="posOpArapuca1-Lat-4" unit="cm" 
-         x="210.01"
+         x="210.02"
 	 y="-733.26" 
 	 z="297.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_4-2"/>
        <position name="posArapuca2-Lat-4" unit="cm" 
-         x="135.01"
+         x="135.02"
 	 y="-734" 
 	 z="297.8018"/>
        <rotationref ref="rIdentity"/>
@@ -12224,14 +12224,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_4-2"/>
        <position name="posOpArapuca2-Lat-4" unit="cm" 
-         x="135.01"
+         x="135.02"
 	 y="-733.26" 
 	 z="297.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_4-3"/>
        <position name="posArapuca3-Lat-4" unit="cm" 
-         x="60.01"
+         x="60.02"
 	 y="-734" 
 	 z="297.8018"/>
        <rotationref ref="rIdentity"/>
@@ -12239,14 +12239,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_4-3"/>
        <position name="posOpArapuca3-Lat-4" unit="cm" 
-         x="60.01"
+         x="60.02"
 	 y="-733.26" 
 	 z="297.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_4-4"/>
        <position name="posArapuca4-Lat-4" unit="cm" 
-         x="285.01"
+         x="285.02"
 	 y="734" 
 	 z="297.8018"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -12254,14 +12254,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_4-4"/>
        <position name="posOpArapuca4-Lat-4" unit="cm" 
-         x="285.01"
+         x="285.02"
 	 y="733.26" 
 	 z="297.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_4-5"/>
        <position name="posArapuca5-Lat-4" unit="cm" 
-         x="210.01"
+         x="210.02"
 	 y="734" 
 	 z="297.8018"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -12269,14 +12269,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_4-5"/>
        <position name="posOpArapuca5-Lat-4" unit="cm" 
-         x="210.01"
+         x="210.02"
 	 y="733.26" 
 	 z="297.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_4-6"/>
        <position name="posArapuca6-Lat-4" unit="cm" 
-         x="135.01"
+         x="135.02"
 	 y="734" 
 	 z="297.8018"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -12284,14 +12284,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_4-6"/>
        <position name="posOpArapuca6-Lat-4" unit="cm" 
-         x="135.01"
+         x="135.02"
 	 y="733.26" 
 	 z="297.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_4-7"/>
        <position name="posArapuca7-Lat-4" unit="cm" 
-         x="60.01"
+         x="60.02"
 	 y="734" 
 	 z="297.8018"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -12299,14 +12299,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_4-7"/>
        <position name="posOpArapuca7-Lat-4" unit="cm" 
-         x="60.01"
+         x="60.02"
 	 y="733.26" 
 	 z="297.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_5-0"/>
        <position name="posArapuca0-Lat-5" unit="cm" 
-         x="285.01"
+         x="285.02"
 	 y="-734" 
 	 z="595.6036"/>
        <rotationref ref="rIdentity"/>
@@ -12314,14 +12314,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_5-0"/>
        <position name="posOpArapuca0-Lat-5" unit="cm" 
-         x="285.01"
+         x="285.02"
 	 y="-733.26" 
 	 z="595.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_5-1"/>
        <position name="posArapuca1-Lat-5" unit="cm" 
-         x="210.01"
+         x="210.02"
 	 y="-734" 
 	 z="595.6036"/>
        <rotationref ref="rIdentity"/>
@@ -12329,14 +12329,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_5-1"/>
        <position name="posOpArapuca1-Lat-5" unit="cm" 
-         x="210.01"
+         x="210.02"
 	 y="-733.26" 
 	 z="595.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_5-2"/>
        <position name="posArapuca2-Lat-5" unit="cm" 
-         x="135.01"
+         x="135.02"
 	 y="-734" 
 	 z="595.6036"/>
        <rotationref ref="rIdentity"/>
@@ -12344,14 +12344,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_5-2"/>
        <position name="posOpArapuca2-Lat-5" unit="cm" 
-         x="135.01"
+         x="135.02"
 	 y="-733.26" 
 	 z="595.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_5-3"/>
        <position name="posArapuca3-Lat-5" unit="cm" 
-         x="60.01"
+         x="60.02"
 	 y="-734" 
 	 z="595.6036"/>
        <rotationref ref="rIdentity"/>
@@ -12359,14 +12359,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_5-3"/>
        <position name="posOpArapuca3-Lat-5" unit="cm" 
-         x="60.01"
+         x="60.02"
 	 y="-733.26" 
 	 z="595.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_5-4"/>
        <position name="posArapuca4-Lat-5" unit="cm" 
-         x="285.01"
+         x="285.02"
 	 y="734" 
 	 z="595.6036"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -12374,14 +12374,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_5-4"/>
        <position name="posOpArapuca4-Lat-5" unit="cm" 
-         x="285.01"
+         x="285.02"
 	 y="733.26" 
 	 z="595.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_5-5"/>
        <position name="posArapuca5-Lat-5" unit="cm" 
-         x="210.01"
+         x="210.02"
 	 y="734" 
 	 z="595.6036"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -12389,14 +12389,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_5-5"/>
        <position name="posOpArapuca5-Lat-5" unit="cm" 
-         x="210.01"
+         x="210.02"
 	 y="733.26" 
 	 z="595.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_5-6"/>
        <position name="posArapuca6-Lat-5" unit="cm" 
-         x="135.01"
+         x="135.02"
 	 y="734" 
 	 z="595.6036"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -12404,14 +12404,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_5-6"/>
        <position name="posOpArapuca6-Lat-5" unit="cm" 
-         x="135.01"
+         x="135.02"
 	 y="733.26" 
 	 z="595.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_5-7"/>
        <position name="posArapuca7-Lat-5" unit="cm" 
-         x="60.01"
+         x="60.02"
 	 y="734" 
 	 z="595.6036"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -12419,14 +12419,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_5-7"/>
        <position name="posOpArapuca7-Lat-5" unit="cm" 
-         x="60.01"
+         x="60.02"
 	 y="733.26" 
 	 z="595.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_6-0"/>
        <position name="posArapuca0-Lat-6" unit="cm" 
-         x="285.01"
+         x="285.02"
 	 y="-734" 
 	 z="893.4054"/>
        <rotationref ref="rIdentity"/>
@@ -12434,14 +12434,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_6-0"/>
        <position name="posOpArapuca0-Lat-6" unit="cm" 
-         x="285.01"
+         x="285.02"
 	 y="-733.26" 
 	 z="893.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_6-1"/>
        <position name="posArapuca1-Lat-6" unit="cm" 
-         x="210.01"
+         x="210.02"
 	 y="-734" 
 	 z="893.4054"/>
        <rotationref ref="rIdentity"/>
@@ -12449,14 +12449,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_6-1"/>
        <position name="posOpArapuca1-Lat-6" unit="cm" 
-         x="210.01"
+         x="210.02"
 	 y="-733.26" 
 	 z="893.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_6-2"/>
        <position name="posArapuca2-Lat-6" unit="cm" 
-         x="135.01"
+         x="135.02"
 	 y="-734" 
 	 z="893.4054"/>
        <rotationref ref="rIdentity"/>
@@ -12464,14 +12464,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_6-2"/>
        <position name="posOpArapuca2-Lat-6" unit="cm" 
-         x="135.01"
+         x="135.02"
 	 y="-733.26" 
 	 z="893.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_6-3"/>
        <position name="posArapuca3-Lat-6" unit="cm" 
-         x="60.01"
+         x="60.02"
 	 y="-734" 
 	 z="893.4054"/>
        <rotationref ref="rIdentity"/>
@@ -12479,14 +12479,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_6-3"/>
        <position name="posOpArapuca3-Lat-6" unit="cm" 
-         x="60.01"
+         x="60.02"
 	 y="-733.26" 
 	 z="893.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_6-4"/>
        <position name="posArapuca4-Lat-6" unit="cm" 
-         x="285.01"
+         x="285.02"
 	 y="734" 
 	 z="893.4054"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -12494,14 +12494,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_6-4"/>
        <position name="posOpArapuca4-Lat-6" unit="cm" 
-         x="285.01"
+         x="285.02"
 	 y="733.26" 
 	 z="893.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_6-5"/>
        <position name="posArapuca5-Lat-6" unit="cm" 
-         x="210.01"
+         x="210.02"
 	 y="734" 
 	 z="893.4054"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -12509,14 +12509,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_6-5"/>
        <position name="posOpArapuca5-Lat-6" unit="cm" 
-         x="210.01"
+         x="210.02"
 	 y="733.26" 
 	 z="893.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_6-6"/>
        <position name="posArapuca6-Lat-6" unit="cm" 
-         x="135.01"
+         x="135.02"
 	 y="734" 
 	 z="893.4054"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -12524,14 +12524,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_6-6"/>
        <position name="posOpArapuca6-Lat-6" unit="cm" 
-         x="135.01"
+         x="135.02"
 	 y="733.26" 
 	 z="893.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_6-7"/>
        <position name="posArapuca7-Lat-6" unit="cm" 
-         x="60.01"
+         x="60.02"
 	 y="734" 
 	 z="893.4054"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -12539,7 +12539,7 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_6-7"/>
        <position name="posOpArapuca7-Lat-6" unit="cm" 
-         x="60.01"
+         x="60.02"
 	 y="733.26" 
 	 z="893.4054"/>
      </physvol>
@@ -12579,7 +12579,7 @@
 
       <physvol>
         <volumeref ref="volDetEnclosure"/>
-	<position name="posDetEnclosure" unit="cm" x="50.04" y="-1.13686837721616e-13" z="1045.8063"/>
+	<position name="posDetEnclosure" unit="cm" x="50.0500000000001" y="-1.13686837721616e-13" z="1045.8063"/>
       </physvol>
 
     </volume>

--- a/dunecore/Geometry/gdml/dunevd10kt_3view_v3_refactored_1x8x14ref_nowires.gdml
+++ b/dunecore/Geometry/gdml/dunevd10kt_3view_v3_refactored_1x8x14ref_nowires.gdml
@@ -572,12 +572,118 @@
       y="1548"
       z="2291.6126"/>
 
+    <box name="ExternalAuxOut" lunit="cm" 
+      x="850.08 - 100"
+      y="1548 - 2*2.5 - 2*40"
+      z="2291.6126"/>
+
+    <box name="ExternalAuxIn" lunit="cm" 
+      x="850.08"
+      y="1359.17"
+      z="2291.6126 + 1"/>
+
+   <subtraction name="ExternalActive">
+      <first ref="ExternalAuxOut"/>
+      <second ref="ExternalAuxIn"/>
+    </subtraction>
+
     <subtraction name="SteelShell">
       <first ref="Cryostat"/>
       <second ref="ArgonInterior"/>
     </subtraction>
 
 
+
+    <box name="CathodeBlock" lunit="cm"
+      x="4"
+      y="336"
+      z="297.8018" />
+
+    <box name="CathodeVoid" lunit="cm"
+      x="5"
+      y="76.35"
+      z="67" />
+
+    <subtraction name="Cathode1">
+      <first ref="CathodeBlock"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub1" x="0" y="-122.525" z="-108.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode2">
+      <first ref="Cathode1"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub2" x="0" y="-122.525" z="-37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode3">
+      <first ref="Cathode2"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub3" x="0" y="-122.525" z="37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode4">
+      <first ref="Cathode3"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub4" x="0" y="-122.525" z="108.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode5">
+      <first ref="Cathode4"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub5" x="0" y="-42.175" z="-108.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode6">
+      <first ref="Cathode5"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub6" x="0" y="-42.175" z="-37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode7">
+      <first ref="Cathode6"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub7" x="0" y="-42.175" z="37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode8">
+      <first ref="Cathode7"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub8" x="0" y="-42.175" z="108.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode9">
+      <first ref="Cathode8"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub9" x="0" y="42.175" z="-108.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode10">
+      <first ref="Cathode9"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub10" x="0" y="42.175" z="-37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode11">
+      <first ref="Cathode10"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub11" x="0" y="42.175" z="37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode12">
+      <first ref="Cathode11"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub12" x="0" y="42.175" z="108.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode13">
+      <first ref="Cathode12"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub13" x="0" y="122.525" z="-108.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode14">
+      <first ref="Cathode13"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub14" x="0" y="122.525" z="-37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode15">
+      <first ref="Cathode14"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub15" x="0" y="122.525" z="37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="CathodeGrid">
+      <first ref="Cathode15"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub16" x="0" y="122.525" z="108.5" unit="cm"/>
+    </subtraction>
 
     <box name="FoamPadBlock" lunit="cm"
       x="1010.32"
@@ -643,36 +749,36 @@
     <materialref ref="LAr"/>
     <solidref ref="CRMZPlane"/>
   </volume>
-   
-   <volume name="volReflectiveAnode">
+     
+   <volume name="volAnodePlate">
      <materialref ref="vm2000"/>
      <solidref ref="CRMZPlane"/>
-   </volume>
+  </volume>
    <volume name="volTPC">
      <materialref ref="LAr"/>
        <solidref ref="CRM"/>
        <physvol>
        <volumeref ref="volTPCPlaneU"/>
        <position name="posPlaneU" unit="cm" 
-         x="324.99" y="0" z="0"/>
+         x="324.97" y="0" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volTPCPlaneY"/>
        <position name="posPlaneY" unit="cm" 
-         x="325.01" y="0" z="0"/>
+         x="324.99" y="0" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volTPCPlaneZ"/>
        <position name="posPlaneZ" unit="cm" 
-         x="325.03" y="0" z="0"/>
+         x="325.01" y="0" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volReflectiveAnode"/>
-       <position name="posReflectiveAnode" unit="cm" 
-         x="324.97" y="0" z="0"/>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate" unit="cm" 
+         x="325.03" y="0" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>    
      <physvol>
@@ -687,9 +793,21 @@
       <materialref ref="STEEL_STAINLESS_Fe7Cr2Ni" />
       <solidref ref="SteelShell" />
     </volume>
+    <volume name="volGroundGrid">
+      <materialref ref="STEEL_STAINLESS_Fe7Cr2Ni" />
+      <solidref ref="CathodeGrid" />
+    </volume>    
     <volume name="volGaseousArgon">
       <materialref ref="ArGas"/>
       <solidref ref="GaseousArgon"/>
+    </volume>
+    <volume name="volExternalActive">
+      <materialref ref="LAr"/>
+      <solidref ref="ExternalActive"/>
+      <auxiliary auxtype="SensDet" auxvalue="SimEnergyDeposit"/>
+      <auxiliary auxtype="StepLimit" auxunit="cm" auxvalue="0.5208*cm"/>
+      <auxiliary auxtype="Efield" auxunit="V/cm" auxvalue="0*V/cm"/>
+      <colorref ref="green"/>
     </volume>
     <volume name="volArapucaDouble_0-0-0">
       <materialref ref="G10" />
@@ -2036,7 +2154,6 @@
       <solidref ref="ArapucaAcceptanceWindow"/>
     </volume>
 
-
     <volume name="volCryostat">
       <materialref ref="LAr" />
       <solidref ref="Cryostat" />
@@ -2047,6 +2164,10 @@
       <physvol>
         <volumeref ref="volSteelShell"/>
         <position name="posSteelShell" unit="cm" x="0" y="0" z="0"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volExternalActive"/>
+        <position name="posExternalActive" unit="cm" x="-100/2" y="0" z="0"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC"/>
@@ -3148,1690 +3269,1802 @@
      <position name="posFieldShaper107" unit="cm"  x="319.96" y="-676.3" z="0" />
      <rotation name="rotFS107" unit="deg" x="0" y="0" z="90" />
   </physvol>
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-0" unit="cm" x="-328.04" y="-506" z="-896.9054"/>
+      </physvol>
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-1" unit="cm" x="-328.04" y="-170" z="-896.9054"/>
+      </physvol>
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-2" unit="cm" x="-328.04" y="166" z="-896.9054"/>
+      </physvol>
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-3" unit="cm" x="-328.04" y="502" z="-896.9054"/>
+      </physvol>
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-4" unit="cm" x="-328.04" y="-506" z="-599.1036"/>
+      </physvol>
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-5" unit="cm" x="-328.04" y="-170" z="-599.1036"/>
+      </physvol>
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-6" unit="cm" x="-328.04" y="166" z="-599.1036"/>
+      </physvol>
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-7" unit="cm" x="-328.04" y="502" z="-599.1036"/>
+      </physvol>
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-8" unit="cm" x="-328.04" y="-506" z="-301.3018"/>
+      </physvol>
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-9" unit="cm" x="-328.04" y="-170" z="-301.3018"/>
+      </physvol>
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-10" unit="cm" x="-328.04" y="166" z="-301.3018"/>
+      </physvol>
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-11" unit="cm" x="-328.04" y="502" z="-301.3018"/>
+      </physvol>
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-12" unit="cm" x="-328.04" y="-506" z="-3.49999999999989"/>
+      </physvol>
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-13" unit="cm" x="-328.04" y="-170" z="-3.49999999999989"/>
+      </physvol>
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-14" unit="cm" x="-328.04" y="166" z="-3.49999999999989"/>
+      </physvol>
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-15" unit="cm" x="-328.04" y="502" z="-3.49999999999989"/>
+      </physvol>
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-16" unit="cm" x="-328.04" y="-506" z="294.3018"/>
+      </physvol>
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-17" unit="cm" x="-328.04" y="-170" z="294.3018"/>
+      </physvol>
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-18" unit="cm" x="-328.04" y="166" z="294.3018"/>
+      </physvol>
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-19" unit="cm" x="-328.04" y="502" z="294.3018"/>
+      </physvol>
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-20" unit="cm" x="-328.04" y="-506" z="592.1036"/>
+      </physvol>
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-21" unit="cm" x="-328.04" y="-170" z="592.1036"/>
+      </physvol>
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-22" unit="cm" x="-328.04" y="166" z="592.1036"/>
+      </physvol>
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-23" unit="cm" x="-328.04" y="502" z="592.1036"/>
+      </physvol>
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-24" unit="cm" x="-328.04" y="-506" z="889.9054"/>
+      </physvol>
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-25" unit="cm" x="-328.04" y="-170" z="889.9054"/>
+      </physvol>
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-26" unit="cm" x="-328.04" y="166" z="889.9054"/>
+      </physvol>
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-27" unit="cm" x="-328.04" y="502" z="889.9054"/>
+      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-0-0"/>
        <position name="posArapucaDouble0-Frame-0-0" unit="cm" 
-         x="-327.04"
-	 y="-627.55" 
-	 z="-858.805175"/>
+         x="-328.04"
+	 y="-633.7" 
+	 z="-859.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-0"/>
        <position name="posOpArapucaDouble0-Frame-0-0" unit="cm" 
-         x="-326.3"
-	 y="-627.55" 
-	 z="-858.805175"/>
+         x="-327.3"
+	 y="-633.7" 
+	 z="-859.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-0-1"/>
        <position name="posArapucaDouble1-Frame-0-0" unit="cm" 
-         x="-327.04"
-	 y="-537" 
-	 z="-996.456075"/>
+         x="-328.04"
+	 y="-543" 
+	 z="-1005.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-1"/>
        <position name="posOpArapucaDouble1-Frame-0-0" unit="cm" 
-         x="-326.3"
-	 y="-537" 
-	 z="-996.456075"/>
+         x="-327.3"
+	 y="-543" 
+	 z="-1005.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-0-2"/>
        <position name="posArapucaDouble2-Frame-0-0" unit="cm" 
-         x="-327.04"
-	 y="-471" 
-	 z="-790.354725"/>
+         x="-328.04"
+	 y="-469" 
+	 z="-788.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-2"/>
        <position name="posOpArapucaDouble2-Frame-0-0" unit="cm" 
-         x="-326.3"
-	 y="-471" 
-	 z="-790.354725"/>
+         x="-327.3"
+	 y="-469" 
+	 z="-788.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-0-3"/>
        <position name="posArapucaDouble3-Frame-0-0" unit="cm" 
-         x="-327.04"
-	 y="-380.45" 
-	 z="-928.005625"/>
+         x="-328.04"
+	 y="-378.3" 
+	 z="-934.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-3"/>
        <position name="posOpArapucaDouble3-Frame-0-0" unit="cm" 
-         x="-326.3"
-	 y="-380.45" 
-	 z="-928.005625"/>
+         x="-327.3"
+	 y="-378.3" 
+	 z="-934.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-1-0"/>
        <position name="posArapucaDouble0-Frame-0-1" unit="cm" 
-         x="-327.04"
-	 y="-627.55" 
-	 z="-561.003375"/>
+         x="-328.04"
+	 y="-633.7" 
+	 z="-561.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-0"/>
        <position name="posOpArapucaDouble0-Frame-0-1" unit="cm" 
-         x="-326.3"
-	 y="-627.55" 
-	 z="-561.003375"/>
+         x="-327.3"
+	 y="-633.7" 
+	 z="-561.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-1-1"/>
        <position name="posArapucaDouble1-Frame-0-1" unit="cm" 
-         x="-327.04"
-	 y="-537" 
-	 z="-698.654275"/>
+         x="-328.04"
+	 y="-543" 
+	 z="-707.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-1"/>
        <position name="posOpArapucaDouble1-Frame-0-1" unit="cm" 
-         x="-326.3"
-	 y="-537" 
-	 z="-698.654275"/>
+         x="-327.3"
+	 y="-543" 
+	 z="-707.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-1-2"/>
        <position name="posArapucaDouble2-Frame-0-1" unit="cm" 
-         x="-327.04"
-	 y="-471" 
-	 z="-492.552925"/>
+         x="-328.04"
+	 y="-469" 
+	 z="-490.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-2"/>
        <position name="posOpArapucaDouble2-Frame-0-1" unit="cm" 
-         x="-326.3"
-	 y="-471" 
-	 z="-492.552925"/>
+         x="-327.3"
+	 y="-469" 
+	 z="-490.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-1-3"/>
        <position name="posArapucaDouble3-Frame-0-1" unit="cm" 
-         x="-327.04"
-	 y="-380.45" 
-	 z="-630.203825"/>
+         x="-328.04"
+	 y="-378.3" 
+	 z="-636.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-3"/>
        <position name="posOpArapucaDouble3-Frame-0-1" unit="cm" 
-         x="-326.3"
-	 y="-380.45" 
-	 z="-630.203825"/>
+         x="-327.3"
+	 y="-378.3" 
+	 z="-636.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-2-0"/>
        <position name="posArapucaDouble0-Frame-0-2" unit="cm" 
-         x="-327.04"
-	 y="-627.55" 
-	 z="-263.201575"/>
+         x="-328.04"
+	 y="-633.7" 
+	 z="-263.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-0"/>
        <position name="posOpArapucaDouble0-Frame-0-2" unit="cm" 
-         x="-326.3"
-	 y="-627.55" 
-	 z="-263.201575"/>
+         x="-327.3"
+	 y="-633.7" 
+	 z="-263.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-2-1"/>
        <position name="posArapucaDouble1-Frame-0-2" unit="cm" 
-         x="-327.04"
-	 y="-537" 
-	 z="-400.852475"/>
+         x="-328.04"
+	 y="-543" 
+	 z="-409.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-1"/>
        <position name="posOpArapucaDouble1-Frame-0-2" unit="cm" 
-         x="-326.3"
-	 y="-537" 
-	 z="-400.852475"/>
+         x="-327.3"
+	 y="-543" 
+	 z="-409.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-2-2"/>
        <position name="posArapucaDouble2-Frame-0-2" unit="cm" 
-         x="-327.04"
-	 y="-471" 
-	 z="-194.751125"/>
+         x="-328.04"
+	 y="-469" 
+	 z="-192.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-2"/>
        <position name="posOpArapucaDouble2-Frame-0-2" unit="cm" 
-         x="-326.3"
-	 y="-471" 
-	 z="-194.751125"/>
+         x="-327.3"
+	 y="-469" 
+	 z="-192.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-2-3"/>
        <position name="posArapucaDouble3-Frame-0-2" unit="cm" 
-         x="-327.04"
-	 y="-380.45" 
-	 z="-332.402025"/>
+         x="-328.04"
+	 y="-378.3" 
+	 z="-338.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-3"/>
        <position name="posOpArapucaDouble3-Frame-0-2" unit="cm" 
-         x="-326.3"
-	 y="-380.45" 
-	 z="-332.402025"/>
+         x="-327.3"
+	 y="-378.3" 
+	 z="-338.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-3-0"/>
        <position name="posArapucaDouble0-Frame-0-3" unit="cm" 
-         x="-327.04"
-	 y="-627.55" 
-	 z="34.6002250000001"/>
+         x="-328.04"
+	 y="-633.7" 
+	 z="34.0000000000001"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-3-0"/>
        <position name="posOpArapucaDouble0-Frame-0-3" unit="cm" 
-         x="-326.3"
-	 y="-627.55" 
-	 z="34.6002250000001"/>
+         x="-327.3"
+	 y="-633.7" 
+	 z="34.0000000000001"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-3-1"/>
        <position name="posArapucaDouble1-Frame-0-3" unit="cm" 
-         x="-327.04"
-	 y="-537" 
-	 z="-103.050675"/>
+         x="-328.04"
+	 y="-543" 
+	 z="-112"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-3-1"/>
        <position name="posOpArapucaDouble1-Frame-0-3" unit="cm" 
-         x="-326.3"
-	 y="-537" 
-	 z="-103.050675"/>
+         x="-327.3"
+	 y="-543" 
+	 z="-112"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-3-2"/>
        <position name="posArapucaDouble2-Frame-0-3" unit="cm" 
-         x="-327.04"
-	 y="-471" 
-	 z="103.050675"/>
+         x="-328.04"
+	 y="-469" 
+	 z="105"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-3-2"/>
        <position name="posOpArapucaDouble2-Frame-0-3" unit="cm" 
-         x="-326.3"
-	 y="-471" 
-	 z="103.050675"/>
+         x="-327.3"
+	 y="-469" 
+	 z="105"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-3-3"/>
        <position name="posArapucaDouble3-Frame-0-3" unit="cm" 
-         x="-327.04"
-	 y="-380.45" 
-	 z="-34.6002249999999"/>
+         x="-328.04"
+	 y="-378.3" 
+	 z="-40.9999999999999"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-3-3"/>
        <position name="posOpArapucaDouble3-Frame-0-3" unit="cm" 
-         x="-326.3"
-	 y="-380.45" 
-	 z="-34.6002249999999"/>
+         x="-327.3"
+	 y="-378.3" 
+	 z="-40.9999999999999"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-4-0"/>
        <position name="posArapucaDouble0-Frame-0-4" unit="cm" 
-         x="-327.04"
-	 y="-627.55" 
-	 z="332.402025"/>
+         x="-328.04"
+	 y="-633.7" 
+	 z="331.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-4-0"/>
        <position name="posOpArapucaDouble0-Frame-0-4" unit="cm" 
-         x="-326.3"
-	 y="-627.55" 
-	 z="332.402025"/>
+         x="-327.3"
+	 y="-633.7" 
+	 z="331.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-4-1"/>
        <position name="posArapucaDouble1-Frame-0-4" unit="cm" 
-         x="-327.04"
-	 y="-537" 
-	 z="194.751125"/>
+         x="-328.04"
+	 y="-543" 
+	 z="185.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-4-1"/>
        <position name="posOpArapucaDouble1-Frame-0-4" unit="cm" 
-         x="-326.3"
-	 y="-537" 
-	 z="194.751125"/>
+         x="-327.3"
+	 y="-543" 
+	 z="185.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-4-2"/>
        <position name="posArapucaDouble2-Frame-0-4" unit="cm" 
-         x="-327.04"
-	 y="-471" 
-	 z="400.852475"/>
+         x="-328.04"
+	 y="-469" 
+	 z="402.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-4-2"/>
        <position name="posOpArapucaDouble2-Frame-0-4" unit="cm" 
-         x="-326.3"
-	 y="-471" 
-	 z="400.852475"/>
+         x="-327.3"
+	 y="-469" 
+	 z="402.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-4-3"/>
        <position name="posArapucaDouble3-Frame-0-4" unit="cm" 
-         x="-327.04"
-	 y="-380.45" 
-	 z="263.201575"/>
+         x="-328.04"
+	 y="-378.3" 
+	 z="256.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-4-3"/>
        <position name="posOpArapucaDouble3-Frame-0-4" unit="cm" 
-         x="-326.3"
-	 y="-380.45" 
-	 z="263.201575"/>
+         x="-327.3"
+	 y="-378.3" 
+	 z="256.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-5-0"/>
        <position name="posArapucaDouble0-Frame-0-5" unit="cm" 
-         x="-327.04"
-	 y="-627.55" 
-	 z="630.203825"/>
+         x="-328.04"
+	 y="-633.7" 
+	 z="629.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-5-0"/>
        <position name="posOpArapucaDouble0-Frame-0-5" unit="cm" 
-         x="-326.3"
-	 y="-627.55" 
-	 z="630.203825"/>
+         x="-327.3"
+	 y="-633.7" 
+	 z="629.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-5-1"/>
        <position name="posArapucaDouble1-Frame-0-5" unit="cm" 
-         x="-327.04"
-	 y="-537" 
-	 z="492.552925"/>
+         x="-328.04"
+	 y="-543" 
+	 z="483.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-5-1"/>
        <position name="posOpArapucaDouble1-Frame-0-5" unit="cm" 
-         x="-326.3"
-	 y="-537" 
-	 z="492.552925"/>
+         x="-327.3"
+	 y="-543" 
+	 z="483.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-5-2"/>
        <position name="posArapucaDouble2-Frame-0-5" unit="cm" 
-         x="-327.04"
-	 y="-471" 
-	 z="698.654275"/>
+         x="-328.04"
+	 y="-469" 
+	 z="700.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-5-2"/>
        <position name="posOpArapucaDouble2-Frame-0-5" unit="cm" 
-         x="-326.3"
-	 y="-471" 
-	 z="698.654275"/>
+         x="-327.3"
+	 y="-469" 
+	 z="700.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-5-3"/>
        <position name="posArapucaDouble3-Frame-0-5" unit="cm" 
-         x="-327.04"
-	 y="-380.45" 
-	 z="561.003375"/>
+         x="-328.04"
+	 y="-378.3" 
+	 z="554.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-5-3"/>
        <position name="posOpArapucaDouble3-Frame-0-5" unit="cm" 
-         x="-326.3"
-	 y="-380.45" 
-	 z="561.003375"/>
+         x="-327.3"
+	 y="-378.3" 
+	 z="554.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-6-0"/>
        <position name="posArapucaDouble0-Frame-0-6" unit="cm" 
-         x="-327.04"
-	 y="-627.55" 
-	 z="928.005625"/>
+         x="-328.04"
+	 y="-633.7" 
+	 z="927.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-6-0"/>
        <position name="posOpArapucaDouble0-Frame-0-6" unit="cm" 
-         x="-326.3"
-	 y="-627.55" 
-	 z="928.005625"/>
+         x="-327.3"
+	 y="-633.7" 
+	 z="927.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-6-1"/>
        <position name="posArapucaDouble1-Frame-0-6" unit="cm" 
-         x="-327.04"
-	 y="-537" 
-	 z="790.354725"/>
+         x="-328.04"
+	 y="-543" 
+	 z="781.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-6-1"/>
        <position name="posOpArapucaDouble1-Frame-0-6" unit="cm" 
-         x="-326.3"
-	 y="-537" 
-	 z="790.354725"/>
+         x="-327.3"
+	 y="-543" 
+	 z="781.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-6-2"/>
        <position name="posArapucaDouble2-Frame-0-6" unit="cm" 
-         x="-327.04"
-	 y="-471" 
-	 z="996.456075"/>
+         x="-328.04"
+	 y="-469" 
+	 z="998.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-6-2"/>
        <position name="posOpArapucaDouble2-Frame-0-6" unit="cm" 
-         x="-326.3"
-	 y="-471" 
-	 z="996.456075"/>
+         x="-327.3"
+	 y="-469" 
+	 z="998.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-6-3"/>
        <position name="posArapucaDouble3-Frame-0-6" unit="cm" 
-         x="-327.04"
-	 y="-380.45" 
-	 z="858.805175"/>
+         x="-328.04"
+	 y="-378.3" 
+	 z="852.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-6-3"/>
        <position name="posOpArapucaDouble3-Frame-0-6" unit="cm" 
-         x="-326.3"
-	 y="-380.45" 
-	 z="858.805175"/>
+         x="-327.3"
+	 y="-378.3" 
+	 z="852.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-0-0"/>
        <position name="posArapucaDouble0-Frame-1-0" unit="cm" 
-         x="-327.04"
-	 y="-291.55" 
-	 z="-858.805175"/>
+         x="-328.04"
+	 y="-297.7" 
+	 z="-859.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-0"/>
        <position name="posOpArapucaDouble0-Frame-1-0" unit="cm" 
-         x="-326.3"
-	 y="-291.55" 
-	 z="-858.805175"/>
+         x="-327.3"
+	 y="-297.7" 
+	 z="-859.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-0-1"/>
        <position name="posArapucaDouble1-Frame-1-0" unit="cm" 
-         x="-327.04"
-	 y="-201" 
-	 z="-996.456075"/>
+         x="-328.04"
+	 y="-207" 
+	 z="-1005.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-1"/>
        <position name="posOpArapucaDouble1-Frame-1-0" unit="cm" 
-         x="-326.3"
-	 y="-201" 
-	 z="-996.456075"/>
+         x="-327.3"
+	 y="-207" 
+	 z="-1005.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-0-2"/>
        <position name="posArapucaDouble2-Frame-1-0" unit="cm" 
-         x="-327.04"
-	 y="-135" 
-	 z="-790.354725"/>
+         x="-328.04"
+	 y="-133" 
+	 z="-788.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-2"/>
        <position name="posOpArapucaDouble2-Frame-1-0" unit="cm" 
-         x="-326.3"
-	 y="-135" 
-	 z="-790.354725"/>
+         x="-327.3"
+	 y="-133" 
+	 z="-788.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-0-3"/>
        <position name="posArapucaDouble3-Frame-1-0" unit="cm" 
-         x="-327.04"
-	 y="-44.45" 
-	 z="-928.005625"/>
+         x="-328.04"
+	 y="-42.3" 
+	 z="-934.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-3"/>
        <position name="posOpArapucaDouble3-Frame-1-0" unit="cm" 
-         x="-326.3"
-	 y="-44.45" 
-	 z="-928.005625"/>
+         x="-327.3"
+	 y="-42.3" 
+	 z="-934.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-1-0"/>
        <position name="posArapucaDouble0-Frame-1-1" unit="cm" 
-         x="-327.04"
-	 y="-291.55" 
-	 z="-561.003375"/>
+         x="-328.04"
+	 y="-297.7" 
+	 z="-561.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-0"/>
        <position name="posOpArapucaDouble0-Frame-1-1" unit="cm" 
-         x="-326.3"
-	 y="-291.55" 
-	 z="-561.003375"/>
+         x="-327.3"
+	 y="-297.7" 
+	 z="-561.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-1-1"/>
        <position name="posArapucaDouble1-Frame-1-1" unit="cm" 
-         x="-327.04"
-	 y="-201" 
-	 z="-698.654275"/>
+         x="-328.04"
+	 y="-207" 
+	 z="-707.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-1"/>
        <position name="posOpArapucaDouble1-Frame-1-1" unit="cm" 
-         x="-326.3"
-	 y="-201" 
-	 z="-698.654275"/>
+         x="-327.3"
+	 y="-207" 
+	 z="-707.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-1-2"/>
        <position name="posArapucaDouble2-Frame-1-1" unit="cm" 
-         x="-327.04"
-	 y="-135" 
-	 z="-492.552925"/>
+         x="-328.04"
+	 y="-133" 
+	 z="-490.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-2"/>
        <position name="posOpArapucaDouble2-Frame-1-1" unit="cm" 
-         x="-326.3"
-	 y="-135" 
-	 z="-492.552925"/>
+         x="-327.3"
+	 y="-133" 
+	 z="-490.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-1-3"/>
        <position name="posArapucaDouble3-Frame-1-1" unit="cm" 
-         x="-327.04"
-	 y="-44.45" 
-	 z="-630.203825"/>
+         x="-328.04"
+	 y="-42.3" 
+	 z="-636.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-3"/>
        <position name="posOpArapucaDouble3-Frame-1-1" unit="cm" 
-         x="-326.3"
-	 y="-44.45" 
-	 z="-630.203825"/>
+         x="-327.3"
+	 y="-42.3" 
+	 z="-636.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-2-0"/>
        <position name="posArapucaDouble0-Frame-1-2" unit="cm" 
-         x="-327.04"
-	 y="-291.55" 
-	 z="-263.201575"/>
+         x="-328.04"
+	 y="-297.7" 
+	 z="-263.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-0"/>
        <position name="posOpArapucaDouble0-Frame-1-2" unit="cm" 
-         x="-326.3"
-	 y="-291.55" 
-	 z="-263.201575"/>
+         x="-327.3"
+	 y="-297.7" 
+	 z="-263.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-2-1"/>
        <position name="posArapucaDouble1-Frame-1-2" unit="cm" 
-         x="-327.04"
-	 y="-201" 
-	 z="-400.852475"/>
+         x="-328.04"
+	 y="-207" 
+	 z="-409.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-1"/>
        <position name="posOpArapucaDouble1-Frame-1-2" unit="cm" 
-         x="-326.3"
-	 y="-201" 
-	 z="-400.852475"/>
+         x="-327.3"
+	 y="-207" 
+	 z="-409.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-2-2"/>
        <position name="posArapucaDouble2-Frame-1-2" unit="cm" 
-         x="-327.04"
-	 y="-135" 
-	 z="-194.751125"/>
+         x="-328.04"
+	 y="-133" 
+	 z="-192.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-2"/>
        <position name="posOpArapucaDouble2-Frame-1-2" unit="cm" 
-         x="-326.3"
-	 y="-135" 
-	 z="-194.751125"/>
+         x="-327.3"
+	 y="-133" 
+	 z="-192.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-2-3"/>
        <position name="posArapucaDouble3-Frame-1-2" unit="cm" 
-         x="-327.04"
-	 y="-44.45" 
-	 z="-332.402025"/>
+         x="-328.04"
+	 y="-42.3" 
+	 z="-338.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-3"/>
        <position name="posOpArapucaDouble3-Frame-1-2" unit="cm" 
-         x="-326.3"
-	 y="-44.45" 
-	 z="-332.402025"/>
+         x="-327.3"
+	 y="-42.3" 
+	 z="-338.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-3-0"/>
        <position name="posArapucaDouble0-Frame-1-3" unit="cm" 
-         x="-327.04"
-	 y="-291.55" 
-	 z="34.6002250000001"/>
+         x="-328.04"
+	 y="-297.7" 
+	 z="34.0000000000001"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-3-0"/>
        <position name="posOpArapucaDouble0-Frame-1-3" unit="cm" 
-         x="-326.3"
-	 y="-291.55" 
-	 z="34.6002250000001"/>
+         x="-327.3"
+	 y="-297.7" 
+	 z="34.0000000000001"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-3-1"/>
        <position name="posArapucaDouble1-Frame-1-3" unit="cm" 
-         x="-327.04"
-	 y="-201" 
-	 z="-103.050675"/>
+         x="-328.04"
+	 y="-207" 
+	 z="-112"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-3-1"/>
        <position name="posOpArapucaDouble1-Frame-1-3" unit="cm" 
-         x="-326.3"
-	 y="-201" 
-	 z="-103.050675"/>
+         x="-327.3"
+	 y="-207" 
+	 z="-112"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-3-2"/>
        <position name="posArapucaDouble2-Frame-1-3" unit="cm" 
-         x="-327.04"
-	 y="-135" 
-	 z="103.050675"/>
+         x="-328.04"
+	 y="-133" 
+	 z="105"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-3-2"/>
        <position name="posOpArapucaDouble2-Frame-1-3" unit="cm" 
-         x="-326.3"
-	 y="-135" 
-	 z="103.050675"/>
+         x="-327.3"
+	 y="-133" 
+	 z="105"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-3-3"/>
        <position name="posArapucaDouble3-Frame-1-3" unit="cm" 
-         x="-327.04"
-	 y="-44.45" 
-	 z="-34.6002249999999"/>
+         x="-328.04"
+	 y="-42.3" 
+	 z="-40.9999999999999"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-3-3"/>
        <position name="posOpArapucaDouble3-Frame-1-3" unit="cm" 
-         x="-326.3"
-	 y="-44.45" 
-	 z="-34.6002249999999"/>
+         x="-327.3"
+	 y="-42.3" 
+	 z="-40.9999999999999"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-4-0"/>
        <position name="posArapucaDouble0-Frame-1-4" unit="cm" 
-         x="-327.04"
-	 y="-291.55" 
-	 z="332.402025"/>
+         x="-328.04"
+	 y="-297.7" 
+	 z="331.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-4-0"/>
        <position name="posOpArapucaDouble0-Frame-1-4" unit="cm" 
-         x="-326.3"
-	 y="-291.55" 
-	 z="332.402025"/>
+         x="-327.3"
+	 y="-297.7" 
+	 z="331.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-4-1"/>
        <position name="posArapucaDouble1-Frame-1-4" unit="cm" 
-         x="-327.04"
-	 y="-201" 
-	 z="194.751125"/>
+         x="-328.04"
+	 y="-207" 
+	 z="185.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-4-1"/>
        <position name="posOpArapucaDouble1-Frame-1-4" unit="cm" 
-         x="-326.3"
-	 y="-201" 
-	 z="194.751125"/>
+         x="-327.3"
+	 y="-207" 
+	 z="185.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-4-2"/>
        <position name="posArapucaDouble2-Frame-1-4" unit="cm" 
-         x="-327.04"
-	 y="-135" 
-	 z="400.852475"/>
+         x="-328.04"
+	 y="-133" 
+	 z="402.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-4-2"/>
        <position name="posOpArapucaDouble2-Frame-1-4" unit="cm" 
-         x="-326.3"
-	 y="-135" 
-	 z="400.852475"/>
+         x="-327.3"
+	 y="-133" 
+	 z="402.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-4-3"/>
        <position name="posArapucaDouble3-Frame-1-4" unit="cm" 
-         x="-327.04"
-	 y="-44.45" 
-	 z="263.201575"/>
+         x="-328.04"
+	 y="-42.3" 
+	 z="256.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-4-3"/>
        <position name="posOpArapucaDouble3-Frame-1-4" unit="cm" 
-         x="-326.3"
-	 y="-44.45" 
-	 z="263.201575"/>
+         x="-327.3"
+	 y="-42.3" 
+	 z="256.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-5-0"/>
        <position name="posArapucaDouble0-Frame-1-5" unit="cm" 
-         x="-327.04"
-	 y="-291.55" 
-	 z="630.203825"/>
+         x="-328.04"
+	 y="-297.7" 
+	 z="629.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-5-0"/>
        <position name="posOpArapucaDouble0-Frame-1-5" unit="cm" 
-         x="-326.3"
-	 y="-291.55" 
-	 z="630.203825"/>
+         x="-327.3"
+	 y="-297.7" 
+	 z="629.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-5-1"/>
        <position name="posArapucaDouble1-Frame-1-5" unit="cm" 
-         x="-327.04"
-	 y="-201" 
-	 z="492.552925"/>
+         x="-328.04"
+	 y="-207" 
+	 z="483.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-5-1"/>
        <position name="posOpArapucaDouble1-Frame-1-5" unit="cm" 
-         x="-326.3"
-	 y="-201" 
-	 z="492.552925"/>
+         x="-327.3"
+	 y="-207" 
+	 z="483.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-5-2"/>
        <position name="posArapucaDouble2-Frame-1-5" unit="cm" 
-         x="-327.04"
-	 y="-135" 
-	 z="698.654275"/>
+         x="-328.04"
+	 y="-133" 
+	 z="700.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-5-2"/>
        <position name="posOpArapucaDouble2-Frame-1-5" unit="cm" 
-         x="-326.3"
-	 y="-135" 
-	 z="698.654275"/>
+         x="-327.3"
+	 y="-133" 
+	 z="700.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-5-3"/>
        <position name="posArapucaDouble3-Frame-1-5" unit="cm" 
-         x="-327.04"
-	 y="-44.45" 
-	 z="561.003375"/>
+         x="-328.04"
+	 y="-42.3" 
+	 z="554.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-5-3"/>
        <position name="posOpArapucaDouble3-Frame-1-5" unit="cm" 
-         x="-326.3"
-	 y="-44.45" 
-	 z="561.003375"/>
+         x="-327.3"
+	 y="-42.3" 
+	 z="554.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-6-0"/>
        <position name="posArapucaDouble0-Frame-1-6" unit="cm" 
-         x="-327.04"
-	 y="-291.55" 
-	 z="928.005625"/>
+         x="-328.04"
+	 y="-297.7" 
+	 z="927.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-6-0"/>
        <position name="posOpArapucaDouble0-Frame-1-6" unit="cm" 
-         x="-326.3"
-	 y="-291.55" 
-	 z="928.005625"/>
+         x="-327.3"
+	 y="-297.7" 
+	 z="927.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-6-1"/>
        <position name="posArapucaDouble1-Frame-1-6" unit="cm" 
-         x="-327.04"
-	 y="-201" 
-	 z="790.354725"/>
+         x="-328.04"
+	 y="-207" 
+	 z="781.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-6-1"/>
        <position name="posOpArapucaDouble1-Frame-1-6" unit="cm" 
-         x="-326.3"
-	 y="-201" 
-	 z="790.354725"/>
+         x="-327.3"
+	 y="-207" 
+	 z="781.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-6-2"/>
        <position name="posArapucaDouble2-Frame-1-6" unit="cm" 
-         x="-327.04"
-	 y="-135" 
-	 z="996.456075"/>
+         x="-328.04"
+	 y="-133" 
+	 z="998.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-6-2"/>
        <position name="posOpArapucaDouble2-Frame-1-6" unit="cm" 
-         x="-326.3"
-	 y="-135" 
-	 z="996.456075"/>
+         x="-327.3"
+	 y="-133" 
+	 z="998.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-6-3"/>
        <position name="posArapucaDouble3-Frame-1-6" unit="cm" 
-         x="-327.04"
-	 y="-44.45" 
-	 z="858.805175"/>
+         x="-328.04"
+	 y="-42.3" 
+	 z="852.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-6-3"/>
        <position name="posOpArapucaDouble3-Frame-1-6" unit="cm" 
-         x="-326.3"
-	 y="-44.45" 
-	 z="858.805175"/>
+         x="-327.3"
+	 y="-42.3" 
+	 z="852.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-0-0"/>
        <position name="posArapucaDouble0-Frame-2-0" unit="cm" 
-         x="-327.04"
-	 y="44.45" 
-	 z="-858.805175"/>
+         x="-328.04"
+	 y="38.3" 
+	 z="-859.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-0"/>
        <position name="posOpArapucaDouble0-Frame-2-0" unit="cm" 
-         x="-326.3"
-	 y="44.45" 
-	 z="-858.805175"/>
+         x="-327.3"
+	 y="38.3" 
+	 z="-859.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-0-1"/>
        <position name="posArapucaDouble1-Frame-2-0" unit="cm" 
-         x="-327.04"
-	 y="135" 
-	 z="-996.456075"/>
+         x="-328.04"
+	 y="129" 
+	 z="-1005.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-1"/>
        <position name="posOpArapucaDouble1-Frame-2-0" unit="cm" 
-         x="-326.3"
-	 y="135" 
-	 z="-996.456075"/>
+         x="-327.3"
+	 y="129" 
+	 z="-1005.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-0-2"/>
        <position name="posArapucaDouble2-Frame-2-0" unit="cm" 
-         x="-327.04"
-	 y="201" 
-	 z="-790.354725"/>
+         x="-328.04"
+	 y="203" 
+	 z="-788.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-2"/>
        <position name="posOpArapucaDouble2-Frame-2-0" unit="cm" 
-         x="-326.3"
-	 y="201" 
-	 z="-790.354725"/>
+         x="-327.3"
+	 y="203" 
+	 z="-788.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-0-3"/>
        <position name="posArapucaDouble3-Frame-2-0" unit="cm" 
-         x="-327.04"
-	 y="291.55" 
-	 z="-928.005625"/>
+         x="-328.04"
+	 y="293.7" 
+	 z="-934.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-3"/>
        <position name="posOpArapucaDouble3-Frame-2-0" unit="cm" 
-         x="-326.3"
-	 y="291.55" 
-	 z="-928.005625"/>
+         x="-327.3"
+	 y="293.7" 
+	 z="-934.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-1-0"/>
        <position name="posArapucaDouble0-Frame-2-1" unit="cm" 
-         x="-327.04"
-	 y="44.45" 
-	 z="-561.003375"/>
+         x="-328.04"
+	 y="38.3" 
+	 z="-561.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-0"/>
        <position name="posOpArapucaDouble0-Frame-2-1" unit="cm" 
-         x="-326.3"
-	 y="44.45" 
-	 z="-561.003375"/>
+         x="-327.3"
+	 y="38.3" 
+	 z="-561.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-1-1"/>
        <position name="posArapucaDouble1-Frame-2-1" unit="cm" 
-         x="-327.04"
-	 y="135" 
-	 z="-698.654275"/>
+         x="-328.04"
+	 y="129" 
+	 z="-707.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-1"/>
        <position name="posOpArapucaDouble1-Frame-2-1" unit="cm" 
-         x="-326.3"
-	 y="135" 
-	 z="-698.654275"/>
+         x="-327.3"
+	 y="129" 
+	 z="-707.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-1-2"/>
        <position name="posArapucaDouble2-Frame-2-1" unit="cm" 
-         x="-327.04"
-	 y="201" 
-	 z="-492.552925"/>
+         x="-328.04"
+	 y="203" 
+	 z="-490.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-2"/>
        <position name="posOpArapucaDouble2-Frame-2-1" unit="cm" 
-         x="-326.3"
-	 y="201" 
-	 z="-492.552925"/>
+         x="-327.3"
+	 y="203" 
+	 z="-490.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-1-3"/>
        <position name="posArapucaDouble3-Frame-2-1" unit="cm" 
-         x="-327.04"
-	 y="291.55" 
-	 z="-630.203825"/>
+         x="-328.04"
+	 y="293.7" 
+	 z="-636.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-3"/>
        <position name="posOpArapucaDouble3-Frame-2-1" unit="cm" 
-         x="-326.3"
-	 y="291.55" 
-	 z="-630.203825"/>
+         x="-327.3"
+	 y="293.7" 
+	 z="-636.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-2-0"/>
        <position name="posArapucaDouble0-Frame-2-2" unit="cm" 
-         x="-327.04"
-	 y="44.45" 
-	 z="-263.201575"/>
+         x="-328.04"
+	 y="38.3" 
+	 z="-263.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-0"/>
        <position name="posOpArapucaDouble0-Frame-2-2" unit="cm" 
-         x="-326.3"
-	 y="44.45" 
-	 z="-263.201575"/>
+         x="-327.3"
+	 y="38.3" 
+	 z="-263.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-2-1"/>
        <position name="posArapucaDouble1-Frame-2-2" unit="cm" 
-         x="-327.04"
-	 y="135" 
-	 z="-400.852475"/>
+         x="-328.04"
+	 y="129" 
+	 z="-409.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-1"/>
        <position name="posOpArapucaDouble1-Frame-2-2" unit="cm" 
-         x="-326.3"
-	 y="135" 
-	 z="-400.852475"/>
+         x="-327.3"
+	 y="129" 
+	 z="-409.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-2-2"/>
        <position name="posArapucaDouble2-Frame-2-2" unit="cm" 
-         x="-327.04"
-	 y="201" 
-	 z="-194.751125"/>
+         x="-328.04"
+	 y="203" 
+	 z="-192.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-2"/>
        <position name="posOpArapucaDouble2-Frame-2-2" unit="cm" 
-         x="-326.3"
-	 y="201" 
-	 z="-194.751125"/>
+         x="-327.3"
+	 y="203" 
+	 z="-192.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-2-3"/>
        <position name="posArapucaDouble3-Frame-2-2" unit="cm" 
-         x="-327.04"
-	 y="291.55" 
-	 z="-332.402025"/>
+         x="-328.04"
+	 y="293.7" 
+	 z="-338.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-3"/>
        <position name="posOpArapucaDouble3-Frame-2-2" unit="cm" 
-         x="-326.3"
-	 y="291.55" 
-	 z="-332.402025"/>
+         x="-327.3"
+	 y="293.7" 
+	 z="-338.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-3-0"/>
        <position name="posArapucaDouble0-Frame-2-3" unit="cm" 
-         x="-327.04"
-	 y="44.45" 
-	 z="34.6002250000001"/>
+         x="-328.04"
+	 y="38.3" 
+	 z="34.0000000000001"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-3-0"/>
        <position name="posOpArapucaDouble0-Frame-2-3" unit="cm" 
-         x="-326.3"
-	 y="44.45" 
-	 z="34.6002250000001"/>
+         x="-327.3"
+	 y="38.3" 
+	 z="34.0000000000001"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-3-1"/>
        <position name="posArapucaDouble1-Frame-2-3" unit="cm" 
-         x="-327.04"
-	 y="135" 
-	 z="-103.050675"/>
+         x="-328.04"
+	 y="129" 
+	 z="-112"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-3-1"/>
        <position name="posOpArapucaDouble1-Frame-2-3" unit="cm" 
-         x="-326.3"
-	 y="135" 
-	 z="-103.050675"/>
+         x="-327.3"
+	 y="129" 
+	 z="-112"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-3-2"/>
        <position name="posArapucaDouble2-Frame-2-3" unit="cm" 
-         x="-327.04"
-	 y="201" 
-	 z="103.050675"/>
+         x="-328.04"
+	 y="203" 
+	 z="105"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-3-2"/>
        <position name="posOpArapucaDouble2-Frame-2-3" unit="cm" 
-         x="-326.3"
-	 y="201" 
-	 z="103.050675"/>
+         x="-327.3"
+	 y="203" 
+	 z="105"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-3-3"/>
        <position name="posArapucaDouble3-Frame-2-3" unit="cm" 
-         x="-327.04"
-	 y="291.55" 
-	 z="-34.6002249999999"/>
+         x="-328.04"
+	 y="293.7" 
+	 z="-40.9999999999999"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-3-3"/>
        <position name="posOpArapucaDouble3-Frame-2-3" unit="cm" 
-         x="-326.3"
-	 y="291.55" 
-	 z="-34.6002249999999"/>
+         x="-327.3"
+	 y="293.7" 
+	 z="-40.9999999999999"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-4-0"/>
        <position name="posArapucaDouble0-Frame-2-4" unit="cm" 
-         x="-327.04"
-	 y="44.45" 
-	 z="332.402025"/>
+         x="-328.04"
+	 y="38.3" 
+	 z="331.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-4-0"/>
        <position name="posOpArapucaDouble0-Frame-2-4" unit="cm" 
-         x="-326.3"
-	 y="44.45" 
-	 z="332.402025"/>
+         x="-327.3"
+	 y="38.3" 
+	 z="331.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-4-1"/>
        <position name="posArapucaDouble1-Frame-2-4" unit="cm" 
-         x="-327.04"
-	 y="135" 
-	 z="194.751125"/>
+         x="-328.04"
+	 y="129" 
+	 z="185.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-4-1"/>
        <position name="posOpArapucaDouble1-Frame-2-4" unit="cm" 
-         x="-326.3"
-	 y="135" 
-	 z="194.751125"/>
+         x="-327.3"
+	 y="129" 
+	 z="185.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-4-2"/>
        <position name="posArapucaDouble2-Frame-2-4" unit="cm" 
-         x="-327.04"
-	 y="201" 
-	 z="400.852475"/>
+         x="-328.04"
+	 y="203" 
+	 z="402.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-4-2"/>
        <position name="posOpArapucaDouble2-Frame-2-4" unit="cm" 
-         x="-326.3"
-	 y="201" 
-	 z="400.852475"/>
+         x="-327.3"
+	 y="203" 
+	 z="402.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-4-3"/>
        <position name="posArapucaDouble3-Frame-2-4" unit="cm" 
-         x="-327.04"
-	 y="291.55" 
-	 z="263.201575"/>
+         x="-328.04"
+	 y="293.7" 
+	 z="256.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-4-3"/>
        <position name="posOpArapucaDouble3-Frame-2-4" unit="cm" 
-         x="-326.3"
-	 y="291.55" 
-	 z="263.201575"/>
+         x="-327.3"
+	 y="293.7" 
+	 z="256.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-5-0"/>
        <position name="posArapucaDouble0-Frame-2-5" unit="cm" 
-         x="-327.04"
-	 y="44.45" 
-	 z="630.203825"/>
+         x="-328.04"
+	 y="38.3" 
+	 z="629.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-5-0"/>
        <position name="posOpArapucaDouble0-Frame-2-5" unit="cm" 
-         x="-326.3"
-	 y="44.45" 
-	 z="630.203825"/>
+         x="-327.3"
+	 y="38.3" 
+	 z="629.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-5-1"/>
        <position name="posArapucaDouble1-Frame-2-5" unit="cm" 
-         x="-327.04"
-	 y="135" 
-	 z="492.552925"/>
+         x="-328.04"
+	 y="129" 
+	 z="483.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-5-1"/>
        <position name="posOpArapucaDouble1-Frame-2-5" unit="cm" 
-         x="-326.3"
-	 y="135" 
-	 z="492.552925"/>
+         x="-327.3"
+	 y="129" 
+	 z="483.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-5-2"/>
        <position name="posArapucaDouble2-Frame-2-5" unit="cm" 
-         x="-327.04"
-	 y="201" 
-	 z="698.654275"/>
+         x="-328.04"
+	 y="203" 
+	 z="700.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-5-2"/>
        <position name="posOpArapucaDouble2-Frame-2-5" unit="cm" 
-         x="-326.3"
-	 y="201" 
-	 z="698.654275"/>
+         x="-327.3"
+	 y="203" 
+	 z="700.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-5-3"/>
        <position name="posArapucaDouble3-Frame-2-5" unit="cm" 
-         x="-327.04"
-	 y="291.55" 
-	 z="561.003375"/>
+         x="-328.04"
+	 y="293.7" 
+	 z="554.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-5-3"/>
        <position name="posOpArapucaDouble3-Frame-2-5" unit="cm" 
-         x="-326.3"
-	 y="291.55" 
-	 z="561.003375"/>
+         x="-327.3"
+	 y="293.7" 
+	 z="554.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-6-0"/>
        <position name="posArapucaDouble0-Frame-2-6" unit="cm" 
-         x="-327.04"
-	 y="44.45" 
-	 z="928.005625"/>
+         x="-328.04"
+	 y="38.3" 
+	 z="927.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-6-0"/>
        <position name="posOpArapucaDouble0-Frame-2-6" unit="cm" 
-         x="-326.3"
-	 y="44.45" 
-	 z="928.005625"/>
+         x="-327.3"
+	 y="38.3" 
+	 z="927.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-6-1"/>
        <position name="posArapucaDouble1-Frame-2-6" unit="cm" 
-         x="-327.04"
-	 y="135" 
-	 z="790.354725"/>
+         x="-328.04"
+	 y="129" 
+	 z="781.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-6-1"/>
        <position name="posOpArapucaDouble1-Frame-2-6" unit="cm" 
-         x="-326.3"
-	 y="135" 
-	 z="790.354725"/>
+         x="-327.3"
+	 y="129" 
+	 z="781.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-6-2"/>
        <position name="posArapucaDouble2-Frame-2-6" unit="cm" 
-         x="-327.04"
-	 y="201" 
-	 z="996.456075"/>
+         x="-328.04"
+	 y="203" 
+	 z="998.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-6-2"/>
        <position name="posOpArapucaDouble2-Frame-2-6" unit="cm" 
-         x="-326.3"
-	 y="201" 
-	 z="996.456075"/>
+         x="-327.3"
+	 y="203" 
+	 z="998.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-6-3"/>
        <position name="posArapucaDouble3-Frame-2-6" unit="cm" 
-         x="-327.04"
-	 y="291.55" 
-	 z="858.805175"/>
+         x="-328.04"
+	 y="293.7" 
+	 z="852.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-6-3"/>
        <position name="posOpArapucaDouble3-Frame-2-6" unit="cm" 
-         x="-326.3"
-	 y="291.55" 
-	 z="858.805175"/>
+         x="-327.3"
+	 y="293.7" 
+	 z="852.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-0-0"/>
        <position name="posArapucaDouble0-Frame-3-0" unit="cm" 
-         x="-327.04"
-	 y="380.45" 
-	 z="-858.805175"/>
+         x="-328.04"
+	 y="374.3" 
+	 z="-859.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-0"/>
        <position name="posOpArapucaDouble0-Frame-3-0" unit="cm" 
-         x="-326.3"
-	 y="380.45" 
-	 z="-858.805175"/>
+         x="-327.3"
+	 y="374.3" 
+	 z="-859.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-0-1"/>
        <position name="posArapucaDouble1-Frame-3-0" unit="cm" 
-         x="-327.04"
-	 y="471" 
-	 z="-996.456075"/>
+         x="-328.04"
+	 y="465" 
+	 z="-1005.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-1"/>
        <position name="posOpArapucaDouble1-Frame-3-0" unit="cm" 
-         x="-326.3"
-	 y="471" 
-	 z="-996.456075"/>
+         x="-327.3"
+	 y="465" 
+	 z="-1005.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-0-2"/>
        <position name="posArapucaDouble2-Frame-3-0" unit="cm" 
-         x="-327.04"
-	 y="537" 
-	 z="-790.354725"/>
+         x="-328.04"
+	 y="539" 
+	 z="-788.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-2"/>
        <position name="posOpArapucaDouble2-Frame-3-0" unit="cm" 
-         x="-326.3"
-	 y="537" 
-	 z="-790.354725"/>
+         x="-327.3"
+	 y="539" 
+	 z="-788.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-0-3"/>
        <position name="posArapucaDouble3-Frame-3-0" unit="cm" 
-         x="-327.04"
-	 y="627.55" 
-	 z="-928.005625"/>
+         x="-328.04"
+	 y="629.7" 
+	 z="-934.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-3"/>
        <position name="posOpArapucaDouble3-Frame-3-0" unit="cm" 
-         x="-326.3"
-	 y="627.55" 
-	 z="-928.005625"/>
+         x="-327.3"
+	 y="629.7" 
+	 z="-934.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-1-0"/>
        <position name="posArapucaDouble0-Frame-3-1" unit="cm" 
-         x="-327.04"
-	 y="380.45" 
-	 z="-561.003375"/>
+         x="-328.04"
+	 y="374.3" 
+	 z="-561.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-0"/>
        <position name="posOpArapucaDouble0-Frame-3-1" unit="cm" 
-         x="-326.3"
-	 y="380.45" 
-	 z="-561.003375"/>
+         x="-327.3"
+	 y="374.3" 
+	 z="-561.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-1-1"/>
        <position name="posArapucaDouble1-Frame-3-1" unit="cm" 
-         x="-327.04"
-	 y="471" 
-	 z="-698.654275"/>
+         x="-328.04"
+	 y="465" 
+	 z="-707.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-1"/>
        <position name="posOpArapucaDouble1-Frame-3-1" unit="cm" 
-         x="-326.3"
-	 y="471" 
-	 z="-698.654275"/>
+         x="-327.3"
+	 y="465" 
+	 z="-707.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-1-2"/>
        <position name="posArapucaDouble2-Frame-3-1" unit="cm" 
-         x="-327.04"
-	 y="537" 
-	 z="-492.552925"/>
+         x="-328.04"
+	 y="539" 
+	 z="-490.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-2"/>
        <position name="posOpArapucaDouble2-Frame-3-1" unit="cm" 
-         x="-326.3"
-	 y="537" 
-	 z="-492.552925"/>
+         x="-327.3"
+	 y="539" 
+	 z="-490.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-1-3"/>
        <position name="posArapucaDouble3-Frame-3-1" unit="cm" 
-         x="-327.04"
-	 y="627.55" 
-	 z="-630.203825"/>
+         x="-328.04"
+	 y="629.7" 
+	 z="-636.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-3"/>
        <position name="posOpArapucaDouble3-Frame-3-1" unit="cm" 
-         x="-326.3"
-	 y="627.55" 
-	 z="-630.203825"/>
+         x="-327.3"
+	 y="629.7" 
+	 z="-636.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-2-0"/>
        <position name="posArapucaDouble0-Frame-3-2" unit="cm" 
-         x="-327.04"
-	 y="380.45" 
-	 z="-263.201575"/>
+         x="-328.04"
+	 y="374.3" 
+	 z="-263.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-0"/>
        <position name="posOpArapucaDouble0-Frame-3-2" unit="cm" 
-         x="-326.3"
-	 y="380.45" 
-	 z="-263.201575"/>
+         x="-327.3"
+	 y="374.3" 
+	 z="-263.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-2-1"/>
        <position name="posArapucaDouble1-Frame-3-2" unit="cm" 
-         x="-327.04"
-	 y="471" 
-	 z="-400.852475"/>
+         x="-328.04"
+	 y="465" 
+	 z="-409.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-1"/>
        <position name="posOpArapucaDouble1-Frame-3-2" unit="cm" 
-         x="-326.3"
-	 y="471" 
-	 z="-400.852475"/>
+         x="-327.3"
+	 y="465" 
+	 z="-409.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-2-2"/>
        <position name="posArapucaDouble2-Frame-3-2" unit="cm" 
-         x="-327.04"
-	 y="537" 
-	 z="-194.751125"/>
+         x="-328.04"
+	 y="539" 
+	 z="-192.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-2"/>
        <position name="posOpArapucaDouble2-Frame-3-2" unit="cm" 
-         x="-326.3"
-	 y="537" 
-	 z="-194.751125"/>
+         x="-327.3"
+	 y="539" 
+	 z="-192.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-2-3"/>
        <position name="posArapucaDouble3-Frame-3-2" unit="cm" 
-         x="-327.04"
-	 y="627.55" 
-	 z="-332.402025"/>
+         x="-328.04"
+	 y="629.7" 
+	 z="-338.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-3"/>
        <position name="posOpArapucaDouble3-Frame-3-2" unit="cm" 
-         x="-326.3"
-	 y="627.55" 
-	 z="-332.402025"/>
+         x="-327.3"
+	 y="629.7" 
+	 z="-338.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-3-0"/>
        <position name="posArapucaDouble0-Frame-3-3" unit="cm" 
-         x="-327.04"
-	 y="380.45" 
-	 z="34.6002250000001"/>
+         x="-328.04"
+	 y="374.3" 
+	 z="34.0000000000001"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-3-0"/>
        <position name="posOpArapucaDouble0-Frame-3-3" unit="cm" 
-         x="-326.3"
-	 y="380.45" 
-	 z="34.6002250000001"/>
+         x="-327.3"
+	 y="374.3" 
+	 z="34.0000000000001"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-3-1"/>
        <position name="posArapucaDouble1-Frame-3-3" unit="cm" 
-         x="-327.04"
-	 y="471" 
-	 z="-103.050675"/>
+         x="-328.04"
+	 y="465" 
+	 z="-112"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-3-1"/>
        <position name="posOpArapucaDouble1-Frame-3-3" unit="cm" 
-         x="-326.3"
-	 y="471" 
-	 z="-103.050675"/>
+         x="-327.3"
+	 y="465" 
+	 z="-112"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-3-2"/>
        <position name="posArapucaDouble2-Frame-3-3" unit="cm" 
-         x="-327.04"
-	 y="537" 
-	 z="103.050675"/>
+         x="-328.04"
+	 y="539" 
+	 z="105"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-3-2"/>
        <position name="posOpArapucaDouble2-Frame-3-3" unit="cm" 
-         x="-326.3"
-	 y="537" 
-	 z="103.050675"/>
+         x="-327.3"
+	 y="539" 
+	 z="105"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-3-3"/>
        <position name="posArapucaDouble3-Frame-3-3" unit="cm" 
-         x="-327.04"
-	 y="627.55" 
-	 z="-34.6002249999999"/>
+         x="-328.04"
+	 y="629.7" 
+	 z="-40.9999999999999"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-3-3"/>
        <position name="posOpArapucaDouble3-Frame-3-3" unit="cm" 
-         x="-326.3"
-	 y="627.55" 
-	 z="-34.6002249999999"/>
+         x="-327.3"
+	 y="629.7" 
+	 z="-40.9999999999999"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-4-0"/>
        <position name="posArapucaDouble0-Frame-3-4" unit="cm" 
-         x="-327.04"
-	 y="380.45" 
-	 z="332.402025"/>
+         x="-328.04"
+	 y="374.3" 
+	 z="331.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-4-0"/>
        <position name="posOpArapucaDouble0-Frame-3-4" unit="cm" 
-         x="-326.3"
-	 y="380.45" 
-	 z="332.402025"/>
+         x="-327.3"
+	 y="374.3" 
+	 z="331.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-4-1"/>
        <position name="posArapucaDouble1-Frame-3-4" unit="cm" 
-         x="-327.04"
-	 y="471" 
-	 z="194.751125"/>
+         x="-328.04"
+	 y="465" 
+	 z="185.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-4-1"/>
        <position name="posOpArapucaDouble1-Frame-3-4" unit="cm" 
-         x="-326.3"
-	 y="471" 
-	 z="194.751125"/>
+         x="-327.3"
+	 y="465" 
+	 z="185.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-4-2"/>
        <position name="posArapucaDouble2-Frame-3-4" unit="cm" 
-         x="-327.04"
-	 y="537" 
-	 z="400.852475"/>
+         x="-328.04"
+	 y="539" 
+	 z="402.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-4-2"/>
        <position name="posOpArapucaDouble2-Frame-3-4" unit="cm" 
-         x="-326.3"
-	 y="537" 
-	 z="400.852475"/>
+         x="-327.3"
+	 y="539" 
+	 z="402.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-4-3"/>
        <position name="posArapucaDouble3-Frame-3-4" unit="cm" 
-         x="-327.04"
-	 y="627.55" 
-	 z="263.201575"/>
+         x="-328.04"
+	 y="629.7" 
+	 z="256.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-4-3"/>
        <position name="posOpArapucaDouble3-Frame-3-4" unit="cm" 
-         x="-326.3"
-	 y="627.55" 
-	 z="263.201575"/>
+         x="-327.3"
+	 y="629.7" 
+	 z="256.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-5-0"/>
        <position name="posArapucaDouble0-Frame-3-5" unit="cm" 
-         x="-327.04"
-	 y="380.45" 
-	 z="630.203825"/>
+         x="-328.04"
+	 y="374.3" 
+	 z="629.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-5-0"/>
        <position name="posOpArapucaDouble0-Frame-3-5" unit="cm" 
-         x="-326.3"
-	 y="380.45" 
-	 z="630.203825"/>
+         x="-327.3"
+	 y="374.3" 
+	 z="629.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-5-1"/>
        <position name="posArapucaDouble1-Frame-3-5" unit="cm" 
-         x="-327.04"
-	 y="471" 
-	 z="492.552925"/>
+         x="-328.04"
+	 y="465" 
+	 z="483.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-5-1"/>
        <position name="posOpArapucaDouble1-Frame-3-5" unit="cm" 
-         x="-326.3"
-	 y="471" 
-	 z="492.552925"/>
+         x="-327.3"
+	 y="465" 
+	 z="483.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-5-2"/>
        <position name="posArapucaDouble2-Frame-3-5" unit="cm" 
-         x="-327.04"
-	 y="537" 
-	 z="698.654275"/>
+         x="-328.04"
+	 y="539" 
+	 z="700.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-5-2"/>
        <position name="posOpArapucaDouble2-Frame-3-5" unit="cm" 
-         x="-326.3"
-	 y="537" 
-	 z="698.654275"/>
+         x="-327.3"
+	 y="539" 
+	 z="700.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-5-3"/>
        <position name="posArapucaDouble3-Frame-3-5" unit="cm" 
-         x="-327.04"
-	 y="627.55" 
-	 z="561.003375"/>
+         x="-328.04"
+	 y="629.7" 
+	 z="554.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-5-3"/>
        <position name="posOpArapucaDouble3-Frame-3-5" unit="cm" 
-         x="-326.3"
-	 y="627.55" 
-	 z="561.003375"/>
+         x="-327.3"
+	 y="629.7" 
+	 z="554.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-6-0"/>
        <position name="posArapucaDouble0-Frame-3-6" unit="cm" 
-         x="-327.04"
-	 y="380.45" 
-	 z="928.005625"/>
+         x="-328.04"
+	 y="374.3" 
+	 z="927.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-6-0"/>
        <position name="posOpArapucaDouble0-Frame-3-6" unit="cm" 
-         x="-326.3"
-	 y="380.45" 
-	 z="928.005625"/>
+         x="-327.3"
+	 y="374.3" 
+	 z="927.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-6-1"/>
        <position name="posArapucaDouble1-Frame-3-6" unit="cm" 
-         x="-327.04"
-	 y="471" 
-	 z="790.354725"/>
+         x="-328.04"
+	 y="465" 
+	 z="781.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-6-1"/>
        <position name="posOpArapucaDouble1-Frame-3-6" unit="cm" 
-         x="-326.3"
-	 y="471" 
-	 z="790.354725"/>
+         x="-327.3"
+	 y="465" 
+	 z="781.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-6-2"/>
        <position name="posArapucaDouble2-Frame-3-6" unit="cm" 
-         x="-327.04"
-	 y="537" 
-	 z="996.456075"/>
+         x="-328.04"
+	 y="539" 
+	 z="998.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-6-2"/>
        <position name="posOpArapucaDouble2-Frame-3-6" unit="cm" 
-         x="-326.3"
-	 y="537" 
-	 z="996.456075"/>
+         x="-327.3"
+	 y="539" 
+	 z="998.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-6-3"/>
        <position name="posArapucaDouble3-Frame-3-6" unit="cm" 
-         x="-327.04"
-	 y="627.55" 
-	 z="858.805175"/>
+         x="-328.04"
+	 y="629.7" 
+	 z="852.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-6-3"/>
        <position name="posOpArapucaDouble3-Frame-3-6" unit="cm" 
-         x="-326.3"
-	 y="627.55" 
-	 z="858.805175"/>
+         x="-327.3"
+	 y="629.7" 
+	 z="852.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-0"/>
        <position name="posArapuca0-Lat-0" unit="cm" 
-         x="285.03"
+         x="285.01"
 	 y="-734" 
 	 z="-893.4054"/>
        <rotationref ref="rIdentity"/>
@@ -4839,14 +5072,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-0"/>
        <position name="posOpArapuca0-Lat-0" unit="cm" 
-         x="285.03"
+         x="285.01"
 	 y="-733.26" 
 	 z="-893.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-1"/>
        <position name="posArapuca1-Lat-0" unit="cm" 
-         x="210.03"
+         x="210.01"
 	 y="-734" 
 	 z="-893.4054"/>
        <rotationref ref="rIdentity"/>
@@ -4854,14 +5087,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-1"/>
        <position name="posOpArapuca1-Lat-0" unit="cm" 
-         x="210.03"
+         x="210.01"
 	 y="-733.26" 
 	 z="-893.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-2"/>
        <position name="posArapuca2-Lat-0" unit="cm" 
-         x="135.03"
+         x="135.01"
 	 y="-734" 
 	 z="-893.4054"/>
        <rotationref ref="rIdentity"/>
@@ -4869,14 +5102,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-2"/>
        <position name="posOpArapuca2-Lat-0" unit="cm" 
-         x="135.03"
+         x="135.01"
 	 y="-733.26" 
 	 z="-893.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-3"/>
        <position name="posArapuca3-Lat-0" unit="cm" 
-         x="60.03"
+         x="60.01"
 	 y="-734" 
 	 z="-893.4054"/>
        <rotationref ref="rIdentity"/>
@@ -4884,14 +5117,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-3"/>
        <position name="posOpArapuca3-Lat-0" unit="cm" 
-         x="60.03"
+         x="60.01"
 	 y="-733.26" 
 	 z="-893.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-4"/>
        <position name="posArapuca4-Lat-0" unit="cm" 
-         x="285.03"
+         x="285.01"
 	 y="734" 
 	 z="-893.4054"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -4899,14 +5132,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-4"/>
        <position name="posOpArapuca4-Lat-0" unit="cm" 
-         x="285.03"
+         x="285.01"
 	 y="733.26" 
 	 z="-893.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-5"/>
        <position name="posArapuca5-Lat-0" unit="cm" 
-         x="210.03"
+         x="210.01"
 	 y="734" 
 	 z="-893.4054"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -4914,14 +5147,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-5"/>
        <position name="posOpArapuca5-Lat-0" unit="cm" 
-         x="210.03"
+         x="210.01"
 	 y="733.26" 
 	 z="-893.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-6"/>
        <position name="posArapuca6-Lat-0" unit="cm" 
-         x="135.03"
+         x="135.01"
 	 y="734" 
 	 z="-893.4054"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -4929,14 +5162,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-6"/>
        <position name="posOpArapuca6-Lat-0" unit="cm" 
-         x="135.03"
+         x="135.01"
 	 y="733.26" 
 	 z="-893.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-7"/>
        <position name="posArapuca7-Lat-0" unit="cm" 
-         x="60.03"
+         x="60.01"
 	 y="734" 
 	 z="-893.4054"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -4944,14 +5177,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-7"/>
        <position name="posOpArapuca7-Lat-0" unit="cm" 
-         x="60.03"
+         x="60.01"
 	 y="733.26" 
 	 z="-893.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-0"/>
        <position name="posArapuca0-Lat-1" unit="cm" 
-         x="285.03"
+         x="285.01"
 	 y="-734" 
 	 z="-595.6036"/>
        <rotationref ref="rIdentity"/>
@@ -4959,14 +5192,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-0"/>
        <position name="posOpArapuca0-Lat-1" unit="cm" 
-         x="285.03"
+         x="285.01"
 	 y="-733.26" 
 	 z="-595.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-1"/>
        <position name="posArapuca1-Lat-1" unit="cm" 
-         x="210.03"
+         x="210.01"
 	 y="-734" 
 	 z="-595.6036"/>
        <rotationref ref="rIdentity"/>
@@ -4974,14 +5207,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-1"/>
        <position name="posOpArapuca1-Lat-1" unit="cm" 
-         x="210.03"
+         x="210.01"
 	 y="-733.26" 
 	 z="-595.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-2"/>
        <position name="posArapuca2-Lat-1" unit="cm" 
-         x="135.03"
+         x="135.01"
 	 y="-734" 
 	 z="-595.6036"/>
        <rotationref ref="rIdentity"/>
@@ -4989,14 +5222,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-2"/>
        <position name="posOpArapuca2-Lat-1" unit="cm" 
-         x="135.03"
+         x="135.01"
 	 y="-733.26" 
 	 z="-595.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-3"/>
        <position name="posArapuca3-Lat-1" unit="cm" 
-         x="60.03"
+         x="60.01"
 	 y="-734" 
 	 z="-595.6036"/>
        <rotationref ref="rIdentity"/>
@@ -5004,14 +5237,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-3"/>
        <position name="posOpArapuca3-Lat-1" unit="cm" 
-         x="60.03"
+         x="60.01"
 	 y="-733.26" 
 	 z="-595.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-4"/>
        <position name="posArapuca4-Lat-1" unit="cm" 
-         x="285.03"
+         x="285.01"
 	 y="734" 
 	 z="-595.6036"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5019,14 +5252,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-4"/>
        <position name="posOpArapuca4-Lat-1" unit="cm" 
-         x="285.03"
+         x="285.01"
 	 y="733.26" 
 	 z="-595.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-5"/>
        <position name="posArapuca5-Lat-1" unit="cm" 
-         x="210.03"
+         x="210.01"
 	 y="734" 
 	 z="-595.6036"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5034,14 +5267,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-5"/>
        <position name="posOpArapuca5-Lat-1" unit="cm" 
-         x="210.03"
+         x="210.01"
 	 y="733.26" 
 	 z="-595.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-6"/>
        <position name="posArapuca6-Lat-1" unit="cm" 
-         x="135.03"
+         x="135.01"
 	 y="734" 
 	 z="-595.6036"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5049,14 +5282,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-6"/>
        <position name="posOpArapuca6-Lat-1" unit="cm" 
-         x="135.03"
+         x="135.01"
 	 y="733.26" 
 	 z="-595.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-7"/>
        <position name="posArapuca7-Lat-1" unit="cm" 
-         x="60.03"
+         x="60.01"
 	 y="734" 
 	 z="-595.6036"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5064,14 +5297,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-7"/>
        <position name="posOpArapuca7-Lat-1" unit="cm" 
-         x="60.03"
+         x="60.01"
 	 y="733.26" 
 	 z="-595.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-0"/>
        <position name="posArapuca0-Lat-2" unit="cm" 
-         x="285.03"
+         x="285.01"
 	 y="-734" 
 	 z="-297.8018"/>
        <rotationref ref="rIdentity"/>
@@ -5079,14 +5312,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-0"/>
        <position name="posOpArapuca0-Lat-2" unit="cm" 
-         x="285.03"
+         x="285.01"
 	 y="-733.26" 
 	 z="-297.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-1"/>
        <position name="posArapuca1-Lat-2" unit="cm" 
-         x="210.03"
+         x="210.01"
 	 y="-734" 
 	 z="-297.8018"/>
        <rotationref ref="rIdentity"/>
@@ -5094,14 +5327,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-1"/>
        <position name="posOpArapuca1-Lat-2" unit="cm" 
-         x="210.03"
+         x="210.01"
 	 y="-733.26" 
 	 z="-297.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-2"/>
        <position name="posArapuca2-Lat-2" unit="cm" 
-         x="135.03"
+         x="135.01"
 	 y="-734" 
 	 z="-297.8018"/>
        <rotationref ref="rIdentity"/>
@@ -5109,14 +5342,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-2"/>
        <position name="posOpArapuca2-Lat-2" unit="cm" 
-         x="135.03"
+         x="135.01"
 	 y="-733.26" 
 	 z="-297.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-3"/>
        <position name="posArapuca3-Lat-2" unit="cm" 
-         x="60.03"
+         x="60.01"
 	 y="-734" 
 	 z="-297.8018"/>
        <rotationref ref="rIdentity"/>
@@ -5124,14 +5357,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-3"/>
        <position name="posOpArapuca3-Lat-2" unit="cm" 
-         x="60.03"
+         x="60.01"
 	 y="-733.26" 
 	 z="-297.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-4"/>
        <position name="posArapuca4-Lat-2" unit="cm" 
-         x="285.03"
+         x="285.01"
 	 y="734" 
 	 z="-297.8018"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5139,14 +5372,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-4"/>
        <position name="posOpArapuca4-Lat-2" unit="cm" 
-         x="285.03"
+         x="285.01"
 	 y="733.26" 
 	 z="-297.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-5"/>
        <position name="posArapuca5-Lat-2" unit="cm" 
-         x="210.03"
+         x="210.01"
 	 y="734" 
 	 z="-297.8018"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5154,14 +5387,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-5"/>
        <position name="posOpArapuca5-Lat-2" unit="cm" 
-         x="210.03"
+         x="210.01"
 	 y="733.26" 
 	 z="-297.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-6"/>
        <position name="posArapuca6-Lat-2" unit="cm" 
-         x="135.03"
+         x="135.01"
 	 y="734" 
 	 z="-297.8018"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5169,14 +5402,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-6"/>
        <position name="posOpArapuca6-Lat-2" unit="cm" 
-         x="135.03"
+         x="135.01"
 	 y="733.26" 
 	 z="-297.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-7"/>
        <position name="posArapuca7-Lat-2" unit="cm" 
-         x="60.03"
+         x="60.01"
 	 y="734" 
 	 z="-297.8018"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5184,14 +5417,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-7"/>
        <position name="posOpArapuca7-Lat-2" unit="cm" 
-         x="60.03"
+         x="60.01"
 	 y="733.26" 
 	 z="-297.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_3-0"/>
        <position name="posArapuca0-Lat-3" unit="cm" 
-         x="285.03"
+         x="285.01"
 	 y="-734" 
 	 z="1.13686837721616e-13"/>
        <rotationref ref="rIdentity"/>
@@ -5199,14 +5432,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_3-0"/>
        <position name="posOpArapuca0-Lat-3" unit="cm" 
-         x="285.03"
+         x="285.01"
 	 y="-733.26" 
 	 z="1.13686837721616e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_3-1"/>
        <position name="posArapuca1-Lat-3" unit="cm" 
-         x="210.03"
+         x="210.01"
 	 y="-734" 
 	 z="1.13686837721616e-13"/>
        <rotationref ref="rIdentity"/>
@@ -5214,14 +5447,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_3-1"/>
        <position name="posOpArapuca1-Lat-3" unit="cm" 
-         x="210.03"
+         x="210.01"
 	 y="-733.26" 
 	 z="1.13686837721616e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_3-2"/>
        <position name="posArapuca2-Lat-3" unit="cm" 
-         x="135.03"
+         x="135.01"
 	 y="-734" 
 	 z="1.13686837721616e-13"/>
        <rotationref ref="rIdentity"/>
@@ -5229,14 +5462,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_3-2"/>
        <position name="posOpArapuca2-Lat-3" unit="cm" 
-         x="135.03"
+         x="135.01"
 	 y="-733.26" 
 	 z="1.13686837721616e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_3-3"/>
        <position name="posArapuca3-Lat-3" unit="cm" 
-         x="60.03"
+         x="60.01"
 	 y="-734" 
 	 z="1.13686837721616e-13"/>
        <rotationref ref="rIdentity"/>
@@ -5244,14 +5477,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_3-3"/>
        <position name="posOpArapuca3-Lat-3" unit="cm" 
-         x="60.03"
+         x="60.01"
 	 y="-733.26" 
 	 z="1.13686837721616e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_3-4"/>
        <position name="posArapuca4-Lat-3" unit="cm" 
-         x="285.03"
+         x="285.01"
 	 y="734" 
 	 z="1.13686837721616e-13"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5259,14 +5492,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_3-4"/>
        <position name="posOpArapuca4-Lat-3" unit="cm" 
-         x="285.03"
+         x="285.01"
 	 y="733.26" 
 	 z="1.13686837721616e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_3-5"/>
        <position name="posArapuca5-Lat-3" unit="cm" 
-         x="210.03"
+         x="210.01"
 	 y="734" 
 	 z="1.13686837721616e-13"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5274,14 +5507,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_3-5"/>
        <position name="posOpArapuca5-Lat-3" unit="cm" 
-         x="210.03"
+         x="210.01"
 	 y="733.26" 
 	 z="1.13686837721616e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_3-6"/>
        <position name="posArapuca6-Lat-3" unit="cm" 
-         x="135.03"
+         x="135.01"
 	 y="734" 
 	 z="1.13686837721616e-13"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5289,14 +5522,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_3-6"/>
        <position name="posOpArapuca6-Lat-3" unit="cm" 
-         x="135.03"
+         x="135.01"
 	 y="733.26" 
 	 z="1.13686837721616e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_3-7"/>
        <position name="posArapuca7-Lat-3" unit="cm" 
-         x="60.03"
+         x="60.01"
 	 y="734" 
 	 z="1.13686837721616e-13"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5304,14 +5537,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_3-7"/>
        <position name="posOpArapuca7-Lat-3" unit="cm" 
-         x="60.03"
+         x="60.01"
 	 y="733.26" 
 	 z="1.13686837721616e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_4-0"/>
        <position name="posArapuca0-Lat-4" unit="cm" 
-         x="285.03"
+         x="285.01"
 	 y="-734" 
 	 z="297.8018"/>
        <rotationref ref="rIdentity"/>
@@ -5319,14 +5552,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_4-0"/>
        <position name="posOpArapuca0-Lat-4" unit="cm" 
-         x="285.03"
+         x="285.01"
 	 y="-733.26" 
 	 z="297.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_4-1"/>
        <position name="posArapuca1-Lat-4" unit="cm" 
-         x="210.03"
+         x="210.01"
 	 y="-734" 
 	 z="297.8018"/>
        <rotationref ref="rIdentity"/>
@@ -5334,14 +5567,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_4-1"/>
        <position name="posOpArapuca1-Lat-4" unit="cm" 
-         x="210.03"
+         x="210.01"
 	 y="-733.26" 
 	 z="297.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_4-2"/>
        <position name="posArapuca2-Lat-4" unit="cm" 
-         x="135.03"
+         x="135.01"
 	 y="-734" 
 	 z="297.8018"/>
        <rotationref ref="rIdentity"/>
@@ -5349,14 +5582,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_4-2"/>
        <position name="posOpArapuca2-Lat-4" unit="cm" 
-         x="135.03"
+         x="135.01"
 	 y="-733.26" 
 	 z="297.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_4-3"/>
        <position name="posArapuca3-Lat-4" unit="cm" 
-         x="60.03"
+         x="60.01"
 	 y="-734" 
 	 z="297.8018"/>
        <rotationref ref="rIdentity"/>
@@ -5364,14 +5597,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_4-3"/>
        <position name="posOpArapuca3-Lat-4" unit="cm" 
-         x="60.03"
+         x="60.01"
 	 y="-733.26" 
 	 z="297.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_4-4"/>
        <position name="posArapuca4-Lat-4" unit="cm" 
-         x="285.03"
+         x="285.01"
 	 y="734" 
 	 z="297.8018"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5379,14 +5612,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_4-4"/>
        <position name="posOpArapuca4-Lat-4" unit="cm" 
-         x="285.03"
+         x="285.01"
 	 y="733.26" 
 	 z="297.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_4-5"/>
        <position name="posArapuca5-Lat-4" unit="cm" 
-         x="210.03"
+         x="210.01"
 	 y="734" 
 	 z="297.8018"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5394,14 +5627,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_4-5"/>
        <position name="posOpArapuca5-Lat-4" unit="cm" 
-         x="210.03"
+         x="210.01"
 	 y="733.26" 
 	 z="297.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_4-6"/>
        <position name="posArapuca6-Lat-4" unit="cm" 
-         x="135.03"
+         x="135.01"
 	 y="734" 
 	 z="297.8018"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5409,14 +5642,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_4-6"/>
        <position name="posOpArapuca6-Lat-4" unit="cm" 
-         x="135.03"
+         x="135.01"
 	 y="733.26" 
 	 z="297.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_4-7"/>
        <position name="posArapuca7-Lat-4" unit="cm" 
-         x="60.03"
+         x="60.01"
 	 y="734" 
 	 z="297.8018"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5424,14 +5657,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_4-7"/>
        <position name="posOpArapuca7-Lat-4" unit="cm" 
-         x="60.03"
+         x="60.01"
 	 y="733.26" 
 	 z="297.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_5-0"/>
        <position name="posArapuca0-Lat-5" unit="cm" 
-         x="285.03"
+         x="285.01"
 	 y="-734" 
 	 z="595.6036"/>
        <rotationref ref="rIdentity"/>
@@ -5439,14 +5672,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_5-0"/>
        <position name="posOpArapuca0-Lat-5" unit="cm" 
-         x="285.03"
+         x="285.01"
 	 y="-733.26" 
 	 z="595.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_5-1"/>
        <position name="posArapuca1-Lat-5" unit="cm" 
-         x="210.03"
+         x="210.01"
 	 y="-734" 
 	 z="595.6036"/>
        <rotationref ref="rIdentity"/>
@@ -5454,14 +5687,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_5-1"/>
        <position name="posOpArapuca1-Lat-5" unit="cm" 
-         x="210.03"
+         x="210.01"
 	 y="-733.26" 
 	 z="595.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_5-2"/>
        <position name="posArapuca2-Lat-5" unit="cm" 
-         x="135.03"
+         x="135.01"
 	 y="-734" 
 	 z="595.6036"/>
        <rotationref ref="rIdentity"/>
@@ -5469,14 +5702,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_5-2"/>
        <position name="posOpArapuca2-Lat-5" unit="cm" 
-         x="135.03"
+         x="135.01"
 	 y="-733.26" 
 	 z="595.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_5-3"/>
        <position name="posArapuca3-Lat-5" unit="cm" 
-         x="60.03"
+         x="60.01"
 	 y="-734" 
 	 z="595.6036"/>
        <rotationref ref="rIdentity"/>
@@ -5484,14 +5717,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_5-3"/>
        <position name="posOpArapuca3-Lat-5" unit="cm" 
-         x="60.03"
+         x="60.01"
 	 y="-733.26" 
 	 z="595.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_5-4"/>
        <position name="posArapuca4-Lat-5" unit="cm" 
-         x="285.03"
+         x="285.01"
 	 y="734" 
 	 z="595.6036"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5499,14 +5732,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_5-4"/>
        <position name="posOpArapuca4-Lat-5" unit="cm" 
-         x="285.03"
+         x="285.01"
 	 y="733.26" 
 	 z="595.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_5-5"/>
        <position name="posArapuca5-Lat-5" unit="cm" 
-         x="210.03"
+         x="210.01"
 	 y="734" 
 	 z="595.6036"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5514,14 +5747,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_5-5"/>
        <position name="posOpArapuca5-Lat-5" unit="cm" 
-         x="210.03"
+         x="210.01"
 	 y="733.26" 
 	 z="595.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_5-6"/>
        <position name="posArapuca6-Lat-5" unit="cm" 
-         x="135.03"
+         x="135.01"
 	 y="734" 
 	 z="595.6036"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5529,14 +5762,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_5-6"/>
        <position name="posOpArapuca6-Lat-5" unit="cm" 
-         x="135.03"
+         x="135.01"
 	 y="733.26" 
 	 z="595.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_5-7"/>
        <position name="posArapuca7-Lat-5" unit="cm" 
-         x="60.03"
+         x="60.01"
 	 y="734" 
 	 z="595.6036"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5544,14 +5777,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_5-7"/>
        <position name="posOpArapuca7-Lat-5" unit="cm" 
-         x="60.03"
+         x="60.01"
 	 y="733.26" 
 	 z="595.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_6-0"/>
        <position name="posArapuca0-Lat-6" unit="cm" 
-         x="285.03"
+         x="285.01"
 	 y="-734" 
 	 z="893.4054"/>
        <rotationref ref="rIdentity"/>
@@ -5559,14 +5792,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_6-0"/>
        <position name="posOpArapuca0-Lat-6" unit="cm" 
-         x="285.03"
+         x="285.01"
 	 y="-733.26" 
 	 z="893.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_6-1"/>
        <position name="posArapuca1-Lat-6" unit="cm" 
-         x="210.03"
+         x="210.01"
 	 y="-734" 
 	 z="893.4054"/>
        <rotationref ref="rIdentity"/>
@@ -5574,14 +5807,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_6-1"/>
        <position name="posOpArapuca1-Lat-6" unit="cm" 
-         x="210.03"
+         x="210.01"
 	 y="-733.26" 
 	 z="893.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_6-2"/>
        <position name="posArapuca2-Lat-6" unit="cm" 
-         x="135.03"
+         x="135.01"
 	 y="-734" 
 	 z="893.4054"/>
        <rotationref ref="rIdentity"/>
@@ -5589,14 +5822,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_6-2"/>
        <position name="posOpArapuca2-Lat-6" unit="cm" 
-         x="135.03"
+         x="135.01"
 	 y="-733.26" 
 	 z="893.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_6-3"/>
        <position name="posArapuca3-Lat-6" unit="cm" 
-         x="60.03"
+         x="60.01"
 	 y="-734" 
 	 z="893.4054"/>
        <rotationref ref="rIdentity"/>
@@ -5604,14 +5837,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_6-3"/>
        <position name="posOpArapuca3-Lat-6" unit="cm" 
-         x="60.03"
+         x="60.01"
 	 y="-733.26" 
 	 z="893.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_6-4"/>
        <position name="posArapuca4-Lat-6" unit="cm" 
-         x="285.03"
+         x="285.01"
 	 y="734" 
 	 z="893.4054"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5619,14 +5852,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_6-4"/>
        <position name="posOpArapuca4-Lat-6" unit="cm" 
-         x="285.03"
+         x="285.01"
 	 y="733.26" 
 	 z="893.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_6-5"/>
        <position name="posArapuca5-Lat-6" unit="cm" 
-         x="210.03"
+         x="210.01"
 	 y="734" 
 	 z="893.4054"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5634,14 +5867,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_6-5"/>
        <position name="posOpArapuca5-Lat-6" unit="cm" 
-         x="210.03"
+         x="210.01"
 	 y="733.26" 
 	 z="893.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_6-6"/>
        <position name="posArapuca6-Lat-6" unit="cm" 
-         x="135.03"
+         x="135.01"
 	 y="734" 
 	 z="893.4054"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5649,14 +5882,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_6-6"/>
        <position name="posOpArapuca6-Lat-6" unit="cm" 
-         x="135.03"
+         x="135.01"
 	 y="733.26" 
 	 z="893.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_6-7"/>
        <position name="posArapuca7-Lat-6" unit="cm" 
-         x="60.03"
+         x="60.01"
 	 y="734" 
 	 z="893.4054"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5664,7 +5897,7 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_6-7"/>
        <position name="posOpArapuca7-Lat-6" unit="cm" 
-         x="60.03"
+         x="60.01"
 	 y="733.26" 
 	 z="893.4054"/>
      </physvol>

--- a/dunecore/Geometry/gdml/dunevd10kt_3view_v3_refactored_1x8x14ref_nowires.gdml
+++ b/dunecore/Geometry/gdml/dunevd10kt_3view_v3_refactored_1x8x14ref_nowires.gdml
@@ -489,7 +489,7 @@
     
 
    <box name="CRM"
-      x="650.08" 
+      x="650.1" 
       y="168" 
       z="148.9009"
       lunit="cm"/>
@@ -558,12 +558,12 @@
 
 
     <box name="Cryostat" lunit="cm" 
-      x="850.32" 
+      x="850.34" 
       y="1548.24" 
       z="2291.8526"/>
 
     <box name="ArgonInterior" lunit="cm" 
-      x="850.08"
+      x="850.1"
       y="1548"
       z="2291.6126"/>
 
@@ -573,12 +573,12 @@
       z="2291.6126"/>
 
     <box name="ExternalAuxOut" lunit="cm" 
-      x="850.08 - 100"
+      x="850.1 - 100"
       y="1548 - 2*2.5 - 2*40"
       z="2291.6126"/>
 
     <box name="ExternalAuxIn" lunit="cm" 
-      x="850.08"
+      x="850.1"
       y="1359.17"
       z="2291.6126 + 1"/>
 
@@ -686,7 +686,7 @@
     </subtraction>
 
     <box name="FoamPadBlock" lunit="cm"
-      x="1010.32"
+      x="1010.34"
       y="1708.24"
       z="2451.8526" />
 
@@ -697,7 +697,7 @@
     </subtraction>
 
     <box name="SteelSupportBlock" lunit="cm"
-      x="1210.32"
+      x="1210.34"
       y="1908.24"
       z="2651.8526" />
 
@@ -708,13 +708,13 @@
     </subtraction>
 
     <box name="DetEnclosure" lunit="cm" 
-      x="1310.32"
+      x="1310.34"
       y="2108.24"
       z="2851.8526"/>
 
 
     <box name="World" lunit="cm" 
-      x="9310.32" 
+      x="9310.34" 
       y="10108.24" 
       z="10851.8526"/>
 </solids>
@@ -760,31 +760,31 @@
        <physvol>
        <volumeref ref="volTPCPlaneU"/>
        <position name="posPlaneU" unit="cm" 
-         x="324.97" y="0" z="0"/>
+         x="324.98" y="0" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volTPCPlaneY"/>
        <position name="posPlaneY" unit="cm" 
-         x="324.99" y="0" z="0"/>
+         x="325" y="0" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volTPCPlaneZ"/>
        <position name="posPlaneZ" unit="cm" 
-         x="325.01" y="0" z="0"/>
+         x="325.02" y="0" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volAnodePlate"/>
        <position name="posAnodePlate" unit="cm" 
-         x="325.03" y="0" z="0"/>
+         x="325.04" y="0" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>    
      <physvol>
        <volumeref ref="volTPCActive"/>
        <position name="posActive" unit="cm" 
-        x="-0.04" y="" z="0"/>
+        x="-0.05" y="" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
    </volume>
@@ -2159,7 +2159,7 @@
       <solidref ref="Cryostat" />
       <physvol>
         <volumeref ref="volGaseousArgon"/>
-        <position name="posGaseousArgon" unit="cm" x="375.04" y="0" z="0"/>
+        <position name="posGaseousArgon" unit="cm" x="375.05" y="0" z="0"/>
       </physvol>
       <physvol>
         <volumeref ref="volSteelShell"/>
@@ -2731,660 +2731,660 @@
       </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper0" unit="cm"  x="-322.04" y="-676.3" z="0" />
+     <position name="posFieldShaper0" unit="cm"  x="-322.05" y="-676.3" z="0" />
      <rotation name="rotFS0" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper1" unit="cm"  x="-316.04" y="-676.3" z="0" />
+     <position name="posFieldShaper1" unit="cm"  x="-316.05" y="-676.3" z="0" />
      <rotation name="rotFS1" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper2" unit="cm"  x="-310.04" y="-676.3" z="0" />
+     <position name="posFieldShaper2" unit="cm"  x="-310.05" y="-676.3" z="0" />
      <rotation name="rotFS2" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper3" unit="cm"  x="-304.04" y="-676.3" z="0" />
+     <position name="posFieldShaper3" unit="cm"  x="-304.05" y="-676.3" z="0" />
      <rotation name="rotFS3" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper4" unit="cm"  x="-298.04" y="-676.3" z="0" />
+     <position name="posFieldShaper4" unit="cm"  x="-298.05" y="-676.3" z="0" />
      <rotation name="rotFS4" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper5" unit="cm"  x="-292.04" y="-676.3" z="0" />
+     <position name="posFieldShaper5" unit="cm"  x="-292.05" y="-676.3" z="0" />
      <rotation name="rotFS5" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper6" unit="cm"  x="-286.04" y="-676.3" z="0" />
+     <position name="posFieldShaper6" unit="cm"  x="-286.05" y="-676.3" z="0" />
      <rotation name="rotFS6" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper7" unit="cm"  x="-280.04" y="-676.3" z="0" />
+     <position name="posFieldShaper7" unit="cm"  x="-280.05" y="-676.3" z="0" />
      <rotation name="rotFS7" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper8" unit="cm"  x="-274.04" y="-676.3" z="0" />
+     <position name="posFieldShaper8" unit="cm"  x="-274.05" y="-676.3" z="0" />
      <rotation name="rotFS8" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper9" unit="cm"  x="-268.04" y="-676.3" z="0" />
+     <position name="posFieldShaper9" unit="cm"  x="-268.05" y="-676.3" z="0" />
      <rotation name="rotFS9" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper10" unit="cm"  x="-262.04" y="-676.3" z="0" />
+     <position name="posFieldShaper10" unit="cm"  x="-262.05" y="-676.3" z="0" />
      <rotation name="rotFS10" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper11" unit="cm"  x="-256.04" y="-676.3" z="0" />
+     <position name="posFieldShaper11" unit="cm"  x="-256.05" y="-676.3" z="0" />
      <rotation name="rotFS11" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper12" unit="cm"  x="-250.04" y="-676.3" z="0" />
+     <position name="posFieldShaper12" unit="cm"  x="-250.05" y="-676.3" z="0" />
      <rotation name="rotFS12" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper13" unit="cm"  x="-244.04" y="-676.3" z="0" />
+     <position name="posFieldShaper13" unit="cm"  x="-244.05" y="-676.3" z="0" />
      <rotation name="rotFS13" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper14" unit="cm"  x="-238.04" y="-676.3" z="0" />
+     <position name="posFieldShaper14" unit="cm"  x="-238.05" y="-676.3" z="0" />
      <rotation name="rotFS14" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper15" unit="cm"  x="-232.04" y="-676.3" z="0" />
+     <position name="posFieldShaper15" unit="cm"  x="-232.05" y="-676.3" z="0" />
      <rotation name="rotFS15" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper16" unit="cm"  x="-226.04" y="-676.3" z="0" />
+     <position name="posFieldShaper16" unit="cm"  x="-226.05" y="-676.3" z="0" />
      <rotation name="rotFS16" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper17" unit="cm"  x="-220.04" y="-676.3" z="0" />
+     <position name="posFieldShaper17" unit="cm"  x="-220.05" y="-676.3" z="0" />
      <rotation name="rotFS17" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper18" unit="cm"  x="-214.04" y="-676.3" z="0" />
+     <position name="posFieldShaper18" unit="cm"  x="-214.05" y="-676.3" z="0" />
      <rotation name="rotFS18" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper19" unit="cm"  x="-208.04" y="-676.3" z="0" />
+     <position name="posFieldShaper19" unit="cm"  x="-208.05" y="-676.3" z="0" />
      <rotation name="rotFS19" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper20" unit="cm"  x="-202.04" y="-676.3" z="0" />
+     <position name="posFieldShaper20" unit="cm"  x="-202.05" y="-676.3" z="0" />
      <rotation name="rotFS20" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper21" unit="cm"  x="-196.04" y="-676.3" z="0" />
+     <position name="posFieldShaper21" unit="cm"  x="-196.05" y="-676.3" z="0" />
      <rotation name="rotFS21" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper22" unit="cm"  x="-190.04" y="-676.3" z="0" />
+     <position name="posFieldShaper22" unit="cm"  x="-190.05" y="-676.3" z="0" />
      <rotation name="rotFS22" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper23" unit="cm"  x="-184.04" y="-676.3" z="0" />
+     <position name="posFieldShaper23" unit="cm"  x="-184.05" y="-676.3" z="0" />
      <rotation name="rotFS23" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper24" unit="cm"  x="-178.04" y="-676.3" z="0" />
+     <position name="posFieldShaper24" unit="cm"  x="-178.05" y="-676.3" z="0" />
      <rotation name="rotFS24" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper25" unit="cm"  x="-172.04" y="-676.3" z="0" />
+     <position name="posFieldShaper25" unit="cm"  x="-172.05" y="-676.3" z="0" />
      <rotation name="rotFS25" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper26" unit="cm"  x="-166.04" y="-676.3" z="0" />
+     <position name="posFieldShaper26" unit="cm"  x="-166.05" y="-676.3" z="0" />
      <rotation name="rotFS26" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper27" unit="cm"  x="-160.04" y="-676.3" z="0" />
+     <position name="posFieldShaper27" unit="cm"  x="-160.05" y="-676.3" z="0" />
      <rotation name="rotFS27" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper28" unit="cm"  x="-154.04" y="-676.3" z="0" />
+     <position name="posFieldShaper28" unit="cm"  x="-154.05" y="-676.3" z="0" />
      <rotation name="rotFS28" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper29" unit="cm"  x="-148.04" y="-676.3" z="0" />
+     <position name="posFieldShaper29" unit="cm"  x="-148.05" y="-676.3" z="0" />
      <rotation name="rotFS29" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper30" unit="cm"  x="-142.04" y="-676.3" z="0" />
+     <position name="posFieldShaper30" unit="cm"  x="-142.05" y="-676.3" z="0" />
      <rotation name="rotFS30" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper31" unit="cm"  x="-136.04" y="-676.3" z="0" />
+     <position name="posFieldShaper31" unit="cm"  x="-136.05" y="-676.3" z="0" />
      <rotation name="rotFS31" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper32" unit="cm"  x="-130.04" y="-676.3" z="0" />
+     <position name="posFieldShaper32" unit="cm"  x="-130.05" y="-676.3" z="0" />
      <rotation name="rotFS32" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper33" unit="cm"  x="-124.04" y="-676.3" z="0" />
+     <position name="posFieldShaper33" unit="cm"  x="-124.05" y="-676.3" z="0" />
      <rotation name="rotFS33" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper34" unit="cm"  x="-118.04" y="-676.3" z="0" />
+     <position name="posFieldShaper34" unit="cm"  x="-118.05" y="-676.3" z="0" />
      <rotation name="rotFS34" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper35" unit="cm"  x="-112.04" y="-676.3" z="0" />
+     <position name="posFieldShaper35" unit="cm"  x="-112.05" y="-676.3" z="0" />
      <rotation name="rotFS35" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper36" unit="cm"  x="-106.04" y="-676.3" z="0" />
+     <position name="posFieldShaper36" unit="cm"  x="-106.05" y="-676.3" z="0" />
      <rotation name="rotFS36" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper37" unit="cm"  x="-100.04" y="-676.3" z="0" />
+     <position name="posFieldShaper37" unit="cm"  x="-100.05" y="-676.3" z="0" />
      <rotation name="rotFS37" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper38" unit="cm"  x="-94.04" y="-676.3" z="0" />
+     <position name="posFieldShaper38" unit="cm"  x="-94.0500000000001" y="-676.3" z="0" />
      <rotation name="rotFS38" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper39" unit="cm"  x="-88.04" y="-676.3" z="0" />
+     <position name="posFieldShaper39" unit="cm"  x="-88.0500000000001" y="-676.3" z="0" />
      <rotation name="rotFS39" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper40" unit="cm"  x="-82.04" y="-676.3" z="0" />
+     <position name="posFieldShaper40" unit="cm"  x="-82.0500000000001" y="-676.3" z="0" />
      <rotation name="rotFS40" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper41" unit="cm"  x="-76.04" y="-676.3" z="0" />
+     <position name="posFieldShaper41" unit="cm"  x="-76.0500000000001" y="-676.3" z="0" />
      <rotation name="rotFS41" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper42" unit="cm"  x="-70.04" y="-676.3" z="0" />
+     <position name="posFieldShaper42" unit="cm"  x="-70.0500000000001" y="-676.3" z="0" />
      <rotation name="rotFS42" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper43" unit="cm"  x="-64.04" y="-676.3" z="0" />
+     <position name="posFieldShaper43" unit="cm"  x="-64.0500000000001" y="-676.3" z="0" />
      <rotation name="rotFS43" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper44" unit="cm"  x="-58.04" y="-676.3" z="0" />
+     <position name="posFieldShaper44" unit="cm"  x="-58.0500000000001" y="-676.3" z="0" />
      <rotation name="rotFS44" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper45" unit="cm"  x="-52.04" y="-676.3" z="0" />
+     <position name="posFieldShaper45" unit="cm"  x="-52.0500000000001" y="-676.3" z="0" />
      <rotation name="rotFS45" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper46" unit="cm"  x="-46.04" y="-676.3" z="0" />
+     <position name="posFieldShaper46" unit="cm"  x="-46.0500000000001" y="-676.3" z="0" />
      <rotation name="rotFS46" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper47" unit="cm"  x="-40.04" y="-676.3" z="0" />
+     <position name="posFieldShaper47" unit="cm"  x="-40.0500000000001" y="-676.3" z="0" />
      <rotation name="rotFS47" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper48" unit="cm"  x="-34.04" y="-676.3" z="0" />
+     <position name="posFieldShaper48" unit="cm"  x="-34.0500000000001" y="-676.3" z="0" />
      <rotation name="rotFS48" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper49" unit="cm"  x="-28.04" y="-676.3" z="0" />
+     <position name="posFieldShaper49" unit="cm"  x="-28.0500000000001" y="-676.3" z="0" />
      <rotation name="rotFS49" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper50" unit="cm"  x="-22.04" y="-676.3" z="0" />
+     <position name="posFieldShaper50" unit="cm"  x="-22.0500000000001" y="-676.3" z="0" />
      <rotation name="rotFS50" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper51" unit="cm"  x="-16.04" y="-676.3" z="0" />
+     <position name="posFieldShaper51" unit="cm"  x="-16.0500000000001" y="-676.3" z="0" />
      <rotation name="rotFS51" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper52" unit="cm"  x="-10.04" y="-676.3" z="0" />
+     <position name="posFieldShaper52" unit="cm"  x="-10.0500000000001" y="-676.3" z="0" />
      <rotation name="rotFS52" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper53" unit="cm"  x="-4.04000000000001" y="-676.3" z="0" />
+     <position name="posFieldShaper53" unit="cm"  x="-4.05000000000005" y="-676.3" z="0" />
      <rotation name="rotFS53" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper54" unit="cm"  x="1.95999999999999" y="-676.3" z="0" />
+     <position name="posFieldShaper54" unit="cm"  x="1.94999999999995" y="-676.3" z="0" />
      <rotation name="rotFS54" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper55" unit="cm"  x="7.95999999999999" y="-676.3" z="0" />
+     <position name="posFieldShaper55" unit="cm"  x="7.94999999999995" y="-676.3" z="0" />
      <rotation name="rotFS55" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper56" unit="cm"  x="13.96" y="-676.3" z="0" />
+     <position name="posFieldShaper56" unit="cm"  x="13.9499999999999" y="-676.3" z="0" />
      <rotation name="rotFS56" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper57" unit="cm"  x="19.96" y="-676.3" z="0" />
+     <position name="posFieldShaper57" unit="cm"  x="19.9499999999999" y="-676.3" z="0" />
      <rotation name="rotFS57" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper58" unit="cm"  x="25.96" y="-676.3" z="0" />
+     <position name="posFieldShaper58" unit="cm"  x="25.9499999999999" y="-676.3" z="0" />
      <rotation name="rotFS58" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper59" unit="cm"  x="31.96" y="-676.3" z="0" />
+     <position name="posFieldShaper59" unit="cm"  x="31.9499999999999" y="-676.3" z="0" />
      <rotation name="rotFS59" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper60" unit="cm"  x="37.96" y="-676.3" z="0" />
+     <position name="posFieldShaper60" unit="cm"  x="37.9499999999999" y="-676.3" z="0" />
      <rotation name="rotFS60" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper61" unit="cm"  x="43.96" y="-676.3" z="0" />
+     <position name="posFieldShaper61" unit="cm"  x="43.9499999999999" y="-676.3" z="0" />
      <rotation name="rotFS61" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper62" unit="cm"  x="49.96" y="-676.3" z="0" />
+     <position name="posFieldShaper62" unit="cm"  x="49.9499999999999" y="-676.3" z="0" />
      <rotation name="rotFS62" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper63" unit="cm"  x="55.96" y="-676.3" z="0" />
+     <position name="posFieldShaper63" unit="cm"  x="55.9499999999999" y="-676.3" z="0" />
      <rotation name="rotFS63" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper64" unit="cm"  x="61.96" y="-676.3" z="0" />
+     <position name="posFieldShaper64" unit="cm"  x="61.9499999999999" y="-676.3" z="0" />
      <rotation name="rotFS64" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper65" unit="cm"  x="67.96" y="-676.3" z="0" />
+     <position name="posFieldShaper65" unit="cm"  x="67.9499999999999" y="-676.3" z="0" />
      <rotation name="rotFS65" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper66" unit="cm"  x="73.96" y="-676.3" z="0" />
+     <position name="posFieldShaper66" unit="cm"  x="73.9499999999999" y="-676.3" z="0" />
      <rotation name="rotFS66" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper67" unit="cm"  x="79.96" y="-676.3" z="0" />
+     <position name="posFieldShaper67" unit="cm"  x="79.9499999999999" y="-676.3" z="0" />
      <rotation name="rotFS67" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper68" unit="cm"  x="85.96" y="-676.3" z="0" />
+     <position name="posFieldShaper68" unit="cm"  x="85.9499999999999" y="-676.3" z="0" />
      <rotation name="rotFS68" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper69" unit="cm"  x="91.96" y="-676.3" z="0" />
+     <position name="posFieldShaper69" unit="cm"  x="91.9499999999999" y="-676.3" z="0" />
      <rotation name="rotFS69" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper70" unit="cm"  x="97.96" y="-676.3" z="0" />
+     <position name="posFieldShaper70" unit="cm"  x="97.9499999999999" y="-676.3" z="0" />
      <rotation name="rotFS70" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper71" unit="cm"  x="103.96" y="-676.3" z="0" />
+     <position name="posFieldShaper71" unit="cm"  x="103.95" y="-676.3" z="0" />
      <rotation name="rotFS71" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper72" unit="cm"  x="109.96" y="-676.3" z="0" />
+     <position name="posFieldShaper72" unit="cm"  x="109.95" y="-676.3" z="0" />
      <rotation name="rotFS72" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper73" unit="cm"  x="115.96" y="-676.3" z="0" />
+     <position name="posFieldShaper73" unit="cm"  x="115.95" y="-676.3" z="0" />
      <rotation name="rotFS73" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper74" unit="cm"  x="121.96" y="-676.3" z="0" />
+     <position name="posFieldShaper74" unit="cm"  x="121.95" y="-676.3" z="0" />
      <rotation name="rotFS74" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper75" unit="cm"  x="127.96" y="-676.3" z="0" />
+     <position name="posFieldShaper75" unit="cm"  x="127.95" y="-676.3" z="0" />
      <rotation name="rotFS75" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper76" unit="cm"  x="133.96" y="-676.3" z="0" />
+     <position name="posFieldShaper76" unit="cm"  x="133.95" y="-676.3" z="0" />
      <rotation name="rotFS76" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper77" unit="cm"  x="139.96" y="-676.3" z="0" />
+     <position name="posFieldShaper77" unit="cm"  x="139.95" y="-676.3" z="0" />
      <rotation name="rotFS77" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper78" unit="cm"  x="145.96" y="-676.3" z="0" />
+     <position name="posFieldShaper78" unit="cm"  x="145.95" y="-676.3" z="0" />
      <rotation name="rotFS78" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper79" unit="cm"  x="151.96" y="-676.3" z="0" />
+     <position name="posFieldShaper79" unit="cm"  x="151.95" y="-676.3" z="0" />
      <rotation name="rotFS79" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper80" unit="cm"  x="157.96" y="-676.3" z="0" />
+     <position name="posFieldShaper80" unit="cm"  x="157.95" y="-676.3" z="0" />
      <rotation name="rotFS80" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper81" unit="cm"  x="163.96" y="-676.3" z="0" />
+     <position name="posFieldShaper81" unit="cm"  x="163.95" y="-676.3" z="0" />
      <rotation name="rotFS81" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper82" unit="cm"  x="169.96" y="-676.3" z="0" />
+     <position name="posFieldShaper82" unit="cm"  x="169.95" y="-676.3" z="0" />
      <rotation name="rotFS82" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper83" unit="cm"  x="175.96" y="-676.3" z="0" />
+     <position name="posFieldShaper83" unit="cm"  x="175.95" y="-676.3" z="0" />
      <rotation name="rotFS83" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper84" unit="cm"  x="181.96" y="-676.3" z="0" />
+     <position name="posFieldShaper84" unit="cm"  x="181.95" y="-676.3" z="0" />
      <rotation name="rotFS84" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper85" unit="cm"  x="187.96" y="-676.3" z="0" />
+     <position name="posFieldShaper85" unit="cm"  x="187.95" y="-676.3" z="0" />
      <rotation name="rotFS85" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper86" unit="cm"  x="193.96" y="-676.3" z="0" />
+     <position name="posFieldShaper86" unit="cm"  x="193.95" y="-676.3" z="0" />
      <rotation name="rotFS86" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper87" unit="cm"  x="199.96" y="-676.3" z="0" />
+     <position name="posFieldShaper87" unit="cm"  x="199.95" y="-676.3" z="0" />
      <rotation name="rotFS87" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper88" unit="cm"  x="205.96" y="-676.3" z="0" />
+     <position name="posFieldShaper88" unit="cm"  x="205.95" y="-676.3" z="0" />
      <rotation name="rotFS88" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper89" unit="cm"  x="211.96" y="-676.3" z="0" />
+     <position name="posFieldShaper89" unit="cm"  x="211.95" y="-676.3" z="0" />
      <rotation name="rotFS89" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper90" unit="cm"  x="217.96" y="-676.3" z="0" />
+     <position name="posFieldShaper90" unit="cm"  x="217.95" y="-676.3" z="0" />
      <rotation name="rotFS90" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper91" unit="cm"  x="223.96" y="-676.3" z="0" />
+     <position name="posFieldShaper91" unit="cm"  x="223.95" y="-676.3" z="0" />
      <rotation name="rotFS91" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper92" unit="cm"  x="229.96" y="-676.3" z="0" />
+     <position name="posFieldShaper92" unit="cm"  x="229.95" y="-676.3" z="0" />
      <rotation name="rotFS92" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper93" unit="cm"  x="235.96" y="-676.3" z="0" />
+     <position name="posFieldShaper93" unit="cm"  x="235.95" y="-676.3" z="0" />
      <rotation name="rotFS93" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper94" unit="cm"  x="241.96" y="-676.3" z="0" />
+     <position name="posFieldShaper94" unit="cm"  x="241.95" y="-676.3" z="0" />
      <rotation name="rotFS94" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper95" unit="cm"  x="247.96" y="-676.3" z="0" />
+     <position name="posFieldShaper95" unit="cm"  x="247.95" y="-676.3" z="0" />
      <rotation name="rotFS95" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper96" unit="cm"  x="253.96" y="-676.3" z="0" />
+     <position name="posFieldShaper96" unit="cm"  x="253.95" y="-676.3" z="0" />
      <rotation name="rotFS96" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper97" unit="cm"  x="259.96" y="-676.3" z="0" />
+     <position name="posFieldShaper97" unit="cm"  x="259.95" y="-676.3" z="0" />
      <rotation name="rotFS97" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper98" unit="cm"  x="265.96" y="-676.3" z="0" />
+     <position name="posFieldShaper98" unit="cm"  x="265.95" y="-676.3" z="0" />
      <rotation name="rotFS98" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper99" unit="cm"  x="271.96" y="-676.3" z="0" />
+     <position name="posFieldShaper99" unit="cm"  x="271.95" y="-676.3" z="0" />
      <rotation name="rotFS99" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper100" unit="cm"  x="277.96" y="-676.3" z="0" />
+     <position name="posFieldShaper100" unit="cm"  x="277.95" y="-676.3" z="0" />
      <rotation name="rotFS100" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper101" unit="cm"  x="283.96" y="-676.3" z="0" />
+     <position name="posFieldShaper101" unit="cm"  x="283.95" y="-676.3" z="0" />
      <rotation name="rotFS101" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper102" unit="cm"  x="289.96" y="-676.3" z="0" />
+     <position name="posFieldShaper102" unit="cm"  x="289.95" y="-676.3" z="0" />
      <rotation name="rotFS102" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper103" unit="cm"  x="295.96" y="-676.3" z="0" />
+     <position name="posFieldShaper103" unit="cm"  x="295.95" y="-676.3" z="0" />
      <rotation name="rotFS103" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper104" unit="cm"  x="301.96" y="-676.3" z="0" />
+     <position name="posFieldShaper104" unit="cm"  x="301.95" y="-676.3" z="0" />
      <rotation name="rotFS104" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper105" unit="cm"  x="307.96" y="-676.3" z="0" />
+     <position name="posFieldShaper105" unit="cm"  x="307.95" y="-676.3" z="0" />
      <rotation name="rotFS105" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper106" unit="cm"  x="313.96" y="-676.3" z="0" />
+     <position name="posFieldShaper106" unit="cm"  x="313.95" y="-676.3" z="0" />
      <rotation name="rotFS106" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper107" unit="cm"  x="319.96" y="-676.3" z="0" />
+     <position name="posFieldShaper107" unit="cm"  x="319.95" y="-676.3" z="0" />
      <rotation name="rotFS107" unit="deg" x="0" y="0" z="90" />
   </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-0" unit="cm" x="-328.04" y="-506" z="-896.9054"/>
+   <position name="posGroundGrid-0" unit="cm" x="-328.05" y="-506" z="-896.9054"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-1" unit="cm" x="-328.04" y="-170" z="-896.9054"/>
+   <position name="posGroundGrid-1" unit="cm" x="-328.05" y="-170" z="-896.9054"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-2" unit="cm" x="-328.04" y="166" z="-896.9054"/>
+   <position name="posGroundGrid-2" unit="cm" x="-328.05" y="166" z="-896.9054"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-3" unit="cm" x="-328.04" y="502" z="-896.9054"/>
+   <position name="posGroundGrid-3" unit="cm" x="-328.05" y="502" z="-896.9054"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-4" unit="cm" x="-328.04" y="-506" z="-599.1036"/>
+   <position name="posGroundGrid-4" unit="cm" x="-328.05" y="-506" z="-599.1036"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-5" unit="cm" x="-328.04" y="-170" z="-599.1036"/>
+   <position name="posGroundGrid-5" unit="cm" x="-328.05" y="-170" z="-599.1036"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-6" unit="cm" x="-328.04" y="166" z="-599.1036"/>
+   <position name="posGroundGrid-6" unit="cm" x="-328.05" y="166" z="-599.1036"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-7" unit="cm" x="-328.04" y="502" z="-599.1036"/>
+   <position name="posGroundGrid-7" unit="cm" x="-328.05" y="502" z="-599.1036"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-8" unit="cm" x="-328.04" y="-506" z="-301.3018"/>
+   <position name="posGroundGrid-8" unit="cm" x="-328.05" y="-506" z="-301.3018"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-9" unit="cm" x="-328.04" y="-170" z="-301.3018"/>
+   <position name="posGroundGrid-9" unit="cm" x="-328.05" y="-170" z="-301.3018"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-10" unit="cm" x="-328.04" y="166" z="-301.3018"/>
+   <position name="posGroundGrid-10" unit="cm" x="-328.05" y="166" z="-301.3018"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-11" unit="cm" x="-328.04" y="502" z="-301.3018"/>
+   <position name="posGroundGrid-11" unit="cm" x="-328.05" y="502" z="-301.3018"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-12" unit="cm" x="-328.04" y="-506" z="-3.49999999999989"/>
+   <position name="posGroundGrid-12" unit="cm" x="-328.05" y="-506" z="-3.49999999999989"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-13" unit="cm" x="-328.04" y="-170" z="-3.49999999999989"/>
+   <position name="posGroundGrid-13" unit="cm" x="-328.05" y="-170" z="-3.49999999999989"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-14" unit="cm" x="-328.04" y="166" z="-3.49999999999989"/>
+   <position name="posGroundGrid-14" unit="cm" x="-328.05" y="166" z="-3.49999999999989"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-15" unit="cm" x="-328.04" y="502" z="-3.49999999999989"/>
+   <position name="posGroundGrid-15" unit="cm" x="-328.05" y="502" z="-3.49999999999989"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-16" unit="cm" x="-328.04" y="-506" z="294.3018"/>
+   <position name="posGroundGrid-16" unit="cm" x="-328.05" y="-506" z="294.3018"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-17" unit="cm" x="-328.04" y="-170" z="294.3018"/>
+   <position name="posGroundGrid-17" unit="cm" x="-328.05" y="-170" z="294.3018"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-18" unit="cm" x="-328.04" y="166" z="294.3018"/>
+   <position name="posGroundGrid-18" unit="cm" x="-328.05" y="166" z="294.3018"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-19" unit="cm" x="-328.04" y="502" z="294.3018"/>
+   <position name="posGroundGrid-19" unit="cm" x="-328.05" y="502" z="294.3018"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-20" unit="cm" x="-328.04" y="-506" z="592.1036"/>
+   <position name="posGroundGrid-20" unit="cm" x="-328.05" y="-506" z="592.1036"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-21" unit="cm" x="-328.04" y="-170" z="592.1036"/>
+   <position name="posGroundGrid-21" unit="cm" x="-328.05" y="-170" z="592.1036"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-22" unit="cm" x="-328.04" y="166" z="592.1036"/>
+   <position name="posGroundGrid-22" unit="cm" x="-328.05" y="166" z="592.1036"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-23" unit="cm" x="-328.04" y="502" z="592.1036"/>
+   <position name="posGroundGrid-23" unit="cm" x="-328.05" y="502" z="592.1036"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-24" unit="cm" x="-328.04" y="-506" z="889.9054"/>
+   <position name="posGroundGrid-24" unit="cm" x="-328.05" y="-506" z="889.9054"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-25" unit="cm" x="-328.04" y="-170" z="889.9054"/>
+   <position name="posGroundGrid-25" unit="cm" x="-328.05" y="-170" z="889.9054"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-26" unit="cm" x="-328.04" y="166" z="889.9054"/>
+   <position name="posGroundGrid-26" unit="cm" x="-328.05" y="166" z="889.9054"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-27" unit="cm" x="-328.04" y="502" z="889.9054"/>
+   <position name="posGroundGrid-27" unit="cm" x="-328.05" y="502" z="889.9054"/>
       </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-0-0"/>
        <position name="posArapucaDouble0-Frame-0-0" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-633.7" 
 	 z="-859.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3392,14 +3392,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-0"/>
        <position name="posOpArapucaDouble0-Frame-0-0" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-633.7" 
 	 z="-859.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-0-1"/>
        <position name="posArapucaDouble1-Frame-0-0" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-543" 
 	 z="-1005.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3407,14 +3407,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-1"/>
        <position name="posOpArapucaDouble1-Frame-0-0" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-543" 
 	 z="-1005.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-0-2"/>
        <position name="posArapucaDouble2-Frame-0-0" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-469" 
 	 z="-788.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3422,14 +3422,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-2"/>
        <position name="posOpArapucaDouble2-Frame-0-0" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-469" 
 	 z="-788.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-0-3"/>
        <position name="posArapucaDouble3-Frame-0-0" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-378.3" 
 	 z="-934.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3437,14 +3437,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-3"/>
        <position name="posOpArapucaDouble3-Frame-0-0" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-378.3" 
 	 z="-934.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-1-0"/>
        <position name="posArapucaDouble0-Frame-0-1" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-633.7" 
 	 z="-561.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3452,14 +3452,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-0"/>
        <position name="posOpArapucaDouble0-Frame-0-1" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-633.7" 
 	 z="-561.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-1-1"/>
        <position name="posArapucaDouble1-Frame-0-1" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-543" 
 	 z="-707.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3467,14 +3467,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-1"/>
        <position name="posOpArapucaDouble1-Frame-0-1" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-543" 
 	 z="-707.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-1-2"/>
        <position name="posArapucaDouble2-Frame-0-1" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-469" 
 	 z="-490.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3482,14 +3482,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-2"/>
        <position name="posOpArapucaDouble2-Frame-0-1" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-469" 
 	 z="-490.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-1-3"/>
        <position name="posArapucaDouble3-Frame-0-1" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-378.3" 
 	 z="-636.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3497,14 +3497,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-3"/>
        <position name="posOpArapucaDouble3-Frame-0-1" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-378.3" 
 	 z="-636.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-2-0"/>
        <position name="posArapucaDouble0-Frame-0-2" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-633.7" 
 	 z="-263.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3512,14 +3512,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-0"/>
        <position name="posOpArapucaDouble0-Frame-0-2" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-633.7" 
 	 z="-263.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-2-1"/>
        <position name="posArapucaDouble1-Frame-0-2" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-543" 
 	 z="-409.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3527,14 +3527,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-1"/>
        <position name="posOpArapucaDouble1-Frame-0-2" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-543" 
 	 z="-409.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-2-2"/>
        <position name="posArapucaDouble2-Frame-0-2" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-469" 
 	 z="-192.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3542,14 +3542,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-2"/>
        <position name="posOpArapucaDouble2-Frame-0-2" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-469" 
 	 z="-192.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-2-3"/>
        <position name="posArapucaDouble3-Frame-0-2" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-378.3" 
 	 z="-338.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3557,14 +3557,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-3"/>
        <position name="posOpArapucaDouble3-Frame-0-2" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-378.3" 
 	 z="-338.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-3-0"/>
        <position name="posArapucaDouble0-Frame-0-3" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-633.7" 
 	 z="34.0000000000001"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3572,14 +3572,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-3-0"/>
        <position name="posOpArapucaDouble0-Frame-0-3" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-633.7" 
 	 z="34.0000000000001"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-3-1"/>
        <position name="posArapucaDouble1-Frame-0-3" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-543" 
 	 z="-112"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3587,14 +3587,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-3-1"/>
        <position name="posOpArapucaDouble1-Frame-0-3" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-543" 
 	 z="-112"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-3-2"/>
        <position name="posArapucaDouble2-Frame-0-3" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-469" 
 	 z="105"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3602,14 +3602,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-3-2"/>
        <position name="posOpArapucaDouble2-Frame-0-3" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-469" 
 	 z="105"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-3-3"/>
        <position name="posArapucaDouble3-Frame-0-3" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-378.3" 
 	 z="-40.9999999999999"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3617,14 +3617,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-3-3"/>
        <position name="posOpArapucaDouble3-Frame-0-3" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-378.3" 
 	 z="-40.9999999999999"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-4-0"/>
        <position name="posArapucaDouble0-Frame-0-4" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-633.7" 
 	 z="331.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3632,14 +3632,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-4-0"/>
        <position name="posOpArapucaDouble0-Frame-0-4" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-633.7" 
 	 z="331.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-4-1"/>
        <position name="posArapucaDouble1-Frame-0-4" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-543" 
 	 z="185.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3647,14 +3647,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-4-1"/>
        <position name="posOpArapucaDouble1-Frame-0-4" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-543" 
 	 z="185.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-4-2"/>
        <position name="posArapucaDouble2-Frame-0-4" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-469" 
 	 z="402.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3662,14 +3662,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-4-2"/>
        <position name="posOpArapucaDouble2-Frame-0-4" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-469" 
 	 z="402.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-4-3"/>
        <position name="posArapucaDouble3-Frame-0-4" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-378.3" 
 	 z="256.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3677,14 +3677,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-4-3"/>
        <position name="posOpArapucaDouble3-Frame-0-4" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-378.3" 
 	 z="256.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-5-0"/>
        <position name="posArapucaDouble0-Frame-0-5" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-633.7" 
 	 z="629.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3692,14 +3692,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-5-0"/>
        <position name="posOpArapucaDouble0-Frame-0-5" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-633.7" 
 	 z="629.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-5-1"/>
        <position name="posArapucaDouble1-Frame-0-5" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-543" 
 	 z="483.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3707,14 +3707,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-5-1"/>
        <position name="posOpArapucaDouble1-Frame-0-5" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-543" 
 	 z="483.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-5-2"/>
        <position name="posArapucaDouble2-Frame-0-5" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-469" 
 	 z="700.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3722,14 +3722,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-5-2"/>
        <position name="posOpArapucaDouble2-Frame-0-5" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-469" 
 	 z="700.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-5-3"/>
        <position name="posArapucaDouble3-Frame-0-5" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-378.3" 
 	 z="554.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3737,14 +3737,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-5-3"/>
        <position name="posOpArapucaDouble3-Frame-0-5" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-378.3" 
 	 z="554.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-6-0"/>
        <position name="posArapucaDouble0-Frame-0-6" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-633.7" 
 	 z="927.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3752,14 +3752,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-6-0"/>
        <position name="posOpArapucaDouble0-Frame-0-6" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-633.7" 
 	 z="927.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-6-1"/>
        <position name="posArapucaDouble1-Frame-0-6" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-543" 
 	 z="781.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3767,14 +3767,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-6-1"/>
        <position name="posOpArapucaDouble1-Frame-0-6" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-543" 
 	 z="781.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-6-2"/>
        <position name="posArapucaDouble2-Frame-0-6" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-469" 
 	 z="998.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3782,14 +3782,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-6-2"/>
        <position name="posOpArapucaDouble2-Frame-0-6" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-469" 
 	 z="998.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-6-3"/>
        <position name="posArapucaDouble3-Frame-0-6" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-378.3" 
 	 z="852.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3797,14 +3797,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-6-3"/>
        <position name="posOpArapucaDouble3-Frame-0-6" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-378.3" 
 	 z="852.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-0-0"/>
        <position name="posArapucaDouble0-Frame-1-0" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-297.7" 
 	 z="-859.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3812,14 +3812,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-0"/>
        <position name="posOpArapucaDouble0-Frame-1-0" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-297.7" 
 	 z="-859.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-0-1"/>
        <position name="posArapucaDouble1-Frame-1-0" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-207" 
 	 z="-1005.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3827,14 +3827,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-1"/>
        <position name="posOpArapucaDouble1-Frame-1-0" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-207" 
 	 z="-1005.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-0-2"/>
        <position name="posArapucaDouble2-Frame-1-0" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-133" 
 	 z="-788.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3842,14 +3842,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-2"/>
        <position name="posOpArapucaDouble2-Frame-1-0" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-133" 
 	 z="-788.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-0-3"/>
        <position name="posArapucaDouble3-Frame-1-0" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-42.3" 
 	 z="-934.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3857,14 +3857,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-3"/>
        <position name="posOpArapucaDouble3-Frame-1-0" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-42.3" 
 	 z="-934.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-1-0"/>
        <position name="posArapucaDouble0-Frame-1-1" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-297.7" 
 	 z="-561.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3872,14 +3872,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-0"/>
        <position name="posOpArapucaDouble0-Frame-1-1" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-297.7" 
 	 z="-561.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-1-1"/>
        <position name="posArapucaDouble1-Frame-1-1" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-207" 
 	 z="-707.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3887,14 +3887,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-1"/>
        <position name="posOpArapucaDouble1-Frame-1-1" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-207" 
 	 z="-707.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-1-2"/>
        <position name="posArapucaDouble2-Frame-1-1" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-133" 
 	 z="-490.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3902,14 +3902,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-2"/>
        <position name="posOpArapucaDouble2-Frame-1-1" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-133" 
 	 z="-490.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-1-3"/>
        <position name="posArapucaDouble3-Frame-1-1" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-42.3" 
 	 z="-636.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3917,14 +3917,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-3"/>
        <position name="posOpArapucaDouble3-Frame-1-1" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-42.3" 
 	 z="-636.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-2-0"/>
        <position name="posArapucaDouble0-Frame-1-2" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-297.7" 
 	 z="-263.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3932,14 +3932,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-0"/>
        <position name="posOpArapucaDouble0-Frame-1-2" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-297.7" 
 	 z="-263.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-2-1"/>
        <position name="posArapucaDouble1-Frame-1-2" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-207" 
 	 z="-409.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3947,14 +3947,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-1"/>
        <position name="posOpArapucaDouble1-Frame-1-2" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-207" 
 	 z="-409.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-2-2"/>
        <position name="posArapucaDouble2-Frame-1-2" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-133" 
 	 z="-192.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3962,14 +3962,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-2"/>
        <position name="posOpArapucaDouble2-Frame-1-2" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-133" 
 	 z="-192.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-2-3"/>
        <position name="posArapucaDouble3-Frame-1-2" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-42.3" 
 	 z="-338.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3977,14 +3977,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-3"/>
        <position name="posOpArapucaDouble3-Frame-1-2" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-42.3" 
 	 z="-338.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-3-0"/>
        <position name="posArapucaDouble0-Frame-1-3" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-297.7" 
 	 z="34.0000000000001"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3992,14 +3992,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-3-0"/>
        <position name="posOpArapucaDouble0-Frame-1-3" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-297.7" 
 	 z="34.0000000000001"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-3-1"/>
        <position name="posArapucaDouble1-Frame-1-3" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-207" 
 	 z="-112"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4007,14 +4007,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-3-1"/>
        <position name="posOpArapucaDouble1-Frame-1-3" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-207" 
 	 z="-112"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-3-2"/>
        <position name="posArapucaDouble2-Frame-1-3" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-133" 
 	 z="105"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4022,14 +4022,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-3-2"/>
        <position name="posOpArapucaDouble2-Frame-1-3" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-133" 
 	 z="105"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-3-3"/>
        <position name="posArapucaDouble3-Frame-1-3" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-42.3" 
 	 z="-40.9999999999999"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4037,14 +4037,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-3-3"/>
        <position name="posOpArapucaDouble3-Frame-1-3" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-42.3" 
 	 z="-40.9999999999999"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-4-0"/>
        <position name="posArapucaDouble0-Frame-1-4" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-297.7" 
 	 z="331.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4052,14 +4052,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-4-0"/>
        <position name="posOpArapucaDouble0-Frame-1-4" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-297.7" 
 	 z="331.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-4-1"/>
        <position name="posArapucaDouble1-Frame-1-4" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-207" 
 	 z="185.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4067,14 +4067,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-4-1"/>
        <position name="posOpArapucaDouble1-Frame-1-4" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-207" 
 	 z="185.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-4-2"/>
        <position name="posArapucaDouble2-Frame-1-4" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-133" 
 	 z="402.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4082,14 +4082,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-4-2"/>
        <position name="posOpArapucaDouble2-Frame-1-4" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-133" 
 	 z="402.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-4-3"/>
        <position name="posArapucaDouble3-Frame-1-4" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-42.3" 
 	 z="256.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4097,14 +4097,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-4-3"/>
        <position name="posOpArapucaDouble3-Frame-1-4" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-42.3" 
 	 z="256.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-5-0"/>
        <position name="posArapucaDouble0-Frame-1-5" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-297.7" 
 	 z="629.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4112,14 +4112,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-5-0"/>
        <position name="posOpArapucaDouble0-Frame-1-5" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-297.7" 
 	 z="629.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-5-1"/>
        <position name="posArapucaDouble1-Frame-1-5" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-207" 
 	 z="483.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4127,14 +4127,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-5-1"/>
        <position name="posOpArapucaDouble1-Frame-1-5" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-207" 
 	 z="483.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-5-2"/>
        <position name="posArapucaDouble2-Frame-1-5" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-133" 
 	 z="700.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4142,14 +4142,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-5-2"/>
        <position name="posOpArapucaDouble2-Frame-1-5" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-133" 
 	 z="700.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-5-3"/>
        <position name="posArapucaDouble3-Frame-1-5" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-42.3" 
 	 z="554.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4157,14 +4157,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-5-3"/>
        <position name="posOpArapucaDouble3-Frame-1-5" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-42.3" 
 	 z="554.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-6-0"/>
        <position name="posArapucaDouble0-Frame-1-6" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-297.7" 
 	 z="927.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4172,14 +4172,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-6-0"/>
        <position name="posOpArapucaDouble0-Frame-1-6" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-297.7" 
 	 z="927.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-6-1"/>
        <position name="posArapucaDouble1-Frame-1-6" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-207" 
 	 z="781.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4187,14 +4187,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-6-1"/>
        <position name="posOpArapucaDouble1-Frame-1-6" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-207" 
 	 z="781.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-6-2"/>
        <position name="posArapucaDouble2-Frame-1-6" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-133" 
 	 z="998.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4202,14 +4202,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-6-2"/>
        <position name="posOpArapucaDouble2-Frame-1-6" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-133" 
 	 z="998.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-6-3"/>
        <position name="posArapucaDouble3-Frame-1-6" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-42.3" 
 	 z="852.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4217,14 +4217,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-6-3"/>
        <position name="posOpArapucaDouble3-Frame-1-6" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-42.3" 
 	 z="852.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-0-0"/>
        <position name="posArapucaDouble0-Frame-2-0" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="38.3" 
 	 z="-859.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4232,14 +4232,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-0"/>
        <position name="posOpArapucaDouble0-Frame-2-0" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="38.3" 
 	 z="-859.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-0-1"/>
        <position name="posArapucaDouble1-Frame-2-0" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="129" 
 	 z="-1005.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4247,14 +4247,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-1"/>
        <position name="posOpArapucaDouble1-Frame-2-0" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="129" 
 	 z="-1005.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-0-2"/>
        <position name="posArapucaDouble2-Frame-2-0" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="203" 
 	 z="-788.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4262,14 +4262,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-2"/>
        <position name="posOpArapucaDouble2-Frame-2-0" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="203" 
 	 z="-788.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-0-3"/>
        <position name="posArapucaDouble3-Frame-2-0" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="293.7" 
 	 z="-934.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4277,14 +4277,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-3"/>
        <position name="posOpArapucaDouble3-Frame-2-0" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="293.7" 
 	 z="-934.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-1-0"/>
        <position name="posArapucaDouble0-Frame-2-1" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="38.3" 
 	 z="-561.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4292,14 +4292,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-0"/>
        <position name="posOpArapucaDouble0-Frame-2-1" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="38.3" 
 	 z="-561.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-1-1"/>
        <position name="posArapucaDouble1-Frame-2-1" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="129" 
 	 z="-707.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4307,14 +4307,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-1"/>
        <position name="posOpArapucaDouble1-Frame-2-1" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="129" 
 	 z="-707.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-1-2"/>
        <position name="posArapucaDouble2-Frame-2-1" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="203" 
 	 z="-490.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4322,14 +4322,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-2"/>
        <position name="posOpArapucaDouble2-Frame-2-1" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="203" 
 	 z="-490.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-1-3"/>
        <position name="posArapucaDouble3-Frame-2-1" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="293.7" 
 	 z="-636.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4337,14 +4337,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-3"/>
        <position name="posOpArapucaDouble3-Frame-2-1" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="293.7" 
 	 z="-636.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-2-0"/>
        <position name="posArapucaDouble0-Frame-2-2" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="38.3" 
 	 z="-263.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4352,14 +4352,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-0"/>
        <position name="posOpArapucaDouble0-Frame-2-2" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="38.3" 
 	 z="-263.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-2-1"/>
        <position name="posArapucaDouble1-Frame-2-2" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="129" 
 	 z="-409.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4367,14 +4367,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-1"/>
        <position name="posOpArapucaDouble1-Frame-2-2" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="129" 
 	 z="-409.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-2-2"/>
        <position name="posArapucaDouble2-Frame-2-2" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="203" 
 	 z="-192.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4382,14 +4382,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-2"/>
        <position name="posOpArapucaDouble2-Frame-2-2" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="203" 
 	 z="-192.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-2-3"/>
        <position name="posArapucaDouble3-Frame-2-2" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="293.7" 
 	 z="-338.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4397,14 +4397,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-3"/>
        <position name="posOpArapucaDouble3-Frame-2-2" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="293.7" 
 	 z="-338.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-3-0"/>
        <position name="posArapucaDouble0-Frame-2-3" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="38.3" 
 	 z="34.0000000000001"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4412,14 +4412,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-3-0"/>
        <position name="posOpArapucaDouble0-Frame-2-3" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="38.3" 
 	 z="34.0000000000001"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-3-1"/>
        <position name="posArapucaDouble1-Frame-2-3" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="129" 
 	 z="-112"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4427,14 +4427,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-3-1"/>
        <position name="posOpArapucaDouble1-Frame-2-3" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="129" 
 	 z="-112"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-3-2"/>
        <position name="posArapucaDouble2-Frame-2-3" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="203" 
 	 z="105"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4442,14 +4442,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-3-2"/>
        <position name="posOpArapucaDouble2-Frame-2-3" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="203" 
 	 z="105"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-3-3"/>
        <position name="posArapucaDouble3-Frame-2-3" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="293.7" 
 	 z="-40.9999999999999"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4457,14 +4457,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-3-3"/>
        <position name="posOpArapucaDouble3-Frame-2-3" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="293.7" 
 	 z="-40.9999999999999"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-4-0"/>
        <position name="posArapucaDouble0-Frame-2-4" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="38.3" 
 	 z="331.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4472,14 +4472,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-4-0"/>
        <position name="posOpArapucaDouble0-Frame-2-4" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="38.3" 
 	 z="331.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-4-1"/>
        <position name="posArapucaDouble1-Frame-2-4" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="129" 
 	 z="185.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4487,14 +4487,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-4-1"/>
        <position name="posOpArapucaDouble1-Frame-2-4" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="129" 
 	 z="185.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-4-2"/>
        <position name="posArapucaDouble2-Frame-2-4" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="203" 
 	 z="402.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4502,14 +4502,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-4-2"/>
        <position name="posOpArapucaDouble2-Frame-2-4" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="203" 
 	 z="402.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-4-3"/>
        <position name="posArapucaDouble3-Frame-2-4" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="293.7" 
 	 z="256.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4517,14 +4517,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-4-3"/>
        <position name="posOpArapucaDouble3-Frame-2-4" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="293.7" 
 	 z="256.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-5-0"/>
        <position name="posArapucaDouble0-Frame-2-5" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="38.3" 
 	 z="629.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4532,14 +4532,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-5-0"/>
        <position name="posOpArapucaDouble0-Frame-2-5" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="38.3" 
 	 z="629.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-5-1"/>
        <position name="posArapucaDouble1-Frame-2-5" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="129" 
 	 z="483.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4547,14 +4547,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-5-1"/>
        <position name="posOpArapucaDouble1-Frame-2-5" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="129" 
 	 z="483.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-5-2"/>
        <position name="posArapucaDouble2-Frame-2-5" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="203" 
 	 z="700.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4562,14 +4562,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-5-2"/>
        <position name="posOpArapucaDouble2-Frame-2-5" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="203" 
 	 z="700.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-5-3"/>
        <position name="posArapucaDouble3-Frame-2-5" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="293.7" 
 	 z="554.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4577,14 +4577,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-5-3"/>
        <position name="posOpArapucaDouble3-Frame-2-5" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="293.7" 
 	 z="554.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-6-0"/>
        <position name="posArapucaDouble0-Frame-2-6" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="38.3" 
 	 z="927.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4592,14 +4592,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-6-0"/>
        <position name="posOpArapucaDouble0-Frame-2-6" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="38.3" 
 	 z="927.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-6-1"/>
        <position name="posArapucaDouble1-Frame-2-6" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="129" 
 	 z="781.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4607,14 +4607,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-6-1"/>
        <position name="posOpArapucaDouble1-Frame-2-6" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="129" 
 	 z="781.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-6-2"/>
        <position name="posArapucaDouble2-Frame-2-6" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="203" 
 	 z="998.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4622,14 +4622,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-6-2"/>
        <position name="posOpArapucaDouble2-Frame-2-6" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="203" 
 	 z="998.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-6-3"/>
        <position name="posArapucaDouble3-Frame-2-6" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="293.7" 
 	 z="852.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4637,14 +4637,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-6-3"/>
        <position name="posOpArapucaDouble3-Frame-2-6" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="293.7" 
 	 z="852.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-0-0"/>
        <position name="posArapucaDouble0-Frame-3-0" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="374.3" 
 	 z="-859.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4652,14 +4652,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-0"/>
        <position name="posOpArapucaDouble0-Frame-3-0" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="374.3" 
 	 z="-859.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-0-1"/>
        <position name="posArapucaDouble1-Frame-3-0" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="465" 
 	 z="-1005.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4667,14 +4667,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-1"/>
        <position name="posOpArapucaDouble1-Frame-3-0" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="465" 
 	 z="-1005.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-0-2"/>
        <position name="posArapucaDouble2-Frame-3-0" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="539" 
 	 z="-788.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4682,14 +4682,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-2"/>
        <position name="posOpArapucaDouble2-Frame-3-0" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="539" 
 	 z="-788.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-0-3"/>
        <position name="posArapucaDouble3-Frame-3-0" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="629.7" 
 	 z="-934.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4697,14 +4697,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-3"/>
        <position name="posOpArapucaDouble3-Frame-3-0" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="629.7" 
 	 z="-934.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-1-0"/>
        <position name="posArapucaDouble0-Frame-3-1" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="374.3" 
 	 z="-561.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4712,14 +4712,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-0"/>
        <position name="posOpArapucaDouble0-Frame-3-1" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="374.3" 
 	 z="-561.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-1-1"/>
        <position name="posArapucaDouble1-Frame-3-1" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="465" 
 	 z="-707.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4727,14 +4727,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-1"/>
        <position name="posOpArapucaDouble1-Frame-3-1" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="465" 
 	 z="-707.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-1-2"/>
        <position name="posArapucaDouble2-Frame-3-1" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="539" 
 	 z="-490.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4742,14 +4742,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-2"/>
        <position name="posOpArapucaDouble2-Frame-3-1" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="539" 
 	 z="-490.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-1-3"/>
        <position name="posArapucaDouble3-Frame-3-1" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="629.7" 
 	 z="-636.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4757,14 +4757,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-3"/>
        <position name="posOpArapucaDouble3-Frame-3-1" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="629.7" 
 	 z="-636.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-2-0"/>
        <position name="posArapucaDouble0-Frame-3-2" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="374.3" 
 	 z="-263.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4772,14 +4772,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-0"/>
        <position name="posOpArapucaDouble0-Frame-3-2" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="374.3" 
 	 z="-263.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-2-1"/>
        <position name="posArapucaDouble1-Frame-3-2" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="465" 
 	 z="-409.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4787,14 +4787,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-1"/>
        <position name="posOpArapucaDouble1-Frame-3-2" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="465" 
 	 z="-409.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-2-2"/>
        <position name="posArapucaDouble2-Frame-3-2" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="539" 
 	 z="-192.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4802,14 +4802,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-2"/>
        <position name="posOpArapucaDouble2-Frame-3-2" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="539" 
 	 z="-192.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-2-3"/>
        <position name="posArapucaDouble3-Frame-3-2" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="629.7" 
 	 z="-338.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4817,14 +4817,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-3"/>
        <position name="posOpArapucaDouble3-Frame-3-2" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="629.7" 
 	 z="-338.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-3-0"/>
        <position name="posArapucaDouble0-Frame-3-3" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="374.3" 
 	 z="34.0000000000001"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4832,14 +4832,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-3-0"/>
        <position name="posOpArapucaDouble0-Frame-3-3" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="374.3" 
 	 z="34.0000000000001"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-3-1"/>
        <position name="posArapucaDouble1-Frame-3-3" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="465" 
 	 z="-112"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4847,14 +4847,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-3-1"/>
        <position name="posOpArapucaDouble1-Frame-3-3" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="465" 
 	 z="-112"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-3-2"/>
        <position name="posArapucaDouble2-Frame-3-3" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="539" 
 	 z="105"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4862,14 +4862,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-3-2"/>
        <position name="posOpArapucaDouble2-Frame-3-3" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="539" 
 	 z="105"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-3-3"/>
        <position name="posArapucaDouble3-Frame-3-3" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="629.7" 
 	 z="-40.9999999999999"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4877,14 +4877,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-3-3"/>
        <position name="posOpArapucaDouble3-Frame-3-3" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="629.7" 
 	 z="-40.9999999999999"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-4-0"/>
        <position name="posArapucaDouble0-Frame-3-4" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="374.3" 
 	 z="331.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4892,14 +4892,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-4-0"/>
        <position name="posOpArapucaDouble0-Frame-3-4" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="374.3" 
 	 z="331.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-4-1"/>
        <position name="posArapucaDouble1-Frame-3-4" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="465" 
 	 z="185.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4907,14 +4907,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-4-1"/>
        <position name="posOpArapucaDouble1-Frame-3-4" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="465" 
 	 z="185.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-4-2"/>
        <position name="posArapucaDouble2-Frame-3-4" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="539" 
 	 z="402.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4922,14 +4922,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-4-2"/>
        <position name="posOpArapucaDouble2-Frame-3-4" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="539" 
 	 z="402.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-4-3"/>
        <position name="posArapucaDouble3-Frame-3-4" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="629.7" 
 	 z="256.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4937,14 +4937,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-4-3"/>
        <position name="posOpArapucaDouble3-Frame-3-4" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="629.7" 
 	 z="256.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-5-0"/>
        <position name="posArapucaDouble0-Frame-3-5" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="374.3" 
 	 z="629.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4952,14 +4952,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-5-0"/>
        <position name="posOpArapucaDouble0-Frame-3-5" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="374.3" 
 	 z="629.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-5-1"/>
        <position name="posArapucaDouble1-Frame-3-5" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="465" 
 	 z="483.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4967,14 +4967,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-5-1"/>
        <position name="posOpArapucaDouble1-Frame-3-5" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="465" 
 	 z="483.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-5-2"/>
        <position name="posArapucaDouble2-Frame-3-5" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="539" 
 	 z="700.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4982,14 +4982,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-5-2"/>
        <position name="posOpArapucaDouble2-Frame-3-5" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="539" 
 	 z="700.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-5-3"/>
        <position name="posArapucaDouble3-Frame-3-5" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="629.7" 
 	 z="554.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4997,14 +4997,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-5-3"/>
        <position name="posOpArapucaDouble3-Frame-3-5" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="629.7" 
 	 z="554.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-6-0"/>
        <position name="posArapucaDouble0-Frame-3-6" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="374.3" 
 	 z="927.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -5012,14 +5012,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-6-0"/>
        <position name="posOpArapucaDouble0-Frame-3-6" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="374.3" 
 	 z="927.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-6-1"/>
        <position name="posArapucaDouble1-Frame-3-6" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="465" 
 	 z="781.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -5027,14 +5027,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-6-1"/>
        <position name="posOpArapucaDouble1-Frame-3-6" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="465" 
 	 z="781.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-6-2"/>
        <position name="posArapucaDouble2-Frame-3-6" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="539" 
 	 z="998.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -5042,14 +5042,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-6-2"/>
        <position name="posOpArapucaDouble2-Frame-3-6" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="539" 
 	 z="998.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-6-3"/>
        <position name="posArapucaDouble3-Frame-3-6" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="629.7" 
 	 z="852.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -5057,14 +5057,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-6-3"/>
        <position name="posOpArapucaDouble3-Frame-3-6" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="629.7" 
 	 z="852.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-0"/>
        <position name="posArapuca0-Lat-0" unit="cm" 
-         x="285.01"
+         x="285.02"
 	 y="-734" 
 	 z="-893.4054"/>
        <rotationref ref="rIdentity"/>
@@ -5072,14 +5072,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-0"/>
        <position name="posOpArapuca0-Lat-0" unit="cm" 
-         x="285.01"
+         x="285.02"
 	 y="-733.26" 
 	 z="-893.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-1"/>
        <position name="posArapuca1-Lat-0" unit="cm" 
-         x="210.01"
+         x="210.02"
 	 y="-734" 
 	 z="-893.4054"/>
        <rotationref ref="rIdentity"/>
@@ -5087,14 +5087,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-1"/>
        <position name="posOpArapuca1-Lat-0" unit="cm" 
-         x="210.01"
+         x="210.02"
 	 y="-733.26" 
 	 z="-893.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-2"/>
        <position name="posArapuca2-Lat-0" unit="cm" 
-         x="135.01"
+         x="135.02"
 	 y="-734" 
 	 z="-893.4054"/>
        <rotationref ref="rIdentity"/>
@@ -5102,14 +5102,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-2"/>
        <position name="posOpArapuca2-Lat-0" unit="cm" 
-         x="135.01"
+         x="135.02"
 	 y="-733.26" 
 	 z="-893.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-3"/>
        <position name="posArapuca3-Lat-0" unit="cm" 
-         x="60.01"
+         x="60.02"
 	 y="-734" 
 	 z="-893.4054"/>
        <rotationref ref="rIdentity"/>
@@ -5117,14 +5117,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-3"/>
        <position name="posOpArapuca3-Lat-0" unit="cm" 
-         x="60.01"
+         x="60.02"
 	 y="-733.26" 
 	 z="-893.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-4"/>
        <position name="posArapuca4-Lat-0" unit="cm" 
-         x="285.01"
+         x="285.02"
 	 y="734" 
 	 z="-893.4054"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5132,14 +5132,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-4"/>
        <position name="posOpArapuca4-Lat-0" unit="cm" 
-         x="285.01"
+         x="285.02"
 	 y="733.26" 
 	 z="-893.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-5"/>
        <position name="posArapuca5-Lat-0" unit="cm" 
-         x="210.01"
+         x="210.02"
 	 y="734" 
 	 z="-893.4054"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5147,14 +5147,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-5"/>
        <position name="posOpArapuca5-Lat-0" unit="cm" 
-         x="210.01"
+         x="210.02"
 	 y="733.26" 
 	 z="-893.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-6"/>
        <position name="posArapuca6-Lat-0" unit="cm" 
-         x="135.01"
+         x="135.02"
 	 y="734" 
 	 z="-893.4054"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5162,14 +5162,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-6"/>
        <position name="posOpArapuca6-Lat-0" unit="cm" 
-         x="135.01"
+         x="135.02"
 	 y="733.26" 
 	 z="-893.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-7"/>
        <position name="posArapuca7-Lat-0" unit="cm" 
-         x="60.01"
+         x="60.02"
 	 y="734" 
 	 z="-893.4054"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5177,14 +5177,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-7"/>
        <position name="posOpArapuca7-Lat-0" unit="cm" 
-         x="60.01"
+         x="60.02"
 	 y="733.26" 
 	 z="-893.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-0"/>
        <position name="posArapuca0-Lat-1" unit="cm" 
-         x="285.01"
+         x="285.02"
 	 y="-734" 
 	 z="-595.6036"/>
        <rotationref ref="rIdentity"/>
@@ -5192,14 +5192,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-0"/>
        <position name="posOpArapuca0-Lat-1" unit="cm" 
-         x="285.01"
+         x="285.02"
 	 y="-733.26" 
 	 z="-595.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-1"/>
        <position name="posArapuca1-Lat-1" unit="cm" 
-         x="210.01"
+         x="210.02"
 	 y="-734" 
 	 z="-595.6036"/>
        <rotationref ref="rIdentity"/>
@@ -5207,14 +5207,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-1"/>
        <position name="posOpArapuca1-Lat-1" unit="cm" 
-         x="210.01"
+         x="210.02"
 	 y="-733.26" 
 	 z="-595.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-2"/>
        <position name="posArapuca2-Lat-1" unit="cm" 
-         x="135.01"
+         x="135.02"
 	 y="-734" 
 	 z="-595.6036"/>
        <rotationref ref="rIdentity"/>
@@ -5222,14 +5222,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-2"/>
        <position name="posOpArapuca2-Lat-1" unit="cm" 
-         x="135.01"
+         x="135.02"
 	 y="-733.26" 
 	 z="-595.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-3"/>
        <position name="posArapuca3-Lat-1" unit="cm" 
-         x="60.01"
+         x="60.02"
 	 y="-734" 
 	 z="-595.6036"/>
        <rotationref ref="rIdentity"/>
@@ -5237,14 +5237,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-3"/>
        <position name="posOpArapuca3-Lat-1" unit="cm" 
-         x="60.01"
+         x="60.02"
 	 y="-733.26" 
 	 z="-595.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-4"/>
        <position name="posArapuca4-Lat-1" unit="cm" 
-         x="285.01"
+         x="285.02"
 	 y="734" 
 	 z="-595.6036"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5252,14 +5252,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-4"/>
        <position name="posOpArapuca4-Lat-1" unit="cm" 
-         x="285.01"
+         x="285.02"
 	 y="733.26" 
 	 z="-595.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-5"/>
        <position name="posArapuca5-Lat-1" unit="cm" 
-         x="210.01"
+         x="210.02"
 	 y="734" 
 	 z="-595.6036"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5267,14 +5267,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-5"/>
        <position name="posOpArapuca5-Lat-1" unit="cm" 
-         x="210.01"
+         x="210.02"
 	 y="733.26" 
 	 z="-595.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-6"/>
        <position name="posArapuca6-Lat-1" unit="cm" 
-         x="135.01"
+         x="135.02"
 	 y="734" 
 	 z="-595.6036"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5282,14 +5282,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-6"/>
        <position name="posOpArapuca6-Lat-1" unit="cm" 
-         x="135.01"
+         x="135.02"
 	 y="733.26" 
 	 z="-595.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-7"/>
        <position name="posArapuca7-Lat-1" unit="cm" 
-         x="60.01"
+         x="60.02"
 	 y="734" 
 	 z="-595.6036"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5297,14 +5297,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-7"/>
        <position name="posOpArapuca7-Lat-1" unit="cm" 
-         x="60.01"
+         x="60.02"
 	 y="733.26" 
 	 z="-595.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-0"/>
        <position name="posArapuca0-Lat-2" unit="cm" 
-         x="285.01"
+         x="285.02"
 	 y="-734" 
 	 z="-297.8018"/>
        <rotationref ref="rIdentity"/>
@@ -5312,14 +5312,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-0"/>
        <position name="posOpArapuca0-Lat-2" unit="cm" 
-         x="285.01"
+         x="285.02"
 	 y="-733.26" 
 	 z="-297.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-1"/>
        <position name="posArapuca1-Lat-2" unit="cm" 
-         x="210.01"
+         x="210.02"
 	 y="-734" 
 	 z="-297.8018"/>
        <rotationref ref="rIdentity"/>
@@ -5327,14 +5327,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-1"/>
        <position name="posOpArapuca1-Lat-2" unit="cm" 
-         x="210.01"
+         x="210.02"
 	 y="-733.26" 
 	 z="-297.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-2"/>
        <position name="posArapuca2-Lat-2" unit="cm" 
-         x="135.01"
+         x="135.02"
 	 y="-734" 
 	 z="-297.8018"/>
        <rotationref ref="rIdentity"/>
@@ -5342,14 +5342,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-2"/>
        <position name="posOpArapuca2-Lat-2" unit="cm" 
-         x="135.01"
+         x="135.02"
 	 y="-733.26" 
 	 z="-297.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-3"/>
        <position name="posArapuca3-Lat-2" unit="cm" 
-         x="60.01"
+         x="60.02"
 	 y="-734" 
 	 z="-297.8018"/>
        <rotationref ref="rIdentity"/>
@@ -5357,14 +5357,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-3"/>
        <position name="posOpArapuca3-Lat-2" unit="cm" 
-         x="60.01"
+         x="60.02"
 	 y="-733.26" 
 	 z="-297.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-4"/>
        <position name="posArapuca4-Lat-2" unit="cm" 
-         x="285.01"
+         x="285.02"
 	 y="734" 
 	 z="-297.8018"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5372,14 +5372,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-4"/>
        <position name="posOpArapuca4-Lat-2" unit="cm" 
-         x="285.01"
+         x="285.02"
 	 y="733.26" 
 	 z="-297.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-5"/>
        <position name="posArapuca5-Lat-2" unit="cm" 
-         x="210.01"
+         x="210.02"
 	 y="734" 
 	 z="-297.8018"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5387,14 +5387,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-5"/>
        <position name="posOpArapuca5-Lat-2" unit="cm" 
-         x="210.01"
+         x="210.02"
 	 y="733.26" 
 	 z="-297.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-6"/>
        <position name="posArapuca6-Lat-2" unit="cm" 
-         x="135.01"
+         x="135.02"
 	 y="734" 
 	 z="-297.8018"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5402,14 +5402,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-6"/>
        <position name="posOpArapuca6-Lat-2" unit="cm" 
-         x="135.01"
+         x="135.02"
 	 y="733.26" 
 	 z="-297.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-7"/>
        <position name="posArapuca7-Lat-2" unit="cm" 
-         x="60.01"
+         x="60.02"
 	 y="734" 
 	 z="-297.8018"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5417,14 +5417,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-7"/>
        <position name="posOpArapuca7-Lat-2" unit="cm" 
-         x="60.01"
+         x="60.02"
 	 y="733.26" 
 	 z="-297.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_3-0"/>
        <position name="posArapuca0-Lat-3" unit="cm" 
-         x="285.01"
+         x="285.02"
 	 y="-734" 
 	 z="1.13686837721616e-13"/>
        <rotationref ref="rIdentity"/>
@@ -5432,14 +5432,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_3-0"/>
        <position name="posOpArapuca0-Lat-3" unit="cm" 
-         x="285.01"
+         x="285.02"
 	 y="-733.26" 
 	 z="1.13686837721616e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_3-1"/>
        <position name="posArapuca1-Lat-3" unit="cm" 
-         x="210.01"
+         x="210.02"
 	 y="-734" 
 	 z="1.13686837721616e-13"/>
        <rotationref ref="rIdentity"/>
@@ -5447,14 +5447,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_3-1"/>
        <position name="posOpArapuca1-Lat-3" unit="cm" 
-         x="210.01"
+         x="210.02"
 	 y="-733.26" 
 	 z="1.13686837721616e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_3-2"/>
        <position name="posArapuca2-Lat-3" unit="cm" 
-         x="135.01"
+         x="135.02"
 	 y="-734" 
 	 z="1.13686837721616e-13"/>
        <rotationref ref="rIdentity"/>
@@ -5462,14 +5462,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_3-2"/>
        <position name="posOpArapuca2-Lat-3" unit="cm" 
-         x="135.01"
+         x="135.02"
 	 y="-733.26" 
 	 z="1.13686837721616e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_3-3"/>
        <position name="posArapuca3-Lat-3" unit="cm" 
-         x="60.01"
+         x="60.02"
 	 y="-734" 
 	 z="1.13686837721616e-13"/>
        <rotationref ref="rIdentity"/>
@@ -5477,14 +5477,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_3-3"/>
        <position name="posOpArapuca3-Lat-3" unit="cm" 
-         x="60.01"
+         x="60.02"
 	 y="-733.26" 
 	 z="1.13686837721616e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_3-4"/>
        <position name="posArapuca4-Lat-3" unit="cm" 
-         x="285.01"
+         x="285.02"
 	 y="734" 
 	 z="1.13686837721616e-13"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5492,14 +5492,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_3-4"/>
        <position name="posOpArapuca4-Lat-3" unit="cm" 
-         x="285.01"
+         x="285.02"
 	 y="733.26" 
 	 z="1.13686837721616e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_3-5"/>
        <position name="posArapuca5-Lat-3" unit="cm" 
-         x="210.01"
+         x="210.02"
 	 y="734" 
 	 z="1.13686837721616e-13"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5507,14 +5507,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_3-5"/>
        <position name="posOpArapuca5-Lat-3" unit="cm" 
-         x="210.01"
+         x="210.02"
 	 y="733.26" 
 	 z="1.13686837721616e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_3-6"/>
        <position name="posArapuca6-Lat-3" unit="cm" 
-         x="135.01"
+         x="135.02"
 	 y="734" 
 	 z="1.13686837721616e-13"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5522,14 +5522,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_3-6"/>
        <position name="posOpArapuca6-Lat-3" unit="cm" 
-         x="135.01"
+         x="135.02"
 	 y="733.26" 
 	 z="1.13686837721616e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_3-7"/>
        <position name="posArapuca7-Lat-3" unit="cm" 
-         x="60.01"
+         x="60.02"
 	 y="734" 
 	 z="1.13686837721616e-13"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5537,14 +5537,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_3-7"/>
        <position name="posOpArapuca7-Lat-3" unit="cm" 
-         x="60.01"
+         x="60.02"
 	 y="733.26" 
 	 z="1.13686837721616e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_4-0"/>
        <position name="posArapuca0-Lat-4" unit="cm" 
-         x="285.01"
+         x="285.02"
 	 y="-734" 
 	 z="297.8018"/>
        <rotationref ref="rIdentity"/>
@@ -5552,14 +5552,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_4-0"/>
        <position name="posOpArapuca0-Lat-4" unit="cm" 
-         x="285.01"
+         x="285.02"
 	 y="-733.26" 
 	 z="297.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_4-1"/>
        <position name="posArapuca1-Lat-4" unit="cm" 
-         x="210.01"
+         x="210.02"
 	 y="-734" 
 	 z="297.8018"/>
        <rotationref ref="rIdentity"/>
@@ -5567,14 +5567,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_4-1"/>
        <position name="posOpArapuca1-Lat-4" unit="cm" 
-         x="210.01"
+         x="210.02"
 	 y="-733.26" 
 	 z="297.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_4-2"/>
        <position name="posArapuca2-Lat-4" unit="cm" 
-         x="135.01"
+         x="135.02"
 	 y="-734" 
 	 z="297.8018"/>
        <rotationref ref="rIdentity"/>
@@ -5582,14 +5582,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_4-2"/>
        <position name="posOpArapuca2-Lat-4" unit="cm" 
-         x="135.01"
+         x="135.02"
 	 y="-733.26" 
 	 z="297.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_4-3"/>
        <position name="posArapuca3-Lat-4" unit="cm" 
-         x="60.01"
+         x="60.02"
 	 y="-734" 
 	 z="297.8018"/>
        <rotationref ref="rIdentity"/>
@@ -5597,14 +5597,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_4-3"/>
        <position name="posOpArapuca3-Lat-4" unit="cm" 
-         x="60.01"
+         x="60.02"
 	 y="-733.26" 
 	 z="297.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_4-4"/>
        <position name="posArapuca4-Lat-4" unit="cm" 
-         x="285.01"
+         x="285.02"
 	 y="734" 
 	 z="297.8018"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5612,14 +5612,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_4-4"/>
        <position name="posOpArapuca4-Lat-4" unit="cm" 
-         x="285.01"
+         x="285.02"
 	 y="733.26" 
 	 z="297.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_4-5"/>
        <position name="posArapuca5-Lat-4" unit="cm" 
-         x="210.01"
+         x="210.02"
 	 y="734" 
 	 z="297.8018"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5627,14 +5627,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_4-5"/>
        <position name="posOpArapuca5-Lat-4" unit="cm" 
-         x="210.01"
+         x="210.02"
 	 y="733.26" 
 	 z="297.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_4-6"/>
        <position name="posArapuca6-Lat-4" unit="cm" 
-         x="135.01"
+         x="135.02"
 	 y="734" 
 	 z="297.8018"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5642,14 +5642,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_4-6"/>
        <position name="posOpArapuca6-Lat-4" unit="cm" 
-         x="135.01"
+         x="135.02"
 	 y="733.26" 
 	 z="297.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_4-7"/>
        <position name="posArapuca7-Lat-4" unit="cm" 
-         x="60.01"
+         x="60.02"
 	 y="734" 
 	 z="297.8018"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5657,14 +5657,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_4-7"/>
        <position name="posOpArapuca7-Lat-4" unit="cm" 
-         x="60.01"
+         x="60.02"
 	 y="733.26" 
 	 z="297.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_5-0"/>
        <position name="posArapuca0-Lat-5" unit="cm" 
-         x="285.01"
+         x="285.02"
 	 y="-734" 
 	 z="595.6036"/>
        <rotationref ref="rIdentity"/>
@@ -5672,14 +5672,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_5-0"/>
        <position name="posOpArapuca0-Lat-5" unit="cm" 
-         x="285.01"
+         x="285.02"
 	 y="-733.26" 
 	 z="595.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_5-1"/>
        <position name="posArapuca1-Lat-5" unit="cm" 
-         x="210.01"
+         x="210.02"
 	 y="-734" 
 	 z="595.6036"/>
        <rotationref ref="rIdentity"/>
@@ -5687,14 +5687,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_5-1"/>
        <position name="posOpArapuca1-Lat-5" unit="cm" 
-         x="210.01"
+         x="210.02"
 	 y="-733.26" 
 	 z="595.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_5-2"/>
        <position name="posArapuca2-Lat-5" unit="cm" 
-         x="135.01"
+         x="135.02"
 	 y="-734" 
 	 z="595.6036"/>
        <rotationref ref="rIdentity"/>
@@ -5702,14 +5702,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_5-2"/>
        <position name="posOpArapuca2-Lat-5" unit="cm" 
-         x="135.01"
+         x="135.02"
 	 y="-733.26" 
 	 z="595.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_5-3"/>
        <position name="posArapuca3-Lat-5" unit="cm" 
-         x="60.01"
+         x="60.02"
 	 y="-734" 
 	 z="595.6036"/>
        <rotationref ref="rIdentity"/>
@@ -5717,14 +5717,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_5-3"/>
        <position name="posOpArapuca3-Lat-5" unit="cm" 
-         x="60.01"
+         x="60.02"
 	 y="-733.26" 
 	 z="595.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_5-4"/>
        <position name="posArapuca4-Lat-5" unit="cm" 
-         x="285.01"
+         x="285.02"
 	 y="734" 
 	 z="595.6036"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5732,14 +5732,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_5-4"/>
        <position name="posOpArapuca4-Lat-5" unit="cm" 
-         x="285.01"
+         x="285.02"
 	 y="733.26" 
 	 z="595.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_5-5"/>
        <position name="posArapuca5-Lat-5" unit="cm" 
-         x="210.01"
+         x="210.02"
 	 y="734" 
 	 z="595.6036"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5747,14 +5747,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_5-5"/>
        <position name="posOpArapuca5-Lat-5" unit="cm" 
-         x="210.01"
+         x="210.02"
 	 y="733.26" 
 	 z="595.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_5-6"/>
        <position name="posArapuca6-Lat-5" unit="cm" 
-         x="135.01"
+         x="135.02"
 	 y="734" 
 	 z="595.6036"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5762,14 +5762,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_5-6"/>
        <position name="posOpArapuca6-Lat-5" unit="cm" 
-         x="135.01"
+         x="135.02"
 	 y="733.26" 
 	 z="595.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_5-7"/>
        <position name="posArapuca7-Lat-5" unit="cm" 
-         x="60.01"
+         x="60.02"
 	 y="734" 
 	 z="595.6036"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5777,14 +5777,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_5-7"/>
        <position name="posOpArapuca7-Lat-5" unit="cm" 
-         x="60.01"
+         x="60.02"
 	 y="733.26" 
 	 z="595.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_6-0"/>
        <position name="posArapuca0-Lat-6" unit="cm" 
-         x="285.01"
+         x="285.02"
 	 y="-734" 
 	 z="893.4054"/>
        <rotationref ref="rIdentity"/>
@@ -5792,14 +5792,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_6-0"/>
        <position name="posOpArapuca0-Lat-6" unit="cm" 
-         x="285.01"
+         x="285.02"
 	 y="-733.26" 
 	 z="893.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_6-1"/>
        <position name="posArapuca1-Lat-6" unit="cm" 
-         x="210.01"
+         x="210.02"
 	 y="-734" 
 	 z="893.4054"/>
        <rotationref ref="rIdentity"/>
@@ -5807,14 +5807,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_6-1"/>
        <position name="posOpArapuca1-Lat-6" unit="cm" 
-         x="210.01"
+         x="210.02"
 	 y="-733.26" 
 	 z="893.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_6-2"/>
        <position name="posArapuca2-Lat-6" unit="cm" 
-         x="135.01"
+         x="135.02"
 	 y="-734" 
 	 z="893.4054"/>
        <rotationref ref="rIdentity"/>
@@ -5822,14 +5822,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_6-2"/>
        <position name="posOpArapuca2-Lat-6" unit="cm" 
-         x="135.01"
+         x="135.02"
 	 y="-733.26" 
 	 z="893.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_6-3"/>
        <position name="posArapuca3-Lat-6" unit="cm" 
-         x="60.01"
+         x="60.02"
 	 y="-734" 
 	 z="893.4054"/>
        <rotationref ref="rIdentity"/>
@@ -5837,14 +5837,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_6-3"/>
        <position name="posOpArapuca3-Lat-6" unit="cm" 
-         x="60.01"
+         x="60.02"
 	 y="-733.26" 
 	 z="893.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_6-4"/>
        <position name="posArapuca4-Lat-6" unit="cm" 
-         x="285.01"
+         x="285.02"
 	 y="734" 
 	 z="893.4054"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5852,14 +5852,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_6-4"/>
        <position name="posOpArapuca4-Lat-6" unit="cm" 
-         x="285.01"
+         x="285.02"
 	 y="733.26" 
 	 z="893.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_6-5"/>
        <position name="posArapuca5-Lat-6" unit="cm" 
-         x="210.01"
+         x="210.02"
 	 y="734" 
 	 z="893.4054"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5867,14 +5867,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_6-5"/>
        <position name="posOpArapuca5-Lat-6" unit="cm" 
-         x="210.01"
+         x="210.02"
 	 y="733.26" 
 	 z="893.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_6-6"/>
        <position name="posArapuca6-Lat-6" unit="cm" 
-         x="135.01"
+         x="135.02"
 	 y="734" 
 	 z="893.4054"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5882,14 +5882,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_6-6"/>
        <position name="posOpArapuca6-Lat-6" unit="cm" 
-         x="135.01"
+         x="135.02"
 	 y="733.26" 
 	 z="893.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_6-7"/>
        <position name="posArapuca7-Lat-6" unit="cm" 
-         x="60.01"
+         x="60.02"
 	 y="734" 
 	 z="893.4054"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5897,7 +5897,7 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_6-7"/>
        <position name="posOpArapuca7-Lat-6" unit="cm" 
-         x="60.01"
+         x="60.02"
 	 y="733.26" 
 	 z="893.4054"/>
      </physvol>
@@ -5937,7 +5937,7 @@
 
       <physvol>
         <volumeref ref="volDetEnclosure"/>
-	<position name="posDetEnclosure" unit="cm" x="50.04" y="-1.13686837721616e-13" z="1045.8063"/>
+	<position name="posDetEnclosure" unit="cm" x="50.0500000000001" y="-1.13686837721616e-13" z="1045.8063"/>
       </physvol>
 
     </volume>

--- a/dunecore/Geometry/gdml/dunevd10kt_3view_v3_refactored_1x8x14ref_nowires.gdml
+++ b/dunecore/Geometry/gdml/dunevd10kt_3view_v3_refactored_1x8x14ref_nowires.gdml
@@ -508,6 +508,11 @@
       y="168"
       z="148.9009"
       lunit="cm"/>
+   <box name="AnodePlate" 
+      x="0.02/2."
+      y="168"
+      z="148.9009"
+      lunit="cm"/>
    <box name="CRMActive" 
       x="650"
       y="168"
@@ -752,7 +757,7 @@
      
    <volume name="volAnodePlate">
      <materialref ref="vm2000"/>
-     <solidref ref="CRMZPlane"/>
+     <solidref ref="AnodePlate"/>
   </volume>
    <volume name="volTPC">
      <materialref ref="LAr"/>
@@ -760,25 +765,25 @@
        <physvol>
        <volumeref ref="volTPCPlaneU"/>
        <position name="posPlaneU" unit="cm" 
-         x="324.98" y="0" z="0"/>
+         x="324.99" y="0" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volTPCPlaneY"/>
        <position name="posPlaneY" unit="cm" 
-         x="325" y="0" z="0"/>
+         x="325.01" y="0" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volTPCPlaneZ"/>
        <position name="posPlaneZ" unit="cm" 
-         x="325.02" y="0" z="0"/>
+         x="325.03" y="0" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volAnodePlate"/>
        <position name="posAnodePlate" unit="cm" 
-         x="325.04" y="0" z="0"/>
+         x="325.045" y="0" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>    
      <physvol>
@@ -3271,120 +3276,120 @@
   </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-0" unit="cm" x="-328.05" y="-506" z="-896.9054"/>
+   <position name="posGroundGrid-0" unit="cm" x="-328.04" y="-506" z="-896.9054"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-1" unit="cm" x="-328.05" y="-170" z="-896.9054"/>
+   <position name="posGroundGrid-1" unit="cm" x="-328.04" y="-170" z="-896.9054"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-2" unit="cm" x="-328.05" y="166" z="-896.9054"/>
+   <position name="posGroundGrid-2" unit="cm" x="-328.04" y="166" z="-896.9054"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-3" unit="cm" x="-328.05" y="502" z="-896.9054"/>
+   <position name="posGroundGrid-3" unit="cm" x="-328.04" y="502" z="-896.9054"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-4" unit="cm" x="-328.05" y="-506" z="-599.1036"/>
+   <position name="posGroundGrid-4" unit="cm" x="-328.04" y="-506" z="-599.1036"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-5" unit="cm" x="-328.05" y="-170" z="-599.1036"/>
+   <position name="posGroundGrid-5" unit="cm" x="-328.04" y="-170" z="-599.1036"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-6" unit="cm" x="-328.05" y="166" z="-599.1036"/>
+   <position name="posGroundGrid-6" unit="cm" x="-328.04" y="166" z="-599.1036"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-7" unit="cm" x="-328.05" y="502" z="-599.1036"/>
+   <position name="posGroundGrid-7" unit="cm" x="-328.04" y="502" z="-599.1036"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-8" unit="cm" x="-328.05" y="-506" z="-301.3018"/>
+   <position name="posGroundGrid-8" unit="cm" x="-328.04" y="-506" z="-301.3018"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-9" unit="cm" x="-328.05" y="-170" z="-301.3018"/>
+   <position name="posGroundGrid-9" unit="cm" x="-328.04" y="-170" z="-301.3018"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-10" unit="cm" x="-328.05" y="166" z="-301.3018"/>
+   <position name="posGroundGrid-10" unit="cm" x="-328.04" y="166" z="-301.3018"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-11" unit="cm" x="-328.05" y="502" z="-301.3018"/>
+   <position name="posGroundGrid-11" unit="cm" x="-328.04" y="502" z="-301.3018"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-12" unit="cm" x="-328.05" y="-506" z="-3.49999999999989"/>
+   <position name="posGroundGrid-12" unit="cm" x="-328.04" y="-506" z="-3.49999999999989"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-13" unit="cm" x="-328.05" y="-170" z="-3.49999999999989"/>
+   <position name="posGroundGrid-13" unit="cm" x="-328.04" y="-170" z="-3.49999999999989"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-14" unit="cm" x="-328.05" y="166" z="-3.49999999999989"/>
+   <position name="posGroundGrid-14" unit="cm" x="-328.04" y="166" z="-3.49999999999989"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-15" unit="cm" x="-328.05" y="502" z="-3.49999999999989"/>
+   <position name="posGroundGrid-15" unit="cm" x="-328.04" y="502" z="-3.49999999999989"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-16" unit="cm" x="-328.05" y="-506" z="294.3018"/>
+   <position name="posGroundGrid-16" unit="cm" x="-328.04" y="-506" z="294.3018"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-17" unit="cm" x="-328.05" y="-170" z="294.3018"/>
+   <position name="posGroundGrid-17" unit="cm" x="-328.04" y="-170" z="294.3018"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-18" unit="cm" x="-328.05" y="166" z="294.3018"/>
+   <position name="posGroundGrid-18" unit="cm" x="-328.04" y="166" z="294.3018"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-19" unit="cm" x="-328.05" y="502" z="294.3018"/>
+   <position name="posGroundGrid-19" unit="cm" x="-328.04" y="502" z="294.3018"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-20" unit="cm" x="-328.05" y="-506" z="592.1036"/>
+   <position name="posGroundGrid-20" unit="cm" x="-328.04" y="-506" z="592.1036"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-21" unit="cm" x="-328.05" y="-170" z="592.1036"/>
+   <position name="posGroundGrid-21" unit="cm" x="-328.04" y="-170" z="592.1036"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-22" unit="cm" x="-328.05" y="166" z="592.1036"/>
+   <position name="posGroundGrid-22" unit="cm" x="-328.04" y="166" z="592.1036"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-23" unit="cm" x="-328.05" y="502" z="592.1036"/>
+   <position name="posGroundGrid-23" unit="cm" x="-328.04" y="502" z="592.1036"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-24" unit="cm" x="-328.05" y="-506" z="889.9054"/>
+   <position name="posGroundGrid-24" unit="cm" x="-328.04" y="-506" z="889.9054"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-25" unit="cm" x="-328.05" y="-170" z="889.9054"/>
+   <position name="posGroundGrid-25" unit="cm" x="-328.04" y="-170" z="889.9054"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-26" unit="cm" x="-328.05" y="166" z="889.9054"/>
+   <position name="posGroundGrid-26" unit="cm" x="-328.04" y="166" z="889.9054"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-27" unit="cm" x="-328.05" y="502" z="889.9054"/>
+   <position name="posGroundGrid-27" unit="cm" x="-328.04" y="502" z="889.9054"/>
       </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-0-0"/>
        <position name="posArapucaDouble0-Frame-0-0" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-633.7" 
 	 z="-859.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3392,14 +3397,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-0"/>
        <position name="posOpArapucaDouble0-Frame-0-0" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-633.7" 
 	 z="-859.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-0-1"/>
        <position name="posArapucaDouble1-Frame-0-0" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-543" 
 	 z="-1005.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3407,14 +3412,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-1"/>
        <position name="posOpArapucaDouble1-Frame-0-0" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-543" 
 	 z="-1005.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-0-2"/>
        <position name="posArapucaDouble2-Frame-0-0" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-469" 
 	 z="-788.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3422,14 +3427,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-2"/>
        <position name="posOpArapucaDouble2-Frame-0-0" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-469" 
 	 z="-788.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-0-3"/>
        <position name="posArapucaDouble3-Frame-0-0" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-378.3" 
 	 z="-934.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3437,14 +3442,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-3"/>
        <position name="posOpArapucaDouble3-Frame-0-0" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-378.3" 
 	 z="-934.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-1-0"/>
        <position name="posArapucaDouble0-Frame-0-1" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-633.7" 
 	 z="-561.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3452,14 +3457,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-0"/>
        <position name="posOpArapucaDouble0-Frame-0-1" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-633.7" 
 	 z="-561.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-1-1"/>
        <position name="posArapucaDouble1-Frame-0-1" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-543" 
 	 z="-707.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3467,14 +3472,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-1"/>
        <position name="posOpArapucaDouble1-Frame-0-1" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-543" 
 	 z="-707.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-1-2"/>
        <position name="posArapucaDouble2-Frame-0-1" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-469" 
 	 z="-490.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3482,14 +3487,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-2"/>
        <position name="posOpArapucaDouble2-Frame-0-1" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-469" 
 	 z="-490.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-1-3"/>
        <position name="posArapucaDouble3-Frame-0-1" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-378.3" 
 	 z="-636.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3497,14 +3502,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-3"/>
        <position name="posOpArapucaDouble3-Frame-0-1" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-378.3" 
 	 z="-636.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-2-0"/>
        <position name="posArapucaDouble0-Frame-0-2" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-633.7" 
 	 z="-263.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3512,14 +3517,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-0"/>
        <position name="posOpArapucaDouble0-Frame-0-2" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-633.7" 
 	 z="-263.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-2-1"/>
        <position name="posArapucaDouble1-Frame-0-2" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-543" 
 	 z="-409.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3527,14 +3532,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-1"/>
        <position name="posOpArapucaDouble1-Frame-0-2" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-543" 
 	 z="-409.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-2-2"/>
        <position name="posArapucaDouble2-Frame-0-2" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-469" 
 	 z="-192.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3542,14 +3547,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-2"/>
        <position name="posOpArapucaDouble2-Frame-0-2" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-469" 
 	 z="-192.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-2-3"/>
        <position name="posArapucaDouble3-Frame-0-2" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-378.3" 
 	 z="-338.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3557,14 +3562,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-3"/>
        <position name="posOpArapucaDouble3-Frame-0-2" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-378.3" 
 	 z="-338.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-3-0"/>
        <position name="posArapucaDouble0-Frame-0-3" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-633.7" 
 	 z="34.0000000000001"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3572,14 +3577,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-3-0"/>
        <position name="posOpArapucaDouble0-Frame-0-3" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-633.7" 
 	 z="34.0000000000001"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-3-1"/>
        <position name="posArapucaDouble1-Frame-0-3" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-543" 
 	 z="-112"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3587,14 +3592,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-3-1"/>
        <position name="posOpArapucaDouble1-Frame-0-3" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-543" 
 	 z="-112"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-3-2"/>
        <position name="posArapucaDouble2-Frame-0-3" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-469" 
 	 z="105"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3602,14 +3607,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-3-2"/>
        <position name="posOpArapucaDouble2-Frame-0-3" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-469" 
 	 z="105"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-3-3"/>
        <position name="posArapucaDouble3-Frame-0-3" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-378.3" 
 	 z="-40.9999999999999"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3617,14 +3622,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-3-3"/>
        <position name="posOpArapucaDouble3-Frame-0-3" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-378.3" 
 	 z="-40.9999999999999"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-4-0"/>
        <position name="posArapucaDouble0-Frame-0-4" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-633.7" 
 	 z="331.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3632,14 +3637,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-4-0"/>
        <position name="posOpArapucaDouble0-Frame-0-4" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-633.7" 
 	 z="331.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-4-1"/>
        <position name="posArapucaDouble1-Frame-0-4" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-543" 
 	 z="185.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3647,14 +3652,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-4-1"/>
        <position name="posOpArapucaDouble1-Frame-0-4" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-543" 
 	 z="185.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-4-2"/>
        <position name="posArapucaDouble2-Frame-0-4" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-469" 
 	 z="402.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3662,14 +3667,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-4-2"/>
        <position name="posOpArapucaDouble2-Frame-0-4" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-469" 
 	 z="402.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-4-3"/>
        <position name="posArapucaDouble3-Frame-0-4" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-378.3" 
 	 z="256.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3677,14 +3682,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-4-3"/>
        <position name="posOpArapucaDouble3-Frame-0-4" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-378.3" 
 	 z="256.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-5-0"/>
        <position name="posArapucaDouble0-Frame-0-5" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-633.7" 
 	 z="629.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3692,14 +3697,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-5-0"/>
        <position name="posOpArapucaDouble0-Frame-0-5" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-633.7" 
 	 z="629.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-5-1"/>
        <position name="posArapucaDouble1-Frame-0-5" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-543" 
 	 z="483.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3707,14 +3712,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-5-1"/>
        <position name="posOpArapucaDouble1-Frame-0-5" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-543" 
 	 z="483.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-5-2"/>
        <position name="posArapucaDouble2-Frame-0-5" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-469" 
 	 z="700.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3722,14 +3727,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-5-2"/>
        <position name="posOpArapucaDouble2-Frame-0-5" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-469" 
 	 z="700.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-5-3"/>
        <position name="posArapucaDouble3-Frame-0-5" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-378.3" 
 	 z="554.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3737,14 +3742,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-5-3"/>
        <position name="posOpArapucaDouble3-Frame-0-5" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-378.3" 
 	 z="554.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-6-0"/>
        <position name="posArapucaDouble0-Frame-0-6" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-633.7" 
 	 z="927.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3752,14 +3757,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-6-0"/>
        <position name="posOpArapucaDouble0-Frame-0-6" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-633.7" 
 	 z="927.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-6-1"/>
        <position name="posArapucaDouble1-Frame-0-6" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-543" 
 	 z="781.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3767,14 +3772,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-6-1"/>
        <position name="posOpArapucaDouble1-Frame-0-6" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-543" 
 	 z="781.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-6-2"/>
        <position name="posArapucaDouble2-Frame-0-6" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-469" 
 	 z="998.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3782,14 +3787,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-6-2"/>
        <position name="posOpArapucaDouble2-Frame-0-6" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-469" 
 	 z="998.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-6-3"/>
        <position name="posArapucaDouble3-Frame-0-6" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-378.3" 
 	 z="852.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3797,14 +3802,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-6-3"/>
        <position name="posOpArapucaDouble3-Frame-0-6" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-378.3" 
 	 z="852.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-0-0"/>
        <position name="posArapucaDouble0-Frame-1-0" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-297.7" 
 	 z="-859.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3812,14 +3817,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-0"/>
        <position name="posOpArapucaDouble0-Frame-1-0" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-297.7" 
 	 z="-859.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-0-1"/>
        <position name="posArapucaDouble1-Frame-1-0" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-207" 
 	 z="-1005.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3827,14 +3832,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-1"/>
        <position name="posOpArapucaDouble1-Frame-1-0" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-207" 
 	 z="-1005.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-0-2"/>
        <position name="posArapucaDouble2-Frame-1-0" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-133" 
 	 z="-788.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3842,14 +3847,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-2"/>
        <position name="posOpArapucaDouble2-Frame-1-0" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-133" 
 	 z="-788.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-0-3"/>
        <position name="posArapucaDouble3-Frame-1-0" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-42.3" 
 	 z="-934.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3857,14 +3862,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-3"/>
        <position name="posOpArapucaDouble3-Frame-1-0" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-42.3" 
 	 z="-934.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-1-0"/>
        <position name="posArapucaDouble0-Frame-1-1" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-297.7" 
 	 z="-561.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3872,14 +3877,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-0"/>
        <position name="posOpArapucaDouble0-Frame-1-1" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-297.7" 
 	 z="-561.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-1-1"/>
        <position name="posArapucaDouble1-Frame-1-1" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-207" 
 	 z="-707.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3887,14 +3892,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-1"/>
        <position name="posOpArapucaDouble1-Frame-1-1" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-207" 
 	 z="-707.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-1-2"/>
        <position name="posArapucaDouble2-Frame-1-1" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-133" 
 	 z="-490.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3902,14 +3907,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-2"/>
        <position name="posOpArapucaDouble2-Frame-1-1" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-133" 
 	 z="-490.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-1-3"/>
        <position name="posArapucaDouble3-Frame-1-1" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-42.3" 
 	 z="-636.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3917,14 +3922,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-3"/>
        <position name="posOpArapucaDouble3-Frame-1-1" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-42.3" 
 	 z="-636.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-2-0"/>
        <position name="posArapucaDouble0-Frame-1-2" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-297.7" 
 	 z="-263.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3932,14 +3937,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-0"/>
        <position name="posOpArapucaDouble0-Frame-1-2" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-297.7" 
 	 z="-263.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-2-1"/>
        <position name="posArapucaDouble1-Frame-1-2" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-207" 
 	 z="-409.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3947,14 +3952,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-1"/>
        <position name="posOpArapucaDouble1-Frame-1-2" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-207" 
 	 z="-409.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-2-2"/>
        <position name="posArapucaDouble2-Frame-1-2" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-133" 
 	 z="-192.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3962,14 +3967,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-2"/>
        <position name="posOpArapucaDouble2-Frame-1-2" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-133" 
 	 z="-192.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-2-3"/>
        <position name="posArapucaDouble3-Frame-1-2" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-42.3" 
 	 z="-338.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3977,14 +3982,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-3"/>
        <position name="posOpArapucaDouble3-Frame-1-2" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-42.3" 
 	 z="-338.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-3-0"/>
        <position name="posArapucaDouble0-Frame-1-3" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-297.7" 
 	 z="34.0000000000001"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -3992,14 +3997,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-3-0"/>
        <position name="posOpArapucaDouble0-Frame-1-3" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-297.7" 
 	 z="34.0000000000001"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-3-1"/>
        <position name="posArapucaDouble1-Frame-1-3" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-207" 
 	 z="-112"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4007,14 +4012,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-3-1"/>
        <position name="posOpArapucaDouble1-Frame-1-3" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-207" 
 	 z="-112"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-3-2"/>
        <position name="posArapucaDouble2-Frame-1-3" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-133" 
 	 z="105"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4022,14 +4027,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-3-2"/>
        <position name="posOpArapucaDouble2-Frame-1-3" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-133" 
 	 z="105"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-3-3"/>
        <position name="posArapucaDouble3-Frame-1-3" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-42.3" 
 	 z="-40.9999999999999"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4037,14 +4042,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-3-3"/>
        <position name="posOpArapucaDouble3-Frame-1-3" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-42.3" 
 	 z="-40.9999999999999"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-4-0"/>
        <position name="posArapucaDouble0-Frame-1-4" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-297.7" 
 	 z="331.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4052,14 +4057,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-4-0"/>
        <position name="posOpArapucaDouble0-Frame-1-4" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-297.7" 
 	 z="331.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-4-1"/>
        <position name="posArapucaDouble1-Frame-1-4" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-207" 
 	 z="185.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4067,14 +4072,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-4-1"/>
        <position name="posOpArapucaDouble1-Frame-1-4" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-207" 
 	 z="185.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-4-2"/>
        <position name="posArapucaDouble2-Frame-1-4" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-133" 
 	 z="402.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4082,14 +4087,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-4-2"/>
        <position name="posOpArapucaDouble2-Frame-1-4" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-133" 
 	 z="402.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-4-3"/>
        <position name="posArapucaDouble3-Frame-1-4" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-42.3" 
 	 z="256.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4097,14 +4102,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-4-3"/>
        <position name="posOpArapucaDouble3-Frame-1-4" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-42.3" 
 	 z="256.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-5-0"/>
        <position name="posArapucaDouble0-Frame-1-5" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-297.7" 
 	 z="629.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4112,14 +4117,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-5-0"/>
        <position name="posOpArapucaDouble0-Frame-1-5" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-297.7" 
 	 z="629.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-5-1"/>
        <position name="posArapucaDouble1-Frame-1-5" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-207" 
 	 z="483.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4127,14 +4132,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-5-1"/>
        <position name="posOpArapucaDouble1-Frame-1-5" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-207" 
 	 z="483.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-5-2"/>
        <position name="posArapucaDouble2-Frame-1-5" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-133" 
 	 z="700.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4142,14 +4147,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-5-2"/>
        <position name="posOpArapucaDouble2-Frame-1-5" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-133" 
 	 z="700.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-5-3"/>
        <position name="posArapucaDouble3-Frame-1-5" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-42.3" 
 	 z="554.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4157,14 +4162,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-5-3"/>
        <position name="posOpArapucaDouble3-Frame-1-5" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-42.3" 
 	 z="554.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-6-0"/>
        <position name="posArapucaDouble0-Frame-1-6" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-297.7" 
 	 z="927.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4172,14 +4177,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-6-0"/>
        <position name="posOpArapucaDouble0-Frame-1-6" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-297.7" 
 	 z="927.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-6-1"/>
        <position name="posArapucaDouble1-Frame-1-6" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-207" 
 	 z="781.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4187,14 +4192,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-6-1"/>
        <position name="posOpArapucaDouble1-Frame-1-6" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-207" 
 	 z="781.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-6-2"/>
        <position name="posArapucaDouble2-Frame-1-6" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-133" 
 	 z="998.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4202,14 +4207,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-6-2"/>
        <position name="posOpArapucaDouble2-Frame-1-6" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-133" 
 	 z="998.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-6-3"/>
        <position name="posArapucaDouble3-Frame-1-6" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-42.3" 
 	 z="852.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4217,14 +4222,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-6-3"/>
        <position name="posOpArapucaDouble3-Frame-1-6" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-42.3" 
 	 z="852.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-0-0"/>
        <position name="posArapucaDouble0-Frame-2-0" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="38.3" 
 	 z="-859.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4232,14 +4237,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-0"/>
        <position name="posOpArapucaDouble0-Frame-2-0" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="38.3" 
 	 z="-859.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-0-1"/>
        <position name="posArapucaDouble1-Frame-2-0" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="129" 
 	 z="-1005.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4247,14 +4252,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-1"/>
        <position name="posOpArapucaDouble1-Frame-2-0" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="129" 
 	 z="-1005.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-0-2"/>
        <position name="posArapucaDouble2-Frame-2-0" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="203" 
 	 z="-788.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4262,14 +4267,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-2"/>
        <position name="posOpArapucaDouble2-Frame-2-0" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="203" 
 	 z="-788.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-0-3"/>
        <position name="posArapucaDouble3-Frame-2-0" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="293.7" 
 	 z="-934.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4277,14 +4282,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-3"/>
        <position name="posOpArapucaDouble3-Frame-2-0" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="293.7" 
 	 z="-934.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-1-0"/>
        <position name="posArapucaDouble0-Frame-2-1" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="38.3" 
 	 z="-561.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4292,14 +4297,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-0"/>
        <position name="posOpArapucaDouble0-Frame-2-1" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="38.3" 
 	 z="-561.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-1-1"/>
        <position name="posArapucaDouble1-Frame-2-1" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="129" 
 	 z="-707.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4307,14 +4312,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-1"/>
        <position name="posOpArapucaDouble1-Frame-2-1" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="129" 
 	 z="-707.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-1-2"/>
        <position name="posArapucaDouble2-Frame-2-1" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="203" 
 	 z="-490.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4322,14 +4327,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-2"/>
        <position name="posOpArapucaDouble2-Frame-2-1" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="203" 
 	 z="-490.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-1-3"/>
        <position name="posArapucaDouble3-Frame-2-1" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="293.7" 
 	 z="-636.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4337,14 +4342,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-3"/>
        <position name="posOpArapucaDouble3-Frame-2-1" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="293.7" 
 	 z="-636.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-2-0"/>
        <position name="posArapucaDouble0-Frame-2-2" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="38.3" 
 	 z="-263.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4352,14 +4357,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-0"/>
        <position name="posOpArapucaDouble0-Frame-2-2" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="38.3" 
 	 z="-263.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-2-1"/>
        <position name="posArapucaDouble1-Frame-2-2" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="129" 
 	 z="-409.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4367,14 +4372,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-1"/>
        <position name="posOpArapucaDouble1-Frame-2-2" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="129" 
 	 z="-409.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-2-2"/>
        <position name="posArapucaDouble2-Frame-2-2" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="203" 
 	 z="-192.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4382,14 +4387,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-2"/>
        <position name="posOpArapucaDouble2-Frame-2-2" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="203" 
 	 z="-192.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-2-3"/>
        <position name="posArapucaDouble3-Frame-2-2" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="293.7" 
 	 z="-338.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4397,14 +4402,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-3"/>
        <position name="posOpArapucaDouble3-Frame-2-2" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="293.7" 
 	 z="-338.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-3-0"/>
        <position name="posArapucaDouble0-Frame-2-3" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="38.3" 
 	 z="34.0000000000001"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4412,14 +4417,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-3-0"/>
        <position name="posOpArapucaDouble0-Frame-2-3" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="38.3" 
 	 z="34.0000000000001"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-3-1"/>
        <position name="posArapucaDouble1-Frame-2-3" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="129" 
 	 z="-112"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4427,14 +4432,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-3-1"/>
        <position name="posOpArapucaDouble1-Frame-2-3" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="129" 
 	 z="-112"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-3-2"/>
        <position name="posArapucaDouble2-Frame-2-3" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="203" 
 	 z="105"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4442,14 +4447,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-3-2"/>
        <position name="posOpArapucaDouble2-Frame-2-3" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="203" 
 	 z="105"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-3-3"/>
        <position name="posArapucaDouble3-Frame-2-3" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="293.7" 
 	 z="-40.9999999999999"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4457,14 +4462,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-3-3"/>
        <position name="posOpArapucaDouble3-Frame-2-3" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="293.7" 
 	 z="-40.9999999999999"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-4-0"/>
        <position name="posArapucaDouble0-Frame-2-4" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="38.3" 
 	 z="331.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4472,14 +4477,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-4-0"/>
        <position name="posOpArapucaDouble0-Frame-2-4" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="38.3" 
 	 z="331.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-4-1"/>
        <position name="posArapucaDouble1-Frame-2-4" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="129" 
 	 z="185.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4487,14 +4492,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-4-1"/>
        <position name="posOpArapucaDouble1-Frame-2-4" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="129" 
 	 z="185.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-4-2"/>
        <position name="posArapucaDouble2-Frame-2-4" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="203" 
 	 z="402.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4502,14 +4507,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-4-2"/>
        <position name="posOpArapucaDouble2-Frame-2-4" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="203" 
 	 z="402.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-4-3"/>
        <position name="posArapucaDouble3-Frame-2-4" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="293.7" 
 	 z="256.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4517,14 +4522,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-4-3"/>
        <position name="posOpArapucaDouble3-Frame-2-4" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="293.7" 
 	 z="256.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-5-0"/>
        <position name="posArapucaDouble0-Frame-2-5" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="38.3" 
 	 z="629.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4532,14 +4537,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-5-0"/>
        <position name="posOpArapucaDouble0-Frame-2-5" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="38.3" 
 	 z="629.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-5-1"/>
        <position name="posArapucaDouble1-Frame-2-5" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="129" 
 	 z="483.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4547,14 +4552,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-5-1"/>
        <position name="posOpArapucaDouble1-Frame-2-5" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="129" 
 	 z="483.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-5-2"/>
        <position name="posArapucaDouble2-Frame-2-5" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="203" 
 	 z="700.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4562,14 +4567,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-5-2"/>
        <position name="posOpArapucaDouble2-Frame-2-5" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="203" 
 	 z="700.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-5-3"/>
        <position name="posArapucaDouble3-Frame-2-5" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="293.7" 
 	 z="554.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4577,14 +4582,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-5-3"/>
        <position name="posOpArapucaDouble3-Frame-2-5" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="293.7" 
 	 z="554.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-6-0"/>
        <position name="posArapucaDouble0-Frame-2-6" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="38.3" 
 	 z="927.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4592,14 +4597,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-6-0"/>
        <position name="posOpArapucaDouble0-Frame-2-6" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="38.3" 
 	 z="927.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-6-1"/>
        <position name="posArapucaDouble1-Frame-2-6" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="129" 
 	 z="781.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4607,14 +4612,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-6-1"/>
        <position name="posOpArapucaDouble1-Frame-2-6" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="129" 
 	 z="781.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-6-2"/>
        <position name="posArapucaDouble2-Frame-2-6" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="203" 
 	 z="998.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4622,14 +4627,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-6-2"/>
        <position name="posOpArapucaDouble2-Frame-2-6" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="203" 
 	 z="998.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-6-3"/>
        <position name="posArapucaDouble3-Frame-2-6" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="293.7" 
 	 z="852.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4637,14 +4642,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-6-3"/>
        <position name="posOpArapucaDouble3-Frame-2-6" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="293.7" 
 	 z="852.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-0-0"/>
        <position name="posArapucaDouble0-Frame-3-0" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="374.3" 
 	 z="-859.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4652,14 +4657,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-0"/>
        <position name="posOpArapucaDouble0-Frame-3-0" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="374.3" 
 	 z="-859.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-0-1"/>
        <position name="posArapucaDouble1-Frame-3-0" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="465" 
 	 z="-1005.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4667,14 +4672,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-1"/>
        <position name="posOpArapucaDouble1-Frame-3-0" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="465" 
 	 z="-1005.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-0-2"/>
        <position name="posArapucaDouble2-Frame-3-0" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="539" 
 	 z="-788.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4682,14 +4687,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-2"/>
        <position name="posOpArapucaDouble2-Frame-3-0" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="539" 
 	 z="-788.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-0-3"/>
        <position name="posArapucaDouble3-Frame-3-0" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="629.7" 
 	 z="-934.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4697,14 +4702,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-3"/>
        <position name="posOpArapucaDouble3-Frame-3-0" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="629.7" 
 	 z="-934.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-1-0"/>
        <position name="posArapucaDouble0-Frame-3-1" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="374.3" 
 	 z="-561.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4712,14 +4717,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-0"/>
        <position name="posOpArapucaDouble0-Frame-3-1" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="374.3" 
 	 z="-561.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-1-1"/>
        <position name="posArapucaDouble1-Frame-3-1" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="465" 
 	 z="-707.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4727,14 +4732,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-1"/>
        <position name="posOpArapucaDouble1-Frame-3-1" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="465" 
 	 z="-707.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-1-2"/>
        <position name="posArapucaDouble2-Frame-3-1" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="539" 
 	 z="-490.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4742,14 +4747,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-2"/>
        <position name="posOpArapucaDouble2-Frame-3-1" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="539" 
 	 z="-490.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-1-3"/>
        <position name="posArapucaDouble3-Frame-3-1" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="629.7" 
 	 z="-636.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4757,14 +4762,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-3"/>
        <position name="posOpArapucaDouble3-Frame-3-1" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="629.7" 
 	 z="-636.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-2-0"/>
        <position name="posArapucaDouble0-Frame-3-2" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="374.3" 
 	 z="-263.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4772,14 +4777,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-0"/>
        <position name="posOpArapucaDouble0-Frame-3-2" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="374.3" 
 	 z="-263.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-2-1"/>
        <position name="posArapucaDouble1-Frame-3-2" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="465" 
 	 z="-409.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4787,14 +4792,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-1"/>
        <position name="posOpArapucaDouble1-Frame-3-2" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="465" 
 	 z="-409.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-2-2"/>
        <position name="posArapucaDouble2-Frame-3-2" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="539" 
 	 z="-192.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4802,14 +4807,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-2"/>
        <position name="posOpArapucaDouble2-Frame-3-2" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="539" 
 	 z="-192.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-2-3"/>
        <position name="posArapucaDouble3-Frame-3-2" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="629.7" 
 	 z="-338.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4817,14 +4822,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-3"/>
        <position name="posOpArapucaDouble3-Frame-3-2" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="629.7" 
 	 z="-338.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-3-0"/>
        <position name="posArapucaDouble0-Frame-3-3" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="374.3" 
 	 z="34.0000000000001"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4832,14 +4837,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-3-0"/>
        <position name="posOpArapucaDouble0-Frame-3-3" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="374.3" 
 	 z="34.0000000000001"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-3-1"/>
        <position name="posArapucaDouble1-Frame-3-3" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="465" 
 	 z="-112"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4847,14 +4852,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-3-1"/>
        <position name="posOpArapucaDouble1-Frame-3-3" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="465" 
 	 z="-112"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-3-2"/>
        <position name="posArapucaDouble2-Frame-3-3" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="539" 
 	 z="105"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4862,14 +4867,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-3-2"/>
        <position name="posOpArapucaDouble2-Frame-3-3" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="539" 
 	 z="105"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-3-3"/>
        <position name="posArapucaDouble3-Frame-3-3" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="629.7" 
 	 z="-40.9999999999999"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4877,14 +4882,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-3-3"/>
        <position name="posOpArapucaDouble3-Frame-3-3" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="629.7" 
 	 z="-40.9999999999999"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-4-0"/>
        <position name="posArapucaDouble0-Frame-3-4" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="374.3" 
 	 z="331.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4892,14 +4897,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-4-0"/>
        <position name="posOpArapucaDouble0-Frame-3-4" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="374.3" 
 	 z="331.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-4-1"/>
        <position name="posArapucaDouble1-Frame-3-4" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="465" 
 	 z="185.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4907,14 +4912,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-4-1"/>
        <position name="posOpArapucaDouble1-Frame-3-4" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="465" 
 	 z="185.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-4-2"/>
        <position name="posArapucaDouble2-Frame-3-4" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="539" 
 	 z="402.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4922,14 +4927,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-4-2"/>
        <position name="posOpArapucaDouble2-Frame-3-4" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="539" 
 	 z="402.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-4-3"/>
        <position name="posArapucaDouble3-Frame-3-4" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="629.7" 
 	 z="256.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4937,14 +4942,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-4-3"/>
        <position name="posOpArapucaDouble3-Frame-3-4" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="629.7" 
 	 z="256.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-5-0"/>
        <position name="posArapucaDouble0-Frame-3-5" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="374.3" 
 	 z="629.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4952,14 +4957,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-5-0"/>
        <position name="posOpArapucaDouble0-Frame-3-5" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="374.3" 
 	 z="629.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-5-1"/>
        <position name="posArapucaDouble1-Frame-3-5" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="465" 
 	 z="483.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4967,14 +4972,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-5-1"/>
        <position name="posOpArapucaDouble1-Frame-3-5" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="465" 
 	 z="483.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-5-2"/>
        <position name="posArapucaDouble2-Frame-3-5" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="539" 
 	 z="700.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4982,14 +4987,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-5-2"/>
        <position name="posOpArapucaDouble2-Frame-3-5" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="539" 
 	 z="700.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-5-3"/>
        <position name="posArapucaDouble3-Frame-3-5" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="629.7" 
 	 z="554.6036"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -4997,14 +5002,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-5-3"/>
        <position name="posOpArapucaDouble3-Frame-3-5" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="629.7" 
 	 z="554.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-6-0"/>
        <position name="posArapucaDouble0-Frame-3-6" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="374.3" 
 	 z="927.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -5012,14 +5017,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-6-0"/>
        <position name="posOpArapucaDouble0-Frame-3-6" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="374.3" 
 	 z="927.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-6-1"/>
        <position name="posArapucaDouble1-Frame-3-6" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="465" 
 	 z="781.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -5027,14 +5032,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-6-1"/>
        <position name="posOpArapucaDouble1-Frame-3-6" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="465" 
 	 z="781.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-6-2"/>
        <position name="posArapucaDouble2-Frame-3-6" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="539" 
 	 z="998.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -5042,14 +5047,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-6-2"/>
        <position name="posOpArapucaDouble2-Frame-3-6" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="539" 
 	 z="998.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-6-3"/>
        <position name="posArapucaDouble3-Frame-3-6" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="629.7" 
 	 z="852.4054"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -5057,14 +5062,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-6-3"/>
        <position name="posOpArapucaDouble3-Frame-3-6" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="629.7" 
 	 z="852.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-0"/>
        <position name="posArapuca0-Lat-0" unit="cm" 
-         x="285.02"
+         x="285.03"
 	 y="-734" 
 	 z="-893.4054"/>
        <rotationref ref="rIdentity"/>
@@ -5072,14 +5077,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-0"/>
        <position name="posOpArapuca0-Lat-0" unit="cm" 
-         x="285.02"
+         x="285.03"
 	 y="-733.26" 
 	 z="-893.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-1"/>
        <position name="posArapuca1-Lat-0" unit="cm" 
-         x="210.02"
+         x="210.03"
 	 y="-734" 
 	 z="-893.4054"/>
        <rotationref ref="rIdentity"/>
@@ -5087,14 +5092,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-1"/>
        <position name="posOpArapuca1-Lat-0" unit="cm" 
-         x="210.02"
+         x="210.03"
 	 y="-733.26" 
 	 z="-893.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-2"/>
        <position name="posArapuca2-Lat-0" unit="cm" 
-         x="135.02"
+         x="135.03"
 	 y="-734" 
 	 z="-893.4054"/>
        <rotationref ref="rIdentity"/>
@@ -5102,14 +5107,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-2"/>
        <position name="posOpArapuca2-Lat-0" unit="cm" 
-         x="135.02"
+         x="135.03"
 	 y="-733.26" 
 	 z="-893.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-3"/>
        <position name="posArapuca3-Lat-0" unit="cm" 
-         x="60.02"
+         x="60.03"
 	 y="-734" 
 	 z="-893.4054"/>
        <rotationref ref="rIdentity"/>
@@ -5117,14 +5122,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-3"/>
        <position name="posOpArapuca3-Lat-0" unit="cm" 
-         x="60.02"
+         x="60.03"
 	 y="-733.26" 
 	 z="-893.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-4"/>
        <position name="posArapuca4-Lat-0" unit="cm" 
-         x="285.02"
+         x="285.03"
 	 y="734" 
 	 z="-893.4054"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5132,14 +5137,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-4"/>
        <position name="posOpArapuca4-Lat-0" unit="cm" 
-         x="285.02"
+         x="285.03"
 	 y="733.26" 
 	 z="-893.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-5"/>
        <position name="posArapuca5-Lat-0" unit="cm" 
-         x="210.02"
+         x="210.03"
 	 y="734" 
 	 z="-893.4054"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5147,14 +5152,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-5"/>
        <position name="posOpArapuca5-Lat-0" unit="cm" 
-         x="210.02"
+         x="210.03"
 	 y="733.26" 
 	 z="-893.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-6"/>
        <position name="posArapuca6-Lat-0" unit="cm" 
-         x="135.02"
+         x="135.03"
 	 y="734" 
 	 z="-893.4054"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5162,14 +5167,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-6"/>
        <position name="posOpArapuca6-Lat-0" unit="cm" 
-         x="135.02"
+         x="135.03"
 	 y="733.26" 
 	 z="-893.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-7"/>
        <position name="posArapuca7-Lat-0" unit="cm" 
-         x="60.02"
+         x="60.03"
 	 y="734" 
 	 z="-893.4054"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5177,14 +5182,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-7"/>
        <position name="posOpArapuca7-Lat-0" unit="cm" 
-         x="60.02"
+         x="60.03"
 	 y="733.26" 
 	 z="-893.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-0"/>
        <position name="posArapuca0-Lat-1" unit="cm" 
-         x="285.02"
+         x="285.03"
 	 y="-734" 
 	 z="-595.6036"/>
        <rotationref ref="rIdentity"/>
@@ -5192,14 +5197,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-0"/>
        <position name="posOpArapuca0-Lat-1" unit="cm" 
-         x="285.02"
+         x="285.03"
 	 y="-733.26" 
 	 z="-595.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-1"/>
        <position name="posArapuca1-Lat-1" unit="cm" 
-         x="210.02"
+         x="210.03"
 	 y="-734" 
 	 z="-595.6036"/>
        <rotationref ref="rIdentity"/>
@@ -5207,14 +5212,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-1"/>
        <position name="posOpArapuca1-Lat-1" unit="cm" 
-         x="210.02"
+         x="210.03"
 	 y="-733.26" 
 	 z="-595.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-2"/>
        <position name="posArapuca2-Lat-1" unit="cm" 
-         x="135.02"
+         x="135.03"
 	 y="-734" 
 	 z="-595.6036"/>
        <rotationref ref="rIdentity"/>
@@ -5222,14 +5227,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-2"/>
        <position name="posOpArapuca2-Lat-1" unit="cm" 
-         x="135.02"
+         x="135.03"
 	 y="-733.26" 
 	 z="-595.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-3"/>
        <position name="posArapuca3-Lat-1" unit="cm" 
-         x="60.02"
+         x="60.03"
 	 y="-734" 
 	 z="-595.6036"/>
        <rotationref ref="rIdentity"/>
@@ -5237,14 +5242,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-3"/>
        <position name="posOpArapuca3-Lat-1" unit="cm" 
-         x="60.02"
+         x="60.03"
 	 y="-733.26" 
 	 z="-595.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-4"/>
        <position name="posArapuca4-Lat-1" unit="cm" 
-         x="285.02"
+         x="285.03"
 	 y="734" 
 	 z="-595.6036"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5252,14 +5257,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-4"/>
        <position name="posOpArapuca4-Lat-1" unit="cm" 
-         x="285.02"
+         x="285.03"
 	 y="733.26" 
 	 z="-595.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-5"/>
        <position name="posArapuca5-Lat-1" unit="cm" 
-         x="210.02"
+         x="210.03"
 	 y="734" 
 	 z="-595.6036"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5267,14 +5272,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-5"/>
        <position name="posOpArapuca5-Lat-1" unit="cm" 
-         x="210.02"
+         x="210.03"
 	 y="733.26" 
 	 z="-595.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-6"/>
        <position name="posArapuca6-Lat-1" unit="cm" 
-         x="135.02"
+         x="135.03"
 	 y="734" 
 	 z="-595.6036"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5282,14 +5287,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-6"/>
        <position name="posOpArapuca6-Lat-1" unit="cm" 
-         x="135.02"
+         x="135.03"
 	 y="733.26" 
 	 z="-595.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-7"/>
        <position name="posArapuca7-Lat-1" unit="cm" 
-         x="60.02"
+         x="60.03"
 	 y="734" 
 	 z="-595.6036"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5297,14 +5302,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-7"/>
        <position name="posOpArapuca7-Lat-1" unit="cm" 
-         x="60.02"
+         x="60.03"
 	 y="733.26" 
 	 z="-595.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-0"/>
        <position name="posArapuca0-Lat-2" unit="cm" 
-         x="285.02"
+         x="285.03"
 	 y="-734" 
 	 z="-297.8018"/>
        <rotationref ref="rIdentity"/>
@@ -5312,14 +5317,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-0"/>
        <position name="posOpArapuca0-Lat-2" unit="cm" 
-         x="285.02"
+         x="285.03"
 	 y="-733.26" 
 	 z="-297.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-1"/>
        <position name="posArapuca1-Lat-2" unit="cm" 
-         x="210.02"
+         x="210.03"
 	 y="-734" 
 	 z="-297.8018"/>
        <rotationref ref="rIdentity"/>
@@ -5327,14 +5332,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-1"/>
        <position name="posOpArapuca1-Lat-2" unit="cm" 
-         x="210.02"
+         x="210.03"
 	 y="-733.26" 
 	 z="-297.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-2"/>
        <position name="posArapuca2-Lat-2" unit="cm" 
-         x="135.02"
+         x="135.03"
 	 y="-734" 
 	 z="-297.8018"/>
        <rotationref ref="rIdentity"/>
@@ -5342,14 +5347,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-2"/>
        <position name="posOpArapuca2-Lat-2" unit="cm" 
-         x="135.02"
+         x="135.03"
 	 y="-733.26" 
 	 z="-297.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-3"/>
        <position name="posArapuca3-Lat-2" unit="cm" 
-         x="60.02"
+         x="60.03"
 	 y="-734" 
 	 z="-297.8018"/>
        <rotationref ref="rIdentity"/>
@@ -5357,14 +5362,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-3"/>
        <position name="posOpArapuca3-Lat-2" unit="cm" 
-         x="60.02"
+         x="60.03"
 	 y="-733.26" 
 	 z="-297.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-4"/>
        <position name="posArapuca4-Lat-2" unit="cm" 
-         x="285.02"
+         x="285.03"
 	 y="734" 
 	 z="-297.8018"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5372,14 +5377,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-4"/>
        <position name="posOpArapuca4-Lat-2" unit="cm" 
-         x="285.02"
+         x="285.03"
 	 y="733.26" 
 	 z="-297.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-5"/>
        <position name="posArapuca5-Lat-2" unit="cm" 
-         x="210.02"
+         x="210.03"
 	 y="734" 
 	 z="-297.8018"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5387,14 +5392,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-5"/>
        <position name="posOpArapuca5-Lat-2" unit="cm" 
-         x="210.02"
+         x="210.03"
 	 y="733.26" 
 	 z="-297.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-6"/>
        <position name="posArapuca6-Lat-2" unit="cm" 
-         x="135.02"
+         x="135.03"
 	 y="734" 
 	 z="-297.8018"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5402,14 +5407,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-6"/>
        <position name="posOpArapuca6-Lat-2" unit="cm" 
-         x="135.02"
+         x="135.03"
 	 y="733.26" 
 	 z="-297.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-7"/>
        <position name="posArapuca7-Lat-2" unit="cm" 
-         x="60.02"
+         x="60.03"
 	 y="734" 
 	 z="-297.8018"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5417,14 +5422,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-7"/>
        <position name="posOpArapuca7-Lat-2" unit="cm" 
-         x="60.02"
+         x="60.03"
 	 y="733.26" 
 	 z="-297.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_3-0"/>
        <position name="posArapuca0-Lat-3" unit="cm" 
-         x="285.02"
+         x="285.03"
 	 y="-734" 
 	 z="1.13686837721616e-13"/>
        <rotationref ref="rIdentity"/>
@@ -5432,14 +5437,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_3-0"/>
        <position name="posOpArapuca0-Lat-3" unit="cm" 
-         x="285.02"
+         x="285.03"
 	 y="-733.26" 
 	 z="1.13686837721616e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_3-1"/>
        <position name="posArapuca1-Lat-3" unit="cm" 
-         x="210.02"
+         x="210.03"
 	 y="-734" 
 	 z="1.13686837721616e-13"/>
        <rotationref ref="rIdentity"/>
@@ -5447,14 +5452,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_3-1"/>
        <position name="posOpArapuca1-Lat-3" unit="cm" 
-         x="210.02"
+         x="210.03"
 	 y="-733.26" 
 	 z="1.13686837721616e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_3-2"/>
        <position name="posArapuca2-Lat-3" unit="cm" 
-         x="135.02"
+         x="135.03"
 	 y="-734" 
 	 z="1.13686837721616e-13"/>
        <rotationref ref="rIdentity"/>
@@ -5462,14 +5467,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_3-2"/>
        <position name="posOpArapuca2-Lat-3" unit="cm" 
-         x="135.02"
+         x="135.03"
 	 y="-733.26" 
 	 z="1.13686837721616e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_3-3"/>
        <position name="posArapuca3-Lat-3" unit="cm" 
-         x="60.02"
+         x="60.03"
 	 y="-734" 
 	 z="1.13686837721616e-13"/>
        <rotationref ref="rIdentity"/>
@@ -5477,14 +5482,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_3-3"/>
        <position name="posOpArapuca3-Lat-3" unit="cm" 
-         x="60.02"
+         x="60.03"
 	 y="-733.26" 
 	 z="1.13686837721616e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_3-4"/>
        <position name="posArapuca4-Lat-3" unit="cm" 
-         x="285.02"
+         x="285.03"
 	 y="734" 
 	 z="1.13686837721616e-13"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5492,14 +5497,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_3-4"/>
        <position name="posOpArapuca4-Lat-3" unit="cm" 
-         x="285.02"
+         x="285.03"
 	 y="733.26" 
 	 z="1.13686837721616e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_3-5"/>
        <position name="posArapuca5-Lat-3" unit="cm" 
-         x="210.02"
+         x="210.03"
 	 y="734" 
 	 z="1.13686837721616e-13"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5507,14 +5512,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_3-5"/>
        <position name="posOpArapuca5-Lat-3" unit="cm" 
-         x="210.02"
+         x="210.03"
 	 y="733.26" 
 	 z="1.13686837721616e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_3-6"/>
        <position name="posArapuca6-Lat-3" unit="cm" 
-         x="135.02"
+         x="135.03"
 	 y="734" 
 	 z="1.13686837721616e-13"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5522,14 +5527,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_3-6"/>
        <position name="posOpArapuca6-Lat-3" unit="cm" 
-         x="135.02"
+         x="135.03"
 	 y="733.26" 
 	 z="1.13686837721616e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_3-7"/>
        <position name="posArapuca7-Lat-3" unit="cm" 
-         x="60.02"
+         x="60.03"
 	 y="734" 
 	 z="1.13686837721616e-13"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5537,14 +5542,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_3-7"/>
        <position name="posOpArapuca7-Lat-3" unit="cm" 
-         x="60.02"
+         x="60.03"
 	 y="733.26" 
 	 z="1.13686837721616e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_4-0"/>
        <position name="posArapuca0-Lat-4" unit="cm" 
-         x="285.02"
+         x="285.03"
 	 y="-734" 
 	 z="297.8018"/>
        <rotationref ref="rIdentity"/>
@@ -5552,14 +5557,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_4-0"/>
        <position name="posOpArapuca0-Lat-4" unit="cm" 
-         x="285.02"
+         x="285.03"
 	 y="-733.26" 
 	 z="297.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_4-1"/>
        <position name="posArapuca1-Lat-4" unit="cm" 
-         x="210.02"
+         x="210.03"
 	 y="-734" 
 	 z="297.8018"/>
        <rotationref ref="rIdentity"/>
@@ -5567,14 +5572,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_4-1"/>
        <position name="posOpArapuca1-Lat-4" unit="cm" 
-         x="210.02"
+         x="210.03"
 	 y="-733.26" 
 	 z="297.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_4-2"/>
        <position name="posArapuca2-Lat-4" unit="cm" 
-         x="135.02"
+         x="135.03"
 	 y="-734" 
 	 z="297.8018"/>
        <rotationref ref="rIdentity"/>
@@ -5582,14 +5587,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_4-2"/>
        <position name="posOpArapuca2-Lat-4" unit="cm" 
-         x="135.02"
+         x="135.03"
 	 y="-733.26" 
 	 z="297.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_4-3"/>
        <position name="posArapuca3-Lat-4" unit="cm" 
-         x="60.02"
+         x="60.03"
 	 y="-734" 
 	 z="297.8018"/>
        <rotationref ref="rIdentity"/>
@@ -5597,14 +5602,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_4-3"/>
        <position name="posOpArapuca3-Lat-4" unit="cm" 
-         x="60.02"
+         x="60.03"
 	 y="-733.26" 
 	 z="297.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_4-4"/>
        <position name="posArapuca4-Lat-4" unit="cm" 
-         x="285.02"
+         x="285.03"
 	 y="734" 
 	 z="297.8018"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5612,14 +5617,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_4-4"/>
        <position name="posOpArapuca4-Lat-4" unit="cm" 
-         x="285.02"
+         x="285.03"
 	 y="733.26" 
 	 z="297.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_4-5"/>
        <position name="posArapuca5-Lat-4" unit="cm" 
-         x="210.02"
+         x="210.03"
 	 y="734" 
 	 z="297.8018"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5627,14 +5632,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_4-5"/>
        <position name="posOpArapuca5-Lat-4" unit="cm" 
-         x="210.02"
+         x="210.03"
 	 y="733.26" 
 	 z="297.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_4-6"/>
        <position name="posArapuca6-Lat-4" unit="cm" 
-         x="135.02"
+         x="135.03"
 	 y="734" 
 	 z="297.8018"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5642,14 +5647,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_4-6"/>
        <position name="posOpArapuca6-Lat-4" unit="cm" 
-         x="135.02"
+         x="135.03"
 	 y="733.26" 
 	 z="297.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_4-7"/>
        <position name="posArapuca7-Lat-4" unit="cm" 
-         x="60.02"
+         x="60.03"
 	 y="734" 
 	 z="297.8018"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5657,14 +5662,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_4-7"/>
        <position name="posOpArapuca7-Lat-4" unit="cm" 
-         x="60.02"
+         x="60.03"
 	 y="733.26" 
 	 z="297.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_5-0"/>
        <position name="posArapuca0-Lat-5" unit="cm" 
-         x="285.02"
+         x="285.03"
 	 y="-734" 
 	 z="595.6036"/>
        <rotationref ref="rIdentity"/>
@@ -5672,14 +5677,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_5-0"/>
        <position name="posOpArapuca0-Lat-5" unit="cm" 
-         x="285.02"
+         x="285.03"
 	 y="-733.26" 
 	 z="595.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_5-1"/>
        <position name="posArapuca1-Lat-5" unit="cm" 
-         x="210.02"
+         x="210.03"
 	 y="-734" 
 	 z="595.6036"/>
        <rotationref ref="rIdentity"/>
@@ -5687,14 +5692,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_5-1"/>
        <position name="posOpArapuca1-Lat-5" unit="cm" 
-         x="210.02"
+         x="210.03"
 	 y="-733.26" 
 	 z="595.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_5-2"/>
        <position name="posArapuca2-Lat-5" unit="cm" 
-         x="135.02"
+         x="135.03"
 	 y="-734" 
 	 z="595.6036"/>
        <rotationref ref="rIdentity"/>
@@ -5702,14 +5707,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_5-2"/>
        <position name="posOpArapuca2-Lat-5" unit="cm" 
-         x="135.02"
+         x="135.03"
 	 y="-733.26" 
 	 z="595.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_5-3"/>
        <position name="posArapuca3-Lat-5" unit="cm" 
-         x="60.02"
+         x="60.03"
 	 y="-734" 
 	 z="595.6036"/>
        <rotationref ref="rIdentity"/>
@@ -5717,14 +5722,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_5-3"/>
        <position name="posOpArapuca3-Lat-5" unit="cm" 
-         x="60.02"
+         x="60.03"
 	 y="-733.26" 
 	 z="595.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_5-4"/>
        <position name="posArapuca4-Lat-5" unit="cm" 
-         x="285.02"
+         x="285.03"
 	 y="734" 
 	 z="595.6036"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5732,14 +5737,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_5-4"/>
        <position name="posOpArapuca4-Lat-5" unit="cm" 
-         x="285.02"
+         x="285.03"
 	 y="733.26" 
 	 z="595.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_5-5"/>
        <position name="posArapuca5-Lat-5" unit="cm" 
-         x="210.02"
+         x="210.03"
 	 y="734" 
 	 z="595.6036"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5747,14 +5752,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_5-5"/>
        <position name="posOpArapuca5-Lat-5" unit="cm" 
-         x="210.02"
+         x="210.03"
 	 y="733.26" 
 	 z="595.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_5-6"/>
        <position name="posArapuca6-Lat-5" unit="cm" 
-         x="135.02"
+         x="135.03"
 	 y="734" 
 	 z="595.6036"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5762,14 +5767,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_5-6"/>
        <position name="posOpArapuca6-Lat-5" unit="cm" 
-         x="135.02"
+         x="135.03"
 	 y="733.26" 
 	 z="595.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_5-7"/>
        <position name="posArapuca7-Lat-5" unit="cm" 
-         x="60.02"
+         x="60.03"
 	 y="734" 
 	 z="595.6036"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5777,14 +5782,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_5-7"/>
        <position name="posOpArapuca7-Lat-5" unit="cm" 
-         x="60.02"
+         x="60.03"
 	 y="733.26" 
 	 z="595.6036"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_6-0"/>
        <position name="posArapuca0-Lat-6" unit="cm" 
-         x="285.02"
+         x="285.03"
 	 y="-734" 
 	 z="893.4054"/>
        <rotationref ref="rIdentity"/>
@@ -5792,14 +5797,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_6-0"/>
        <position name="posOpArapuca0-Lat-6" unit="cm" 
-         x="285.02"
+         x="285.03"
 	 y="-733.26" 
 	 z="893.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_6-1"/>
        <position name="posArapuca1-Lat-6" unit="cm" 
-         x="210.02"
+         x="210.03"
 	 y="-734" 
 	 z="893.4054"/>
        <rotationref ref="rIdentity"/>
@@ -5807,14 +5812,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_6-1"/>
        <position name="posOpArapuca1-Lat-6" unit="cm" 
-         x="210.02"
+         x="210.03"
 	 y="-733.26" 
 	 z="893.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_6-2"/>
        <position name="posArapuca2-Lat-6" unit="cm" 
-         x="135.02"
+         x="135.03"
 	 y="-734" 
 	 z="893.4054"/>
        <rotationref ref="rIdentity"/>
@@ -5822,14 +5827,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_6-2"/>
        <position name="posOpArapuca2-Lat-6" unit="cm" 
-         x="135.02"
+         x="135.03"
 	 y="-733.26" 
 	 z="893.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_6-3"/>
        <position name="posArapuca3-Lat-6" unit="cm" 
-         x="60.02"
+         x="60.03"
 	 y="-734" 
 	 z="893.4054"/>
        <rotationref ref="rIdentity"/>
@@ -5837,14 +5842,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_6-3"/>
        <position name="posOpArapuca3-Lat-6" unit="cm" 
-         x="60.02"
+         x="60.03"
 	 y="-733.26" 
 	 z="893.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_6-4"/>
        <position name="posArapuca4-Lat-6" unit="cm" 
-         x="285.02"
+         x="285.03"
 	 y="734" 
 	 z="893.4054"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5852,14 +5857,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_6-4"/>
        <position name="posOpArapuca4-Lat-6" unit="cm" 
-         x="285.02"
+         x="285.03"
 	 y="733.26" 
 	 z="893.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_6-5"/>
        <position name="posArapuca5-Lat-6" unit="cm" 
-         x="210.02"
+         x="210.03"
 	 y="734" 
 	 z="893.4054"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5867,14 +5872,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_6-5"/>
        <position name="posOpArapuca5-Lat-6" unit="cm" 
-         x="210.02"
+         x="210.03"
 	 y="733.26" 
 	 z="893.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_6-6"/>
        <position name="posArapuca6-Lat-6" unit="cm" 
-         x="135.02"
+         x="135.03"
 	 y="734" 
 	 z="893.4054"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5882,14 +5887,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_6-6"/>
        <position name="posOpArapuca6-Lat-6" unit="cm" 
-         x="135.02"
+         x="135.03"
 	 y="733.26" 
 	 z="893.4054"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_6-7"/>
        <position name="posArapuca7-Lat-6" unit="cm" 
-         x="60.02"
+         x="60.03"
 	 y="734" 
 	 z="893.4054"/>
        <rotationref ref="rPlus180AboutX"/>
@@ -5897,7 +5902,7 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_6-7"/>
        <position name="posOpArapuca7-Lat-6" unit="cm" 
-         x="60.02"
+         x="60.03"
 	 y="733.26" 
 	 z="893.4054"/>
      </physvol>

--- a/dunecore/Geometry/gdml/dunevd10kt_3view_v3_refactored_1x8x6ref.gdml
+++ b/dunecore/Geometry/gdml/dunevd10kt_3view_v3_refactored_1x8x6ref.gdml
@@ -508,6 +508,11 @@
       y="168"
       z="148.9009"
       lunit="cm"/>
+   <box name="AnodePlate" 
+      x="0.02/2."
+      y="168"
+      z="148.9009"
+      lunit="cm"/>
    <box name="CRMActive" 
       x="650"
       y="168"
@@ -7394,7 +7399,7 @@
      
    <volume name="volAnodePlate">
      <materialref ref="vm2000"/>
-     <solidref ref="CRMZPlane"/>
+     <solidref ref="AnodePlate"/>
   </volume>
    <volume name="volTPC">
      <materialref ref="LAr"/>
@@ -7402,25 +7407,25 @@
        <physvol>
        <volumeref ref="volTPCPlaneU"/>
        <position name="posPlaneU" unit="cm" 
-         x="324.98" y="0" z="0"/>
+         x="324.99" y="0" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volTPCPlaneY"/>
        <position name="posPlaneY" unit="cm" 
-         x="325" y="0" z="0"/>
+         x="325.01" y="0" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volTPCPlaneZ"/>
        <position name="posPlaneZ" unit="cm" 
-         x="325.02" y="0" z="0"/>
+         x="325.03" y="0" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volAnodePlate"/>
        <position name="posAnodePlate" unit="cm" 
-         x="325.04" y="0" z="0"/>
+         x="325.045" y="0" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>    
      <physvol>
@@ -8477,44 +8482,44 @@
   </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-0" unit="cm" x="-328.05" y="-337.5" z="-299.3018"/>
+   <position name="posGroundGrid-0" unit="cm" x="-328.04" y="-337.5" z="-299.3018"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-1" unit="cm" x="-328.05" y="-1.5" z="-299.3018"/>
+   <position name="posGroundGrid-1" unit="cm" x="-328.04" y="-1.5" z="-299.3018"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-2" unit="cm" x="-328.05" y="334.5" z="-299.3018"/>
+   <position name="posGroundGrid-2" unit="cm" x="-328.04" y="334.5" z="-299.3018"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-3" unit="cm" x="-328.05" y="-337.5" z="-1.50000000000006"/>
+   <position name="posGroundGrid-3" unit="cm" x="-328.04" y="-337.5" z="-1.50000000000006"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-4" unit="cm" x="-328.05" y="-1.5" z="-1.50000000000006"/>
+   <position name="posGroundGrid-4" unit="cm" x="-328.04" y="-1.5" z="-1.50000000000006"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-5" unit="cm" x="-328.05" y="334.5" z="-1.50000000000006"/>
+   <position name="posGroundGrid-5" unit="cm" x="-328.04" y="334.5" z="-1.50000000000006"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-6" unit="cm" x="-328.05" y="-337.5" z="296.3018"/>
+   <position name="posGroundGrid-6" unit="cm" x="-328.04" y="-337.5" z="296.3018"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-7" unit="cm" x="-328.05" y="-1.5" z="296.3018"/>
+   <position name="posGroundGrid-7" unit="cm" x="-328.04" y="-1.5" z="296.3018"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-8" unit="cm" x="-328.05" y="334.5" z="296.3018"/>
+   <position name="posGroundGrid-8" unit="cm" x="-328.04" y="334.5" z="296.3018"/>
       </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-0-0"/>
        <position name="posArapucaDouble0-Frame-0-0" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-465.2" 
 	 z="-261.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -8522,14 +8527,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-0"/>
        <position name="posOpArapucaDouble0-Frame-0-0" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-465.2" 
 	 z="-261.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-0-1"/>
        <position name="posArapucaDouble1-Frame-0-0" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-374.5" 
 	 z="-407.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -8537,14 +8542,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-1"/>
        <position name="posOpArapucaDouble1-Frame-0-0" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-374.5" 
 	 z="-407.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-0-2"/>
        <position name="posArapucaDouble2-Frame-0-0" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-300.5" 
 	 z="-190.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -8552,14 +8557,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-2"/>
        <position name="posOpArapucaDouble2-Frame-0-0" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-300.5" 
 	 z="-190.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-0-3"/>
        <position name="posArapucaDouble3-Frame-0-0" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-209.8" 
 	 z="-336.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -8567,14 +8572,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-3"/>
        <position name="posOpArapucaDouble3-Frame-0-0" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-209.8" 
 	 z="-336.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-1-0"/>
        <position name="posArapucaDouble0-Frame-0-1" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-465.2" 
 	 z="35.9999999999999"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -8582,14 +8587,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-0"/>
        <position name="posOpArapucaDouble0-Frame-0-1" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-465.2" 
 	 z="35.9999999999999"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-1-1"/>
        <position name="posArapucaDouble1-Frame-0-1" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-374.5" 
 	 z="-110"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -8597,14 +8602,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-1"/>
        <position name="posOpArapucaDouble1-Frame-0-1" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-374.5" 
 	 z="-110"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-1-2"/>
        <position name="posArapucaDouble2-Frame-0-1" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-300.5" 
 	 z="107"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -8612,14 +8617,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-2"/>
        <position name="posOpArapucaDouble2-Frame-0-1" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-300.5" 
 	 z="107"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-1-3"/>
        <position name="posArapucaDouble3-Frame-0-1" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-209.8" 
 	 z="-39.0000000000001"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -8627,14 +8632,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-3"/>
        <position name="posOpArapucaDouble3-Frame-0-1" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-209.8" 
 	 z="-39.0000000000001"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-2-0"/>
        <position name="posArapucaDouble0-Frame-0-2" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-465.2" 
 	 z="333.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -8642,14 +8647,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-0"/>
        <position name="posOpArapucaDouble0-Frame-0-2" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-465.2" 
 	 z="333.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-2-1"/>
        <position name="posArapucaDouble1-Frame-0-2" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-374.5" 
 	 z="187.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -8657,14 +8662,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-1"/>
        <position name="posOpArapucaDouble1-Frame-0-2" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-374.5" 
 	 z="187.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-2-2"/>
        <position name="posArapucaDouble2-Frame-0-2" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-300.5" 
 	 z="404.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -8672,14 +8677,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-2"/>
        <position name="posOpArapucaDouble2-Frame-0-2" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-300.5" 
 	 z="404.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-2-3"/>
        <position name="posArapucaDouble3-Frame-0-2" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-209.8" 
 	 z="258.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -8687,14 +8692,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-3"/>
        <position name="posOpArapucaDouble3-Frame-0-2" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-209.8" 
 	 z="258.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-0-0"/>
        <position name="posArapucaDouble0-Frame-1-0" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-129.2" 
 	 z="-261.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -8702,14 +8707,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-0"/>
        <position name="posOpArapucaDouble0-Frame-1-0" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-129.2" 
 	 z="-261.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-0-1"/>
        <position name="posArapucaDouble1-Frame-1-0" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-38.5" 
 	 z="-407.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -8717,14 +8722,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-1"/>
        <position name="posOpArapucaDouble1-Frame-1-0" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-38.5" 
 	 z="-407.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-0-2"/>
        <position name="posArapucaDouble2-Frame-1-0" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="35.5" 
 	 z="-190.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -8732,14 +8737,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-2"/>
        <position name="posOpArapucaDouble2-Frame-1-0" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="35.5" 
 	 z="-190.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-0-3"/>
        <position name="posArapucaDouble3-Frame-1-0" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="126.2" 
 	 z="-336.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -8747,14 +8752,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-3"/>
        <position name="posOpArapucaDouble3-Frame-1-0" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="126.2" 
 	 z="-336.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-1-0"/>
        <position name="posArapucaDouble0-Frame-1-1" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-129.2" 
 	 z="35.9999999999999"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -8762,14 +8767,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-0"/>
        <position name="posOpArapucaDouble0-Frame-1-1" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-129.2" 
 	 z="35.9999999999999"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-1-1"/>
        <position name="posArapucaDouble1-Frame-1-1" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-38.5" 
 	 z="-110"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -8777,14 +8782,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-1"/>
        <position name="posOpArapucaDouble1-Frame-1-1" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-38.5" 
 	 z="-110"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-1-2"/>
        <position name="posArapucaDouble2-Frame-1-1" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="35.5" 
 	 z="107"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -8792,14 +8797,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-2"/>
        <position name="posOpArapucaDouble2-Frame-1-1" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="35.5" 
 	 z="107"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-1-3"/>
        <position name="posArapucaDouble3-Frame-1-1" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="126.2" 
 	 z="-39.0000000000001"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -8807,14 +8812,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-3"/>
        <position name="posOpArapucaDouble3-Frame-1-1" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="126.2" 
 	 z="-39.0000000000001"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-2-0"/>
        <position name="posArapucaDouble0-Frame-1-2" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-129.2" 
 	 z="333.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -8822,14 +8827,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-0"/>
        <position name="posOpArapucaDouble0-Frame-1-2" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-129.2" 
 	 z="333.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-2-1"/>
        <position name="posArapucaDouble1-Frame-1-2" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-38.5" 
 	 z="187.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -8837,14 +8842,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-1"/>
        <position name="posOpArapucaDouble1-Frame-1-2" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-38.5" 
 	 z="187.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-2-2"/>
        <position name="posArapucaDouble2-Frame-1-2" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="35.5" 
 	 z="404.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -8852,14 +8857,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-2"/>
        <position name="posOpArapucaDouble2-Frame-1-2" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="35.5" 
 	 z="404.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-2-3"/>
        <position name="posArapucaDouble3-Frame-1-2" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="126.2" 
 	 z="258.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -8867,14 +8872,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-3"/>
        <position name="posOpArapucaDouble3-Frame-1-2" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="126.2" 
 	 z="258.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-0-0"/>
        <position name="posArapucaDouble0-Frame-2-0" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="206.8" 
 	 z="-261.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -8882,14 +8887,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-0"/>
        <position name="posOpArapucaDouble0-Frame-2-0" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="206.8" 
 	 z="-261.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-0-1"/>
        <position name="posArapucaDouble1-Frame-2-0" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="297.5" 
 	 z="-407.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -8897,14 +8902,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-1"/>
        <position name="posOpArapucaDouble1-Frame-2-0" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="297.5" 
 	 z="-407.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-0-2"/>
        <position name="posArapucaDouble2-Frame-2-0" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="371.5" 
 	 z="-190.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -8912,14 +8917,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-2"/>
        <position name="posOpArapucaDouble2-Frame-2-0" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="371.5" 
 	 z="-190.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-0-3"/>
        <position name="posArapucaDouble3-Frame-2-0" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="462.2" 
 	 z="-336.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -8927,14 +8932,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-3"/>
        <position name="posOpArapucaDouble3-Frame-2-0" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="462.2" 
 	 z="-336.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-1-0"/>
        <position name="posArapucaDouble0-Frame-2-1" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="206.8" 
 	 z="35.9999999999999"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -8942,14 +8947,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-0"/>
        <position name="posOpArapucaDouble0-Frame-2-1" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="206.8" 
 	 z="35.9999999999999"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-1-1"/>
        <position name="posArapucaDouble1-Frame-2-1" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="297.5" 
 	 z="-110"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -8957,14 +8962,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-1"/>
        <position name="posOpArapucaDouble1-Frame-2-1" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="297.5" 
 	 z="-110"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-1-2"/>
        <position name="posArapucaDouble2-Frame-2-1" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="371.5" 
 	 z="107"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -8972,14 +8977,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-2"/>
        <position name="posOpArapucaDouble2-Frame-2-1" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="371.5" 
 	 z="107"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-1-3"/>
        <position name="posArapucaDouble3-Frame-2-1" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="462.2" 
 	 z="-39.0000000000001"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -8987,14 +8992,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-3"/>
        <position name="posOpArapucaDouble3-Frame-2-1" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="462.2" 
 	 z="-39.0000000000001"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-2-0"/>
        <position name="posArapucaDouble0-Frame-2-2" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="206.8" 
 	 z="333.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -9002,14 +9007,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-0"/>
        <position name="posOpArapucaDouble0-Frame-2-2" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="206.8" 
 	 z="333.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-2-1"/>
        <position name="posArapucaDouble1-Frame-2-2" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="297.5" 
 	 z="187.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -9017,14 +9022,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-1"/>
        <position name="posOpArapucaDouble1-Frame-2-2" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="297.5" 
 	 z="187.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-2-2"/>
        <position name="posArapucaDouble2-Frame-2-2" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="371.5" 
 	 z="404.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -9032,14 +9037,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-2"/>
        <position name="posOpArapucaDouble2-Frame-2-2" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="371.5" 
 	 z="404.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-2-3"/>
        <position name="posArapucaDouble3-Frame-2-2" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="462.2" 
 	 z="258.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -9047,7 +9052,7 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-3"/>
        <position name="posOpArapucaDouble3-Frame-2-2" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="462.2" 
 	 z="258.8018"/>
      </physvol>

--- a/dunecore/Geometry/gdml/dunevd10kt_3view_v3_refactored_1x8x6ref.gdml
+++ b/dunecore/Geometry/gdml/dunevd10kt_3view_v3_refactored_1x8x6ref.gdml
@@ -489,7 +489,7 @@
     
 
    <box name="CRM"
-      x="650.08" 
+      x="650.1" 
       y="168" 
       z="148.9009"
       lunit="cm"/>
@@ -1848,12 +1848,12 @@
 
 
     <box name="Cryostat" lunit="cm" 
-      x="850.32" 
+      x="850.34" 
       y="1211.24" 
       z="1096.6454"/>
 
     <box name="ArgonInterior" lunit="cm" 
-      x="850.08"
+      x="850.1"
       y="1211"
       z="1096.4054"/>
 
@@ -1863,12 +1863,12 @@
       z="1096.4054"/>
 
     <box name="ExternalAuxOut" lunit="cm" 
-      x="850.08 - 100"
+      x="850.1 - 100"
       y="1211 - 2*2.5 - 2*40"
       z="1096.4054"/>
 
     <box name="ExternalAuxIn" lunit="cm" 
-      x="850.08"
+      x="850.1"
       y="1022.17"
       z="1096.4054 + 1"/>
 
@@ -1976,7 +1976,7 @@
     </subtraction>
 
     <box name="FoamPadBlock" lunit="cm"
-      x="1010.32"
+      x="1010.34"
       y="1371.24"
       z="1256.6454" />
 
@@ -1987,7 +1987,7 @@
     </subtraction>
 
     <box name="SteelSupportBlock" lunit="cm"
-      x="1210.32"
+      x="1210.34"
       y="1571.24"
       z="1456.6454" />
 
@@ -1998,13 +1998,13 @@
     </subtraction>
 
     <box name="DetEnclosure" lunit="cm" 
-      x="1310.32"
+      x="1310.34"
       y="1771.24"
       z="1656.6454"/>
 
 
     <box name="World" lunit="cm" 
-      x="9310.32" 
+      x="9310.34" 
       y="9771.24" 
       z="9656.6454"/>
 </solids>
@@ -7402,31 +7402,31 @@
        <physvol>
        <volumeref ref="volTPCPlaneU"/>
        <position name="posPlaneU" unit="cm" 
-         x="324.97" y="0" z="0"/>
+         x="324.98" y="0" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volTPCPlaneY"/>
        <position name="posPlaneY" unit="cm" 
-         x="324.99" y="0" z="0"/>
+         x="325" y="0" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volTPCPlaneZ"/>
        <position name="posPlaneZ" unit="cm" 
-         x="325.01" y="0" z="0"/>
+         x="325.02" y="0" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volAnodePlate"/>
        <position name="posAnodePlate" unit="cm" 
-         x="325.03" y="0" z="0"/>
+         x="325.04" y="0" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>    
      <physvol>
        <volumeref ref="volTPCActive"/>
        <position name="posActive" unit="cm" 
-        x="-0.04" y="" z="0"/>
+        x="-0.05" y="" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
    </volume>
@@ -7745,7 +7745,7 @@
       <solidref ref="Cryostat" />
       <physvol>
         <volumeref ref="volGaseousArgon"/>
-        <position name="posGaseousArgon" unit="cm" x="375.04" y="0" z="0"/>
+        <position name="posGaseousArgon" unit="cm" x="375.05" y="0" z="0"/>
       </physvol>
       <physvol>
         <volumeref ref="volSteelShell"/>
@@ -7937,584 +7937,584 @@
       </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper0" unit="cm"  x="-322.04" y="-507.8" z="0" />
+     <position name="posFieldShaper0" unit="cm"  x="-322.05" y="-507.8" z="0" />
      <rotation name="rotFS0" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper1" unit="cm"  x="-316.04" y="-507.8" z="0" />
+     <position name="posFieldShaper1" unit="cm"  x="-316.05" y="-507.8" z="0" />
      <rotation name="rotFS1" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper2" unit="cm"  x="-310.04" y="-507.8" z="0" />
+     <position name="posFieldShaper2" unit="cm"  x="-310.05" y="-507.8" z="0" />
      <rotation name="rotFS2" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper3" unit="cm"  x="-304.04" y="-507.8" z="0" />
+     <position name="posFieldShaper3" unit="cm"  x="-304.05" y="-507.8" z="0" />
      <rotation name="rotFS3" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper4" unit="cm"  x="-298.04" y="-507.8" z="0" />
+     <position name="posFieldShaper4" unit="cm"  x="-298.05" y="-507.8" z="0" />
      <rotation name="rotFS4" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper5" unit="cm"  x="-292.04" y="-507.8" z="0" />
+     <position name="posFieldShaper5" unit="cm"  x="-292.05" y="-507.8" z="0" />
      <rotation name="rotFS5" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper6" unit="cm"  x="-286.04" y="-507.8" z="0" />
+     <position name="posFieldShaper6" unit="cm"  x="-286.05" y="-507.8" z="0" />
      <rotation name="rotFS6" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper7" unit="cm"  x="-280.04" y="-507.8" z="0" />
+     <position name="posFieldShaper7" unit="cm"  x="-280.05" y="-507.8" z="0" />
      <rotation name="rotFS7" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper8" unit="cm"  x="-274.04" y="-507.8" z="0" />
+     <position name="posFieldShaper8" unit="cm"  x="-274.05" y="-507.8" z="0" />
      <rotation name="rotFS8" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper9" unit="cm"  x="-268.04" y="-507.8" z="0" />
+     <position name="posFieldShaper9" unit="cm"  x="-268.05" y="-507.8" z="0" />
      <rotation name="rotFS9" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper10" unit="cm"  x="-262.04" y="-507.8" z="0" />
+     <position name="posFieldShaper10" unit="cm"  x="-262.05" y="-507.8" z="0" />
      <rotation name="rotFS10" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper11" unit="cm"  x="-256.04" y="-507.8" z="0" />
+     <position name="posFieldShaper11" unit="cm"  x="-256.05" y="-507.8" z="0" />
      <rotation name="rotFS11" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper12" unit="cm"  x="-250.04" y="-507.8" z="0" />
+     <position name="posFieldShaper12" unit="cm"  x="-250.05" y="-507.8" z="0" />
      <rotation name="rotFS12" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper13" unit="cm"  x="-244.04" y="-507.8" z="0" />
+     <position name="posFieldShaper13" unit="cm"  x="-244.05" y="-507.8" z="0" />
      <rotation name="rotFS13" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper14" unit="cm"  x="-238.04" y="-507.8" z="0" />
+     <position name="posFieldShaper14" unit="cm"  x="-238.05" y="-507.8" z="0" />
      <rotation name="rotFS14" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper15" unit="cm"  x="-232.04" y="-507.8" z="0" />
+     <position name="posFieldShaper15" unit="cm"  x="-232.05" y="-507.8" z="0" />
      <rotation name="rotFS15" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper16" unit="cm"  x="-226.04" y="-507.8" z="0" />
+     <position name="posFieldShaper16" unit="cm"  x="-226.05" y="-507.8" z="0" />
      <rotation name="rotFS16" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper17" unit="cm"  x="-220.04" y="-507.8" z="0" />
+     <position name="posFieldShaper17" unit="cm"  x="-220.05" y="-507.8" z="0" />
      <rotation name="rotFS17" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper18" unit="cm"  x="-214.04" y="-507.8" z="0" />
+     <position name="posFieldShaper18" unit="cm"  x="-214.05" y="-507.8" z="0" />
      <rotation name="rotFS18" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper19" unit="cm"  x="-208.04" y="-507.8" z="0" />
+     <position name="posFieldShaper19" unit="cm"  x="-208.05" y="-507.8" z="0" />
      <rotation name="rotFS19" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper20" unit="cm"  x="-202.04" y="-507.8" z="0" />
+     <position name="posFieldShaper20" unit="cm"  x="-202.05" y="-507.8" z="0" />
      <rotation name="rotFS20" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper21" unit="cm"  x="-196.04" y="-507.8" z="0" />
+     <position name="posFieldShaper21" unit="cm"  x="-196.05" y="-507.8" z="0" />
      <rotation name="rotFS21" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper22" unit="cm"  x="-190.04" y="-507.8" z="0" />
+     <position name="posFieldShaper22" unit="cm"  x="-190.05" y="-507.8" z="0" />
      <rotation name="rotFS22" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper23" unit="cm"  x="-184.04" y="-507.8" z="0" />
+     <position name="posFieldShaper23" unit="cm"  x="-184.05" y="-507.8" z="0" />
      <rotation name="rotFS23" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper24" unit="cm"  x="-178.04" y="-507.8" z="0" />
+     <position name="posFieldShaper24" unit="cm"  x="-178.05" y="-507.8" z="0" />
      <rotation name="rotFS24" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper25" unit="cm"  x="-172.04" y="-507.8" z="0" />
+     <position name="posFieldShaper25" unit="cm"  x="-172.05" y="-507.8" z="0" />
      <rotation name="rotFS25" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper26" unit="cm"  x="-166.04" y="-507.8" z="0" />
+     <position name="posFieldShaper26" unit="cm"  x="-166.05" y="-507.8" z="0" />
      <rotation name="rotFS26" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper27" unit="cm"  x="-160.04" y="-507.8" z="0" />
+     <position name="posFieldShaper27" unit="cm"  x="-160.05" y="-507.8" z="0" />
      <rotation name="rotFS27" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper28" unit="cm"  x="-154.04" y="-507.8" z="0" />
+     <position name="posFieldShaper28" unit="cm"  x="-154.05" y="-507.8" z="0" />
      <rotation name="rotFS28" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper29" unit="cm"  x="-148.04" y="-507.8" z="0" />
+     <position name="posFieldShaper29" unit="cm"  x="-148.05" y="-507.8" z="0" />
      <rotation name="rotFS29" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper30" unit="cm"  x="-142.04" y="-507.8" z="0" />
+     <position name="posFieldShaper30" unit="cm"  x="-142.05" y="-507.8" z="0" />
      <rotation name="rotFS30" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper31" unit="cm"  x="-136.04" y="-507.8" z="0" />
+     <position name="posFieldShaper31" unit="cm"  x="-136.05" y="-507.8" z="0" />
      <rotation name="rotFS31" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper32" unit="cm"  x="-130.04" y="-507.8" z="0" />
+     <position name="posFieldShaper32" unit="cm"  x="-130.05" y="-507.8" z="0" />
      <rotation name="rotFS32" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper33" unit="cm"  x="-124.04" y="-507.8" z="0" />
+     <position name="posFieldShaper33" unit="cm"  x="-124.05" y="-507.8" z="0" />
      <rotation name="rotFS33" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper34" unit="cm"  x="-118.04" y="-507.8" z="0" />
+     <position name="posFieldShaper34" unit="cm"  x="-118.05" y="-507.8" z="0" />
      <rotation name="rotFS34" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper35" unit="cm"  x="-112.04" y="-507.8" z="0" />
+     <position name="posFieldShaper35" unit="cm"  x="-112.05" y="-507.8" z="0" />
      <rotation name="rotFS35" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper36" unit="cm"  x="-106.04" y="-507.8" z="0" />
+     <position name="posFieldShaper36" unit="cm"  x="-106.05" y="-507.8" z="0" />
      <rotation name="rotFS36" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper37" unit="cm"  x="-100.04" y="-507.8" z="0" />
+     <position name="posFieldShaper37" unit="cm"  x="-100.05" y="-507.8" z="0" />
      <rotation name="rotFS37" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper38" unit="cm"  x="-94.04" y="-507.8" z="0" />
+     <position name="posFieldShaper38" unit="cm"  x="-94.0500000000001" y="-507.8" z="0" />
      <rotation name="rotFS38" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper39" unit="cm"  x="-88.04" y="-507.8" z="0" />
+     <position name="posFieldShaper39" unit="cm"  x="-88.0500000000001" y="-507.8" z="0" />
      <rotation name="rotFS39" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper40" unit="cm"  x="-82.04" y="-507.8" z="0" />
+     <position name="posFieldShaper40" unit="cm"  x="-82.0500000000001" y="-507.8" z="0" />
      <rotation name="rotFS40" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper41" unit="cm"  x="-76.04" y="-507.8" z="0" />
+     <position name="posFieldShaper41" unit="cm"  x="-76.0500000000001" y="-507.8" z="0" />
      <rotation name="rotFS41" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper42" unit="cm"  x="-70.04" y="-507.8" z="0" />
+     <position name="posFieldShaper42" unit="cm"  x="-70.0500000000001" y="-507.8" z="0" />
      <rotation name="rotFS42" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper43" unit="cm"  x="-64.04" y="-507.8" z="0" />
+     <position name="posFieldShaper43" unit="cm"  x="-64.0500000000001" y="-507.8" z="0" />
      <rotation name="rotFS43" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper44" unit="cm"  x="-58.04" y="-507.8" z="0" />
+     <position name="posFieldShaper44" unit="cm"  x="-58.0500000000001" y="-507.8" z="0" />
      <rotation name="rotFS44" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper45" unit="cm"  x="-52.04" y="-507.8" z="0" />
+     <position name="posFieldShaper45" unit="cm"  x="-52.0500000000001" y="-507.8" z="0" />
      <rotation name="rotFS45" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper46" unit="cm"  x="-46.04" y="-507.8" z="0" />
+     <position name="posFieldShaper46" unit="cm"  x="-46.0500000000001" y="-507.8" z="0" />
      <rotation name="rotFS46" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper47" unit="cm"  x="-40.04" y="-507.8" z="0" />
+     <position name="posFieldShaper47" unit="cm"  x="-40.0500000000001" y="-507.8" z="0" />
      <rotation name="rotFS47" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper48" unit="cm"  x="-34.04" y="-507.8" z="0" />
+     <position name="posFieldShaper48" unit="cm"  x="-34.0500000000001" y="-507.8" z="0" />
      <rotation name="rotFS48" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper49" unit="cm"  x="-28.04" y="-507.8" z="0" />
+     <position name="posFieldShaper49" unit="cm"  x="-28.0500000000001" y="-507.8" z="0" />
      <rotation name="rotFS49" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper50" unit="cm"  x="-22.04" y="-507.8" z="0" />
+     <position name="posFieldShaper50" unit="cm"  x="-22.0500000000001" y="-507.8" z="0" />
      <rotation name="rotFS50" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper51" unit="cm"  x="-16.04" y="-507.8" z="0" />
+     <position name="posFieldShaper51" unit="cm"  x="-16.0500000000001" y="-507.8" z="0" />
      <rotation name="rotFS51" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper52" unit="cm"  x="-10.04" y="-507.8" z="0" />
+     <position name="posFieldShaper52" unit="cm"  x="-10.0500000000001" y="-507.8" z="0" />
      <rotation name="rotFS52" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper53" unit="cm"  x="-4.04000000000001" y="-507.8" z="0" />
+     <position name="posFieldShaper53" unit="cm"  x="-4.05000000000005" y="-507.8" z="0" />
      <rotation name="rotFS53" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper54" unit="cm"  x="1.95999999999999" y="-507.8" z="0" />
+     <position name="posFieldShaper54" unit="cm"  x="1.94999999999995" y="-507.8" z="0" />
      <rotation name="rotFS54" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper55" unit="cm"  x="7.95999999999999" y="-507.8" z="0" />
+     <position name="posFieldShaper55" unit="cm"  x="7.94999999999995" y="-507.8" z="0" />
      <rotation name="rotFS55" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper56" unit="cm"  x="13.96" y="-507.8" z="0" />
+     <position name="posFieldShaper56" unit="cm"  x="13.9499999999999" y="-507.8" z="0" />
      <rotation name="rotFS56" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper57" unit="cm"  x="19.96" y="-507.8" z="0" />
+     <position name="posFieldShaper57" unit="cm"  x="19.9499999999999" y="-507.8" z="0" />
      <rotation name="rotFS57" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper58" unit="cm"  x="25.96" y="-507.8" z="0" />
+     <position name="posFieldShaper58" unit="cm"  x="25.9499999999999" y="-507.8" z="0" />
      <rotation name="rotFS58" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper59" unit="cm"  x="31.96" y="-507.8" z="0" />
+     <position name="posFieldShaper59" unit="cm"  x="31.9499999999999" y="-507.8" z="0" />
      <rotation name="rotFS59" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper60" unit="cm"  x="37.96" y="-507.8" z="0" />
+     <position name="posFieldShaper60" unit="cm"  x="37.9499999999999" y="-507.8" z="0" />
      <rotation name="rotFS60" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper61" unit="cm"  x="43.96" y="-507.8" z="0" />
+     <position name="posFieldShaper61" unit="cm"  x="43.9499999999999" y="-507.8" z="0" />
      <rotation name="rotFS61" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper62" unit="cm"  x="49.96" y="-507.8" z="0" />
+     <position name="posFieldShaper62" unit="cm"  x="49.9499999999999" y="-507.8" z="0" />
      <rotation name="rotFS62" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper63" unit="cm"  x="55.96" y="-507.8" z="0" />
+     <position name="posFieldShaper63" unit="cm"  x="55.9499999999999" y="-507.8" z="0" />
      <rotation name="rotFS63" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper64" unit="cm"  x="61.96" y="-507.8" z="0" />
+     <position name="posFieldShaper64" unit="cm"  x="61.9499999999999" y="-507.8" z="0" />
      <rotation name="rotFS64" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper65" unit="cm"  x="67.96" y="-507.8" z="0" />
+     <position name="posFieldShaper65" unit="cm"  x="67.9499999999999" y="-507.8" z="0" />
      <rotation name="rotFS65" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper66" unit="cm"  x="73.96" y="-507.8" z="0" />
+     <position name="posFieldShaper66" unit="cm"  x="73.9499999999999" y="-507.8" z="0" />
      <rotation name="rotFS66" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper67" unit="cm"  x="79.96" y="-507.8" z="0" />
+     <position name="posFieldShaper67" unit="cm"  x="79.9499999999999" y="-507.8" z="0" />
      <rotation name="rotFS67" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper68" unit="cm"  x="85.96" y="-507.8" z="0" />
+     <position name="posFieldShaper68" unit="cm"  x="85.9499999999999" y="-507.8" z="0" />
      <rotation name="rotFS68" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper69" unit="cm"  x="91.96" y="-507.8" z="0" />
+     <position name="posFieldShaper69" unit="cm"  x="91.9499999999999" y="-507.8" z="0" />
      <rotation name="rotFS69" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper70" unit="cm"  x="97.96" y="-507.8" z="0" />
+     <position name="posFieldShaper70" unit="cm"  x="97.9499999999999" y="-507.8" z="0" />
      <rotation name="rotFS70" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper71" unit="cm"  x="103.96" y="-507.8" z="0" />
+     <position name="posFieldShaper71" unit="cm"  x="103.95" y="-507.8" z="0" />
      <rotation name="rotFS71" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper72" unit="cm"  x="109.96" y="-507.8" z="0" />
+     <position name="posFieldShaper72" unit="cm"  x="109.95" y="-507.8" z="0" />
      <rotation name="rotFS72" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper73" unit="cm"  x="115.96" y="-507.8" z="0" />
+     <position name="posFieldShaper73" unit="cm"  x="115.95" y="-507.8" z="0" />
      <rotation name="rotFS73" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper74" unit="cm"  x="121.96" y="-507.8" z="0" />
+     <position name="posFieldShaper74" unit="cm"  x="121.95" y="-507.8" z="0" />
      <rotation name="rotFS74" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper75" unit="cm"  x="127.96" y="-507.8" z="0" />
+     <position name="posFieldShaper75" unit="cm"  x="127.95" y="-507.8" z="0" />
      <rotation name="rotFS75" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper76" unit="cm"  x="133.96" y="-507.8" z="0" />
+     <position name="posFieldShaper76" unit="cm"  x="133.95" y="-507.8" z="0" />
      <rotation name="rotFS76" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper77" unit="cm"  x="139.96" y="-507.8" z="0" />
+     <position name="posFieldShaper77" unit="cm"  x="139.95" y="-507.8" z="0" />
      <rotation name="rotFS77" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper78" unit="cm"  x="145.96" y="-507.8" z="0" />
+     <position name="posFieldShaper78" unit="cm"  x="145.95" y="-507.8" z="0" />
      <rotation name="rotFS78" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper79" unit="cm"  x="151.96" y="-507.8" z="0" />
+     <position name="posFieldShaper79" unit="cm"  x="151.95" y="-507.8" z="0" />
      <rotation name="rotFS79" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper80" unit="cm"  x="157.96" y="-507.8" z="0" />
+     <position name="posFieldShaper80" unit="cm"  x="157.95" y="-507.8" z="0" />
      <rotation name="rotFS80" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper81" unit="cm"  x="163.96" y="-507.8" z="0" />
+     <position name="posFieldShaper81" unit="cm"  x="163.95" y="-507.8" z="0" />
      <rotation name="rotFS81" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper82" unit="cm"  x="169.96" y="-507.8" z="0" />
+     <position name="posFieldShaper82" unit="cm"  x="169.95" y="-507.8" z="0" />
      <rotation name="rotFS82" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper83" unit="cm"  x="175.96" y="-507.8" z="0" />
+     <position name="posFieldShaper83" unit="cm"  x="175.95" y="-507.8" z="0" />
      <rotation name="rotFS83" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper84" unit="cm"  x="181.96" y="-507.8" z="0" />
+     <position name="posFieldShaper84" unit="cm"  x="181.95" y="-507.8" z="0" />
      <rotation name="rotFS84" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper85" unit="cm"  x="187.96" y="-507.8" z="0" />
+     <position name="posFieldShaper85" unit="cm"  x="187.95" y="-507.8" z="0" />
      <rotation name="rotFS85" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper86" unit="cm"  x="193.96" y="-507.8" z="0" />
+     <position name="posFieldShaper86" unit="cm"  x="193.95" y="-507.8" z="0" />
      <rotation name="rotFS86" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper87" unit="cm"  x="199.96" y="-507.8" z="0" />
+     <position name="posFieldShaper87" unit="cm"  x="199.95" y="-507.8" z="0" />
      <rotation name="rotFS87" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper88" unit="cm"  x="205.96" y="-507.8" z="0" />
+     <position name="posFieldShaper88" unit="cm"  x="205.95" y="-507.8" z="0" />
      <rotation name="rotFS88" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper89" unit="cm"  x="211.96" y="-507.8" z="0" />
+     <position name="posFieldShaper89" unit="cm"  x="211.95" y="-507.8" z="0" />
      <rotation name="rotFS89" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper90" unit="cm"  x="217.96" y="-507.8" z="0" />
+     <position name="posFieldShaper90" unit="cm"  x="217.95" y="-507.8" z="0" />
      <rotation name="rotFS90" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper91" unit="cm"  x="223.96" y="-507.8" z="0" />
+     <position name="posFieldShaper91" unit="cm"  x="223.95" y="-507.8" z="0" />
      <rotation name="rotFS91" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper92" unit="cm"  x="229.96" y="-507.8" z="0" />
+     <position name="posFieldShaper92" unit="cm"  x="229.95" y="-507.8" z="0" />
      <rotation name="rotFS92" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper93" unit="cm"  x="235.96" y="-507.8" z="0" />
+     <position name="posFieldShaper93" unit="cm"  x="235.95" y="-507.8" z="0" />
      <rotation name="rotFS93" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper94" unit="cm"  x="241.96" y="-507.8" z="0" />
+     <position name="posFieldShaper94" unit="cm"  x="241.95" y="-507.8" z="0" />
      <rotation name="rotFS94" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper95" unit="cm"  x="247.96" y="-507.8" z="0" />
+     <position name="posFieldShaper95" unit="cm"  x="247.95" y="-507.8" z="0" />
      <rotation name="rotFS95" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper96" unit="cm"  x="253.96" y="-507.8" z="0" />
+     <position name="posFieldShaper96" unit="cm"  x="253.95" y="-507.8" z="0" />
      <rotation name="rotFS96" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper97" unit="cm"  x="259.96" y="-507.8" z="0" />
+     <position name="posFieldShaper97" unit="cm"  x="259.95" y="-507.8" z="0" />
      <rotation name="rotFS97" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper98" unit="cm"  x="265.96" y="-507.8" z="0" />
+     <position name="posFieldShaper98" unit="cm"  x="265.95" y="-507.8" z="0" />
      <rotation name="rotFS98" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper99" unit="cm"  x="271.96" y="-507.8" z="0" />
+     <position name="posFieldShaper99" unit="cm"  x="271.95" y="-507.8" z="0" />
      <rotation name="rotFS99" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper100" unit="cm"  x="277.96" y="-507.8" z="0" />
+     <position name="posFieldShaper100" unit="cm"  x="277.95" y="-507.8" z="0" />
      <rotation name="rotFS100" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper101" unit="cm"  x="283.96" y="-507.8" z="0" />
+     <position name="posFieldShaper101" unit="cm"  x="283.95" y="-507.8" z="0" />
      <rotation name="rotFS101" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper102" unit="cm"  x="289.96" y="-507.8" z="0" />
+     <position name="posFieldShaper102" unit="cm"  x="289.95" y="-507.8" z="0" />
      <rotation name="rotFS102" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper103" unit="cm"  x="295.96" y="-507.8" z="0" />
+     <position name="posFieldShaper103" unit="cm"  x="295.95" y="-507.8" z="0" />
      <rotation name="rotFS103" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper104" unit="cm"  x="301.96" y="-507.8" z="0" />
+     <position name="posFieldShaper104" unit="cm"  x="301.95" y="-507.8" z="0" />
      <rotation name="rotFS104" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper105" unit="cm"  x="307.96" y="-507.8" z="0" />
+     <position name="posFieldShaper105" unit="cm"  x="307.95" y="-507.8" z="0" />
      <rotation name="rotFS105" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper106" unit="cm"  x="313.96" y="-507.8" z="0" />
+     <position name="posFieldShaper106" unit="cm"  x="313.95" y="-507.8" z="0" />
      <rotation name="rotFS106" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper107" unit="cm"  x="319.96" y="-507.8" z="0" />
+     <position name="posFieldShaper107" unit="cm"  x="319.95" y="-507.8" z="0" />
      <rotation name="rotFS107" unit="deg" x="0" y="0" z="90" />
   </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-0" unit="cm" x="-328.04" y="-337.5" z="-299.3018"/>
+   <position name="posGroundGrid-0" unit="cm" x="-328.05" y="-337.5" z="-299.3018"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-1" unit="cm" x="-328.04" y="-1.5" z="-299.3018"/>
+   <position name="posGroundGrid-1" unit="cm" x="-328.05" y="-1.5" z="-299.3018"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-2" unit="cm" x="-328.04" y="334.5" z="-299.3018"/>
+   <position name="posGroundGrid-2" unit="cm" x="-328.05" y="334.5" z="-299.3018"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-3" unit="cm" x="-328.04" y="-337.5" z="-1.50000000000006"/>
+   <position name="posGroundGrid-3" unit="cm" x="-328.05" y="-337.5" z="-1.50000000000006"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-4" unit="cm" x="-328.04" y="-1.5" z="-1.50000000000006"/>
+   <position name="posGroundGrid-4" unit="cm" x="-328.05" y="-1.5" z="-1.50000000000006"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-5" unit="cm" x="-328.04" y="334.5" z="-1.50000000000006"/>
+   <position name="posGroundGrid-5" unit="cm" x="-328.05" y="334.5" z="-1.50000000000006"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-6" unit="cm" x="-328.04" y="-337.5" z="296.3018"/>
+   <position name="posGroundGrid-6" unit="cm" x="-328.05" y="-337.5" z="296.3018"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-7" unit="cm" x="-328.04" y="-1.5" z="296.3018"/>
+   <position name="posGroundGrid-7" unit="cm" x="-328.05" y="-1.5" z="296.3018"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-8" unit="cm" x="-328.04" y="334.5" z="296.3018"/>
+   <position name="posGroundGrid-8" unit="cm" x="-328.05" y="334.5" z="296.3018"/>
       </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-0-0"/>
        <position name="posArapucaDouble0-Frame-0-0" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-465.2" 
 	 z="-261.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -8522,14 +8522,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-0"/>
        <position name="posOpArapucaDouble0-Frame-0-0" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-465.2" 
 	 z="-261.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-0-1"/>
        <position name="posArapucaDouble1-Frame-0-0" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-374.5" 
 	 z="-407.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -8537,14 +8537,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-1"/>
        <position name="posOpArapucaDouble1-Frame-0-0" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-374.5" 
 	 z="-407.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-0-2"/>
        <position name="posArapucaDouble2-Frame-0-0" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-300.5" 
 	 z="-190.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -8552,14 +8552,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-2"/>
        <position name="posOpArapucaDouble2-Frame-0-0" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-300.5" 
 	 z="-190.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-0-3"/>
        <position name="posArapucaDouble3-Frame-0-0" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-209.8" 
 	 z="-336.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -8567,14 +8567,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-3"/>
        <position name="posOpArapucaDouble3-Frame-0-0" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-209.8" 
 	 z="-336.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-1-0"/>
        <position name="posArapucaDouble0-Frame-0-1" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-465.2" 
 	 z="35.9999999999999"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -8582,14 +8582,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-0"/>
        <position name="posOpArapucaDouble0-Frame-0-1" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-465.2" 
 	 z="35.9999999999999"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-1-1"/>
        <position name="posArapucaDouble1-Frame-0-1" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-374.5" 
 	 z="-110"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -8597,14 +8597,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-1"/>
        <position name="posOpArapucaDouble1-Frame-0-1" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-374.5" 
 	 z="-110"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-1-2"/>
        <position name="posArapucaDouble2-Frame-0-1" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-300.5" 
 	 z="107"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -8612,14 +8612,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-2"/>
        <position name="posOpArapucaDouble2-Frame-0-1" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-300.5" 
 	 z="107"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-1-3"/>
        <position name="posArapucaDouble3-Frame-0-1" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-209.8" 
 	 z="-39.0000000000001"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -8627,14 +8627,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-3"/>
        <position name="posOpArapucaDouble3-Frame-0-1" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-209.8" 
 	 z="-39.0000000000001"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-2-0"/>
        <position name="posArapucaDouble0-Frame-0-2" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-465.2" 
 	 z="333.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -8642,14 +8642,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-0"/>
        <position name="posOpArapucaDouble0-Frame-0-2" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-465.2" 
 	 z="333.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-2-1"/>
        <position name="posArapucaDouble1-Frame-0-2" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-374.5" 
 	 z="187.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -8657,14 +8657,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-1"/>
        <position name="posOpArapucaDouble1-Frame-0-2" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-374.5" 
 	 z="187.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-2-2"/>
        <position name="posArapucaDouble2-Frame-0-2" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-300.5" 
 	 z="404.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -8672,14 +8672,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-2"/>
        <position name="posOpArapucaDouble2-Frame-0-2" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-300.5" 
 	 z="404.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-2-3"/>
        <position name="posArapucaDouble3-Frame-0-2" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-209.8" 
 	 z="258.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -8687,14 +8687,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-3"/>
        <position name="posOpArapucaDouble3-Frame-0-2" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-209.8" 
 	 z="258.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-0-0"/>
        <position name="posArapucaDouble0-Frame-1-0" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-129.2" 
 	 z="-261.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -8702,14 +8702,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-0"/>
        <position name="posOpArapucaDouble0-Frame-1-0" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-129.2" 
 	 z="-261.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-0-1"/>
        <position name="posArapucaDouble1-Frame-1-0" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-38.5" 
 	 z="-407.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -8717,14 +8717,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-1"/>
        <position name="posOpArapucaDouble1-Frame-1-0" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-38.5" 
 	 z="-407.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-0-2"/>
        <position name="posArapucaDouble2-Frame-1-0" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="35.5" 
 	 z="-190.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -8732,14 +8732,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-2"/>
        <position name="posOpArapucaDouble2-Frame-1-0" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="35.5" 
 	 z="-190.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-0-3"/>
        <position name="posArapucaDouble3-Frame-1-0" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="126.2" 
 	 z="-336.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -8747,14 +8747,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-3"/>
        <position name="posOpArapucaDouble3-Frame-1-0" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="126.2" 
 	 z="-336.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-1-0"/>
        <position name="posArapucaDouble0-Frame-1-1" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-129.2" 
 	 z="35.9999999999999"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -8762,14 +8762,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-0"/>
        <position name="posOpArapucaDouble0-Frame-1-1" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-129.2" 
 	 z="35.9999999999999"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-1-1"/>
        <position name="posArapucaDouble1-Frame-1-1" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-38.5" 
 	 z="-110"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -8777,14 +8777,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-1"/>
        <position name="posOpArapucaDouble1-Frame-1-1" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-38.5" 
 	 z="-110"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-1-2"/>
        <position name="posArapucaDouble2-Frame-1-1" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="35.5" 
 	 z="107"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -8792,14 +8792,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-2"/>
        <position name="posOpArapucaDouble2-Frame-1-1" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="35.5" 
 	 z="107"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-1-3"/>
        <position name="posArapucaDouble3-Frame-1-1" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="126.2" 
 	 z="-39.0000000000001"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -8807,14 +8807,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-3"/>
        <position name="posOpArapucaDouble3-Frame-1-1" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="126.2" 
 	 z="-39.0000000000001"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-2-0"/>
        <position name="posArapucaDouble0-Frame-1-2" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-129.2" 
 	 z="333.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -8822,14 +8822,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-0"/>
        <position name="posOpArapucaDouble0-Frame-1-2" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-129.2" 
 	 z="333.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-2-1"/>
        <position name="posArapucaDouble1-Frame-1-2" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-38.5" 
 	 z="187.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -8837,14 +8837,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-1"/>
        <position name="posOpArapucaDouble1-Frame-1-2" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-38.5" 
 	 z="187.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-2-2"/>
        <position name="posArapucaDouble2-Frame-1-2" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="35.5" 
 	 z="404.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -8852,14 +8852,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-2"/>
        <position name="posOpArapucaDouble2-Frame-1-2" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="35.5" 
 	 z="404.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-2-3"/>
        <position name="posArapucaDouble3-Frame-1-2" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="126.2" 
 	 z="258.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -8867,14 +8867,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-3"/>
        <position name="posOpArapucaDouble3-Frame-1-2" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="126.2" 
 	 z="258.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-0-0"/>
        <position name="posArapucaDouble0-Frame-2-0" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="206.8" 
 	 z="-261.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -8882,14 +8882,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-0"/>
        <position name="posOpArapucaDouble0-Frame-2-0" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="206.8" 
 	 z="-261.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-0-1"/>
        <position name="posArapucaDouble1-Frame-2-0" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="297.5" 
 	 z="-407.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -8897,14 +8897,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-1"/>
        <position name="posOpArapucaDouble1-Frame-2-0" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="297.5" 
 	 z="-407.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-0-2"/>
        <position name="posArapucaDouble2-Frame-2-0" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="371.5" 
 	 z="-190.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -8912,14 +8912,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-2"/>
        <position name="posOpArapucaDouble2-Frame-2-0" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="371.5" 
 	 z="-190.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-0-3"/>
        <position name="posArapucaDouble3-Frame-2-0" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="462.2" 
 	 z="-336.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -8927,14 +8927,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-3"/>
        <position name="posOpArapucaDouble3-Frame-2-0" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="462.2" 
 	 z="-336.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-1-0"/>
        <position name="posArapucaDouble0-Frame-2-1" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="206.8" 
 	 z="35.9999999999999"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -8942,14 +8942,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-0"/>
        <position name="posOpArapucaDouble0-Frame-2-1" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="206.8" 
 	 z="35.9999999999999"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-1-1"/>
        <position name="posArapucaDouble1-Frame-2-1" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="297.5" 
 	 z="-110"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -8957,14 +8957,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-1"/>
        <position name="posOpArapucaDouble1-Frame-2-1" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="297.5" 
 	 z="-110"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-1-2"/>
        <position name="posArapucaDouble2-Frame-2-1" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="371.5" 
 	 z="107"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -8972,14 +8972,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-2"/>
        <position name="posOpArapucaDouble2-Frame-2-1" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="371.5" 
 	 z="107"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-1-3"/>
        <position name="posArapucaDouble3-Frame-2-1" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="462.2" 
 	 z="-39.0000000000001"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -8987,14 +8987,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-3"/>
        <position name="posOpArapucaDouble3-Frame-2-1" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="462.2" 
 	 z="-39.0000000000001"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-2-0"/>
        <position name="posArapucaDouble0-Frame-2-2" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="206.8" 
 	 z="333.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -9002,14 +9002,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-0"/>
        <position name="posOpArapucaDouble0-Frame-2-2" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="206.8" 
 	 z="333.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-2-1"/>
        <position name="posArapucaDouble1-Frame-2-2" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="297.5" 
 	 z="187.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -9017,14 +9017,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-1"/>
        <position name="posOpArapucaDouble1-Frame-2-2" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="297.5" 
 	 z="187.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-2-2"/>
        <position name="posArapucaDouble2-Frame-2-2" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="371.5" 
 	 z="404.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -9032,14 +9032,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-2"/>
        <position name="posOpArapucaDouble2-Frame-2-2" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="371.5" 
 	 z="404.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-2-3"/>
        <position name="posArapucaDouble3-Frame-2-2" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="462.2" 
 	 z="258.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -9047,7 +9047,7 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-3"/>
        <position name="posOpArapucaDouble3-Frame-2-2" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="462.2" 
 	 z="258.8018"/>
      </physvol>
@@ -9087,7 +9087,7 @@
 
       <physvol>
         <volumeref ref="volDetEnclosure"/>
-	<position name="posDetEnclosure" unit="cm" x="50.04" y="0" z="448.2027"/>
+	<position name="posDetEnclosure" unit="cm" x="50.0500000000001" y="0" z="448.2027"/>
       </physvol>
 
     </volume>

--- a/dunecore/Geometry/gdml/dunevd10kt_3view_v3_refactored_1x8x6ref.gdml
+++ b/dunecore/Geometry/gdml/dunevd10kt_3view_v3_refactored_1x8x6ref.gdml
@@ -1,0 +1,9098 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<gdml_simple_extension xmlns:gdml_simple_extension="http://www.example.org"
+                       xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"          
+                       xs:noNamespaceSchemaLocation="RefactoredGDMLSchema/SimpleExtension.xsd"> 
+<extension>
+   <color name="magenta"     R="0.0"  G="1.0"  B="0.0"  A="1.0" />
+   <color name="green"       R="0.0"  G="1.0"  B="0.0"  A="1.0" />
+   <color name="red"         R="1.0"  G="0.0"  B="0.0"  A="1.0" />
+   <color name="blue"        R="0.0"  G="0.0"  B="1.0"  A="1.0" />
+   <color name="yellow"      R="1.0"  G="1.0"  B="0.0"  A="1.0" />    
+</extension>
+<define>
+
+<!--
+
+
+
+-->
+
+   <position name="posCryoInDetEnc"     unit="cm" x="-50.0000000000001" y="0" z="0"/>
+   <position name="posCenter"           unit="cm" x="0" y="0" z="0"/>
+   <rotation name="rUWireAboutX"        unit="deg" x="131.63" y="0" z="0"/>
+   <rotation name="rPlus90AboutX"       unit="deg" x="90" y="0" z="0"/>
+   <rotation name="rPlus90AboutY"       unit="deg" x="0" y="90" z="0"/>
+   <rotation name="rPlus90AboutXPlus90AboutY" unit="deg" x="90" y="90" z="0"/>
+   <rotation name="rMinus90AboutX"      unit="deg" x="270" y="0" z="0"/>
+   <rotation name="rMinus90AboutY"      unit="deg" x="0" y="270" z="0"/>
+   <rotation name="rMinus90AboutYMinus90AboutX"       unit="deg" x="270" y="270" z="0"/>
+   <rotation name="rPlus180AboutX"	unit="deg" x="180" y="0"   z="0"/>
+   <rotation name="rPlus180AboutY"	unit="deg" x="0" y="180"   z="0"/>
+   <rotation name="rPlus180AboutXPlus180AboutY"	unit="deg" x="180" y="180"   z="0"/>
+   <rotation name="rIdentity"		unit="deg" x="0" y="0"   z="0"/>
+</define>
+<materials>
+  <element name="videRef" formula="VACUUM" Z="1">  <atom value="1"/> </element>
+  <element name="copper" formula="Cu" Z="29">  <atom value="63.546"/>  </element>
+  <element name="beryllium" formula="Be" Z="4">  <atom value="9.0121831"/>  </element>
+  <element name="bromine" formula="Br" Z="35"> <atom value="79.904"/> </element>
+  <element name="hydrogen" formula="H" Z="1">  <atom value="1.0079"/> </element>
+  <element name="nitrogen" formula="N" Z="7">  <atom value="14.0067"/> </element>
+  <element name="oxygen" formula="O" Z="8">  <atom value="15.999"/> </element>
+  <element name="aluminum" formula="Al" Z="13"> <atom value="26.9815"/>  </element>
+  <element name="silicon" formula="Si" Z="14"> <atom value="28.0855"/>  </element>
+  <element name="carbon" formula="C" Z="6">  <atom value="12.0107"/>  </element>
+  <element name="potassium" formula="K" Z="19"> <atom value="39.0983"/>  </element>
+  <element name="chromium" formula="Cr" Z="24"> <atom value="51.9961"/>  </element>
+  <element name="iron" formula="Fe" Z="26"> <atom value="55.8450"/>  </element>
+  <element name="nickel" formula="Ni" Z="28"> <atom value="58.6934"/>  </element>
+  <element name="calcium" formula="Ca" Z="20"> <atom value="40.078"/>   </element>
+  <element name="magnesium" formula="Mg" Z="12"> <atom value="24.305"/>   </element>
+  <element name="sodium" formula="Na" Z="11"> <atom value="22.99"/>    </element>
+  <element name="titanium" formula="Ti" Z="22"> <atom value="47.867"/>   </element>
+  <element name="argon" formula="Ar" Z="18"> <atom value="39.9480"/>  </element>
+  <element name="sulphur" formula="S" Z="16"> <atom value="32.065"/>  </element>
+  <element name="phosphorus" formula="P" Z="15"> <atom value="30.973"/>  </element>
+
+  <material name="Vacuum" formula="Vacuum">
+   <D value="1.e-25" unit="g/cm3"/>
+   <fraction n="1.0" ref="videRef"/>
+  </material>
+
+  <material name="ALUMINUM_Al" formula="ALUMINUM_Al">
+   <D value="2.6990" unit="g/cm3"/>
+   <fraction n="1.0000" ref="aluminum"/>
+  </material>
+
+  <material name="SILICON_Si" formula="SILICON_Si">
+   <D value="2.3300" unit="g/cm3"/>
+   <fraction n="1.0000" ref="silicon"/>
+  </material>
+
+  <material name="epoxy_resin" formula="C38H40O6Br4">
+   <D value="1.1250" unit="g/cm3"/>
+   <composite n="38" ref="carbon"/>
+   <composite n="40" ref="hydrogen"/>
+   <composite n="6" ref="oxygen"/>
+   <composite n="4" ref="bromine"/>
+  </material>
+
+  <material name="SiO2" formula="SiO2">
+   <D value="2.2" unit="g/cm3"/>
+   <composite n="1" ref="silicon"/>
+   <composite n="2" ref="oxygen"/>
+  </material>
+
+  <material name="Al2O3" formula="Al2O3">
+   <D value="3.97" unit="g/cm3"/>
+   <composite n="2" ref="aluminum"/>
+   <composite n="3" ref="oxygen"/>
+  </material>
+
+  <material name="Fe2O3" formula="Fe2O3">
+   <D value="5.24" unit="g/cm3"/>
+   <composite n="2" ref="iron"/>
+   <composite n="3" ref="oxygen"/>
+  </material>
+
+  <material name="CaO" formula="CaO">
+   <D value="3.35" unit="g/cm3"/>
+   <composite n="1" ref="calcium"/>
+   <composite n="1" ref="oxygen"/>
+  </material>
+
+  <material name="Delrin" formula="CH2O">
+    <D value="1.41" unit="g/cm3"/>
+    <composite n="1" ref="carbon"/>
+    <composite n="2" ref="hydrogen"/>
+    <composite n="1" ref="oxygen"/>
+  </material>
+
+  <material name="MgO" formula="MgO">
+   <D value="3.58" unit="g/cm3"/>
+   <composite n="1" ref="magnesium"/>
+   <composite n="1" ref="oxygen"/>
+  </material>
+
+  <material name="Na2O" formula="Na2O">
+   <D value="2.27" unit="g/cm3"/>
+   <composite n="2" ref="sodium"/>
+   <composite n="1" ref="oxygen"/>
+  </material>
+
+  <material name="TiO2" formula="TiO2">
+   <D value="4.23" unit="g/cm3"/>
+   <composite n="1" ref="titanium"/>
+   <composite n="2" ref="oxygen"/>
+  </material>
+
+  <material name="FeO" formula="FeO">
+   <D value="5.745" unit="g/cm3"/>
+   <composite n="1" ref="iron"/>
+   <composite n="1" ref="oxygen"/>
+  </material>
+
+  <material name="CO2" formula="CO2">
+   <D value="1.562" unit="g/cm3"/>
+   <composite n="1" ref="iron"/>
+   <composite n="2" ref="oxygen"/>
+  </material>
+
+  <material name="P2O5" formula="P2O5">
+   <D value="1.562" unit="g/cm3"/>
+   <composite n="2" ref="phosphorus"/>
+   <composite n="5" ref="oxygen"/>
+  </material>
+
+  <material formula=" " name="DUSEL_Rock">
+    <D value="2.82" unit="g/cm3"/>
+    <fraction n="0.5267" ref="SiO2"/>
+    <fraction n="0.1174" ref="FeO"/>
+    <fraction n="0.1025" ref="Al2O3"/>
+    <fraction n="0.0473" ref="MgO"/>
+    <fraction n="0.0422" ref="CO2"/>
+    <fraction n="0.0382" ref="CaO"/>
+    <fraction n="0.0240" ref="carbon"/>
+    <fraction n="0.0186" ref="sulphur"/>
+    <fraction n="0.0053" ref="Na2O"/>
+    <fraction n="0.00070" ref="P2O5"/>
+    <fraction n="0.0771" ref="oxygen"/>
+  </material> 
+
+  <material formula="Air" name="Air">
+   <D value="0.001205" unit="g/cm3"/>
+   <fraction n="0.781154" ref="nitrogen"/>
+   <fraction n="0.209476" ref="oxygen"/>
+   <fraction n="0.00934" ref="argon"/>
+  </material>
+
+  <material name="fibrous_glass">
+   <D value="2.74351" unit="g/cm3"/>
+   <fraction n="0.600" ref="SiO2"/>
+   <fraction n="0.118" ref="Al2O3"/>
+   <fraction n="0.001" ref="Fe2O3"/>
+   <fraction n="0.224" ref="CaO"/>
+   <fraction n="0.034" ref="MgO"/>
+   <fraction n="0.010" ref="Na2O"/>
+   <fraction n="0.013" ref="TiO2"/>
+  </material>
+
+  <!-- density referenced from EHN1-Cold Cryostats Technical Requirements:
+       https://edms.cern.ch/document/1543254 -->
+  <material name="FD_foam">
+   <D value="0.09" unit="g/cm3"/>
+   <fraction n="0.95" ref="Air"/>
+   <fraction n="0.05" ref="fibrous_glass"/>
+  </material>
+
+  <!-- Foam density is 70 kg / m^3 for the 3x1x1 -->
+  <material name="foam_3x1x1dp">
+   <D value="0.07" unit="g/cm3"/>
+   <fraction n="0.95" ref="Air"/>
+   <fraction n="0.05" ref="fibrous_glass"/>
+  </material>
+
+  <!-- Copied from protodune_v4.gdml -->
+  <material name="foam_protoDUNEdp">
+   <D value="0.135" unit="g/cm3"/>
+   <composite n="17" ref="carbon"/>
+   <composite n="16" ref="hydrogen"/>
+   <composite n="2" ref="nitrogen"/>
+   <composite n="4" ref="oxygen"/>
+  </material>
+
+  <material name="FR4">
+   <D value="1.98281" unit="g/cm3"/>
+   <fraction n="0.47" ref="epoxy_resin"/>
+   <fraction n="0.53" ref="fibrous_glass"/>
+  </material>
+
+  <material name="STEEL_STAINLESS_Fe7Cr2Ni" formula="STEEL_STAINLESS_Fe7Cr2Ni">
+   <D value="7.9300" unit="g/cm3"/>
+   <fraction n="0.0010" ref="carbon"/>
+   <fraction n="0.1792" ref="chromium"/>
+   <fraction n="0.7298" ref="iron"/>
+   <fraction n="0.0900" ref="nickel"/>
+  </material>
+
+  <material name="Copper_Beryllium_alloy25" formula="Copper_Beryllium_alloy25">
+   <D value="8.26" unit="g/cm3"/>
+   <fraction n="0.981" ref="copper"/>
+   <fraction n="0.019" ref="beryllium"/>
+  </material>
+
+  <material name="LAr" formula="LAr">
+   <D value="1.40" unit="g/cm3"/>
+   <fraction n="1.0000" ref="argon"/>
+  </material>
+
+  <material name="ArGas" formula="ArGas">
+   <D value="0.00166" unit="g/cm3"/>
+   <fraction n="1.0" ref="argon"/>
+  </material>
+
+  <material formula=" " name="G10">
+   <D value="1.7" unit="g/cm3"/>
+   <fraction n="0.2805" ref="silicon"/>
+   <fraction n="0.3954" ref="oxygen"/>
+   <fraction n="0.2990" ref="carbon"/>
+   <fraction n="0.0251" ref="hydrogen"/>
+  </material>
+
+  <material formula=" " name="Granite">
+   <D value="2.7" unit="g/cm3"/>
+   <fraction n="0.438" ref="oxygen"/>
+   <fraction n="0.257" ref="silicon"/>
+   <fraction n="0.222" ref="sodium"/>
+   <fraction n="0.049" ref="aluminum"/>
+   <fraction n="0.019" ref="iron"/>
+   <fraction n="0.015" ref="potassium"/>
+  </material>
+
+  <material formula=" " name="ShotRock">
+   <D value="1.62" unit="g/cm3"/>
+   <fraction n="0.438" ref="oxygen"/>
+   <fraction n="0.257" ref="silicon"/>
+   <fraction n="0.222" ref="sodium"/>
+   <fraction n="0.049" ref="aluminum"/>
+   <fraction n="0.019" ref="iron"/>
+   <fraction n="0.015" ref="potassium"/>
+  </material>
+
+  <material formula=" " name="Dirt">
+   <D value="1.7" unit="g/cm3"/>
+   <fraction n="0.438" ref="oxygen"/>
+   <fraction n="0.257" ref="silicon"/>
+   <fraction n="0.222" ref="sodium"/>
+   <fraction n="0.049" ref="aluminum"/>
+   <fraction n="0.019" ref="iron"/>
+   <fraction n="0.015" ref="potassium"/>
+  </material>
+
+  <material formula=" " name="Concrete">
+   <D value="2.3" unit="g/cm3"/>
+   <fraction n="0.530" ref="oxygen"/>
+   <fraction n="0.335" ref="silicon"/>
+   <fraction n="0.060" ref="calcium"/>
+   <fraction n="0.015" ref="sodium"/>
+   <fraction n="0.020" ref="iron"/>
+   <fraction n="0.040" ref="aluminum"/>
+  </material>
+
+  <material formula="H2O" name="Water">
+   <D value="1.0" unit="g/cm3"/>
+   <fraction n="0.1119" ref="hydrogen"/>
+   <fraction n="0.8881" ref="oxygen"/>
+  </material>
+
+  <material formula="Ti" name="Titanium">
+   <D value="4.506" unit="g/cm3"/>
+   <fraction n="1." ref="titanium"/>
+  </material>
+
+  <material name="TPB" formula="TPB">
+   <D value="1.40" unit="g/cm3"/>
+   <fraction n="1.0000" ref="argon"/>
+  </material>
+
+  <material name="Glass">
+   <D value="2.74351" unit="g/cm3"/>
+   <fraction n="0.600" ref="SiO2"/>
+   <fraction n="0.118" ref="Al2O3"/>
+   <fraction n="0.001" ref="Fe2O3"/>
+   <fraction n="0.224" ref="CaO"/>
+   <fraction n="0.034" ref="MgO"/>
+   <fraction n="0.010" ref="Na2O"/>
+   <fraction n="0.013" ref="TiO2"/>
+  </material>
+
+  <material name="Acrylic">
+   <D value="1.19" unit="g/cm3"/>
+   <fraction n="0.600" ref="carbon"/>
+   <fraction n="0.320" ref="oxygen"/>
+   <fraction n="0.080" ref="hydrogen"/>
+  </material>
+
+  <material name="NiGas1atm80K">
+   <D value="0.0039" unit="g/cm3"/>
+   <fraction n="1.000" ref="nitrogen"/>
+  </material>
+
+  <material name="NiGas">
+   <D value="0.001165" unit="g/cm3"/>
+   <fraction n="1.000" ref="nitrogen"/>
+  </material>
+
+  <material name="PolyurethaneFoam">
+   <D value="0.088" unit="g/cm3"/>
+   <composite n="17" ref="carbon"/>
+   <composite n="16" ref="hydrogen"/>
+   <composite n="2" ref="nitrogen"/>
+   <composite n="4" ref="oxygen"/>
+  </material>
+
+  <material name="ProtoDUNEFoam">
+   <D value="0.135" unit="g/cm3"/>
+   <composite n="17" ref="carbon"/>
+   <composite n="16" ref="hydrogen"/>
+   <composite n="2" ref="nitrogen"/>
+   <composite n="4" ref="oxygen"/>
+  </material>
+
+  <material name="LightPolyurethaneFoam">
+   <D value="0.009" unit="g/cm3"/>
+   <composite n="17" ref="carbon"/>
+   <composite n="16" ref="hydrogen"/>
+   <composite n="2" ref="nitrogen"/>
+   <composite n="4" ref="oxygen"/>
+  </material>
+
+  <material name="ProtoDUNEBWFoam">
+   <D value="0.021" unit="g/cm3"/>
+   <composite n="17" ref="carbon"/>
+   <composite n="16" ref="hydrogen"/>
+   <composite n="2" ref="nitrogen"/>
+   <composite n="4" ref="oxygen"/>
+  </material>
+
+  <material name="GlassWool">
+   <D value="0.035" unit="g/cm3"/>
+   <fraction n="0.65" ref="SiO2"/>
+   <fraction n="0.09" ref="Al2O3"/>
+   <fraction n="0.07" ref="CaO"/>
+   <fraction n="0.03" ref="MgO"/>
+   <fraction n="0.16" ref="Na2O"/>
+  </material>
+
+  <material name="Polystyrene">
+   <D value="1.06" unit="g/cm3"/>
+   <composite n="8" ref="carbon"/>
+   <composite n="8" ref="hydrogen"/>
+  </material>
+
+
+
+  <!-- preliminary values -->
+  <material name="AirSteelMixture" formula="AirSteelMixture">
+   <D value=" 0.001205*(1-0.5) + 7.9300*0.5 " unit="g/cm3"/>
+   <fraction n="0.5" ref="STEEL_STAINLESS_Fe7Cr2Ni"/>
+   <fraction n="0.5"   ref="Air"/>
+  </material>
+  <material name="vm2000" formula="vm2000">
+    <D value="1.2" unit="g/cm3"/>
+    <composite n="2" ref="carbon"/>
+    <composite n="4" ref="hydrogen"/>
+  </material>
+
+</materials>
+<solids>
+     <torus name="FieldShaperCorner" rmin="0.5" rmax="2.285" rtor="2.3" deltaphi="90" startphi="0" aunit="deg" lunit="cm"/>
+     <tube name="FieldShaperLongtube" rmin="0.5" rmax="2.285" z="896.4054" deltaphi="360" startphi="0" aunit="deg" lunit="cm"/>
+     <tube name="FieldShaperLongtubeSlim" rmin="0.5" rmax="0.75" z="896.4054" deltaphi="360" startphi="0" aunit="deg" lunit="cm"/>
+     <tube name="FieldShaperShorttube" rmin="0.5" rmax="2.285" z="1011" deltaphi="360" startphi="0" aunit="deg" lunit="cm"/>
+
+    <union name="FSunion1">
+      <first ref="FieldShaperLongtube"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos1" unit="cm" x="-2.3" y="0" z="448.2027"/>
+		<rotation name="rot1" unit="deg" x="90" y="0" z="0" />
+    </union>
+
+    <union name="FSunion2">
+      <first ref="FSunion1"/>
+      <second ref="FieldShaperShorttube"/>
+   		<position name="esquinapos2" unit="cm" x="-507.8" y="0" z="450.5027"/>
+   		<rotation name="rot2" unit="deg" x="0" y="90" z="0" />
+    </union>
+
+    <union name="FSunion3">
+      <first ref="FSunion2"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos3" unit="cm" x="-1013.3" y="0" z="448.2027"/>
+		<rotation name="rot3" unit="deg" x="90" y="270" z="0" />
+    </union>
+
+    <union name="FSunion4">
+      <first ref="FSunion3"/>
+      <second ref="FieldShaperLongtube"/>
+   		<position name="esquinapos4" unit="cm" x="-1015.6" y="0" z="0"/>
+    </union>
+
+    <union name="FSunion5">
+      <first ref="FSunion4"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos5" unit="cm" x="-1013.3" y="0" z="-448.2027"/>
+		<rotation name="rot5" unit="deg" x="90" y="180" z="0" />
+    </union>
+
+    <union name="FSunion6">
+      <first ref="FSunion5"/>
+      <second ref="FieldShaperShorttube"/>
+   		<position name="esquinapos6" unit="cm" x="-507.8" y="0" z="-450.5027"/>
+		<rotation name="rot6" unit="deg" x="0" y="90" z="0" />
+    </union>
+
+    <union name="FieldShaperSolid">
+      <first ref="FSunion6"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos7" unit="cm" x="-2.3" y="0" z="-448.2027"/>
+		<rotation name="rot7" unit="deg" x="90" y="90" z="0" />
+    </union>
+    
+    <union name="FSunionSlim1">
+      <first ref="FieldShaperLongtubeSlim"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos1" unit="cm" x="-2.3" y="0" z="448.2027"/>
+		<rotation name="rot1" unit="deg" x="90" y="0" z="0" />
+    </union>
+
+    <union name="FSunionSlim2">
+      <first ref="FSunionSlim1"/>
+      <second ref="FieldShaperShorttube"/>
+   		<position name="esquinapos2" unit="cm" x="-507.8" y="0" z="450.5027"/>
+   		<rotation name="rot2" unit="deg" x="0" y="90" z="0" />
+    </union>
+
+    <union name="FSunionSlim3">
+      <first ref="FSunionSlim2"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos3" unit="cm" x="-1013.3" y="0" z="448.2027"/>
+		<rotation name="rot3" unit="deg" x="90" y="270" z="0" />
+    </union>
+
+    <union name="FSunionSlim4">
+      <first ref="FSunionSlim3"/>
+      <second ref="FieldShaperLongtubeSlim"/>
+   		<position name="esquinapos4" unit="cm" x="-1015.6" y="0" z="0"/>
+    </union>
+
+    <union name="FSunionSlim5">
+      <first ref="FSunionSlim4"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos5" unit="cm" x="-1013.3" y="0" z="-448.2027"/>
+		<rotation name="rot5" unit="deg" x="90" y="180" z="0" />
+    </union>
+
+    <union name="FSunionSlim6">
+      <first ref="FSunionSlim5"/>
+      <second ref="FieldShaperShorttube"/>
+   		<position name="esquinapos6" unit="cm" x="-507.8" y="0" z="-450.5027"/>
+		<rotation name="rot6" unit="deg" x="0" y="90" z="0" />
+    </union>
+
+    <union name="FieldShaperSolidSlim">
+      <first ref="FSunionSlim6"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos7" unit="cm" x="-2.3" y="0" z="-448.2027"/>
+		<rotation name="rot7" unit="deg" x="90" y="90" z="0" />
+    </union>
+    
+
+   <box name="CRM"
+      x="650.08" 
+      y="168" 
+      z="148.9009"
+      lunit="cm"/>
+   <box name="CRMUPlane" 
+      x="0.02" 
+      y="168" 
+      z="148.9009"
+      lunit="cm"/>
+   <box name="CRMYPlane" 
+      x="0.02" 
+      y="168" 
+      z="148.9009"
+      lunit="cm"/>
+   <box name="CRMZPlane" 
+      x="0.02"
+      y="168"
+      z="148.9009"
+      lunit="cm"/>
+   <box name="CRMActive" 
+      x="650"
+      y="168"
+      z="148.9009"
+      lunit="cm"/>
+   <tube name="CRMWireU0"
+      rmax="0.5*0.02"
+      z="0.875550971308563"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU1"
+      rmax="0.5*0.02"
+      z="2.62665291392569"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU2"
+      rmax="0.5*0.02"
+      z="4.37775485654281"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU3"
+      rmax="0.5*0.02"
+      z="6.12885679915994"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU4"
+      rmax="0.5*0.02"
+      z="7.87995874177706"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU5"
+      rmax="0.5*0.02"
+      z="9.63106068439417"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU6"
+      rmax="0.5*0.02"
+      z="11.3821626270113"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU7"
+      rmax="0.5*0.02"
+      z="13.1332645696284"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU8"
+      rmax="0.5*0.02"
+      z="14.8843665122456"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU9"
+      rmax="0.5*0.02"
+      z="16.6354684548627"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU10"
+      rmax="0.5*0.02"
+      z="18.3865703974798"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU11"
+      rmax="0.5*0.02"
+      z="20.1376723400969"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU12"
+      rmax="0.5*0.02"
+      z="21.8887742827141"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU13"
+      rmax="0.5*0.02"
+      z="23.6398762253312"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU14"
+      rmax="0.5*0.02"
+      z="25.3909781679483"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU15"
+      rmax="0.5*0.02"
+      z="27.1420801105654"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU16"
+      rmax="0.5*0.02"
+      z="28.8931820531826"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU17"
+      rmax="0.5*0.02"
+      z="30.6442839957997"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU18"
+      rmax="0.5*0.02"
+      z="32.3953859384168"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU19"
+      rmax="0.5*0.02"
+      z="34.1464878810339"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU20"
+      rmax="0.5*0.02"
+      z="35.897589823651"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU21"
+      rmax="0.5*0.02"
+      z="37.6486917662682"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU22"
+      rmax="0.5*0.02"
+      z="39.3997937088853"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU23"
+      rmax="0.5*0.02"
+      z="41.1508956515024"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU24"
+      rmax="0.5*0.02"
+      z="42.9019975941195"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU25"
+      rmax="0.5*0.02"
+      z="44.6530995367366"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU26"
+      rmax="0.5*0.02"
+      z="46.4042014793538"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU27"
+      rmax="0.5*0.02"
+      z="48.1553034219709"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU28"
+      rmax="0.5*0.02"
+      z="49.906405364588"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU29"
+      rmax="0.5*0.02"
+      z="51.6575073072051"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU30"
+      rmax="0.5*0.02"
+      z="53.4086092498223"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU31"
+      rmax="0.5*0.02"
+      z="55.1597111924394"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU32"
+      rmax="0.5*0.02"
+      z="56.9108131350565"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU33"
+      rmax="0.5*0.02"
+      z="58.6619150776736"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU34"
+      rmax="0.5*0.02"
+      z="60.4130170202907"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU35"
+      rmax="0.5*0.02"
+      z="62.1641189629079"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU36"
+      rmax="0.5*0.02"
+      z="63.915220905525"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU37"
+      rmax="0.5*0.02"
+      z="65.6663228481421"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU38"
+      rmax="0.5*0.02"
+      z="67.4174247907592"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU39"
+      rmax="0.5*0.02"
+      z="69.1685267333764"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU40"
+      rmax="0.5*0.02"
+      z="70.9196286759935"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU41"
+      rmax="0.5*0.02"
+      z="72.6707306186106"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU42"
+      rmax="0.5*0.02"
+      z="74.4218325612277"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU43"
+      rmax="0.5*0.02"
+      z="76.1729345038449"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU44"
+      rmax="0.5*0.02"
+      z="77.924036446462"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU45"
+      rmax="0.5*0.02"
+      z="79.6751383890791"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU46"
+      rmax="0.5*0.02"
+      z="81.4262403316963"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU47"
+      rmax="0.5*0.02"
+      z="83.1773422743134"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU48"
+      rmax="0.5*0.02"
+      z="84.9284442169305"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU49"
+      rmax="0.5*0.02"
+      z="86.6795461595477"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU50"
+      rmax="0.5*0.02"
+      z="88.4306481021648"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU51"
+      rmax="0.5*0.02"
+      z="90.1817500447819"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU52"
+      rmax="0.5*0.02"
+      z="91.932851987399"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU53"
+      rmax="0.5*0.02"
+      z="93.6839539300162"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU54"
+      rmax="0.5*0.02"
+      z="95.4350558726333"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU55"
+      rmax="0.5*0.02"
+      z="97.1861578152504"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU56"
+      rmax="0.5*0.02"
+      z="98.9372597578676"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU57"
+      rmax="0.5*0.02"
+      z="100.688361700485"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU58"
+      rmax="0.5*0.02"
+      z="102.439463643102"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU59"
+      rmax="0.5*0.02"
+      z="104.190565585719"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU60"
+      rmax="0.5*0.02"
+      z="105.941667528336"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU61"
+      rmax="0.5*0.02"
+      z="107.692769470953"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU62"
+      rmax="0.5*0.02"
+      z="109.44387141357"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU63"
+      rmax="0.5*0.02"
+      z="111.194973356187"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU64"
+      rmax="0.5*0.02"
+      z="112.946075298805"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU65"
+      rmax="0.5*0.02"
+      z="114.697177241422"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU66"
+      rmax="0.5*0.02"
+      z="116.448279184039"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU67"
+      rmax="0.5*0.02"
+      z="118.199381126656"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU68"
+      rmax="0.5*0.02"
+      z="119.950483069273"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU69"
+      rmax="0.5*0.02"
+      z="121.70158501189"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU70"
+      rmax="0.5*0.02"
+      z="123.452686954507"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU71"
+      rmax="0.5*0.02"
+      z="125.203788897124"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU72"
+      rmax="0.5*0.02"
+      z="126.954890839742"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU73"
+      rmax="0.5*0.02"
+      z="128.705992782359"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU74"
+      rmax="0.5*0.02"
+      z="130.457094724976"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU75"
+      rmax="0.5*0.02"
+      z="132.208196667593"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU76"
+      rmax="0.5*0.02"
+      z="133.95929861021"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU77"
+      rmax="0.5*0.02"
+      z="135.710400552827"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU78"
+      rmax="0.5*0.02"
+      z="137.461502495444"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU79"
+      rmax="0.5*0.02"
+      z="139.212604438061"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU80"
+      rmax="0.5*0.02"
+      z="140.963706380679"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU81"
+      rmax="0.5*0.02"
+      z="142.714808323296"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU82"
+      rmax="0.5*0.02"
+      z="144.465910265913"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU83"
+      rmax="0.5*0.02"
+      z="146.21701220853"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU84"
+      rmax="0.5*0.02"
+      z="147.968114151147"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU85"
+      rmax="0.5*0.02"
+      z="149.719216093764"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU86"
+      rmax="0.5*0.02"
+      z="151.470318036381"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU87"
+      rmax="0.5*0.02"
+      z="153.221419978999"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU88"
+      rmax="0.5*0.02"
+      z="154.972521921616"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU89"
+      rmax="0.5*0.02"
+      z="156.723623864233"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU90"
+      rmax="0.5*0.02"
+      z="158.47472580685"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU91"
+      rmax="0.5*0.02"
+      z="160.225827749467"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU92"
+      rmax="0.5*0.02"
+      z="161.976929692084"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU93"
+      rmax="0.5*0.02"
+      z="163.728031634701"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU94"
+      rmax="0.5*0.02"
+      z="165.479133577318"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU95"
+      rmax="0.5*0.02"
+      z="167.230235519936"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU96"
+      rmax="0.5*0.02"
+      z="168.981337462553"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU97"
+      rmax="0.5*0.02"
+      z="170.73243940517"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU98"
+      rmax="0.5*0.02"
+      z="172.483541347787"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU99"
+      rmax="0.5*0.02"
+      z="174.234643290404"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU100"
+      rmax="0.5*0.02"
+      z="175.985745233021"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU101"
+      rmax="0.5*0.02"
+      z="177.736847175638"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU102"
+      rmax="0.5*0.02"
+      z="179.487949118255"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU103"
+      rmax="0.5*0.02"
+      z="181.239051060873"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU104"
+      rmax="0.5*0.02"
+      z="182.99015300349"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU105"
+      rmax="0.5*0.02"
+      z="184.741254946107"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU106"
+      rmax="0.5*0.02"
+      z="186.492356888724"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU107"
+      rmax="0.5*0.02"
+      z="188.243458831341"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU108"
+      rmax="0.5*0.02"
+      z="189.994560773958"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU109"
+      rmax="0.5*0.02"
+      z="191.745662716575"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU110"
+      rmax="0.5*0.02"
+      z="193.496764659192"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU111"
+      rmax="0.5*0.02"
+      z="195.24786660181"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU112"
+      rmax="0.5*0.02"
+      z="196.998968544427"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU113"
+      rmax="0.5*0.02"
+      z="198.750070487044"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU114"
+      rmax="0.5*0.02"
+      z="200.501172429661"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU115"
+      rmax="0.5*0.02"
+      z="202.252274372278"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU116"
+      rmax="0.5*0.02"
+      z="204.003376314895"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU117"
+      rmax="0.5*0.02"
+      z="205.754478257512"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU118"
+      rmax="0.5*0.02"
+      z="207.505580200129"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU119"
+      rmax="0.5*0.02"
+      z="209.256682142747"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU120"
+      rmax="0.5*0.02"
+      z="211.007784085364"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU121"
+      rmax="0.5*0.02"
+      z="212.758886027981"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU122"
+      rmax="0.5*0.02"
+      z="214.509987970598"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU123"
+      rmax="0.5*0.02"
+      z="216.261089913215"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU124"
+      rmax="0.5*0.02"
+      z="218.012191855832"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU125"
+      rmax="0.5*0.02"
+      z="219.763293798449"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU126"
+      rmax="0.5*0.02"
+      z="221.514395741067"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU127"
+      rmax="0.5*0.02"
+      z="223.265497683684"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU128"
+      rmax="0.5*0.02"
+      z="223.265497683683"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU129"
+      rmax="0.5*0.02"
+      z="221.514395741066"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU130"
+      rmax="0.5*0.02"
+      z="219.763293798449"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU131"
+      rmax="0.5*0.02"
+      z="218.012191855832"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU132"
+      rmax="0.5*0.02"
+      z="216.261089913215"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU133"
+      rmax="0.5*0.02"
+      z="214.509987970597"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU134"
+      rmax="0.5*0.02"
+      z="212.75888602798"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU135"
+      rmax="0.5*0.02"
+      z="211.007784085363"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU136"
+      rmax="0.5*0.02"
+      z="209.256682142746"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU137"
+      rmax="0.5*0.02"
+      z="207.505580200129"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU138"
+      rmax="0.5*0.02"
+      z="205.754478257512"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU139"
+      rmax="0.5*0.02"
+      z="204.003376314895"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU140"
+      rmax="0.5*0.02"
+      z="202.252274372277"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU141"
+      rmax="0.5*0.02"
+      z="200.50117242966"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU142"
+      rmax="0.5*0.02"
+      z="198.750070487043"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU143"
+      rmax="0.5*0.02"
+      z="196.998968544426"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU144"
+      rmax="0.5*0.02"
+      z="195.247866601809"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU145"
+      rmax="0.5*0.02"
+      z="193.496764659192"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU146"
+      rmax="0.5*0.02"
+      z="191.745662716575"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU147"
+      rmax="0.5*0.02"
+      z="189.994560773958"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU148"
+      rmax="0.5*0.02"
+      z="188.243458831341"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU149"
+      rmax="0.5*0.02"
+      z="186.492356888723"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU150"
+      rmax="0.5*0.02"
+      z="184.741254946106"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU151"
+      rmax="0.5*0.02"
+      z="182.990153003489"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU152"
+      rmax="0.5*0.02"
+      z="181.239051060872"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU153"
+      rmax="0.5*0.02"
+      z="179.487949118255"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU154"
+      rmax="0.5*0.02"
+      z="177.736847175638"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU155"
+      rmax="0.5*0.02"
+      z="175.985745233021"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU156"
+      rmax="0.5*0.02"
+      z="174.234643290404"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU157"
+      rmax="0.5*0.02"
+      z="172.483541347787"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU158"
+      rmax="0.5*0.02"
+      z="170.73243940517"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU159"
+      rmax="0.5*0.02"
+      z="168.981337462552"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU160"
+      rmax="0.5*0.02"
+      z="167.230235519935"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU161"
+      rmax="0.5*0.02"
+      z="165.479133577318"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU162"
+      rmax="0.5*0.02"
+      z="163.728031634701"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU163"
+      rmax="0.5*0.02"
+      z="161.976929692084"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU164"
+      rmax="0.5*0.02"
+      z="160.225827749467"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU165"
+      rmax="0.5*0.02"
+      z="158.47472580685"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU166"
+      rmax="0.5*0.02"
+      z="156.723623864233"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU167"
+      rmax="0.5*0.02"
+      z="154.972521921616"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU168"
+      rmax="0.5*0.02"
+      z="153.221419978999"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU169"
+      rmax="0.5*0.02"
+      z="151.470318036381"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU170"
+      rmax="0.5*0.02"
+      z="149.719216093764"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU171"
+      rmax="0.5*0.02"
+      z="147.968114151147"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU172"
+      rmax="0.5*0.02"
+      z="146.21701220853"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU173"
+      rmax="0.5*0.02"
+      z="144.465910265913"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU174"
+      rmax="0.5*0.02"
+      z="142.714808323296"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU175"
+      rmax="0.5*0.02"
+      z="140.963706380679"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU176"
+      rmax="0.5*0.02"
+      z="139.212604438062"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU177"
+      rmax="0.5*0.02"
+      z="137.461502495445"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU178"
+      rmax="0.5*0.02"
+      z="135.710400552828"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU179"
+      rmax="0.5*0.02"
+      z="133.95929861021"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU180"
+      rmax="0.5*0.02"
+      z="132.208196667593"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU181"
+      rmax="0.5*0.02"
+      z="130.457094724976"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU182"
+      rmax="0.5*0.02"
+      z="128.705992782359"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU183"
+      rmax="0.5*0.02"
+      z="126.954890839742"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU184"
+      rmax="0.5*0.02"
+      z="125.203788897125"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU185"
+      rmax="0.5*0.02"
+      z="123.452686954508"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU186"
+      rmax="0.5*0.02"
+      z="121.701585011891"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU187"
+      rmax="0.5*0.02"
+      z="119.950483069274"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU188"
+      rmax="0.5*0.02"
+      z="118.199381126657"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU189"
+      rmax="0.5*0.02"
+      z="116.448279184039"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU190"
+      rmax="0.5*0.02"
+      z="114.697177241422"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU191"
+      rmax="0.5*0.02"
+      z="112.946075298805"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU192"
+      rmax="0.5*0.02"
+      z="111.194973356188"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU193"
+      rmax="0.5*0.02"
+      z="109.443871413571"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU194"
+      rmax="0.5*0.02"
+      z="107.692769470954"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU195"
+      rmax="0.5*0.02"
+      z="105.941667528337"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU196"
+      rmax="0.5*0.02"
+      z="104.19056558572"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU197"
+      rmax="0.5*0.02"
+      z="102.439463643103"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU198"
+      rmax="0.5*0.02"
+      z="100.688361700486"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU199"
+      rmax="0.5*0.02"
+      z="98.9372597578684"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU200"
+      rmax="0.5*0.02"
+      z="97.1861578152513"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU201"
+      rmax="0.5*0.02"
+      z="95.4350558726343"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU202"
+      rmax="0.5*0.02"
+      z="93.6839539300172"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU203"
+      rmax="0.5*0.02"
+      z="91.9328519874001"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU204"
+      rmax="0.5*0.02"
+      z="90.181750044783"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU205"
+      rmax="0.5*0.02"
+      z="88.4306481021658"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU206"
+      rmax="0.5*0.02"
+      z="86.6795461595488"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU207"
+      rmax="0.5*0.02"
+      z="84.9284442169317"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU208"
+      rmax="0.5*0.02"
+      z="83.1773422743145"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU209"
+      rmax="0.5*0.02"
+      z="81.4262403316975"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU210"
+      rmax="0.5*0.02"
+      z="79.6751383890803"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU211"
+      rmax="0.5*0.02"
+      z="77.9240364464633"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU212"
+      rmax="0.5*0.02"
+      z="76.1729345038461"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU213"
+      rmax="0.5*0.02"
+      z="74.4218325612291"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU214"
+      rmax="0.5*0.02"
+      z="72.670730618612"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU215"
+      rmax="0.5*0.02"
+      z="70.9196286759948"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU216"
+      rmax="0.5*0.02"
+      z="69.1685267333778"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU217"
+      rmax="0.5*0.02"
+      z="67.4174247907606"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU218"
+      rmax="0.5*0.02"
+      z="65.6663228481435"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU219"
+      rmax="0.5*0.02"
+      z="63.9152209055265"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU220"
+      rmax="0.5*0.02"
+      z="62.1641189629093"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU221"
+      rmax="0.5*0.02"
+      z="60.4130170202923"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU222"
+      rmax="0.5*0.02"
+      z="58.6619150776752"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU223"
+      rmax="0.5*0.02"
+      z="56.910813135058"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU224"
+      rmax="0.5*0.02"
+      z="55.159711192441"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU225"
+      rmax="0.5*0.02"
+      z="53.4086092498239"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU226"
+      rmax="0.5*0.02"
+      z="51.6575073072067"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU227"
+      rmax="0.5*0.02"
+      z="49.9064053645897"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU228"
+      rmax="0.5*0.02"
+      z="48.1553034219725"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU229"
+      rmax="0.5*0.02"
+      z="46.4042014793555"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU230"
+      rmax="0.5*0.02"
+      z="44.6530995367384"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU231"
+      rmax="0.5*0.02"
+      z="42.9019975941212"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU232"
+      rmax="0.5*0.02"
+      z="41.1508956515042"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU233"
+      rmax="0.5*0.02"
+      z="39.399793708887"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU234"
+      rmax="0.5*0.02"
+      z="37.64869176627"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU235"
+      rmax="0.5*0.02"
+      z="35.8975898236529"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU236"
+      rmax="0.5*0.02"
+      z="34.1464878810357"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU237"
+      rmax="0.5*0.02"
+      z="32.3953859384187"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU238"
+      rmax="0.5*0.02"
+      z="30.6442839958015"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU239"
+      rmax="0.5*0.02"
+      z="28.8931820531845"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU240"
+      rmax="0.5*0.02"
+      z="27.1420801105674"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU241"
+      rmax="0.5*0.02"
+      z="25.3909781679502"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU242"
+      rmax="0.5*0.02"
+      z="23.6398762253332"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU243"
+      rmax="0.5*0.02"
+      z="21.888774282716"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU244"
+      rmax="0.5*0.02"
+      z="20.1376723400989"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU245"
+      rmax="0.5*0.02"
+      z="18.3865703974819"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU246"
+      rmax="0.5*0.02"
+      z="16.6354684548648"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU247"
+      rmax="0.5*0.02"
+      z="14.8843665122477"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU248"
+      rmax="0.5*0.02"
+      z="13.1332645696306"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU249"
+      rmax="0.5*0.02"
+      z="11.3821626270135"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU250"
+      rmax="0.5*0.02"
+      z="9.63106068439639"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU251"
+      rmax="0.5*0.02"
+      z="7.87995874177926"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU252"
+      rmax="0.5*0.02"
+      z="6.12885679916218"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU253"
+      rmax="0.5*0.02"
+      z="4.37775485654507"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU254"
+      rmax="0.5*0.02"
+      z="2.62665291392794"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU255"
+      rmax="0.5*0.02"
+      z="0.875550971310878"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireY"
+      rmax="0.5*0.02"
+      z="148.9009"               
+      deltaphi="360" 
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireZ"
+      rmax="0.5*0.02"
+      z="168"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+
+    <box name="ArapucaOut" lunit="cm"
+      x="65"
+      y="2.5"
+      z="65"/>
+
+    <box name="ArapucaIn" lunit="cm"
+      x="60"
+      y="2.5"
+      z="60"/>
+
+     <subtraction name="ArapucaWalls">
+      <first  ref="ArapucaOut"/>
+      <second ref="ArapucaIn"/>
+      <position name="posArapucaSub" x="0" y="1.25" z="0." unit="cm"/>
+      </subtraction>
+
+    <box name="ArapucaAcceptanceWindow" lunit="cm"
+      x="60"
+      y="1"
+      z="60"/>
+
+    <box name="ArapucaDoubleIn" lunit="cm"
+      x="60"
+      y="3.5"
+      z="60"/>
+
+     <subtraction name="ArapucaDoubleWalls">
+      <first  ref="ArapucaOut"/>
+      <second ref="ArapucaDoubleIn"/>
+      <position name="posArapucaDoubleSub" x="0" y="0" z="0" unit="cm"/>
+      </subtraction>
+
+    <box name="ArapucaDoubleAcceptanceWindow" lunit="cm"
+      x="2.48"
+      y="60"
+      z="60"/>
+
+    <box name="ArapucaCathodeAcceptanceWindow" lunit="cm"
+      x="1"
+      y="60"
+      z="60"/>
+
+
+    <box name="Cryostat" lunit="cm" 
+      x="850.32" 
+      y="1211.24" 
+      z="1096.6454"/>
+
+    <box name="ArgonInterior" lunit="cm" 
+      x="850.08"
+      y="1211"
+      z="1096.4054"/>
+
+    <box name="GaseousArgon" lunit="cm" 
+      x="100"
+      y="1211"
+      z="1096.4054"/>
+
+    <box name="ExternalAuxOut" lunit="cm" 
+      x="850.08 - 100"
+      y="1211 - 2*2.5 - 2*40"
+      z="1096.4054"/>
+
+    <box name="ExternalAuxIn" lunit="cm" 
+      x="850.08"
+      y="1022.17"
+      z="1096.4054 + 1"/>
+
+   <subtraction name="ExternalActive">
+      <first ref="ExternalAuxOut"/>
+      <second ref="ExternalAuxIn"/>
+    </subtraction>
+
+    <subtraction name="SteelShell">
+      <first ref="Cryostat"/>
+      <second ref="ArgonInterior"/>
+    </subtraction>
+
+
+
+    <box name="CathodeBlock" lunit="cm"
+      x="4"
+      y="336"
+      z="297.8018" />
+
+    <box name="CathodeVoid" lunit="cm"
+      x="5"
+      y="76.35"
+      z="67" />
+
+    <subtraction name="Cathode1">
+      <first ref="CathodeBlock"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub1" x="0" y="-122.525" z="-108.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode2">
+      <first ref="Cathode1"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub2" x="0" y="-122.525" z="-37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode3">
+      <first ref="Cathode2"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub3" x="0" y="-122.525" z="37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode4">
+      <first ref="Cathode3"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub4" x="0" y="-122.525" z="108.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode5">
+      <first ref="Cathode4"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub5" x="0" y="-42.175" z="-108.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode6">
+      <first ref="Cathode5"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub6" x="0" y="-42.175" z="-37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode7">
+      <first ref="Cathode6"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub7" x="0" y="-42.175" z="37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode8">
+      <first ref="Cathode7"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub8" x="0" y="-42.175" z="108.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode9">
+      <first ref="Cathode8"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub9" x="0" y="42.175" z="-108.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode10">
+      <first ref="Cathode9"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub10" x="0" y="42.175" z="-37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode11">
+      <first ref="Cathode10"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub11" x="0" y="42.175" z="37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode12">
+      <first ref="Cathode11"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub12" x="0" y="42.175" z="108.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode13">
+      <first ref="Cathode12"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub13" x="0" y="122.525" z="-108.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode14">
+      <first ref="Cathode13"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub14" x="0" y="122.525" z="-37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode15">
+      <first ref="Cathode14"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub15" x="0" y="122.525" z="37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="CathodeGrid">
+      <first ref="Cathode15"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub16" x="0" y="122.525" z="108.5" unit="cm"/>
+    </subtraction>
+
+    <box name="FoamPadBlock" lunit="cm"
+      x="1010.32"
+      y="1371.24"
+      z="1256.6454" />
+
+    <subtraction name="FoamPadding">
+      <first ref="FoamPadBlock"/>
+      <second ref="Cryostat"/>
+      <positionref ref="posCenter"/>
+    </subtraction>
+
+    <box name="SteelSupportBlock" lunit="cm"
+      x="1210.32"
+      y="1571.24"
+      z="1456.6454" />
+
+    <subtraction name="SteelSupport">
+      <first ref="SteelSupportBlock"/>
+      <second ref="FoamPadBlock"/>
+      <positionref ref="posCenter"/>
+    </subtraction>
+
+    <box name="DetEnclosure" lunit="cm" 
+      x="1310.32"
+      y="1771.24"
+      z="1656.6454"/>
+
+
+    <box name="World" lunit="cm" 
+      x="9310.32" 
+      y="9771.24" 
+      z="9656.6454"/>
+</solids>
+<structure>
+<volume name="volFieldShaper">
+  <materialref ref="Al2O3"/>
+  <solidref ref="FieldShaperSolid"/>
+</volume>
+<volume name="volFieldShaperSlim">
+  <materialref ref="Al2O3"/>
+  <solidref ref="FieldShaperSolidSlim"/>
+</volume>
+
+
+    <volume name="volTPCActive">
+      <materialref ref="LAr"/>
+      <solidref ref="CRMActive"/>
+      <auxiliary auxtype="SensDet" auxvalue="SimEnergyDeposit"/>
+      <auxiliary auxtype="StepLimit" auxunit="cm" auxvalue="0.5208*cm"/>
+      <auxiliary auxtype="Efield" auxunit="V/cm" auxvalue="500*V/cm"/>
+      <colorref ref="blue"/>
+    </volume>
+    <volume name="volTPCWireU0">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU0"/>
+    </volume>
+    <volume name="volTPCWireU1">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU1"/>
+    </volume>
+    <volume name="volTPCWireU2">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU2"/>
+    </volume>
+    <volume name="volTPCWireU3">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU3"/>
+    </volume>
+    <volume name="volTPCWireU4">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU4"/>
+    </volume>
+    <volume name="volTPCWireU5">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU5"/>
+    </volume>
+    <volume name="volTPCWireU6">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU6"/>
+    </volume>
+    <volume name="volTPCWireU7">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU7"/>
+    </volume>
+    <volume name="volTPCWireU8">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU8"/>
+    </volume>
+    <volume name="volTPCWireU9">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU9"/>
+    </volume>
+    <volume name="volTPCWireU10">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU10"/>
+    </volume>
+    <volume name="volTPCWireU11">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU11"/>
+    </volume>
+    <volume name="volTPCWireU12">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU12"/>
+    </volume>
+    <volume name="volTPCWireU13">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU13"/>
+    </volume>
+    <volume name="volTPCWireU14">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU14"/>
+    </volume>
+    <volume name="volTPCWireU15">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU15"/>
+    </volume>
+    <volume name="volTPCWireU16">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU16"/>
+    </volume>
+    <volume name="volTPCWireU17">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU17"/>
+    </volume>
+    <volume name="volTPCWireU18">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU18"/>
+    </volume>
+    <volume name="volTPCWireU19">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU19"/>
+    </volume>
+    <volume name="volTPCWireU20">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU20"/>
+    </volume>
+    <volume name="volTPCWireU21">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU21"/>
+    </volume>
+    <volume name="volTPCWireU22">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU22"/>
+    </volume>
+    <volume name="volTPCWireU23">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU23"/>
+    </volume>
+    <volume name="volTPCWireU24">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU24"/>
+    </volume>
+    <volume name="volTPCWireU25">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU25"/>
+    </volume>
+    <volume name="volTPCWireU26">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU26"/>
+    </volume>
+    <volume name="volTPCWireU27">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU27"/>
+    </volume>
+    <volume name="volTPCWireU28">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU28"/>
+    </volume>
+    <volume name="volTPCWireU29">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU29"/>
+    </volume>
+    <volume name="volTPCWireU30">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU30"/>
+    </volume>
+    <volume name="volTPCWireU31">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU31"/>
+    </volume>
+    <volume name="volTPCWireU32">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU32"/>
+    </volume>
+    <volume name="volTPCWireU33">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU33"/>
+    </volume>
+    <volume name="volTPCWireU34">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU34"/>
+    </volume>
+    <volume name="volTPCWireU35">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU35"/>
+    </volume>
+    <volume name="volTPCWireU36">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU36"/>
+    </volume>
+    <volume name="volTPCWireU37">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU37"/>
+    </volume>
+    <volume name="volTPCWireU38">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU38"/>
+    </volume>
+    <volume name="volTPCWireU39">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU39"/>
+    </volume>
+    <volume name="volTPCWireU40">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU40"/>
+    </volume>
+    <volume name="volTPCWireU41">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU41"/>
+    </volume>
+    <volume name="volTPCWireU42">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU42"/>
+    </volume>
+    <volume name="volTPCWireU43">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU43"/>
+    </volume>
+    <volume name="volTPCWireU44">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU44"/>
+    </volume>
+    <volume name="volTPCWireU45">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU45"/>
+    </volume>
+    <volume name="volTPCWireU46">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU46"/>
+    </volume>
+    <volume name="volTPCWireU47">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU47"/>
+    </volume>
+    <volume name="volTPCWireU48">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU48"/>
+    </volume>
+    <volume name="volTPCWireU49">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU49"/>
+    </volume>
+    <volume name="volTPCWireU50">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU50"/>
+    </volume>
+    <volume name="volTPCWireU51">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU51"/>
+    </volume>
+    <volume name="volTPCWireU52">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU52"/>
+    </volume>
+    <volume name="volTPCWireU53">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU53"/>
+    </volume>
+    <volume name="volTPCWireU54">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU54"/>
+    </volume>
+    <volume name="volTPCWireU55">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU55"/>
+    </volume>
+    <volume name="volTPCWireU56">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU56"/>
+    </volume>
+    <volume name="volTPCWireU57">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU57"/>
+    </volume>
+    <volume name="volTPCWireU58">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU58"/>
+    </volume>
+    <volume name="volTPCWireU59">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU59"/>
+    </volume>
+    <volume name="volTPCWireU60">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU60"/>
+    </volume>
+    <volume name="volTPCWireU61">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU61"/>
+    </volume>
+    <volume name="volTPCWireU62">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU62"/>
+    </volume>
+    <volume name="volTPCWireU63">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU63"/>
+    </volume>
+    <volume name="volTPCWireU64">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU64"/>
+    </volume>
+    <volume name="volTPCWireU65">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU65"/>
+    </volume>
+    <volume name="volTPCWireU66">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU66"/>
+    </volume>
+    <volume name="volTPCWireU67">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU67"/>
+    </volume>
+    <volume name="volTPCWireU68">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU68"/>
+    </volume>
+    <volume name="volTPCWireU69">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU69"/>
+    </volume>
+    <volume name="volTPCWireU70">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU70"/>
+    </volume>
+    <volume name="volTPCWireU71">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU71"/>
+    </volume>
+    <volume name="volTPCWireU72">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU72"/>
+    </volume>
+    <volume name="volTPCWireU73">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU73"/>
+    </volume>
+    <volume name="volTPCWireU74">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU74"/>
+    </volume>
+    <volume name="volTPCWireU75">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU75"/>
+    </volume>
+    <volume name="volTPCWireU76">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU76"/>
+    </volume>
+    <volume name="volTPCWireU77">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU77"/>
+    </volume>
+    <volume name="volTPCWireU78">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU78"/>
+    </volume>
+    <volume name="volTPCWireU79">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU79"/>
+    </volume>
+    <volume name="volTPCWireU80">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU80"/>
+    </volume>
+    <volume name="volTPCWireU81">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU81"/>
+    </volume>
+    <volume name="volTPCWireU82">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU82"/>
+    </volume>
+    <volume name="volTPCWireU83">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU83"/>
+    </volume>
+    <volume name="volTPCWireU84">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU84"/>
+    </volume>
+    <volume name="volTPCWireU85">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU85"/>
+    </volume>
+    <volume name="volTPCWireU86">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU86"/>
+    </volume>
+    <volume name="volTPCWireU87">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU87"/>
+    </volume>
+    <volume name="volTPCWireU88">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU88"/>
+    </volume>
+    <volume name="volTPCWireU89">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU89"/>
+    </volume>
+    <volume name="volTPCWireU90">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU90"/>
+    </volume>
+    <volume name="volTPCWireU91">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU91"/>
+    </volume>
+    <volume name="volTPCWireU92">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU92"/>
+    </volume>
+    <volume name="volTPCWireU93">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU93"/>
+    </volume>
+    <volume name="volTPCWireU94">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU94"/>
+    </volume>
+    <volume name="volTPCWireU95">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU95"/>
+    </volume>
+    <volume name="volTPCWireU96">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU96"/>
+    </volume>
+    <volume name="volTPCWireU97">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU97"/>
+    </volume>
+    <volume name="volTPCWireU98">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU98"/>
+    </volume>
+    <volume name="volTPCWireU99">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU99"/>
+    </volume>
+    <volume name="volTPCWireU100">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU100"/>
+    </volume>
+    <volume name="volTPCWireU101">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU101"/>
+    </volume>
+    <volume name="volTPCWireU102">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU102"/>
+    </volume>
+    <volume name="volTPCWireU103">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU103"/>
+    </volume>
+    <volume name="volTPCWireU104">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU104"/>
+    </volume>
+    <volume name="volTPCWireU105">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU105"/>
+    </volume>
+    <volume name="volTPCWireU106">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU106"/>
+    </volume>
+    <volume name="volTPCWireU107">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU107"/>
+    </volume>
+    <volume name="volTPCWireU108">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU108"/>
+    </volume>
+    <volume name="volTPCWireU109">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU109"/>
+    </volume>
+    <volume name="volTPCWireU110">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU110"/>
+    </volume>
+    <volume name="volTPCWireU111">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU111"/>
+    </volume>
+    <volume name="volTPCWireU112">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU112"/>
+    </volume>
+    <volume name="volTPCWireU113">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU113"/>
+    </volume>
+    <volume name="volTPCWireU114">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU114"/>
+    </volume>
+    <volume name="volTPCWireU115">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU115"/>
+    </volume>
+    <volume name="volTPCWireU116">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU116"/>
+    </volume>
+    <volume name="volTPCWireU117">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU117"/>
+    </volume>
+    <volume name="volTPCWireU118">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU118"/>
+    </volume>
+    <volume name="volTPCWireU119">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU119"/>
+    </volume>
+    <volume name="volTPCWireU120">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU120"/>
+    </volume>
+    <volume name="volTPCWireU121">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU121"/>
+    </volume>
+    <volume name="volTPCWireU122">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU122"/>
+    </volume>
+    <volume name="volTPCWireU123">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU123"/>
+    </volume>
+    <volume name="volTPCWireU124">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU124"/>
+    </volume>
+    <volume name="volTPCWireU125">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU125"/>
+    </volume>
+    <volume name="volTPCWireU126">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU126"/>
+    </volume>
+    <volume name="volTPCWireU127">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU127"/>
+    </volume>
+    <volume name="volTPCWireU128">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU128"/>
+    </volume>
+    <volume name="volTPCWireU129">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU129"/>
+    </volume>
+    <volume name="volTPCWireU130">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU130"/>
+    </volume>
+    <volume name="volTPCWireU131">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU131"/>
+    </volume>
+    <volume name="volTPCWireU132">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU132"/>
+    </volume>
+    <volume name="volTPCWireU133">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU133"/>
+    </volume>
+    <volume name="volTPCWireU134">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU134"/>
+    </volume>
+    <volume name="volTPCWireU135">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU135"/>
+    </volume>
+    <volume name="volTPCWireU136">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU136"/>
+    </volume>
+    <volume name="volTPCWireU137">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU137"/>
+    </volume>
+    <volume name="volTPCWireU138">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU138"/>
+    </volume>
+    <volume name="volTPCWireU139">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU139"/>
+    </volume>
+    <volume name="volTPCWireU140">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU140"/>
+    </volume>
+    <volume name="volTPCWireU141">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU141"/>
+    </volume>
+    <volume name="volTPCWireU142">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU142"/>
+    </volume>
+    <volume name="volTPCWireU143">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU143"/>
+    </volume>
+    <volume name="volTPCWireU144">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU144"/>
+    </volume>
+    <volume name="volTPCWireU145">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU145"/>
+    </volume>
+    <volume name="volTPCWireU146">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU146"/>
+    </volume>
+    <volume name="volTPCWireU147">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU147"/>
+    </volume>
+    <volume name="volTPCWireU148">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU148"/>
+    </volume>
+    <volume name="volTPCWireU149">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU149"/>
+    </volume>
+    <volume name="volTPCWireU150">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU150"/>
+    </volume>
+    <volume name="volTPCWireU151">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU151"/>
+    </volume>
+    <volume name="volTPCWireU152">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU152"/>
+    </volume>
+    <volume name="volTPCWireU153">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU153"/>
+    </volume>
+    <volume name="volTPCWireU154">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU154"/>
+    </volume>
+    <volume name="volTPCWireU155">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU155"/>
+    </volume>
+    <volume name="volTPCWireU156">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU156"/>
+    </volume>
+    <volume name="volTPCWireU157">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU157"/>
+    </volume>
+    <volume name="volTPCWireU158">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU158"/>
+    </volume>
+    <volume name="volTPCWireU159">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU159"/>
+    </volume>
+    <volume name="volTPCWireU160">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU160"/>
+    </volume>
+    <volume name="volTPCWireU161">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU161"/>
+    </volume>
+    <volume name="volTPCWireU162">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU162"/>
+    </volume>
+    <volume name="volTPCWireU163">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU163"/>
+    </volume>
+    <volume name="volTPCWireU164">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU164"/>
+    </volume>
+    <volume name="volTPCWireU165">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU165"/>
+    </volume>
+    <volume name="volTPCWireU166">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU166"/>
+    </volume>
+    <volume name="volTPCWireU167">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU167"/>
+    </volume>
+    <volume name="volTPCWireU168">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU168"/>
+    </volume>
+    <volume name="volTPCWireU169">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU169"/>
+    </volume>
+    <volume name="volTPCWireU170">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU170"/>
+    </volume>
+    <volume name="volTPCWireU171">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU171"/>
+    </volume>
+    <volume name="volTPCWireU172">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU172"/>
+    </volume>
+    <volume name="volTPCWireU173">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU173"/>
+    </volume>
+    <volume name="volTPCWireU174">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU174"/>
+    </volume>
+    <volume name="volTPCWireU175">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU175"/>
+    </volume>
+    <volume name="volTPCWireU176">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU176"/>
+    </volume>
+    <volume name="volTPCWireU177">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU177"/>
+    </volume>
+    <volume name="volTPCWireU178">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU178"/>
+    </volume>
+    <volume name="volTPCWireU179">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU179"/>
+    </volume>
+    <volume name="volTPCWireU180">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU180"/>
+    </volume>
+    <volume name="volTPCWireU181">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU181"/>
+    </volume>
+    <volume name="volTPCWireU182">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU182"/>
+    </volume>
+    <volume name="volTPCWireU183">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU183"/>
+    </volume>
+    <volume name="volTPCWireU184">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU184"/>
+    </volume>
+    <volume name="volTPCWireU185">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU185"/>
+    </volume>
+    <volume name="volTPCWireU186">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU186"/>
+    </volume>
+    <volume name="volTPCWireU187">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU187"/>
+    </volume>
+    <volume name="volTPCWireU188">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU188"/>
+    </volume>
+    <volume name="volTPCWireU189">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU189"/>
+    </volume>
+    <volume name="volTPCWireU190">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU190"/>
+    </volume>
+    <volume name="volTPCWireU191">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU191"/>
+    </volume>
+    <volume name="volTPCWireU192">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU192"/>
+    </volume>
+    <volume name="volTPCWireU193">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU193"/>
+    </volume>
+    <volume name="volTPCWireU194">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU194"/>
+    </volume>
+    <volume name="volTPCWireU195">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU195"/>
+    </volume>
+    <volume name="volTPCWireU196">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU196"/>
+    </volume>
+    <volume name="volTPCWireU197">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU197"/>
+    </volume>
+    <volume name="volTPCWireU198">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU198"/>
+    </volume>
+    <volume name="volTPCWireU199">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU199"/>
+    </volume>
+    <volume name="volTPCWireU200">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU200"/>
+    </volume>
+    <volume name="volTPCWireU201">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU201"/>
+    </volume>
+    <volume name="volTPCWireU202">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU202"/>
+    </volume>
+    <volume name="volTPCWireU203">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU203"/>
+    </volume>
+    <volume name="volTPCWireU204">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU204"/>
+    </volume>
+    <volume name="volTPCWireU205">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU205"/>
+    </volume>
+    <volume name="volTPCWireU206">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU206"/>
+    </volume>
+    <volume name="volTPCWireU207">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU207"/>
+    </volume>
+    <volume name="volTPCWireU208">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU208"/>
+    </volume>
+    <volume name="volTPCWireU209">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU209"/>
+    </volume>
+    <volume name="volTPCWireU210">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU210"/>
+    </volume>
+    <volume name="volTPCWireU211">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU211"/>
+    </volume>
+    <volume name="volTPCWireU212">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU212"/>
+    </volume>
+    <volume name="volTPCWireU213">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU213"/>
+    </volume>
+    <volume name="volTPCWireU214">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU214"/>
+    </volume>
+    <volume name="volTPCWireU215">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU215"/>
+    </volume>
+    <volume name="volTPCWireU216">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU216"/>
+    </volume>
+    <volume name="volTPCWireU217">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU217"/>
+    </volume>
+    <volume name="volTPCWireU218">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU218"/>
+    </volume>
+    <volume name="volTPCWireU219">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU219"/>
+    </volume>
+    <volume name="volTPCWireU220">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU220"/>
+    </volume>
+    <volume name="volTPCWireU221">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU221"/>
+    </volume>
+    <volume name="volTPCWireU222">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU222"/>
+    </volume>
+    <volume name="volTPCWireU223">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU223"/>
+    </volume>
+    <volume name="volTPCWireU224">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU224"/>
+    </volume>
+    <volume name="volTPCWireU225">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU225"/>
+    </volume>
+    <volume name="volTPCWireU226">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU226"/>
+    </volume>
+    <volume name="volTPCWireU227">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU227"/>
+    </volume>
+    <volume name="volTPCWireU228">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU228"/>
+    </volume>
+    <volume name="volTPCWireU229">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU229"/>
+    </volume>
+    <volume name="volTPCWireU230">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU230"/>
+    </volume>
+    <volume name="volTPCWireU231">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU231"/>
+    </volume>
+    <volume name="volTPCWireU232">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU232"/>
+    </volume>
+    <volume name="volTPCWireU233">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU233"/>
+    </volume>
+    <volume name="volTPCWireU234">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU234"/>
+    </volume>
+    <volume name="volTPCWireU235">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU235"/>
+    </volume>
+    <volume name="volTPCWireU236">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU236"/>
+    </volume>
+    <volume name="volTPCWireU237">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU237"/>
+    </volume>
+    <volume name="volTPCWireU238">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU238"/>
+    </volume>
+    <volume name="volTPCWireU239">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU239"/>
+    </volume>
+    <volume name="volTPCWireU240">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU240"/>
+    </volume>
+    <volume name="volTPCWireU241">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU241"/>
+    </volume>
+    <volume name="volTPCWireU242">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU242"/>
+    </volume>
+    <volume name="volTPCWireU243">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU243"/>
+    </volume>
+    <volume name="volTPCWireU244">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU244"/>
+    </volume>
+    <volume name="volTPCWireU245">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU245"/>
+    </volume>
+    <volume name="volTPCWireU246">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU246"/>
+    </volume>
+    <volume name="volTPCWireU247">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU247"/>
+    </volume>
+    <volume name="volTPCWireU248">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU248"/>
+    </volume>
+    <volume name="volTPCWireU249">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU249"/>
+    </volume>
+    <volume name="volTPCWireU250">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU250"/>
+    </volume>
+    <volume name="volTPCWireU251">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU251"/>
+    </volume>
+    <volume name="volTPCWireU252">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU252"/>
+    </volume>
+    <volume name="volTPCWireU253">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU253"/>
+    </volume>
+    <volume name="volTPCWireU254">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU254"/>
+    </volume>
+    <volume name="volTPCWireU255">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU255"/>
+    </volume>
+    <volume name="volTPCWireY">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireY"/>
+    </volume>
+    <volume name="volTPCWireZ">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireZ"/>
+    </volume>
+   <volume name="volTPCPlaneU">
+     <materialref ref="LAr"/>
+     <solidref ref="CRMUPlane"/>
+     <physvol>
+       <volumeref ref="volTPCWireU0"/> 
+       <position name="posWireU0" unit="cm" x="0" y="-83.4399379809595" z="-74.1596073595279"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU1"/> 
+       <position name="posWireU1" unit="cm" x="0" y="-82.7855070948343" z="-73.5779633802374"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU2"/> 
+       <position name="posWireU2" unit="cm" x="0" y="-82.1310762087091" z="-72.996319400947"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU3"/> 
+       <position name="posWireU3" unit="cm" x="0" y="-81.476645322584" z="-72.4146754216566"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU4"/> 
+       <position name="posWireU4" unit="cm" x="0" y="-80.8222144364588" z="-71.8330314423662"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU5"/> 
+       <position name="posWireU5" unit="cm" x="0" y="-80.1677835503336" z="-71.2513874630758"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU6"/> 
+       <position name="posWireU6" unit="cm" x="0" y="-79.5133526642084" z="-70.6697434837854"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU7"/> 
+       <position name="posWireU7" unit="cm" x="0" y="-78.8589217780833" z="-70.0880995044949"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU8"/> 
+       <position name="posWireU8" unit="cm" x="0" y="-78.2044908919581" z="-69.5064555252045"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU9"/> 
+       <position name="posWireU9" unit="cm" x="0" y="-77.5500600058329" z="-68.9248115459141"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU10"/> 
+       <position name="posWireU10" unit="cm" x="0" y="-76.8956291197078" z="-68.3431675666237"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU11"/> 
+       <position name="posWireU11" unit="cm" x="0" y="-76.2411982335826" z="-67.7615235873333"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU12"/> 
+       <position name="posWireU12" unit="cm" x="0" y="-75.5867673474574" z="-67.1798796080429"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU13"/> 
+       <position name="posWireU13" unit="cm" x="0" y="-74.9323364613322" z="-66.5982356287525"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU14"/> 
+       <position name="posWireU14" unit="cm" x="0" y="-74.2779055752071" z="-66.016591649462"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU15"/> 
+       <position name="posWireU15" unit="cm" x="0" y="-73.6234746890819" z="-65.4349476701716"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU16"/> 
+       <position name="posWireU16" unit="cm" x="0" y="-72.9690438029567" z="-64.8533036908812"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU17"/> 
+       <position name="posWireU17" unit="cm" x="0" y="-72.3146129168315" z="-64.2716597115908"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU18"/> 
+       <position name="posWireU18" unit="cm" x="0" y="-71.6601820307064" z="-63.6900157323004"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU19"/> 
+       <position name="posWireU19" unit="cm" x="0" y="-71.0057511445812" z="-63.10837175301"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU20"/> 
+       <position name="posWireU20" unit="cm" x="0" y="-70.351320258456" z="-62.5267277737196"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU21"/> 
+       <position name="posWireU21" unit="cm" x="0" y="-69.6968893723309" z="-61.9450837944292"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU22"/> 
+       <position name="posWireU22" unit="cm" x="0" y="-69.0424584862057" z="-61.3634398151387"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU23"/> 
+       <position name="posWireU23" unit="cm" x="0" y="-68.3880276000805" z="-60.7817958358483"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU24"/> 
+       <position name="posWireU24" unit="cm" x="0" y="-67.7335967139554" z="-60.2001518565579"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU25"/> 
+       <position name="posWireU25" unit="cm" x="0" y="-67.0791658278302" z="-59.6185078772675"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU26"/> 
+       <position name="posWireU26" unit="cm" x="0" y="-66.424734941705" z="-59.0368638979771"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU27"/> 
+       <position name="posWireU27" unit="cm" x="0" y="-65.7703040555798" z="-58.4552199186867"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU28"/> 
+       <position name="posWireU28" unit="cm" x="0" y="-65.1158731694547" z="-57.8735759393963"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU29"/> 
+       <position name="posWireU29" unit="cm" x="0" y="-64.4614422833295" z="-57.2919319601058"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU30"/> 
+       <position name="posWireU30" unit="cm" x="0" y="-63.8070113972043" z="-56.7102879808154"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU31"/> 
+       <position name="posWireU31" unit="cm" x="0" y="-63.1525805110792" z="-56.128644001525"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU32"/> 
+       <position name="posWireU32" unit="cm" x="0" y="-62.498149624954" z="-55.5470000222346"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU33"/> 
+       <position name="posWireU33" unit="cm" x="0" y="-61.8437187388288" z="-54.9653560429442"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU34"/> 
+       <position name="posWireU34" unit="cm" x="0" y="-61.1892878527036" z="-54.3837120636538"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU35"/> 
+       <position name="posWireU35" unit="cm" x="0" y="-60.5348569665785" z="-53.8020680843634"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU36"/> 
+       <position name="posWireU36" unit="cm" x="0" y="-59.8804260804533" z="-53.220424105073"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU37"/> 
+       <position name="posWireU37" unit="cm" x="0" y="-59.2259951943281" z="-52.6387801257825"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU38"/> 
+       <position name="posWireU38" unit="cm" x="0" y="-58.571564308203" z="-52.0571361464921"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU39"/> 
+       <position name="posWireU39" unit="cm" x="0" y="-57.9171334220778" z="-51.4754921672017"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU40"/> 
+       <position name="posWireU40" unit="cm" x="0" y="-57.2627025359526" z="-50.8938481879113"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU41"/> 
+       <position name="posWireU41" unit="cm" x="0" y="-56.6082716498274" z="-50.3122042086209"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU42"/> 
+       <position name="posWireU42" unit="cm" x="0" y="-55.9538407637023" z="-49.7305602293305"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU43"/> 
+       <position name="posWireU43" unit="cm" x="0" y="-55.2994098775771" z="-49.14891625004"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU44"/> 
+       <position name="posWireU44" unit="cm" x="0" y="-54.6449789914519" z="-48.5672722707496"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU45"/> 
+       <position name="posWireU45" unit="cm" x="0" y="-53.9905481053267" z="-47.9856282914592"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU46"/> 
+       <position name="posWireU46" unit="cm" x="0" y="-53.3361172192016" z="-47.4039843121688"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU47"/> 
+       <position name="posWireU47" unit="cm" x="0" y="-52.6816863330764" z="-46.8223403328784"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU48"/> 
+       <position name="posWireU48" unit="cm" x="0" y="-52.0272554469512" z="-46.240696353588"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU49"/> 
+       <position name="posWireU49" unit="cm" x="0" y="-51.372824560826" z="-45.6590523742975"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU50"/> 
+       <position name="posWireU50" unit="cm" x="0" y="-50.7183936747009" z="-45.0774083950071"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU51"/> 
+       <position name="posWireU51" unit="cm" x="0" y="-50.0639627885757" z="-44.4957644157167"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU52"/> 
+       <position name="posWireU52" unit="cm" x="0" y="-49.4095319024505" z="-43.9141204364263"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU53"/> 
+       <position name="posWireU53" unit="cm" x="0" y="-48.7551010163253" z="-43.3324764571359"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU54"/> 
+       <position name="posWireU54" unit="cm" x="0" y="-48.1006701302002" z="-42.7508324778455"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU55"/> 
+       <position name="posWireU55" unit="cm" x="0" y="-47.446239244075" z="-42.1691884985551"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU56"/> 
+       <position name="posWireU56" unit="cm" x="0" y="-46.7918083579498" z="-41.5875445192646"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU57"/> 
+       <position name="posWireU57" unit="cm" x="0" y="-46.1373774718246" z="-41.0059005399742"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU58"/> 
+       <position name="posWireU58" unit="cm" x="0" y="-45.4829465856995" z="-40.4242565606838"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU59"/> 
+       <position name="posWireU59" unit="cm" x="0" y="-44.8285156995743" z="-39.8426125813934"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU60"/> 
+       <position name="posWireU60" unit="cm" x="0" y="-44.1740848134491" z="-39.260968602103"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU61"/> 
+       <position name="posWireU61" unit="cm" x="0" y="-43.5196539273239" z="-38.6793246228126"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU62"/> 
+       <position name="posWireU62" unit="cm" x="0" y="-42.8652230411988" z="-38.0976806435221"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU63"/> 
+       <position name="posWireU63" unit="cm" x="0" y="-42.2107921550736" z="-37.5160366642317"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU64"/> 
+       <position name="posWireU64" unit="cm" x="0" y="-41.5563612689484" z="-36.9343926849413"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU65"/> 
+       <position name="posWireU65" unit="cm" x="0" y="-40.9019303828233" z="-36.3527487056509"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU66"/> 
+       <position name="posWireU66" unit="cm" x="0" y="-40.2474994966981" z="-35.7711047263605"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU67"/> 
+       <position name="posWireU67" unit="cm" x="0" y="-39.5930686105729" z="-35.1894607470701"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU68"/> 
+       <position name="posWireU68" unit="cm" x="0" y="-38.9386377244477" z="-34.6078167677796"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU69"/> 
+       <position name="posWireU69" unit="cm" x="0" y="-38.2842068383226" z="-34.0261727884892"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU70"/> 
+       <position name="posWireU70" unit="cm" x="0" y="-37.6297759521974" z="-33.4445288091988"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU71"/> 
+       <position name="posWireU71" unit="cm" x="0" y="-36.9753450660722" z="-32.8628848299084"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU72"/> 
+       <position name="posWireU72" unit="cm" x="0" y="-36.320914179947" z="-32.281240850618"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU73"/> 
+       <position name="posWireU73" unit="cm" x="0" y="-35.6664832938219" z="-31.6995968713276"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU74"/> 
+       <position name="posWireU74" unit="cm" x="0" y="-35.0120524076967" z="-31.1179528920372"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU75"/> 
+       <position name="posWireU75" unit="cm" x="0" y="-34.3576215215715" z="-30.5363089127467"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU76"/> 
+       <position name="posWireU76" unit="cm" x="0" y="-33.7031906354463" z="-29.9546649334563"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU77"/> 
+       <position name="posWireU77" unit="cm" x="0" y="-33.0487597493212" z="-29.3730209541659"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU78"/> 
+       <position name="posWireU78" unit="cm" x="0" y="-32.394328863196" z="-28.7913769748755"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU79"/> 
+       <position name="posWireU79" unit="cm" x="0" y="-31.7398979770708" z="-28.2097329955851"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU80"/> 
+       <position name="posWireU80" unit="cm" x="0" y="-31.0854670909456" z="-27.6280890162947"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU81"/> 
+       <position name="posWireU81" unit="cm" x="0" y="-30.4310362048205" z="-27.0464450370042"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU82"/> 
+       <position name="posWireU82" unit="cm" x="0" y="-29.7766053186953" z="-26.4648010577138"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU83"/> 
+       <position name="posWireU83" unit="cm" x="0" y="-29.1221744325701" z="-25.8831570784234"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU84"/> 
+       <position name="posWireU84" unit="cm" x="0" y="-28.467743546445" z="-25.301513099133"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU85"/> 
+       <position name="posWireU85" unit="cm" x="0" y="-27.8133126603198" z="-24.7198691198426"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU86"/> 
+       <position name="posWireU86" unit="cm" x="0" y="-27.1588817741946" z="-24.1382251405522"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU87"/> 
+       <position name="posWireU87" unit="cm" x="0" y="-26.5044508880694" z="-23.5565811612617"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU88"/> 
+       <position name="posWireU88" unit="cm" x="0" y="-25.8500200019443" z="-22.9749371819713"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU89"/> 
+       <position name="posWireU89" unit="cm" x="0" y="-25.1955891158191" z="-22.3932932026809"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU90"/> 
+       <position name="posWireU90" unit="cm" x="0" y="-24.5411582296939" z="-21.8116492233905"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU91"/> 
+       <position name="posWireU91" unit="cm" x="0" y="-23.8867273435687" z="-21.2300052441001"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU92"/> 
+       <position name="posWireU92" unit="cm" x="0" y="-23.2322964574436" z="-20.6483612648097"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU93"/> 
+       <position name="posWireU93" unit="cm" x="0" y="-22.5778655713184" z="-20.0667172855192"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU94"/> 
+       <position name="posWireU94" unit="cm" x="0" y="-21.9234346851932" z="-19.4850733062288"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU95"/> 
+       <position name="posWireU95" unit="cm" x="0" y="-21.269003799068" z="-18.9034293269384"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU96"/> 
+       <position name="posWireU96" unit="cm" x="0" y="-20.6145729129429" z="-18.321785347648"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU97"/> 
+       <position name="posWireU97" unit="cm" x="0" y="-19.9601420268177" z="-17.7401413683576"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU98"/> 
+       <position name="posWireU98" unit="cm" x="0" y="-19.3057111406925" z="-17.1584973890672"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU99"/> 
+       <position name="posWireU99" unit="cm" x="0" y="-18.6512802545673" z="-16.5768534097767"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU100"/> 
+       <position name="posWireU100" unit="cm" x="0" y="-17.9968493684422" z="-15.9952094304863"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU101"/> 
+       <position name="posWireU101" unit="cm" x="0" y="-17.342418482317" z="-15.4135654511959"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU102"/> 
+       <position name="posWireU102" unit="cm" x="0" y="-16.6879875961918" z="-14.8319214719055"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU103"/> 
+       <position name="posWireU103" unit="cm" x="0" y="-16.0335567100666" z="-14.2502774926151"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU104"/> 
+       <position name="posWireU104" unit="cm" x="0" y="-15.3791258239415" z="-13.6686335133247"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU105"/> 
+       <position name="posWireU105" unit="cm" x="0" y="-14.7246949378163" z="-13.0869895340343"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU106"/> 
+       <position name="posWireU106" unit="cm" x="0" y="-14.0702640516911" z="-12.5053455547438"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU107"/> 
+       <position name="posWireU107" unit="cm" x="0" y="-13.415833165566" z="-11.9237015754534"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU108"/> 
+       <position name="posWireU108" unit="cm" x="0" y="-12.7614022794408" z="-11.342057596163"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU109"/> 
+       <position name="posWireU109" unit="cm" x="0" y="-12.1069713933156" z="-10.7604136168726"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU110"/> 
+       <position name="posWireU110" unit="cm" x="0" y="-11.4525405071904" z="-10.1787696375822"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU111"/> 
+       <position name="posWireU111" unit="cm" x="0" y="-10.7981096210653" z="-9.59712565829176"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU112"/> 
+       <position name="posWireU112" unit="cm" x="0" y="-10.1436787349401" z="-9.01548167900135"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU113"/> 
+       <position name="posWireU113" unit="cm" x="0" y="-9.4892478488149" z="-8.43383769971093"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU114"/> 
+       <position name="posWireU114" unit="cm" x="0" y="-8.83481696268973" z="-7.85219372042052"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU115"/> 
+       <position name="posWireU115" unit="cm" x="0" y="-8.18038607656456" z="-7.2705497411301"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU116"/> 
+       <position name="posWireU116" unit="cm" x="0" y="-7.52595519043939" z="-6.68890576183968"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU117"/> 
+       <position name="posWireU117" unit="cm" x="0" y="-6.87152430431422" z="-6.10726178254927"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU118"/> 
+       <position name="posWireU118" unit="cm" x="0" y="-6.21709341818904" z="-5.52561780325885"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU119"/> 
+       <position name="posWireU119" unit="cm" x="0" y="-5.56266253206387" z="-4.94397382396843"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU120"/> 
+       <position name="posWireU120" unit="cm" x="0" y="-4.90823164593868" z="-4.36232984467803"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU121"/> 
+       <position name="posWireU121" unit="cm" x="0" y="-4.25380075981352" z="-3.78068586538761"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU122"/> 
+       <position name="posWireU122" unit="cm" x="0" y="-3.59936987368835" z="-3.19904188609719"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU123"/> 
+       <position name="posWireU123" unit="cm" x="0" y="-2.94493898756318" z="-2.61739790680677"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU124"/> 
+       <position name="posWireU124" unit="cm" x="0" y="-2.29050810143798" z="-2.03575392751635"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU125"/> 
+       <position name="posWireU125" unit="cm" x="0" y="-1.63607721531281" z="-1.45410994822593"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU126"/> 
+       <position name="posWireU126" unit="cm" x="0" y="-0.98164632918764" z="-0.872465968935515"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU127"/> 
+       <position name="posWireU127" unit="cm" x="0" y="-0.327215443062471" z="-0.290821989645096"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU128"/> 
+       <position name="posWireU128" unit="cm" x="0" y="0.327215443062705" z="0.290821989645316"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU129"/> 
+       <position name="posWireU129" unit="cm" x="0" y="0.981646329187875" z="0.872465968935728"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU130"/> 
+       <position name="posWireU130" unit="cm" x="0" y="1.63607721531305" z="1.45410994822615"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU131"/> 
+       <position name="posWireU131" unit="cm" x="0" y="2.29050810143823" z="2.03575392751656"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU132"/> 
+       <position name="posWireU132" unit="cm" x="0" y="2.9449389875634" z="2.61739790680698"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU133"/> 
+       <position name="posWireU133" unit="cm" x="0" y="3.59936987368857" z="3.19904188609739"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU134"/> 
+       <position name="posWireU134" unit="cm" x="0" y="4.25380075981374" z="3.7806858653878"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU135"/> 
+       <position name="posWireU135" unit="cm" x="0" y="4.90823164593891" z="4.36232984467821"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU136"/> 
+       <position name="posWireU136" unit="cm" x="0" y="5.56266253206409" z="4.94397382396863"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU137"/> 
+       <position name="posWireU137" unit="cm" x="0" y="6.21709341818926" z="5.52561780325905"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU138"/> 
+       <position name="posWireU138" unit="cm" x="0" y="6.87152430431443" z="6.10726178254946"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU139"/> 
+       <position name="posWireU139" unit="cm" x="0" y="7.5259551904396" z="6.68890576183988"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU140"/> 
+       <position name="posWireU140" unit="cm" x="0" y="8.18038607656479" z="7.2705497411303"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU141"/> 
+       <position name="posWireU141" unit="cm" x="0" y="8.83481696268996" z="7.85219372042071"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU142"/> 
+       <position name="posWireU142" unit="cm" x="0" y="9.48924784881513" z="8.43383769971113"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU143"/> 
+       <position name="posWireU143" unit="cm" x="0" y="10.1436787349403" z="9.01548167900155"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU144"/> 
+       <position name="posWireU144" unit="cm" x="0" y="10.7981096210655" z="9.59712565829196"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU145"/> 
+       <position name="posWireU145" unit="cm" x="0" y="11.4525405071907" z="10.1787696375824"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU146"/> 
+       <position name="posWireU146" unit="cm" x="0" y="12.1069713933158" z="10.7604136168728"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU147"/> 
+       <position name="posWireU147" unit="cm" x="0" y="12.761402279441" z="11.3420575961632"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU148"/> 
+       <position name="posWireU148" unit="cm" x="0" y="13.4158331655662" z="11.9237015754536"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU149"/> 
+       <position name="posWireU149" unit="cm" x="0" y="14.0702640516913" z="12.505345554744"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU150"/> 
+       <position name="posWireU150" unit="cm" x="0" y="14.7246949378165" z="13.0869895340344"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU151"/> 
+       <position name="posWireU151" unit="cm" x="0" y="15.3791258239416" z="13.6686335133248"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU152"/> 
+       <position name="posWireU152" unit="cm" x="0" y="16.0335567100668" z="14.2502774926152"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU153"/> 
+       <position name="posWireU153" unit="cm" x="0" y="16.687987596192" z="14.8319214719056"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU154"/> 
+       <position name="posWireU154" unit="cm" x="0" y="17.3424184823171" z="15.413565451196"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU155"/> 
+       <position name="posWireU155" unit="cm" x="0" y="17.9968493684423" z="15.9952094304864"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU156"/> 
+       <position name="posWireU156" unit="cm" x="0" y="18.6512802545675" z="16.5768534097769"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU157"/> 
+       <position name="posWireU157" unit="cm" x="0" y="19.3057111406926" z="17.1584973890673"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU158"/> 
+       <position name="posWireU158" unit="cm" x="0" y="19.9601420268178" z="17.7401413683577"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU159"/> 
+       <position name="posWireU159" unit="cm" x="0" y="20.614572912943" z="18.3217853476481"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU160"/> 
+       <position name="posWireU160" unit="cm" x="0" y="21.2690037990681" z="18.9034293269385"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU161"/> 
+       <position name="posWireU161" unit="cm" x="0" y="21.9234346851933" z="19.4850733062289"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU162"/> 
+       <position name="posWireU162" unit="cm" x="0" y="22.5778655713184" z="20.0667172855193"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU163"/> 
+       <position name="posWireU163" unit="cm" x="0" y="23.2322964574436" z="20.6483612648097"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU164"/> 
+       <position name="posWireU164" unit="cm" x="0" y="23.8867273435688" z="21.2300052441001"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU165"/> 
+       <position name="posWireU165" unit="cm" x="0" y="24.5411582296939" z="21.8116492233905"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU166"/> 
+       <position name="posWireU166" unit="cm" x="0" y="25.1955891158191" z="22.3932932026809"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU167"/> 
+       <position name="posWireU167" unit="cm" x="0" y="25.8500200019443" z="22.9749371819713"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU168"/> 
+       <position name="posWireU168" unit="cm" x="0" y="26.5044508880694" z="23.5565811612617"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU169"/> 
+       <position name="posWireU169" unit="cm" x="0" y="27.1588817741946" z="24.1382251405521"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU170"/> 
+       <position name="posWireU170" unit="cm" x="0" y="27.8133126603198" z="24.7198691198426"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU171"/> 
+       <position name="posWireU171" unit="cm" x="0" y="28.4677435464449" z="25.301513099133"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU172"/> 
+       <position name="posWireU172" unit="cm" x="0" y="29.1221744325701" z="25.8831570784234"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU173"/> 
+       <position name="posWireU173" unit="cm" x="0" y="29.7766053186952" z="26.4648010577138"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU174"/> 
+       <position name="posWireU174" unit="cm" x="0" y="30.4310362048204" z="27.0464450370042"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU175"/> 
+       <position name="posWireU175" unit="cm" x="0" y="31.0854670909456" z="27.6280890162946"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU176"/> 
+       <position name="posWireU176" unit="cm" x="0" y="31.7398979770707" z="28.209732995585"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU177"/> 
+       <position name="posWireU177" unit="cm" x="0" y="32.3943288631959" z="28.7913769748754"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU178"/> 
+       <position name="posWireU178" unit="cm" x="0" y="33.0487597493211" z="29.3730209541658"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU179"/> 
+       <position name="posWireU179" unit="cm" x="0" y="33.7031906354462" z="29.9546649334562"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU180"/> 
+       <position name="posWireU180" unit="cm" x="0" y="34.3576215215714" z="30.5363089127466"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU181"/> 
+       <position name="posWireU181" unit="cm" x="0" y="35.0120524076965" z="31.117952892037"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU182"/> 
+       <position name="posWireU182" unit="cm" x="0" y="35.6664832938217" z="31.6995968713274"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU183"/> 
+       <position name="posWireU183" unit="cm" x="0" y="36.3209141799469" z="32.2812408506178"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU184"/> 
+       <position name="posWireU184" unit="cm" x="0" y="36.975345066072" z="32.8628848299082"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU185"/> 
+       <position name="posWireU185" unit="cm" x="0" y="37.6297759521972" z="33.4445288091987"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU186"/> 
+       <position name="posWireU186" unit="cm" x="0" y="38.2842068383224" z="34.026172788489"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU187"/> 
+       <position name="posWireU187" unit="cm" x="0" y="38.9386377244475" z="34.6078167677795"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU188"/> 
+       <position name="posWireU188" unit="cm" x="0" y="39.5930686105727" z="35.1894607470699"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU189"/> 
+       <position name="posWireU189" unit="cm" x="0" y="40.2474994966978" z="35.7711047263603"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU190"/> 
+       <position name="posWireU190" unit="cm" x="0" y="40.901930382823" z="36.3527487056507"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU191"/> 
+       <position name="posWireU191" unit="cm" x="0" y="41.5563612689482" z="36.9343926849411"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU192"/> 
+       <position name="posWireU192" unit="cm" x="0" y="42.2107921550733" z="37.5160366642315"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU193"/> 
+       <position name="posWireU193" unit="cm" x="0" y="42.8652230411985" z="38.0976806435219"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU194"/> 
+       <position name="posWireU194" unit="cm" x="0" y="43.5196539273237" z="38.6793246228123"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU195"/> 
+       <position name="posWireU195" unit="cm" x="0" y="44.1740848134488" z="39.2609686021027"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU196"/> 
+       <position name="posWireU196" unit="cm" x="0" y="44.828515699574" z="39.8426125813931"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU197"/> 
+       <position name="posWireU197" unit="cm" x="0" y="45.4829465856992" z="40.4242565606835"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU198"/> 
+       <position name="posWireU198" unit="cm" x="0" y="46.1373774718243" z="41.0059005399739"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU199"/> 
+       <position name="posWireU199" unit="cm" x="0" y="46.7918083579495" z="41.5875445192643"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU200"/> 
+       <position name="posWireU200" unit="cm" x="0" y="47.4462392440746" z="42.1691884985547"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU201"/> 
+       <position name="posWireU201" unit="cm" x="0" y="48.1006701301998" z="42.7508324778452"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU202"/> 
+       <position name="posWireU202" unit="cm" x="0" y="48.755101016325" z="43.3324764571356"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU203"/> 
+       <position name="posWireU203" unit="cm" x="0" y="49.4095319024501" z="43.9141204364259"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU204"/> 
+       <position name="posWireU204" unit="cm" x="0" y="50.0639627885753" z="44.4957644157164"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU205"/> 
+       <position name="posWireU205" unit="cm" x="0" y="50.7183936747005" z="45.0774083950068"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU206"/> 
+       <position name="posWireU206" unit="cm" x="0" y="51.3728245608256" z="45.6590523742972"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU207"/> 
+       <position name="posWireU207" unit="cm" x="0" y="52.0272554469508" z="46.2406963535876"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU208"/> 
+       <position name="posWireU208" unit="cm" x="0" y="52.681686333076" z="46.822340332878"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU209"/> 
+       <position name="posWireU209" unit="cm" x="0" y="53.3361172192011" z="47.4039843121684"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU210"/> 
+       <position name="posWireU210" unit="cm" x="0" y="53.9905481053263" z="47.9856282914588"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU211"/> 
+       <position name="posWireU211" unit="cm" x="0" y="54.6449789914514" z="48.5672722707492"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU212"/> 
+       <position name="posWireU212" unit="cm" x="0" y="55.2994098775766" z="49.1489162500396"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU213"/> 
+       <position name="posWireU213" unit="cm" x="0" y="55.9538407637018" z="49.73056022933"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU214"/> 
+       <position name="posWireU214" unit="cm" x="0" y="56.6082716498269" z="50.3122042086204"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU215"/> 
+       <position name="posWireU215" unit="cm" x="0" y="57.2627025359521" z="50.8938481879108"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU216"/> 
+       <position name="posWireU216" unit="cm" x="0" y="57.9171334220772" z="51.4754921672012"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU217"/> 
+       <position name="posWireU217" unit="cm" x="0" y="58.5715643082024" z="52.0571361464917"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU218"/> 
+       <position name="posWireU218" unit="cm" x="0" y="59.2259951943276" z="52.6387801257821"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU219"/> 
+       <position name="posWireU219" unit="cm" x="0" y="59.8804260804527" z="53.2204241050725"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU220"/> 
+       <position name="posWireU220" unit="cm" x="0" y="60.5348569665779" z="53.8020680843629"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU221"/> 
+       <position name="posWireU221" unit="cm" x="0" y="61.1892878527031" z="54.3837120636533"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU222"/> 
+       <position name="posWireU222" unit="cm" x="0" y="61.8437187388282" z="54.9653560429437"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU223"/> 
+       <position name="posWireU223" unit="cm" x="0" y="62.4981496249534" z="55.5470000222341"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU224"/> 
+       <position name="posWireU224" unit="cm" x="0" y="63.1525805110786" z="56.1286440015245"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU225"/> 
+       <position name="posWireU225" unit="cm" x="0" y="63.8070113972037" z="56.7102879808149"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU226"/> 
+       <position name="posWireU226" unit="cm" x="0" y="64.4614422833289" z="57.2919319601053"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU227"/> 
+       <position name="posWireU227" unit="cm" x="0" y="65.115873169454" z="57.8735759393957"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU228"/> 
+       <position name="posWireU228" unit="cm" x="0" y="65.7703040555792" z="58.4552199186861"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU229"/> 
+       <position name="posWireU229" unit="cm" x="0" y="66.4247349417044" z="59.0368638979765"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU230"/> 
+       <position name="posWireU230" unit="cm" x="0" y="67.0791658278295" z="59.6185078772669"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU231"/> 
+       <position name="posWireU231" unit="cm" x="0" y="67.7335967139547" z="60.2001518565573"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU232"/> 
+       <position name="posWireU232" unit="cm" x="0" y="68.3880276000799" z="60.7817958358477"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU233"/> 
+       <position name="posWireU233" unit="cm" x="0" y="69.042458486205" z="61.3634398151382"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU234"/> 
+       <position name="posWireU234" unit="cm" x="0" y="69.6968893723302" z="61.9450837944285"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU235"/> 
+       <position name="posWireU235" unit="cm" x="0" y="70.3513202584554" z="62.526727773719"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU236"/> 
+       <position name="posWireU236" unit="cm" x="0" y="71.0057511445805" z="63.1083717530094"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU237"/> 
+       <position name="posWireU237" unit="cm" x="0" y="71.6601820307057" z="63.6900157322998"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU238"/> 
+       <position name="posWireU238" unit="cm" x="0" y="72.3146129168309" z="64.2716597115902"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU239"/> 
+       <position name="posWireU239" unit="cm" x="0" y="72.969043802956" z="64.8533036908806"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU240"/> 
+       <position name="posWireU240" unit="cm" x="0" y="73.6234746890812" z="65.434947670171"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU241"/> 
+       <position name="posWireU241" unit="cm" x="0" y="74.2779055752063" z="66.0165916494614"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU242"/> 
+       <position name="posWireU242" unit="cm" x="0" y="74.9323364613315" z="66.5982356287518"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU243"/> 
+       <position name="posWireU243" unit="cm" x="0" y="75.5867673474567" z="67.1798796080422"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU244"/> 
+       <position name="posWireU244" unit="cm" x="0" y="76.2411982335818" z="67.7615235873326"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU245"/> 
+       <position name="posWireU245" unit="cm" x="0" y="76.895629119707" z="68.343167566623"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU246"/> 
+       <position name="posWireU246" unit="cm" x="0" y="77.5500600058322" z="68.9248115459134"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU247"/> 
+       <position name="posWireU247" unit="cm" x="0" y="78.2044908919573" z="69.5064555252038"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU248"/> 
+       <position name="posWireU248" unit="cm" x="0" y="78.8589217780825" z="70.0880995044943"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU249"/> 
+       <position name="posWireU249" unit="cm" x="0" y="79.5133526642076" z="70.6697434837847"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU250"/> 
+       <position name="posWireU250" unit="cm" x="0" y="80.1677835503328" z="71.251387463075"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU251"/> 
+       <position name="posWireU251" unit="cm" x="0" y="80.822214436458" z="71.8330314423655"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU252"/> 
+       <position name="posWireU252" unit="cm" x="0" y="81.4766453225831" z="72.4146754216559"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU253"/> 
+       <position name="posWireU253" unit="cm" x="0" y="82.1310762087083" z="72.9963194009463"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU254"/> 
+       <position name="posWireU254" unit="cm" x="0" y="82.7855070948335" z="73.5779633802367"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU255"/> 
+       <position name="posWireU255" unit="cm" x="0" y="83.4399379809586" z="74.1596073595271"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+   </volume>
+  <volume name="volTPCPlaneY">
+    <materialref ref="LAr"/>
+    <solidref ref="CRMYPlane"/>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY0" unit="cm" x="0" y="-83.7375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY1" unit="cm" x="0" y="-83.2125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY2" unit="cm" x="0" y="-82.6875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY3" unit="cm" x="0" y="-82.1625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY4" unit="cm" x="0" y="-81.6375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY5" unit="cm" x="0" y="-81.1125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY6" unit="cm" x="0" y="-80.5875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY7" unit="cm" x="0" y="-80.0625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY8" unit="cm" x="0" y="-79.5375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY9" unit="cm" x="0" y="-79.0125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY10" unit="cm" x="0" y="-78.4875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY11" unit="cm" x="0" y="-77.9625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY12" unit="cm" x="0" y="-77.4375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY13" unit="cm" x="0" y="-76.9125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY14" unit="cm" x="0" y="-76.3875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY15" unit="cm" x="0" y="-75.8625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY16" unit="cm" x="0" y="-75.3375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY17" unit="cm" x="0" y="-74.8125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY18" unit="cm" x="0" y="-74.2875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY19" unit="cm" x="0" y="-73.7625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY20" unit="cm" x="0" y="-73.2375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY21" unit="cm" x="0" y="-72.7125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY22" unit="cm" x="0" y="-72.1875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY23" unit="cm" x="0" y="-71.6625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY24" unit="cm" x="0" y="-71.1375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY25" unit="cm" x="0" y="-70.6125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY26" unit="cm" x="0" y="-70.0875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY27" unit="cm" x="0" y="-69.5625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY28" unit="cm" x="0" y="-69.0375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY29" unit="cm" x="0" y="-68.5125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY30" unit="cm" x="0" y="-67.9875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY31" unit="cm" x="0" y="-67.4625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY32" unit="cm" x="0" y="-66.9375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY33" unit="cm" x="0" y="-66.4125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY34" unit="cm" x="0" y="-65.8875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY35" unit="cm" x="0" y="-65.3625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY36" unit="cm" x="0" y="-64.8375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY37" unit="cm" x="0" y="-64.3125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY38" unit="cm" x="0" y="-63.7875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY39" unit="cm" x="0" y="-63.2625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY40" unit="cm" x="0" y="-62.7375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY41" unit="cm" x="0" y="-62.2125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY42" unit="cm" x="0" y="-61.6875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY43" unit="cm" x="0" y="-61.1625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY44" unit="cm" x="0" y="-60.6375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY45" unit="cm" x="0" y="-60.1125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY46" unit="cm" x="0" y="-59.5875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY47" unit="cm" x="0" y="-59.0625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY48" unit="cm" x="0" y="-58.5375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY49" unit="cm" x="0" y="-58.0125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY50" unit="cm" x="0" y="-57.4875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY51" unit="cm" x="0" y="-56.9625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY52" unit="cm" x="0" y="-56.4375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY53" unit="cm" x="0" y="-55.9125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY54" unit="cm" x="0" y="-55.3875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY55" unit="cm" x="0" y="-54.8625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY56" unit="cm" x="0" y="-54.3375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY57" unit="cm" x="0" y="-53.8125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY58" unit="cm" x="0" y="-53.2875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY59" unit="cm" x="0" y="-52.7625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY60" unit="cm" x="0" y="-52.2375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY61" unit="cm" x="0" y="-51.7125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY62" unit="cm" x="0" y="-51.1875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY63" unit="cm" x="0" y="-50.6625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY64" unit="cm" x="0" y="-50.1375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY65" unit="cm" x="0" y="-49.6125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY66" unit="cm" x="0" y="-49.0875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY67" unit="cm" x="0" y="-48.5625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY68" unit="cm" x="0" y="-48.0375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY69" unit="cm" x="0" y="-47.5125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY70" unit="cm" x="0" y="-46.9875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY71" unit="cm" x="0" y="-46.4625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY72" unit="cm" x="0" y="-45.9375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY73" unit="cm" x="0" y="-45.4125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY74" unit="cm" x="0" y="-44.8875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY75" unit="cm" x="0" y="-44.3625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY76" unit="cm" x="0" y="-43.8375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY77" unit="cm" x="0" y="-43.3125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY78" unit="cm" x="0" y="-42.7875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY79" unit="cm" x="0" y="-42.2625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY80" unit="cm" x="0" y="-41.7375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY81" unit="cm" x="0" y="-41.2125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY82" unit="cm" x="0" y="-40.6875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY83" unit="cm" x="0" y="-40.1625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY84" unit="cm" x="0" y="-39.6375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY85" unit="cm" x="0" y="-39.1125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY86" unit="cm" x="0" y="-38.5875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY87" unit="cm" x="0" y="-38.0625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY88" unit="cm" x="0" y="-37.5375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY89" unit="cm" x="0" y="-37.0125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY90" unit="cm" x="0" y="-36.4875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY91" unit="cm" x="0" y="-35.9625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY92" unit="cm" x="0" y="-35.4375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY93" unit="cm" x="0" y="-34.9125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY94" unit="cm" x="0" y="-34.3875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY95" unit="cm" x="0" y="-33.8625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY96" unit="cm" x="0" y="-33.3375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY97" unit="cm" x="0" y="-32.8125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY98" unit="cm" x="0" y="-32.2875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY99" unit="cm" x="0" y="-31.7625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY100" unit="cm" x="0" y="-31.2375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY101" unit="cm" x="0" y="-30.7125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY102" unit="cm" x="0" y="-30.1875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY103" unit="cm" x="0" y="-29.6625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY104" unit="cm" x="0" y="-29.1375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY105" unit="cm" x="0" y="-28.6125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY106" unit="cm" x="0" y="-28.0875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY107" unit="cm" x="0" y="-27.5625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY108" unit="cm" x="0" y="-27.0375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY109" unit="cm" x="0" y="-26.5125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY110" unit="cm" x="0" y="-25.9875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY111" unit="cm" x="0" y="-25.4625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY112" unit="cm" x="0" y="-24.9375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY113" unit="cm" x="0" y="-24.4125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY114" unit="cm" x="0" y="-23.8875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY115" unit="cm" x="0" y="-23.3625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY116" unit="cm" x="0" y="-22.8375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY117" unit="cm" x="0" y="-22.3125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY118" unit="cm" x="0" y="-21.7875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY119" unit="cm" x="0" y="-21.2625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY120" unit="cm" x="0" y="-20.7375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY121" unit="cm" x="0" y="-20.2125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY122" unit="cm" x="0" y="-19.6875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY123" unit="cm" x="0" y="-19.1625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY124" unit="cm" x="0" y="-18.6375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY125" unit="cm" x="0" y="-18.1125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY126" unit="cm" x="0" y="-17.5875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY127" unit="cm" x="0" y="-17.0625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY128" unit="cm" x="0" y="-16.5375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY129" unit="cm" x="0" y="-16.0125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY130" unit="cm" x="0" y="-15.4875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY131" unit="cm" x="0" y="-14.9625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY132" unit="cm" x="0" y="-14.4375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY133" unit="cm" x="0" y="-13.9125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY134" unit="cm" x="0" y="-13.3875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY135" unit="cm" x="0" y="-12.8625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY136" unit="cm" x="0" y="-12.3375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY137" unit="cm" x="0" y="-11.8125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY138" unit="cm" x="0" y="-11.2875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY139" unit="cm" x="0" y="-10.7625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY140" unit="cm" x="0" y="-10.2375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY141" unit="cm" x="0" y="-9.7125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY142" unit="cm" x="0" y="-9.1875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY143" unit="cm" x="0" y="-8.6625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY144" unit="cm" x="0" y="-8.1375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY145" unit="cm" x="0" y="-7.6125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY146" unit="cm" x="0" y="-7.0875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY147" unit="cm" x="0" y="-6.5625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY148" unit="cm" x="0" y="-6.0375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY149" unit="cm" x="0" y="-5.5125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY150" unit="cm" x="0" y="-4.9875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY151" unit="cm" x="0" y="-4.4625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY152" unit="cm" x="0" y="-3.9375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY153" unit="cm" x="0" y="-3.4125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY154" unit="cm" x="0" y="-2.8875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY155" unit="cm" x="0" y="-2.3625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY156" unit="cm" x="0" y="-1.8375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY157" unit="cm" x="0" y="-1.3125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY158" unit="cm" x="0" y="-0.7875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY159" unit="cm" x="0" y="-0.2625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY160" unit="cm" x="0" y="0.2625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY161" unit="cm" x="0" y="0.7875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY162" unit="cm" x="0" y="1.3125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY163" unit="cm" x="0" y="1.8375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY164" unit="cm" x="0" y="2.3625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY165" unit="cm" x="0" y="2.8875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY166" unit="cm" x="0" y="3.4125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY167" unit="cm" x="0" y="3.9375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY168" unit="cm" x="0" y="4.4625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY169" unit="cm" x="0" y="4.9875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY170" unit="cm" x="0" y="5.5125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY171" unit="cm" x="0" y="6.0375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY172" unit="cm" x="0" y="6.5625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY173" unit="cm" x="0" y="7.0875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY174" unit="cm" x="0" y="7.6125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY175" unit="cm" x="0" y="8.1375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY176" unit="cm" x="0" y="8.6625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY177" unit="cm" x="0" y="9.1875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY178" unit="cm" x="0" y="9.7125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY179" unit="cm" x="0" y="10.2375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY180" unit="cm" x="0" y="10.7625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY181" unit="cm" x="0" y="11.2875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY182" unit="cm" x="0" y="11.8125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY183" unit="cm" x="0" y="12.3375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY184" unit="cm" x="0" y="12.8625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY185" unit="cm" x="0" y="13.3875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY186" unit="cm" x="0" y="13.9125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY187" unit="cm" x="0" y="14.4375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY188" unit="cm" x="0" y="14.9625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY189" unit="cm" x="0" y="15.4875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY190" unit="cm" x="0" y="16.0125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY191" unit="cm" x="0" y="16.5375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY192" unit="cm" x="0" y="17.0625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY193" unit="cm" x="0" y="17.5875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY194" unit="cm" x="0" y="18.1125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY195" unit="cm" x="0" y="18.6375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY196" unit="cm" x="0" y="19.1625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY197" unit="cm" x="0" y="19.6875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY198" unit="cm" x="0" y="20.2125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY199" unit="cm" x="0" y="20.7375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY200" unit="cm" x="0" y="21.2625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY201" unit="cm" x="0" y="21.7875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY202" unit="cm" x="0" y="22.3125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY203" unit="cm" x="0" y="22.8375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY204" unit="cm" x="0" y="23.3625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY205" unit="cm" x="0" y="23.8875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY206" unit="cm" x="0" y="24.4125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY207" unit="cm" x="0" y="24.9375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY208" unit="cm" x="0" y="25.4625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY209" unit="cm" x="0" y="25.9875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY210" unit="cm" x="0" y="26.5125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY211" unit="cm" x="0" y="27.0375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY212" unit="cm" x="0" y="27.5625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY213" unit="cm" x="0" y="28.0875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY214" unit="cm" x="0" y="28.6125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY215" unit="cm" x="0" y="29.1375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY216" unit="cm" x="0" y="29.6625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY217" unit="cm" x="0" y="30.1875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY218" unit="cm" x="0" y="30.7125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY219" unit="cm" x="0" y="31.2375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY220" unit="cm" x="0" y="31.7625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY221" unit="cm" x="0" y="32.2875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY222" unit="cm" x="0" y="32.8125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY223" unit="cm" x="0" y="33.3375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY224" unit="cm" x="0" y="33.8625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY225" unit="cm" x="0" y="34.3875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY226" unit="cm" x="0" y="34.9125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY227" unit="cm" x="0" y="35.4375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY228" unit="cm" x="0" y="35.9625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY229" unit="cm" x="0" y="36.4875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY230" unit="cm" x="0" y="37.0125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY231" unit="cm" x="0" y="37.5375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY232" unit="cm" x="0" y="38.0625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY233" unit="cm" x="0" y="38.5875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY234" unit="cm" x="0" y="39.1125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY235" unit="cm" x="0" y="39.6375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY236" unit="cm" x="0" y="40.1625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY237" unit="cm" x="0" y="40.6875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY238" unit="cm" x="0" y="41.2125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY239" unit="cm" x="0" y="41.7375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY240" unit="cm" x="0" y="42.2625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY241" unit="cm" x="0" y="42.7875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY242" unit="cm" x="0" y="43.3125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY243" unit="cm" x="0" y="43.8375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY244" unit="cm" x="0" y="44.3625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY245" unit="cm" x="0" y="44.8875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY246" unit="cm" x="0" y="45.4125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY247" unit="cm" x="0" y="45.9375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY248" unit="cm" x="0" y="46.4625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY249" unit="cm" x="0" y="46.9875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY250" unit="cm" x="0" y="47.5125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY251" unit="cm" x="0" y="48.0375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY252" unit="cm" x="0" y="48.5625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY253" unit="cm" x="0" y="49.0875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY254" unit="cm" x="0" y="49.6125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY255" unit="cm" x="0" y="50.1375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY256" unit="cm" x="0" y="50.6625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY257" unit="cm" x="0" y="51.1875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY258" unit="cm" x="0" y="51.7125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY259" unit="cm" x="0" y="52.2375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY260" unit="cm" x="0" y="52.7625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY261" unit="cm" x="0" y="53.2875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY262" unit="cm" x="0" y="53.8125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY263" unit="cm" x="0" y="54.3375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY264" unit="cm" x="0" y="54.8625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY265" unit="cm" x="0" y="55.3875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY266" unit="cm" x="0" y="55.9125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY267" unit="cm" x="0" y="56.4375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY268" unit="cm" x="0" y="56.9625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY269" unit="cm" x="0" y="57.4875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY270" unit="cm" x="0" y="58.0125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY271" unit="cm" x="0" y="58.5375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY272" unit="cm" x="0" y="59.0625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY273" unit="cm" x="0" y="59.5875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY274" unit="cm" x="0" y="60.1125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY275" unit="cm" x="0" y="60.6375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY276" unit="cm" x="0" y="61.1625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY277" unit="cm" x="0" y="61.6875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY278" unit="cm" x="0" y="62.2125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY279" unit="cm" x="0" y="62.7375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY280" unit="cm" x="0" y="63.2625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY281" unit="cm" x="0" y="63.7875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY282" unit="cm" x="0" y="64.3125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY283" unit="cm" x="0" y="64.8375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY284" unit="cm" x="0" y="65.3625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY285" unit="cm" x="0" y="65.8875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY286" unit="cm" x="0" y="66.4125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY287" unit="cm" x="0" y="66.9375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY288" unit="cm" x="0" y="67.4625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY289" unit="cm" x="0" y="67.9875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY290" unit="cm" x="0" y="68.5125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY291" unit="cm" x="0" y="69.0375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY292" unit="cm" x="0" y="69.5625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY293" unit="cm" x="0" y="70.0875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY294" unit="cm" x="0" y="70.6125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY295" unit="cm" x="0" y="71.1375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY296" unit="cm" x="0" y="71.6625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY297" unit="cm" x="0" y="72.1875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY298" unit="cm" x="0" y="72.7125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY299" unit="cm" x="0" y="73.2375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY300" unit="cm" x="0" y="73.7625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY301" unit="cm" x="0" y="74.2875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY302" unit="cm" x="0" y="74.8125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY303" unit="cm" x="0" y="75.3375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY304" unit="cm" x="0" y="75.8625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY305" unit="cm" x="0" y="76.3875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY306" unit="cm" x="0" y="76.9125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY307" unit="cm" x="0" y="77.4375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY308" unit="cm" x="0" y="77.9625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY309" unit="cm" x="0" y="78.4875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY310" unit="cm" x="0" y="79.0125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY311" unit="cm" x="0" y="79.5375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY312" unit="cm" x="0" y="80.0625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY313" unit="cm" x="0" y="80.5875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY314" unit="cm" x="0" y="81.1125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY315" unit="cm" x="0" y="81.6375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY316" unit="cm" x="0" y="82.1625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY317" unit="cm" x="0" y="82.6875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY318" unit="cm" x="0" y="83.2125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY319" unit="cm" x="0" y="83.7375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+  </volume>
+  <volume name="volTPCPlaneZ">
+    <materialref ref="LAr"/>
+    <solidref ref="CRMZPlane"/>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ0" unit="cm" x="0" y="0" z="-74.1895"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ1" unit="cm" x="0" y="0" z="-73.6725"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ2" unit="cm" x="0" y="0" z="-73.1555"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ3" unit="cm" x="0" y="0" z="-72.6385"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ4" unit="cm" x="0" y="0" z="-72.1215"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ5" unit="cm" x="0" y="0" z="-71.6045"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ6" unit="cm" x="0" y="0" z="-71.0875"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ7" unit="cm" x="0" y="0" z="-70.5705"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ8" unit="cm" x="0" y="0" z="-70.0535"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ9" unit="cm" x="0" y="0" z="-69.5365"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ10" unit="cm" x="0" y="0" z="-69.0195"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ11" unit="cm" x="0" y="0" z="-68.5025"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ12" unit="cm" x="0" y="0" z="-67.9855"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ13" unit="cm" x="0" y="0" z="-67.4685"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ14" unit="cm" x="0" y="0" z="-66.9515"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ15" unit="cm" x="0" y="0" z="-66.4345"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ16" unit="cm" x="0" y="0" z="-65.9175"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ17" unit="cm" x="0" y="0" z="-65.4005"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ18" unit="cm" x="0" y="0" z="-64.8835"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ19" unit="cm" x="0" y="0" z="-64.3665"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ20" unit="cm" x="0" y="0" z="-63.8495"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ21" unit="cm" x="0" y="0" z="-63.3325"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ22" unit="cm" x="0" y="0" z="-62.8155"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ23" unit="cm" x="0" y="0" z="-62.2985"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ24" unit="cm" x="0" y="0" z="-61.7815"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ25" unit="cm" x="0" y="0" z="-61.2645"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ26" unit="cm" x="0" y="0" z="-60.7475"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ27" unit="cm" x="0" y="0" z="-60.2305"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ28" unit="cm" x="0" y="0" z="-59.7135"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ29" unit="cm" x="0" y="0" z="-59.1965"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ30" unit="cm" x="0" y="0" z="-58.6795"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ31" unit="cm" x="0" y="0" z="-58.1625"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ32" unit="cm" x="0" y="0" z="-57.6455"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ33" unit="cm" x="0" y="0" z="-57.1285"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ34" unit="cm" x="0" y="0" z="-56.6115"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ35" unit="cm" x="0" y="0" z="-56.0945"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ36" unit="cm" x="0" y="0" z="-55.5775"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ37" unit="cm" x="0" y="0" z="-55.0605"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ38" unit="cm" x="0" y="0" z="-54.5435"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ39" unit="cm" x="0" y="0" z="-54.0265"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ40" unit="cm" x="0" y="0" z="-53.5095"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ41" unit="cm" x="0" y="0" z="-52.9925"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ42" unit="cm" x="0" y="0" z="-52.4755"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ43" unit="cm" x="0" y="0" z="-51.9585"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ44" unit="cm" x="0" y="0" z="-51.4415"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ45" unit="cm" x="0" y="0" z="-50.9245"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ46" unit="cm" x="0" y="0" z="-50.4075"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ47" unit="cm" x="0" y="0" z="-49.8905"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ48" unit="cm" x="0" y="0" z="-49.3735"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ49" unit="cm" x="0" y="0" z="-48.8565"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ50" unit="cm" x="0" y="0" z="-48.3395"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ51" unit="cm" x="0" y="0" z="-47.8225"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ52" unit="cm" x="0" y="0" z="-47.3055"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ53" unit="cm" x="0" y="0" z="-46.7885"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ54" unit="cm" x="0" y="0" z="-46.2715"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ55" unit="cm" x="0" y="0" z="-45.7545"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ56" unit="cm" x="0" y="0" z="-45.2375"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ57" unit="cm" x="0" y="0" z="-44.7205"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ58" unit="cm" x="0" y="0" z="-44.2035"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ59" unit="cm" x="0" y="0" z="-43.6865"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ60" unit="cm" x="0" y="0" z="-43.1695"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ61" unit="cm" x="0" y="0" z="-42.6525"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ62" unit="cm" x="0" y="0" z="-42.1355"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ63" unit="cm" x="0" y="0" z="-41.6185"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ64" unit="cm" x="0" y="0" z="-41.1015"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ65" unit="cm" x="0" y="0" z="-40.5845"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ66" unit="cm" x="0" y="0" z="-40.0675"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ67" unit="cm" x="0" y="0" z="-39.5505"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ68" unit="cm" x="0" y="0" z="-39.0335"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ69" unit="cm" x="0" y="0" z="-38.5165"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ70" unit="cm" x="0" y="0" z="-37.9995"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ71" unit="cm" x="0" y="0" z="-37.4825"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ72" unit="cm" x="0" y="0" z="-36.9655"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ73" unit="cm" x="0" y="0" z="-36.4485"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ74" unit="cm" x="0" y="0" z="-35.9315"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ75" unit="cm" x="0" y="0" z="-35.4145"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ76" unit="cm" x="0" y="0" z="-34.8975"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ77" unit="cm" x="0" y="0" z="-34.3805"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ78" unit="cm" x="0" y="0" z="-33.8635"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ79" unit="cm" x="0" y="0" z="-33.3465"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ80" unit="cm" x="0" y="0" z="-32.8295"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ81" unit="cm" x="0" y="0" z="-32.3125"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ82" unit="cm" x="0" y="0" z="-31.7955"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ83" unit="cm" x="0" y="0" z="-31.2785"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ84" unit="cm" x="0" y="0" z="-30.7615"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ85" unit="cm" x="0" y="0" z="-30.2445"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ86" unit="cm" x="0" y="0" z="-29.7275"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ87" unit="cm" x="0" y="0" z="-29.2105"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ88" unit="cm" x="0" y="0" z="-28.6935"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ89" unit="cm" x="0" y="0" z="-28.1765"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ90" unit="cm" x="0" y="0" z="-27.6595"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ91" unit="cm" x="0" y="0" z="-27.1425"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ92" unit="cm" x="0" y="0" z="-26.6255"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ93" unit="cm" x="0" y="0" z="-26.1085"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ94" unit="cm" x="0" y="0" z="-25.5915"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ95" unit="cm" x="0" y="0" z="-25.0745"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ96" unit="cm" x="0" y="0" z="-24.5575"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ97" unit="cm" x="0" y="0" z="-24.0405"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ98" unit="cm" x="0" y="0" z="-23.5235"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ99" unit="cm" x="0" y="0" z="-23.0065"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ100" unit="cm" x="0" y="0" z="-22.4895"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ101" unit="cm" x="0" y="0" z="-21.9725"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ102" unit="cm" x="0" y="0" z="-21.4555"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ103" unit="cm" x="0" y="0" z="-20.9385"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ104" unit="cm" x="0" y="0" z="-20.4215"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ105" unit="cm" x="0" y="0" z="-19.9045"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ106" unit="cm" x="0" y="0" z="-19.3875"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ107" unit="cm" x="0" y="0" z="-18.8705"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ108" unit="cm" x="0" y="0" z="-18.3535"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ109" unit="cm" x="0" y="0" z="-17.8365"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ110" unit="cm" x="0" y="0" z="-17.3195"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ111" unit="cm" x="0" y="0" z="-16.8025"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ112" unit="cm" x="0" y="0" z="-16.2855"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ113" unit="cm" x="0" y="0" z="-15.7685"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ114" unit="cm" x="0" y="0" z="-15.2515"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ115" unit="cm" x="0" y="0" z="-14.7345"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ116" unit="cm" x="0" y="0" z="-14.2175"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ117" unit="cm" x="0" y="0" z="-13.7005"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ118" unit="cm" x="0" y="0" z="-13.1835"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ119" unit="cm" x="0" y="0" z="-12.6665"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ120" unit="cm" x="0" y="0" z="-12.1495"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ121" unit="cm" x="0" y="0" z="-11.6325"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ122" unit="cm" x="0" y="0" z="-11.1155"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ123" unit="cm" x="0" y="0" z="-10.5985"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ124" unit="cm" x="0" y="0" z="-10.0815"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ125" unit="cm" x="0" y="0" z="-9.5645"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ126" unit="cm" x="0" y="0" z="-9.0475"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ127" unit="cm" x="0" y="0" z="-8.5305"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ128" unit="cm" x="0" y="0" z="-8.0135"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ129" unit="cm" x="0" y="0" z="-7.4965"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ130" unit="cm" x="0" y="0" z="-6.9795"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ131" unit="cm" x="0" y="0" z="-6.4625"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ132" unit="cm" x="0" y="0" z="-5.9455"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ133" unit="cm" x="0" y="0" z="-5.4285"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ134" unit="cm" x="0" y="0" z="-4.9115"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ135" unit="cm" x="0" y="0" z="-4.3945"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ136" unit="cm" x="0" y="0" z="-3.8775"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ137" unit="cm" x="0" y="0" z="-3.3605"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ138" unit="cm" x="0" y="0" z="-2.8435"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ139" unit="cm" x="0" y="0" z="-2.3265"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ140" unit="cm" x="0" y="0" z="-1.8095"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ141" unit="cm" x="0" y="0" z="-1.2925"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ142" unit="cm" x="0" y="0" z="-0.7755"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ143" unit="cm" x="0" y="0" z="-0.2585"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ144" unit="cm" x="0" y="0" z="0.2585"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ145" unit="cm" x="0" y="0" z="0.7755"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ146" unit="cm" x="0" y="0" z="1.2925"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ147" unit="cm" x="0" y="0" z="1.8095"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ148" unit="cm" x="0" y="0" z="2.3265"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ149" unit="cm" x="0" y="0" z="2.8435"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ150" unit="cm" x="0" y="0" z="3.3605"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ151" unit="cm" x="0" y="0" z="3.8775"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ152" unit="cm" x="0" y="0" z="4.3945"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ153" unit="cm" x="0" y="0" z="4.9115"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ154" unit="cm" x="0" y="0" z="5.4285"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ155" unit="cm" x="0" y="0" z="5.9455"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ156" unit="cm" x="0" y="0" z="6.4625"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ157" unit="cm" x="0" y="0" z="6.9795"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ158" unit="cm" x="0" y="0" z="7.4965"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ159" unit="cm" x="0" y="0" z="8.0135"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ160" unit="cm" x="0" y="0" z="8.5305"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ161" unit="cm" x="0" y="0" z="9.0475"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ162" unit="cm" x="0" y="0" z="9.5645"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ163" unit="cm" x="0" y="0" z="10.0815"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ164" unit="cm" x="0" y="0" z="10.5985"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ165" unit="cm" x="0" y="0" z="11.1155"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ166" unit="cm" x="0" y="0" z="11.6325"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ167" unit="cm" x="0" y="0" z="12.1495"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ168" unit="cm" x="0" y="0" z="12.6665"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ169" unit="cm" x="0" y="0" z="13.1835"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ170" unit="cm" x="0" y="0" z="13.7005"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ171" unit="cm" x="0" y="0" z="14.2175"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ172" unit="cm" x="0" y="0" z="14.7345"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ173" unit="cm" x="0" y="0" z="15.2515"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ174" unit="cm" x="0" y="0" z="15.7685"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ175" unit="cm" x="0" y="0" z="16.2855"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ176" unit="cm" x="0" y="0" z="16.8025"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ177" unit="cm" x="0" y="0" z="17.3195"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ178" unit="cm" x="0" y="0" z="17.8365"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ179" unit="cm" x="0" y="0" z="18.3535"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ180" unit="cm" x="0" y="0" z="18.8705"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ181" unit="cm" x="0" y="0" z="19.3875"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ182" unit="cm" x="0" y="0" z="19.9045"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ183" unit="cm" x="0" y="0" z="20.4215"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ184" unit="cm" x="0" y="0" z="20.9385"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ185" unit="cm" x="0" y="0" z="21.4555"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ186" unit="cm" x="0" y="0" z="21.9725"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ187" unit="cm" x="0" y="0" z="22.4895"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ188" unit="cm" x="0" y="0" z="23.0065"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ189" unit="cm" x="0" y="0" z="23.5235"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ190" unit="cm" x="0" y="0" z="24.0405"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ191" unit="cm" x="0" y="0" z="24.5575"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ192" unit="cm" x="0" y="0" z="25.0745"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ193" unit="cm" x="0" y="0" z="25.5915"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ194" unit="cm" x="0" y="0" z="26.1085"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ195" unit="cm" x="0" y="0" z="26.6255"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ196" unit="cm" x="0" y="0" z="27.1425"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ197" unit="cm" x="0" y="0" z="27.6595"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ198" unit="cm" x="0" y="0" z="28.1765"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ199" unit="cm" x="0" y="0" z="28.6935"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ200" unit="cm" x="0" y="0" z="29.2105"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ201" unit="cm" x="0" y="0" z="29.7275"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ202" unit="cm" x="0" y="0" z="30.2445"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ203" unit="cm" x="0" y="0" z="30.7615"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ204" unit="cm" x="0" y="0" z="31.2785"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ205" unit="cm" x="0" y="0" z="31.7955"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ206" unit="cm" x="0" y="0" z="32.3125"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ207" unit="cm" x="0" y="0" z="32.8295"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ208" unit="cm" x="0" y="0" z="33.3465"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ209" unit="cm" x="0" y="0" z="33.8635"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ210" unit="cm" x="0" y="0" z="34.3805"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ211" unit="cm" x="0" y="0" z="34.8975"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ212" unit="cm" x="0" y="0" z="35.4145"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ213" unit="cm" x="0" y="0" z="35.9315"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ214" unit="cm" x="0" y="0" z="36.4485"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ215" unit="cm" x="0" y="0" z="36.9655"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ216" unit="cm" x="0" y="0" z="37.4825"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ217" unit="cm" x="0" y="0" z="37.9995"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ218" unit="cm" x="0" y="0" z="38.5165"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ219" unit="cm" x="0" y="0" z="39.0335"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ220" unit="cm" x="0" y="0" z="39.5505"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ221" unit="cm" x="0" y="0" z="40.0675"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ222" unit="cm" x="0" y="0" z="40.5845"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ223" unit="cm" x="0" y="0" z="41.1015"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ224" unit="cm" x="0" y="0" z="41.6185"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ225" unit="cm" x="0" y="0" z="42.1355"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ226" unit="cm" x="0" y="0" z="42.6525"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ227" unit="cm" x="0" y="0" z="43.1695"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ228" unit="cm" x="0" y="0" z="43.6865"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ229" unit="cm" x="0" y="0" z="44.2035"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ230" unit="cm" x="0" y="0" z="44.7205"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ231" unit="cm" x="0" y="0" z="45.2375"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ232" unit="cm" x="0" y="0" z="45.7545"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ233" unit="cm" x="0" y="0" z="46.2715"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ234" unit="cm" x="0" y="0" z="46.7885"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ235" unit="cm" x="0" y="0" z="47.3055"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ236" unit="cm" x="0" y="0" z="47.8225"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ237" unit="cm" x="0" y="0" z="48.3395"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ238" unit="cm" x="0" y="0" z="48.8565"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ239" unit="cm" x="0" y="0" z="49.3735"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ240" unit="cm" x="0" y="0" z="49.8905"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ241" unit="cm" x="0" y="0" z="50.4075"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ242" unit="cm" x="0" y="0" z="50.9245"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ243" unit="cm" x="0" y="0" z="51.4415"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ244" unit="cm" x="0" y="0" z="51.9585"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ245" unit="cm" x="0" y="0" z="52.4755"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ246" unit="cm" x="0" y="0" z="52.9925"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ247" unit="cm" x="0" y="0" z="53.5095"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ248" unit="cm" x="0" y="0" z="54.0265"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ249" unit="cm" x="0" y="0" z="54.5435"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ250" unit="cm" x="0" y="0" z="55.0605"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ251" unit="cm" x="0" y="0" z="55.5775"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ252" unit="cm" x="0" y="0" z="56.0945"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ253" unit="cm" x="0" y="0" z="56.6115"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ254" unit="cm" x="0" y="0" z="57.1285"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ255" unit="cm" x="0" y="0" z="57.6455"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ256" unit="cm" x="0" y="0" z="58.1625"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ257" unit="cm" x="0" y="0" z="58.6795"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ258" unit="cm" x="0" y="0" z="59.1965"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ259" unit="cm" x="0" y="0" z="59.7135"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ260" unit="cm" x="0" y="0" z="60.2305"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ261" unit="cm" x="0" y="0" z="60.7475"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ262" unit="cm" x="0" y="0" z="61.2645"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ263" unit="cm" x="0" y="0" z="61.7815"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ264" unit="cm" x="0" y="0" z="62.2985"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ265" unit="cm" x="0" y="0" z="62.8155"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ266" unit="cm" x="0" y="0" z="63.3325"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ267" unit="cm" x="0" y="0" z="63.8495"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ268" unit="cm" x="0" y="0" z="64.3665"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ269" unit="cm" x="0" y="0" z="64.8835"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ270" unit="cm" x="0" y="0" z="65.4005"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ271" unit="cm" x="0" y="0" z="65.9175"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ272" unit="cm" x="0" y="0" z="66.4345"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ273" unit="cm" x="0" y="0" z="66.9515"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ274" unit="cm" x="0" y="0" z="67.4685"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ275" unit="cm" x="0" y="0" z="67.9855"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ276" unit="cm" x="0" y="0" z="68.5025"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ277" unit="cm" x="0" y="0" z="69.0195"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ278" unit="cm" x="0" y="0" z="69.5365"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ279" unit="cm" x="0" y="0" z="70.0535"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ280" unit="cm" x="0" y="0" z="70.5705"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ281" unit="cm" x="0" y="0" z="71.0875"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ282" unit="cm" x="0" y="0" z="71.6045"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ283" unit="cm" x="0" y="0" z="72.1215"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ284" unit="cm" x="0" y="0" z="72.6385"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ285" unit="cm" x="0" y="0" z="73.1555"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ286" unit="cm" x="0" y="0" z="73.6725"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ287" unit="cm" x="0" y="0" z="74.1895"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+  </volume>
+     
+   <volume name="volAnodePlate">
+     <materialref ref="vm2000"/>
+     <solidref ref="CRMZPlane"/>
+  </volume>
+   <volume name="volTPC">
+     <materialref ref="LAr"/>
+       <solidref ref="CRM"/>
+       <physvol>
+       <volumeref ref="volTPCPlaneU"/>
+       <position name="posPlaneU" unit="cm" 
+         x="324.97" y="0" z="0"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCPlaneY"/>
+       <position name="posPlaneY" unit="cm" 
+         x="324.99" y="0" z="0"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCPlaneZ"/>
+       <position name="posPlaneZ" unit="cm" 
+         x="325.01" y="0" z="0"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate" unit="cm" 
+         x="325.03" y="0" z="0"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+     <physvol>
+       <volumeref ref="volTPCActive"/>
+       <position name="posActive" unit="cm" 
+        x="-0.04" y="" z="0"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+   </volume>
+ 
+    <volume name="volSteelShell">
+      <materialref ref="STEEL_STAINLESS_Fe7Cr2Ni" />
+      <solidref ref="SteelShell" />
+    </volume>
+    <volume name="volGroundGrid">
+      <materialref ref="STEEL_STAINLESS_Fe7Cr2Ni" />
+      <solidref ref="CathodeGrid" />
+    </volume>    
+    <volume name="volGaseousArgon">
+      <materialref ref="ArGas"/>
+      <solidref ref="GaseousArgon"/>
+    </volume>
+    <volume name="volExternalActive">
+      <materialref ref="LAr"/>
+      <solidref ref="ExternalActive"/>
+      <auxiliary auxtype="SensDet" auxvalue="SimEnergyDeposit"/>
+      <auxiliary auxtype="StepLimit" auxunit="cm" auxvalue="0.5208*cm"/>
+      <auxiliary auxtype="Efield" auxunit="V/cm" auxvalue="0*V/cm"/>
+      <colorref ref="green"/>
+    </volume>
+    <volume name="volArapucaDouble_0-0-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-0-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-0-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-0-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-0-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-0-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-0-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-0-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-1-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-1-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-1-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-1-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-1-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-1-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-1-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-1-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-2-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-2-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-2-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-2-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-2-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-2-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-2-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-2-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-0-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-0-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-0-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-0-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-0-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-0-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-0-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-0-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-1-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-1-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-1-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-1-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-1-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-1-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-1-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-1-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-2-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-2-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-2-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-2-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-2-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-2-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-2-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-2-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-0-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-0-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-0-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-0-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-0-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-0-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-0-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-0-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-1-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-1-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-1-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-1-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-1-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-1-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-1-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-1-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-2-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-2-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-2-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-2-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-2-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-2-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-2-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-2-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+
+    <volume name="volCryostat">
+      <materialref ref="LAr" />
+      <solidref ref="Cryostat" />
+      <physvol>
+        <volumeref ref="volGaseousArgon"/>
+        <position name="posGaseousArgon" unit="cm" x="375.04" y="0" z="0"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volSteelShell"/>
+        <position name="posSteelShell" unit="cm" x="0" y="0" z="0"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volExternalActive"/>
+        <position name="posExternalActive" unit="cm" x="-100/2" y="0" z="0"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-0" unit="cm"
+           x="0" y="-421" z="-373.25225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-1" unit="cm"
+           x="0" y="-253" z="-373.25225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-2" unit="cm"
+           x="0" y="-84" z="-373.25225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-3" unit="cm"
+           x="0" y="84" z="-373.25225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-4" unit="cm"
+           x="0" y="253" z="-373.25225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-5" unit="cm"
+           x="0" y="421" z="-373.25225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-6" unit="cm"
+           x="0" y="-421" z="-224.35135"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-7" unit="cm"
+           x="0" y="-253" z="-224.35135"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-8" unit="cm"
+           x="0" y="-84" z="-224.35135"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-9" unit="cm"
+           x="0" y="84" z="-224.35135"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-10" unit="cm"
+           x="0" y="253" z="-224.35135"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-11" unit="cm"
+           x="0" y="421" z="-224.35135"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-12" unit="cm"
+           x="0" y="-421" z="-74.45045"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-13" unit="cm"
+           x="0" y="-253" z="-74.45045"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-14" unit="cm"
+           x="0" y="-84" z="-74.45045"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-15" unit="cm"
+           x="0" y="84" z="-74.45045"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-16" unit="cm"
+           x="0" y="253" z="-74.45045"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-17" unit="cm"
+           x="0" y="421" z="-74.45045"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-18" unit="cm"
+           x="0" y="-421" z="74.45045"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-19" unit="cm"
+           x="0" y="-253" z="74.45045"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-20" unit="cm"
+           x="0" y="-84" z="74.45045"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-21" unit="cm"
+           x="0" y="84" z="74.45045"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-22" unit="cm"
+           x="0" y="253" z="74.45045"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-23" unit="cm"
+           x="0" y="421" z="74.45045"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-24" unit="cm"
+           x="0" y="-421" z="224.35135"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-25" unit="cm"
+           x="0" y="-253" z="224.35135"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-26" unit="cm"
+           x="0" y="-84" z="224.35135"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-27" unit="cm"
+           x="0" y="84" z="224.35135"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-28" unit="cm"
+           x="0" y="253" z="224.35135"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-29" unit="cm"
+           x="0" y="421" z="224.35135"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-30" unit="cm"
+           x="0" y="-421" z="373.25225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-31" unit="cm"
+           x="0" y="-253" z="373.25225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-32" unit="cm"
+           x="0" y="-84" z="373.25225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-33" unit="cm"
+           x="0" y="84" z="373.25225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-34" unit="cm"
+           x="0" y="253" z="373.25225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-35" unit="cm"
+           x="0" y="421" z="373.25225"/>
+      </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper0" unit="cm"  x="-322.04" y="-507.8" z="0" />
+     <rotation name="rotFS0" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper1" unit="cm"  x="-316.04" y="-507.8" z="0" />
+     <rotation name="rotFS1" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper2" unit="cm"  x="-310.04" y="-507.8" z="0" />
+     <rotation name="rotFS2" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper3" unit="cm"  x="-304.04" y="-507.8" z="0" />
+     <rotation name="rotFS3" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper4" unit="cm"  x="-298.04" y="-507.8" z="0" />
+     <rotation name="rotFS4" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper5" unit="cm"  x="-292.04" y="-507.8" z="0" />
+     <rotation name="rotFS5" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper6" unit="cm"  x="-286.04" y="-507.8" z="0" />
+     <rotation name="rotFS6" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper7" unit="cm"  x="-280.04" y="-507.8" z="0" />
+     <rotation name="rotFS7" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper8" unit="cm"  x="-274.04" y="-507.8" z="0" />
+     <rotation name="rotFS8" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper9" unit="cm"  x="-268.04" y="-507.8" z="0" />
+     <rotation name="rotFS9" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper10" unit="cm"  x="-262.04" y="-507.8" z="0" />
+     <rotation name="rotFS10" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper11" unit="cm"  x="-256.04" y="-507.8" z="0" />
+     <rotation name="rotFS11" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper12" unit="cm"  x="-250.04" y="-507.8" z="0" />
+     <rotation name="rotFS12" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper13" unit="cm"  x="-244.04" y="-507.8" z="0" />
+     <rotation name="rotFS13" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper14" unit="cm"  x="-238.04" y="-507.8" z="0" />
+     <rotation name="rotFS14" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper15" unit="cm"  x="-232.04" y="-507.8" z="0" />
+     <rotation name="rotFS15" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper16" unit="cm"  x="-226.04" y="-507.8" z="0" />
+     <rotation name="rotFS16" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper17" unit="cm"  x="-220.04" y="-507.8" z="0" />
+     <rotation name="rotFS17" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper18" unit="cm"  x="-214.04" y="-507.8" z="0" />
+     <rotation name="rotFS18" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper19" unit="cm"  x="-208.04" y="-507.8" z="0" />
+     <rotation name="rotFS19" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper20" unit="cm"  x="-202.04" y="-507.8" z="0" />
+     <rotation name="rotFS20" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper21" unit="cm"  x="-196.04" y="-507.8" z="0" />
+     <rotation name="rotFS21" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper22" unit="cm"  x="-190.04" y="-507.8" z="0" />
+     <rotation name="rotFS22" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper23" unit="cm"  x="-184.04" y="-507.8" z="0" />
+     <rotation name="rotFS23" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper24" unit="cm"  x="-178.04" y="-507.8" z="0" />
+     <rotation name="rotFS24" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper25" unit="cm"  x="-172.04" y="-507.8" z="0" />
+     <rotation name="rotFS25" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper26" unit="cm"  x="-166.04" y="-507.8" z="0" />
+     <rotation name="rotFS26" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper27" unit="cm"  x="-160.04" y="-507.8" z="0" />
+     <rotation name="rotFS27" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper28" unit="cm"  x="-154.04" y="-507.8" z="0" />
+     <rotation name="rotFS28" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper29" unit="cm"  x="-148.04" y="-507.8" z="0" />
+     <rotation name="rotFS29" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper30" unit="cm"  x="-142.04" y="-507.8" z="0" />
+     <rotation name="rotFS30" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper31" unit="cm"  x="-136.04" y="-507.8" z="0" />
+     <rotation name="rotFS31" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper32" unit="cm"  x="-130.04" y="-507.8" z="0" />
+     <rotation name="rotFS32" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper33" unit="cm"  x="-124.04" y="-507.8" z="0" />
+     <rotation name="rotFS33" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper34" unit="cm"  x="-118.04" y="-507.8" z="0" />
+     <rotation name="rotFS34" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper35" unit="cm"  x="-112.04" y="-507.8" z="0" />
+     <rotation name="rotFS35" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper36" unit="cm"  x="-106.04" y="-507.8" z="0" />
+     <rotation name="rotFS36" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper37" unit="cm"  x="-100.04" y="-507.8" z="0" />
+     <rotation name="rotFS37" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper38" unit="cm"  x="-94.04" y="-507.8" z="0" />
+     <rotation name="rotFS38" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper39" unit="cm"  x="-88.04" y="-507.8" z="0" />
+     <rotation name="rotFS39" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper40" unit="cm"  x="-82.04" y="-507.8" z="0" />
+     <rotation name="rotFS40" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper41" unit="cm"  x="-76.04" y="-507.8" z="0" />
+     <rotation name="rotFS41" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper42" unit="cm"  x="-70.04" y="-507.8" z="0" />
+     <rotation name="rotFS42" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper43" unit="cm"  x="-64.04" y="-507.8" z="0" />
+     <rotation name="rotFS43" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper44" unit="cm"  x="-58.04" y="-507.8" z="0" />
+     <rotation name="rotFS44" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper45" unit="cm"  x="-52.04" y="-507.8" z="0" />
+     <rotation name="rotFS45" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper46" unit="cm"  x="-46.04" y="-507.8" z="0" />
+     <rotation name="rotFS46" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper47" unit="cm"  x="-40.04" y="-507.8" z="0" />
+     <rotation name="rotFS47" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper48" unit="cm"  x="-34.04" y="-507.8" z="0" />
+     <rotation name="rotFS48" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper49" unit="cm"  x="-28.04" y="-507.8" z="0" />
+     <rotation name="rotFS49" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper50" unit="cm"  x="-22.04" y="-507.8" z="0" />
+     <rotation name="rotFS50" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper51" unit="cm"  x="-16.04" y="-507.8" z="0" />
+     <rotation name="rotFS51" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper52" unit="cm"  x="-10.04" y="-507.8" z="0" />
+     <rotation name="rotFS52" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper53" unit="cm"  x="-4.04000000000001" y="-507.8" z="0" />
+     <rotation name="rotFS53" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper54" unit="cm"  x="1.95999999999999" y="-507.8" z="0" />
+     <rotation name="rotFS54" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper55" unit="cm"  x="7.95999999999999" y="-507.8" z="0" />
+     <rotation name="rotFS55" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper56" unit="cm"  x="13.96" y="-507.8" z="0" />
+     <rotation name="rotFS56" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper57" unit="cm"  x="19.96" y="-507.8" z="0" />
+     <rotation name="rotFS57" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper58" unit="cm"  x="25.96" y="-507.8" z="0" />
+     <rotation name="rotFS58" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper59" unit="cm"  x="31.96" y="-507.8" z="0" />
+     <rotation name="rotFS59" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper60" unit="cm"  x="37.96" y="-507.8" z="0" />
+     <rotation name="rotFS60" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper61" unit="cm"  x="43.96" y="-507.8" z="0" />
+     <rotation name="rotFS61" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper62" unit="cm"  x="49.96" y="-507.8" z="0" />
+     <rotation name="rotFS62" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper63" unit="cm"  x="55.96" y="-507.8" z="0" />
+     <rotation name="rotFS63" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper64" unit="cm"  x="61.96" y="-507.8" z="0" />
+     <rotation name="rotFS64" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper65" unit="cm"  x="67.96" y="-507.8" z="0" />
+     <rotation name="rotFS65" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper66" unit="cm"  x="73.96" y="-507.8" z="0" />
+     <rotation name="rotFS66" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper67" unit="cm"  x="79.96" y="-507.8" z="0" />
+     <rotation name="rotFS67" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper68" unit="cm"  x="85.96" y="-507.8" z="0" />
+     <rotation name="rotFS68" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper69" unit="cm"  x="91.96" y="-507.8" z="0" />
+     <rotation name="rotFS69" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper70" unit="cm"  x="97.96" y="-507.8" z="0" />
+     <rotation name="rotFS70" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper71" unit="cm"  x="103.96" y="-507.8" z="0" />
+     <rotation name="rotFS71" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper72" unit="cm"  x="109.96" y="-507.8" z="0" />
+     <rotation name="rotFS72" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper73" unit="cm"  x="115.96" y="-507.8" z="0" />
+     <rotation name="rotFS73" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper74" unit="cm"  x="121.96" y="-507.8" z="0" />
+     <rotation name="rotFS74" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper75" unit="cm"  x="127.96" y="-507.8" z="0" />
+     <rotation name="rotFS75" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper76" unit="cm"  x="133.96" y="-507.8" z="0" />
+     <rotation name="rotFS76" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper77" unit="cm"  x="139.96" y="-507.8" z="0" />
+     <rotation name="rotFS77" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper78" unit="cm"  x="145.96" y="-507.8" z="0" />
+     <rotation name="rotFS78" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper79" unit="cm"  x="151.96" y="-507.8" z="0" />
+     <rotation name="rotFS79" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper80" unit="cm"  x="157.96" y="-507.8" z="0" />
+     <rotation name="rotFS80" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper81" unit="cm"  x="163.96" y="-507.8" z="0" />
+     <rotation name="rotFS81" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper82" unit="cm"  x="169.96" y="-507.8" z="0" />
+     <rotation name="rotFS82" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper83" unit="cm"  x="175.96" y="-507.8" z="0" />
+     <rotation name="rotFS83" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper84" unit="cm"  x="181.96" y="-507.8" z="0" />
+     <rotation name="rotFS84" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper85" unit="cm"  x="187.96" y="-507.8" z="0" />
+     <rotation name="rotFS85" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper86" unit="cm"  x="193.96" y="-507.8" z="0" />
+     <rotation name="rotFS86" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper87" unit="cm"  x="199.96" y="-507.8" z="0" />
+     <rotation name="rotFS87" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper88" unit="cm"  x="205.96" y="-507.8" z="0" />
+     <rotation name="rotFS88" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper89" unit="cm"  x="211.96" y="-507.8" z="0" />
+     <rotation name="rotFS89" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper90" unit="cm"  x="217.96" y="-507.8" z="0" />
+     <rotation name="rotFS90" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper91" unit="cm"  x="223.96" y="-507.8" z="0" />
+     <rotation name="rotFS91" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper92" unit="cm"  x="229.96" y="-507.8" z="0" />
+     <rotation name="rotFS92" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper93" unit="cm"  x="235.96" y="-507.8" z="0" />
+     <rotation name="rotFS93" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper94" unit="cm"  x="241.96" y="-507.8" z="0" />
+     <rotation name="rotFS94" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper95" unit="cm"  x="247.96" y="-507.8" z="0" />
+     <rotation name="rotFS95" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper96" unit="cm"  x="253.96" y="-507.8" z="0" />
+     <rotation name="rotFS96" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper97" unit="cm"  x="259.96" y="-507.8" z="0" />
+     <rotation name="rotFS97" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper98" unit="cm"  x="265.96" y="-507.8" z="0" />
+     <rotation name="rotFS98" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper99" unit="cm"  x="271.96" y="-507.8" z="0" />
+     <rotation name="rotFS99" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper100" unit="cm"  x="277.96" y="-507.8" z="0" />
+     <rotation name="rotFS100" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper101" unit="cm"  x="283.96" y="-507.8" z="0" />
+     <rotation name="rotFS101" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper102" unit="cm"  x="289.96" y="-507.8" z="0" />
+     <rotation name="rotFS102" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper103" unit="cm"  x="295.96" y="-507.8" z="0" />
+     <rotation name="rotFS103" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper104" unit="cm"  x="301.96" y="-507.8" z="0" />
+     <rotation name="rotFS104" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper105" unit="cm"  x="307.96" y="-507.8" z="0" />
+     <rotation name="rotFS105" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper106" unit="cm"  x="313.96" y="-507.8" z="0" />
+     <rotation name="rotFS106" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper107" unit="cm"  x="319.96" y="-507.8" z="0" />
+     <rotation name="rotFS107" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-0" unit="cm" x="-328.04" y="-337.5" z="-299.3018"/>
+      </physvol>
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-1" unit="cm" x="-328.04" y="-1.5" z="-299.3018"/>
+      </physvol>
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-2" unit="cm" x="-328.04" y="334.5" z="-299.3018"/>
+      </physvol>
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-3" unit="cm" x="-328.04" y="-337.5" z="-1.50000000000006"/>
+      </physvol>
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-4" unit="cm" x="-328.04" y="-1.5" z="-1.50000000000006"/>
+      </physvol>
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-5" unit="cm" x="-328.04" y="334.5" z="-1.50000000000006"/>
+      </physvol>
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-6" unit="cm" x="-328.04" y="-337.5" z="296.3018"/>
+      </physvol>
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-7" unit="cm" x="-328.04" y="-1.5" z="296.3018"/>
+      </physvol>
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-8" unit="cm" x="-328.04" y="334.5" z="296.3018"/>
+      </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-0-0"/>
+       <position name="posArapucaDouble0-Frame-0-0" unit="cm" 
+         x="-328.04"
+	 y="-465.2" 
+	 z="-261.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-0"/>
+       <position name="posOpArapucaDouble0-Frame-0-0" unit="cm" 
+         x="-327.3"
+	 y="-465.2" 
+	 z="-261.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-0-1"/>
+       <position name="posArapucaDouble1-Frame-0-0" unit="cm" 
+         x="-328.04"
+	 y="-374.5" 
+	 z="-407.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-1"/>
+       <position name="posOpArapucaDouble1-Frame-0-0" unit="cm" 
+         x="-327.3"
+	 y="-374.5" 
+	 z="-407.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-0-2"/>
+       <position name="posArapucaDouble2-Frame-0-0" unit="cm" 
+         x="-328.04"
+	 y="-300.5" 
+	 z="-190.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-2"/>
+       <position name="posOpArapucaDouble2-Frame-0-0" unit="cm" 
+         x="-327.3"
+	 y="-300.5" 
+	 z="-190.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-0-3"/>
+       <position name="posArapucaDouble3-Frame-0-0" unit="cm" 
+         x="-328.04"
+	 y="-209.8" 
+	 z="-336.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-3"/>
+       <position name="posOpArapucaDouble3-Frame-0-0" unit="cm" 
+         x="-327.3"
+	 y="-209.8" 
+	 z="-336.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-1-0"/>
+       <position name="posArapucaDouble0-Frame-0-1" unit="cm" 
+         x="-328.04"
+	 y="-465.2" 
+	 z="35.9999999999999"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-0"/>
+       <position name="posOpArapucaDouble0-Frame-0-1" unit="cm" 
+         x="-327.3"
+	 y="-465.2" 
+	 z="35.9999999999999"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-1-1"/>
+       <position name="posArapucaDouble1-Frame-0-1" unit="cm" 
+         x="-328.04"
+	 y="-374.5" 
+	 z="-110"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-1"/>
+       <position name="posOpArapucaDouble1-Frame-0-1" unit="cm" 
+         x="-327.3"
+	 y="-374.5" 
+	 z="-110"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-1-2"/>
+       <position name="posArapucaDouble2-Frame-0-1" unit="cm" 
+         x="-328.04"
+	 y="-300.5" 
+	 z="107"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-2"/>
+       <position name="posOpArapucaDouble2-Frame-0-1" unit="cm" 
+         x="-327.3"
+	 y="-300.5" 
+	 z="107"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-1-3"/>
+       <position name="posArapucaDouble3-Frame-0-1" unit="cm" 
+         x="-328.04"
+	 y="-209.8" 
+	 z="-39.0000000000001"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-3"/>
+       <position name="posOpArapucaDouble3-Frame-0-1" unit="cm" 
+         x="-327.3"
+	 y="-209.8" 
+	 z="-39.0000000000001"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-2-0"/>
+       <position name="posArapucaDouble0-Frame-0-2" unit="cm" 
+         x="-328.04"
+	 y="-465.2" 
+	 z="333.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-0"/>
+       <position name="posOpArapucaDouble0-Frame-0-2" unit="cm" 
+         x="-327.3"
+	 y="-465.2" 
+	 z="333.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-2-1"/>
+       <position name="posArapucaDouble1-Frame-0-2" unit="cm" 
+         x="-328.04"
+	 y="-374.5" 
+	 z="187.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-1"/>
+       <position name="posOpArapucaDouble1-Frame-0-2" unit="cm" 
+         x="-327.3"
+	 y="-374.5" 
+	 z="187.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-2-2"/>
+       <position name="posArapucaDouble2-Frame-0-2" unit="cm" 
+         x="-328.04"
+	 y="-300.5" 
+	 z="404.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-2"/>
+       <position name="posOpArapucaDouble2-Frame-0-2" unit="cm" 
+         x="-327.3"
+	 y="-300.5" 
+	 z="404.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-2-3"/>
+       <position name="posArapucaDouble3-Frame-0-2" unit="cm" 
+         x="-328.04"
+	 y="-209.8" 
+	 z="258.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-3"/>
+       <position name="posOpArapucaDouble3-Frame-0-2" unit="cm" 
+         x="-327.3"
+	 y="-209.8" 
+	 z="258.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-0-0"/>
+       <position name="posArapucaDouble0-Frame-1-0" unit="cm" 
+         x="-328.04"
+	 y="-129.2" 
+	 z="-261.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-0"/>
+       <position name="posOpArapucaDouble0-Frame-1-0" unit="cm" 
+         x="-327.3"
+	 y="-129.2" 
+	 z="-261.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-0-1"/>
+       <position name="posArapucaDouble1-Frame-1-0" unit="cm" 
+         x="-328.04"
+	 y="-38.5" 
+	 z="-407.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-1"/>
+       <position name="posOpArapucaDouble1-Frame-1-0" unit="cm" 
+         x="-327.3"
+	 y="-38.5" 
+	 z="-407.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-0-2"/>
+       <position name="posArapucaDouble2-Frame-1-0" unit="cm" 
+         x="-328.04"
+	 y="35.5" 
+	 z="-190.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-2"/>
+       <position name="posOpArapucaDouble2-Frame-1-0" unit="cm" 
+         x="-327.3"
+	 y="35.5" 
+	 z="-190.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-0-3"/>
+       <position name="posArapucaDouble3-Frame-1-0" unit="cm" 
+         x="-328.04"
+	 y="126.2" 
+	 z="-336.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-3"/>
+       <position name="posOpArapucaDouble3-Frame-1-0" unit="cm" 
+         x="-327.3"
+	 y="126.2" 
+	 z="-336.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-1-0"/>
+       <position name="posArapucaDouble0-Frame-1-1" unit="cm" 
+         x="-328.04"
+	 y="-129.2" 
+	 z="35.9999999999999"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-0"/>
+       <position name="posOpArapucaDouble0-Frame-1-1" unit="cm" 
+         x="-327.3"
+	 y="-129.2" 
+	 z="35.9999999999999"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-1-1"/>
+       <position name="posArapucaDouble1-Frame-1-1" unit="cm" 
+         x="-328.04"
+	 y="-38.5" 
+	 z="-110"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-1"/>
+       <position name="posOpArapucaDouble1-Frame-1-1" unit="cm" 
+         x="-327.3"
+	 y="-38.5" 
+	 z="-110"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-1-2"/>
+       <position name="posArapucaDouble2-Frame-1-1" unit="cm" 
+         x="-328.04"
+	 y="35.5" 
+	 z="107"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-2"/>
+       <position name="posOpArapucaDouble2-Frame-1-1" unit="cm" 
+         x="-327.3"
+	 y="35.5" 
+	 z="107"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-1-3"/>
+       <position name="posArapucaDouble3-Frame-1-1" unit="cm" 
+         x="-328.04"
+	 y="126.2" 
+	 z="-39.0000000000001"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-3"/>
+       <position name="posOpArapucaDouble3-Frame-1-1" unit="cm" 
+         x="-327.3"
+	 y="126.2" 
+	 z="-39.0000000000001"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-2-0"/>
+       <position name="posArapucaDouble0-Frame-1-2" unit="cm" 
+         x="-328.04"
+	 y="-129.2" 
+	 z="333.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-0"/>
+       <position name="posOpArapucaDouble0-Frame-1-2" unit="cm" 
+         x="-327.3"
+	 y="-129.2" 
+	 z="333.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-2-1"/>
+       <position name="posArapucaDouble1-Frame-1-2" unit="cm" 
+         x="-328.04"
+	 y="-38.5" 
+	 z="187.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-1"/>
+       <position name="posOpArapucaDouble1-Frame-1-2" unit="cm" 
+         x="-327.3"
+	 y="-38.5" 
+	 z="187.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-2-2"/>
+       <position name="posArapucaDouble2-Frame-1-2" unit="cm" 
+         x="-328.04"
+	 y="35.5" 
+	 z="404.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-2"/>
+       <position name="posOpArapucaDouble2-Frame-1-2" unit="cm" 
+         x="-327.3"
+	 y="35.5" 
+	 z="404.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-2-3"/>
+       <position name="posArapucaDouble3-Frame-1-2" unit="cm" 
+         x="-328.04"
+	 y="126.2" 
+	 z="258.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-3"/>
+       <position name="posOpArapucaDouble3-Frame-1-2" unit="cm" 
+         x="-327.3"
+	 y="126.2" 
+	 z="258.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-0-0"/>
+       <position name="posArapucaDouble0-Frame-2-0" unit="cm" 
+         x="-328.04"
+	 y="206.8" 
+	 z="-261.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-0"/>
+       <position name="posOpArapucaDouble0-Frame-2-0" unit="cm" 
+         x="-327.3"
+	 y="206.8" 
+	 z="-261.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-0-1"/>
+       <position name="posArapucaDouble1-Frame-2-0" unit="cm" 
+         x="-328.04"
+	 y="297.5" 
+	 z="-407.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-1"/>
+       <position name="posOpArapucaDouble1-Frame-2-0" unit="cm" 
+         x="-327.3"
+	 y="297.5" 
+	 z="-407.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-0-2"/>
+       <position name="posArapucaDouble2-Frame-2-0" unit="cm" 
+         x="-328.04"
+	 y="371.5" 
+	 z="-190.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-2"/>
+       <position name="posOpArapucaDouble2-Frame-2-0" unit="cm" 
+         x="-327.3"
+	 y="371.5" 
+	 z="-190.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-0-3"/>
+       <position name="posArapucaDouble3-Frame-2-0" unit="cm" 
+         x="-328.04"
+	 y="462.2" 
+	 z="-336.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-3"/>
+       <position name="posOpArapucaDouble3-Frame-2-0" unit="cm" 
+         x="-327.3"
+	 y="462.2" 
+	 z="-336.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-1-0"/>
+       <position name="posArapucaDouble0-Frame-2-1" unit="cm" 
+         x="-328.04"
+	 y="206.8" 
+	 z="35.9999999999999"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-0"/>
+       <position name="posOpArapucaDouble0-Frame-2-1" unit="cm" 
+         x="-327.3"
+	 y="206.8" 
+	 z="35.9999999999999"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-1-1"/>
+       <position name="posArapucaDouble1-Frame-2-1" unit="cm" 
+         x="-328.04"
+	 y="297.5" 
+	 z="-110"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-1"/>
+       <position name="posOpArapucaDouble1-Frame-2-1" unit="cm" 
+         x="-327.3"
+	 y="297.5" 
+	 z="-110"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-1-2"/>
+       <position name="posArapucaDouble2-Frame-2-1" unit="cm" 
+         x="-328.04"
+	 y="371.5" 
+	 z="107"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-2"/>
+       <position name="posOpArapucaDouble2-Frame-2-1" unit="cm" 
+         x="-327.3"
+	 y="371.5" 
+	 z="107"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-1-3"/>
+       <position name="posArapucaDouble3-Frame-2-1" unit="cm" 
+         x="-328.04"
+	 y="462.2" 
+	 z="-39.0000000000001"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-3"/>
+       <position name="posOpArapucaDouble3-Frame-2-1" unit="cm" 
+         x="-327.3"
+	 y="462.2" 
+	 z="-39.0000000000001"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-2-0"/>
+       <position name="posArapucaDouble0-Frame-2-2" unit="cm" 
+         x="-328.04"
+	 y="206.8" 
+	 z="333.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-0"/>
+       <position name="posOpArapucaDouble0-Frame-2-2" unit="cm" 
+         x="-327.3"
+	 y="206.8" 
+	 z="333.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-2-1"/>
+       <position name="posArapucaDouble1-Frame-2-2" unit="cm" 
+         x="-328.04"
+	 y="297.5" 
+	 z="187.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-1"/>
+       <position name="posOpArapucaDouble1-Frame-2-2" unit="cm" 
+         x="-327.3"
+	 y="297.5" 
+	 z="187.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-2-2"/>
+       <position name="posArapucaDouble2-Frame-2-2" unit="cm" 
+         x="-328.04"
+	 y="371.5" 
+	 z="404.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-2"/>
+       <position name="posOpArapucaDouble2-Frame-2-2" unit="cm" 
+         x="-327.3"
+	 y="371.5" 
+	 z="404.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-2-3"/>
+       <position name="posArapucaDouble3-Frame-2-2" unit="cm" 
+         x="-328.04"
+	 y="462.2" 
+	 z="258.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-3"/>
+       <position name="posOpArapucaDouble3-Frame-2-2" unit="cm" 
+         x="-327.3"
+	 y="462.2" 
+	 z="258.8018"/>
+     </physvol>
+    </volume>
+
+    <volume name="volFoamPadding">
+      <materialref ref="fibrous_glass"/>
+      <solidref ref="FoamPadding"/>
+    </volume>
+
+    <volume name="volSteelSupport">
+      <materialref ref="AirSteelMixture"/>
+      <solidref ref="SteelSupport"/>
+    </volume>
+
+    <volume name="volDetEnclosure">
+      <materialref ref="Air"/>
+      <solidref ref="DetEnclosure"/>
+
+       <physvol>
+           <volumeref ref="volFoamPadding"/>
+           <positionref ref="posCryoInDetEnc"/>
+       </physvol>
+       <physvol>
+           <volumeref ref="volSteelSupport"/>
+           <positionref ref="posCryoInDetEnc"/>
+       </physvol>
+       <physvol>
+           <volumeref ref="volCryostat"/>
+           <positionref ref="posCryoInDetEnc"/>
+       </physvol>
+    </volume>
+
+    <volume name="volWorld" >
+      <materialref ref="DUSEL_Rock"/>
+      <solidref ref="World"/>
+
+      <physvol>
+        <volumeref ref="volDetEnclosure"/>
+	<position name="posDetEnclosure" unit="cm" x="50.04" y="0" z="448.2027"/>
+      </physvol>
+
+    </volume>
+</structure>
+  <setup name="Default" version="1.0">
+    <world ref="volWorld"/>
+  </setup>
+</gdml_simple_extension>

--- a/dunecore/Geometry/gdml/dunevd10kt_3view_v3_refactored_1x8x6ref_nowires.gdml
+++ b/dunecore/Geometry/gdml/dunevd10kt_3view_v3_refactored_1x8x6ref_nowires.gdml
@@ -489,7 +489,7 @@
     
 
    <box name="CRM"
-      x="650.08" 
+      x="650.1" 
       y="168" 
       z="148.9009"
       lunit="cm"/>
@@ -558,12 +558,12 @@
 
 
     <box name="Cryostat" lunit="cm" 
-      x="850.32" 
+      x="850.34" 
       y="1211.24" 
       z="1096.6454"/>
 
     <box name="ArgonInterior" lunit="cm" 
-      x="850.08"
+      x="850.1"
       y="1211"
       z="1096.4054"/>
 
@@ -573,12 +573,12 @@
       z="1096.4054"/>
 
     <box name="ExternalAuxOut" lunit="cm" 
-      x="850.08 - 100"
+      x="850.1 - 100"
       y="1211 - 2*2.5 - 2*40"
       z="1096.4054"/>
 
     <box name="ExternalAuxIn" lunit="cm" 
-      x="850.08"
+      x="850.1"
       y="1022.17"
       z="1096.4054 + 1"/>
 
@@ -686,7 +686,7 @@
     </subtraction>
 
     <box name="FoamPadBlock" lunit="cm"
-      x="1010.32"
+      x="1010.34"
       y="1371.24"
       z="1256.6454" />
 
@@ -697,7 +697,7 @@
     </subtraction>
 
     <box name="SteelSupportBlock" lunit="cm"
-      x="1210.32"
+      x="1210.34"
       y="1571.24"
       z="1456.6454" />
 
@@ -708,13 +708,13 @@
     </subtraction>
 
     <box name="DetEnclosure" lunit="cm" 
-      x="1310.32"
+      x="1310.34"
       y="1771.24"
       z="1656.6454"/>
 
 
     <box name="World" lunit="cm" 
-      x="9310.32" 
+      x="9310.34" 
       y="9771.24" 
       z="9656.6454"/>
 </solids>
@@ -760,31 +760,31 @@
        <physvol>
        <volumeref ref="volTPCPlaneU"/>
        <position name="posPlaneU" unit="cm" 
-         x="324.97" y="0" z="0"/>
+         x="324.98" y="0" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volTPCPlaneY"/>
        <position name="posPlaneY" unit="cm" 
-         x="324.99" y="0" z="0"/>
+         x="325" y="0" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volTPCPlaneZ"/>
        <position name="posPlaneZ" unit="cm" 
-         x="325.01" y="0" z="0"/>
+         x="325.02" y="0" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volAnodePlate"/>
        <position name="posAnodePlate" unit="cm" 
-         x="325.03" y="0" z="0"/>
+         x="325.04" y="0" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>    
      <physvol>
        <volumeref ref="volTPCActive"/>
        <position name="posActive" unit="cm" 
-        x="-0.04" y="" z="0"/>
+        x="-0.05" y="" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
    </volume>
@@ -1103,7 +1103,7 @@
       <solidref ref="Cryostat" />
       <physvol>
         <volumeref ref="volGaseousArgon"/>
-        <position name="posGaseousArgon" unit="cm" x="375.04" y="0" z="0"/>
+        <position name="posGaseousArgon" unit="cm" x="375.05" y="0" z="0"/>
       </physvol>
       <physvol>
         <volumeref ref="volSteelShell"/>
@@ -1295,584 +1295,584 @@
       </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper0" unit="cm"  x="-322.04" y="-507.8" z="0" />
+     <position name="posFieldShaper0" unit="cm"  x="-322.05" y="-507.8" z="0" />
      <rotation name="rotFS0" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper1" unit="cm"  x="-316.04" y="-507.8" z="0" />
+     <position name="posFieldShaper1" unit="cm"  x="-316.05" y="-507.8" z="0" />
      <rotation name="rotFS1" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper2" unit="cm"  x="-310.04" y="-507.8" z="0" />
+     <position name="posFieldShaper2" unit="cm"  x="-310.05" y="-507.8" z="0" />
      <rotation name="rotFS2" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper3" unit="cm"  x="-304.04" y="-507.8" z="0" />
+     <position name="posFieldShaper3" unit="cm"  x="-304.05" y="-507.8" z="0" />
      <rotation name="rotFS3" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper4" unit="cm"  x="-298.04" y="-507.8" z="0" />
+     <position name="posFieldShaper4" unit="cm"  x="-298.05" y="-507.8" z="0" />
      <rotation name="rotFS4" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper5" unit="cm"  x="-292.04" y="-507.8" z="0" />
+     <position name="posFieldShaper5" unit="cm"  x="-292.05" y="-507.8" z="0" />
      <rotation name="rotFS5" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper6" unit="cm"  x="-286.04" y="-507.8" z="0" />
+     <position name="posFieldShaper6" unit="cm"  x="-286.05" y="-507.8" z="0" />
      <rotation name="rotFS6" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper7" unit="cm"  x="-280.04" y="-507.8" z="0" />
+     <position name="posFieldShaper7" unit="cm"  x="-280.05" y="-507.8" z="0" />
      <rotation name="rotFS7" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper8" unit="cm"  x="-274.04" y="-507.8" z="0" />
+     <position name="posFieldShaper8" unit="cm"  x="-274.05" y="-507.8" z="0" />
      <rotation name="rotFS8" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper9" unit="cm"  x="-268.04" y="-507.8" z="0" />
+     <position name="posFieldShaper9" unit="cm"  x="-268.05" y="-507.8" z="0" />
      <rotation name="rotFS9" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper10" unit="cm"  x="-262.04" y="-507.8" z="0" />
+     <position name="posFieldShaper10" unit="cm"  x="-262.05" y="-507.8" z="0" />
      <rotation name="rotFS10" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper11" unit="cm"  x="-256.04" y="-507.8" z="0" />
+     <position name="posFieldShaper11" unit="cm"  x="-256.05" y="-507.8" z="0" />
      <rotation name="rotFS11" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper12" unit="cm"  x="-250.04" y="-507.8" z="0" />
+     <position name="posFieldShaper12" unit="cm"  x="-250.05" y="-507.8" z="0" />
      <rotation name="rotFS12" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper13" unit="cm"  x="-244.04" y="-507.8" z="0" />
+     <position name="posFieldShaper13" unit="cm"  x="-244.05" y="-507.8" z="0" />
      <rotation name="rotFS13" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper14" unit="cm"  x="-238.04" y="-507.8" z="0" />
+     <position name="posFieldShaper14" unit="cm"  x="-238.05" y="-507.8" z="0" />
      <rotation name="rotFS14" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper15" unit="cm"  x="-232.04" y="-507.8" z="0" />
+     <position name="posFieldShaper15" unit="cm"  x="-232.05" y="-507.8" z="0" />
      <rotation name="rotFS15" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper16" unit="cm"  x="-226.04" y="-507.8" z="0" />
+     <position name="posFieldShaper16" unit="cm"  x="-226.05" y="-507.8" z="0" />
      <rotation name="rotFS16" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper17" unit="cm"  x="-220.04" y="-507.8" z="0" />
+     <position name="posFieldShaper17" unit="cm"  x="-220.05" y="-507.8" z="0" />
      <rotation name="rotFS17" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper18" unit="cm"  x="-214.04" y="-507.8" z="0" />
+     <position name="posFieldShaper18" unit="cm"  x="-214.05" y="-507.8" z="0" />
      <rotation name="rotFS18" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper19" unit="cm"  x="-208.04" y="-507.8" z="0" />
+     <position name="posFieldShaper19" unit="cm"  x="-208.05" y="-507.8" z="0" />
      <rotation name="rotFS19" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper20" unit="cm"  x="-202.04" y="-507.8" z="0" />
+     <position name="posFieldShaper20" unit="cm"  x="-202.05" y="-507.8" z="0" />
      <rotation name="rotFS20" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper21" unit="cm"  x="-196.04" y="-507.8" z="0" />
+     <position name="posFieldShaper21" unit="cm"  x="-196.05" y="-507.8" z="0" />
      <rotation name="rotFS21" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper22" unit="cm"  x="-190.04" y="-507.8" z="0" />
+     <position name="posFieldShaper22" unit="cm"  x="-190.05" y="-507.8" z="0" />
      <rotation name="rotFS22" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper23" unit="cm"  x="-184.04" y="-507.8" z="0" />
+     <position name="posFieldShaper23" unit="cm"  x="-184.05" y="-507.8" z="0" />
      <rotation name="rotFS23" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper24" unit="cm"  x="-178.04" y="-507.8" z="0" />
+     <position name="posFieldShaper24" unit="cm"  x="-178.05" y="-507.8" z="0" />
      <rotation name="rotFS24" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper25" unit="cm"  x="-172.04" y="-507.8" z="0" />
+     <position name="posFieldShaper25" unit="cm"  x="-172.05" y="-507.8" z="0" />
      <rotation name="rotFS25" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper26" unit="cm"  x="-166.04" y="-507.8" z="0" />
+     <position name="posFieldShaper26" unit="cm"  x="-166.05" y="-507.8" z="0" />
      <rotation name="rotFS26" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper27" unit="cm"  x="-160.04" y="-507.8" z="0" />
+     <position name="posFieldShaper27" unit="cm"  x="-160.05" y="-507.8" z="0" />
      <rotation name="rotFS27" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper28" unit="cm"  x="-154.04" y="-507.8" z="0" />
+     <position name="posFieldShaper28" unit="cm"  x="-154.05" y="-507.8" z="0" />
      <rotation name="rotFS28" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper29" unit="cm"  x="-148.04" y="-507.8" z="0" />
+     <position name="posFieldShaper29" unit="cm"  x="-148.05" y="-507.8" z="0" />
      <rotation name="rotFS29" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper30" unit="cm"  x="-142.04" y="-507.8" z="0" />
+     <position name="posFieldShaper30" unit="cm"  x="-142.05" y="-507.8" z="0" />
      <rotation name="rotFS30" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper31" unit="cm"  x="-136.04" y="-507.8" z="0" />
+     <position name="posFieldShaper31" unit="cm"  x="-136.05" y="-507.8" z="0" />
      <rotation name="rotFS31" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper32" unit="cm"  x="-130.04" y="-507.8" z="0" />
+     <position name="posFieldShaper32" unit="cm"  x="-130.05" y="-507.8" z="0" />
      <rotation name="rotFS32" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper33" unit="cm"  x="-124.04" y="-507.8" z="0" />
+     <position name="posFieldShaper33" unit="cm"  x="-124.05" y="-507.8" z="0" />
      <rotation name="rotFS33" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper34" unit="cm"  x="-118.04" y="-507.8" z="0" />
+     <position name="posFieldShaper34" unit="cm"  x="-118.05" y="-507.8" z="0" />
      <rotation name="rotFS34" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper35" unit="cm"  x="-112.04" y="-507.8" z="0" />
+     <position name="posFieldShaper35" unit="cm"  x="-112.05" y="-507.8" z="0" />
      <rotation name="rotFS35" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper36" unit="cm"  x="-106.04" y="-507.8" z="0" />
+     <position name="posFieldShaper36" unit="cm"  x="-106.05" y="-507.8" z="0" />
      <rotation name="rotFS36" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper37" unit="cm"  x="-100.04" y="-507.8" z="0" />
+     <position name="posFieldShaper37" unit="cm"  x="-100.05" y="-507.8" z="0" />
      <rotation name="rotFS37" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper38" unit="cm"  x="-94.04" y="-507.8" z="0" />
+     <position name="posFieldShaper38" unit="cm"  x="-94.0500000000001" y="-507.8" z="0" />
      <rotation name="rotFS38" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper39" unit="cm"  x="-88.04" y="-507.8" z="0" />
+     <position name="posFieldShaper39" unit="cm"  x="-88.0500000000001" y="-507.8" z="0" />
      <rotation name="rotFS39" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper40" unit="cm"  x="-82.04" y="-507.8" z="0" />
+     <position name="posFieldShaper40" unit="cm"  x="-82.0500000000001" y="-507.8" z="0" />
      <rotation name="rotFS40" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper41" unit="cm"  x="-76.04" y="-507.8" z="0" />
+     <position name="posFieldShaper41" unit="cm"  x="-76.0500000000001" y="-507.8" z="0" />
      <rotation name="rotFS41" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper42" unit="cm"  x="-70.04" y="-507.8" z="0" />
+     <position name="posFieldShaper42" unit="cm"  x="-70.0500000000001" y="-507.8" z="0" />
      <rotation name="rotFS42" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper43" unit="cm"  x="-64.04" y="-507.8" z="0" />
+     <position name="posFieldShaper43" unit="cm"  x="-64.0500000000001" y="-507.8" z="0" />
      <rotation name="rotFS43" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper44" unit="cm"  x="-58.04" y="-507.8" z="0" />
+     <position name="posFieldShaper44" unit="cm"  x="-58.0500000000001" y="-507.8" z="0" />
      <rotation name="rotFS44" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper45" unit="cm"  x="-52.04" y="-507.8" z="0" />
+     <position name="posFieldShaper45" unit="cm"  x="-52.0500000000001" y="-507.8" z="0" />
      <rotation name="rotFS45" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper46" unit="cm"  x="-46.04" y="-507.8" z="0" />
+     <position name="posFieldShaper46" unit="cm"  x="-46.0500000000001" y="-507.8" z="0" />
      <rotation name="rotFS46" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper47" unit="cm"  x="-40.04" y="-507.8" z="0" />
+     <position name="posFieldShaper47" unit="cm"  x="-40.0500000000001" y="-507.8" z="0" />
      <rotation name="rotFS47" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper48" unit="cm"  x="-34.04" y="-507.8" z="0" />
+     <position name="posFieldShaper48" unit="cm"  x="-34.0500000000001" y="-507.8" z="0" />
      <rotation name="rotFS48" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper49" unit="cm"  x="-28.04" y="-507.8" z="0" />
+     <position name="posFieldShaper49" unit="cm"  x="-28.0500000000001" y="-507.8" z="0" />
      <rotation name="rotFS49" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper50" unit="cm"  x="-22.04" y="-507.8" z="0" />
+     <position name="posFieldShaper50" unit="cm"  x="-22.0500000000001" y="-507.8" z="0" />
      <rotation name="rotFS50" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper51" unit="cm"  x="-16.04" y="-507.8" z="0" />
+     <position name="posFieldShaper51" unit="cm"  x="-16.0500000000001" y="-507.8" z="0" />
      <rotation name="rotFS51" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper52" unit="cm"  x="-10.04" y="-507.8" z="0" />
+     <position name="posFieldShaper52" unit="cm"  x="-10.0500000000001" y="-507.8" z="0" />
      <rotation name="rotFS52" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper53" unit="cm"  x="-4.04000000000001" y="-507.8" z="0" />
+     <position name="posFieldShaper53" unit="cm"  x="-4.05000000000005" y="-507.8" z="0" />
      <rotation name="rotFS53" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper54" unit="cm"  x="1.95999999999999" y="-507.8" z="0" />
+     <position name="posFieldShaper54" unit="cm"  x="1.94999999999995" y="-507.8" z="0" />
      <rotation name="rotFS54" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper55" unit="cm"  x="7.95999999999999" y="-507.8" z="0" />
+     <position name="posFieldShaper55" unit="cm"  x="7.94999999999995" y="-507.8" z="0" />
      <rotation name="rotFS55" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper56" unit="cm"  x="13.96" y="-507.8" z="0" />
+     <position name="posFieldShaper56" unit="cm"  x="13.9499999999999" y="-507.8" z="0" />
      <rotation name="rotFS56" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper57" unit="cm"  x="19.96" y="-507.8" z="0" />
+     <position name="posFieldShaper57" unit="cm"  x="19.9499999999999" y="-507.8" z="0" />
      <rotation name="rotFS57" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper58" unit="cm"  x="25.96" y="-507.8" z="0" />
+     <position name="posFieldShaper58" unit="cm"  x="25.9499999999999" y="-507.8" z="0" />
      <rotation name="rotFS58" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper59" unit="cm"  x="31.96" y="-507.8" z="0" />
+     <position name="posFieldShaper59" unit="cm"  x="31.9499999999999" y="-507.8" z="0" />
      <rotation name="rotFS59" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper60" unit="cm"  x="37.96" y="-507.8" z="0" />
+     <position name="posFieldShaper60" unit="cm"  x="37.9499999999999" y="-507.8" z="0" />
      <rotation name="rotFS60" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper61" unit="cm"  x="43.96" y="-507.8" z="0" />
+     <position name="posFieldShaper61" unit="cm"  x="43.9499999999999" y="-507.8" z="0" />
      <rotation name="rotFS61" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper62" unit="cm"  x="49.96" y="-507.8" z="0" />
+     <position name="posFieldShaper62" unit="cm"  x="49.9499999999999" y="-507.8" z="0" />
      <rotation name="rotFS62" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper63" unit="cm"  x="55.96" y="-507.8" z="0" />
+     <position name="posFieldShaper63" unit="cm"  x="55.9499999999999" y="-507.8" z="0" />
      <rotation name="rotFS63" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper64" unit="cm"  x="61.96" y="-507.8" z="0" />
+     <position name="posFieldShaper64" unit="cm"  x="61.9499999999999" y="-507.8" z="0" />
      <rotation name="rotFS64" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper65" unit="cm"  x="67.96" y="-507.8" z="0" />
+     <position name="posFieldShaper65" unit="cm"  x="67.9499999999999" y="-507.8" z="0" />
      <rotation name="rotFS65" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper66" unit="cm"  x="73.96" y="-507.8" z="0" />
+     <position name="posFieldShaper66" unit="cm"  x="73.9499999999999" y="-507.8" z="0" />
      <rotation name="rotFS66" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper67" unit="cm"  x="79.96" y="-507.8" z="0" />
+     <position name="posFieldShaper67" unit="cm"  x="79.9499999999999" y="-507.8" z="0" />
      <rotation name="rotFS67" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper68" unit="cm"  x="85.96" y="-507.8" z="0" />
+     <position name="posFieldShaper68" unit="cm"  x="85.9499999999999" y="-507.8" z="0" />
      <rotation name="rotFS68" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper69" unit="cm"  x="91.96" y="-507.8" z="0" />
+     <position name="posFieldShaper69" unit="cm"  x="91.9499999999999" y="-507.8" z="0" />
      <rotation name="rotFS69" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper70" unit="cm"  x="97.96" y="-507.8" z="0" />
+     <position name="posFieldShaper70" unit="cm"  x="97.9499999999999" y="-507.8" z="0" />
      <rotation name="rotFS70" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper71" unit="cm"  x="103.96" y="-507.8" z="0" />
+     <position name="posFieldShaper71" unit="cm"  x="103.95" y="-507.8" z="0" />
      <rotation name="rotFS71" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper72" unit="cm"  x="109.96" y="-507.8" z="0" />
+     <position name="posFieldShaper72" unit="cm"  x="109.95" y="-507.8" z="0" />
      <rotation name="rotFS72" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper73" unit="cm"  x="115.96" y="-507.8" z="0" />
+     <position name="posFieldShaper73" unit="cm"  x="115.95" y="-507.8" z="0" />
      <rotation name="rotFS73" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper74" unit="cm"  x="121.96" y="-507.8" z="0" />
+     <position name="posFieldShaper74" unit="cm"  x="121.95" y="-507.8" z="0" />
      <rotation name="rotFS74" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper75" unit="cm"  x="127.96" y="-507.8" z="0" />
+     <position name="posFieldShaper75" unit="cm"  x="127.95" y="-507.8" z="0" />
      <rotation name="rotFS75" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper76" unit="cm"  x="133.96" y="-507.8" z="0" />
+     <position name="posFieldShaper76" unit="cm"  x="133.95" y="-507.8" z="0" />
      <rotation name="rotFS76" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper77" unit="cm"  x="139.96" y="-507.8" z="0" />
+     <position name="posFieldShaper77" unit="cm"  x="139.95" y="-507.8" z="0" />
      <rotation name="rotFS77" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper78" unit="cm"  x="145.96" y="-507.8" z="0" />
+     <position name="posFieldShaper78" unit="cm"  x="145.95" y="-507.8" z="0" />
      <rotation name="rotFS78" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper79" unit="cm"  x="151.96" y="-507.8" z="0" />
+     <position name="posFieldShaper79" unit="cm"  x="151.95" y="-507.8" z="0" />
      <rotation name="rotFS79" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper80" unit="cm"  x="157.96" y="-507.8" z="0" />
+     <position name="posFieldShaper80" unit="cm"  x="157.95" y="-507.8" z="0" />
      <rotation name="rotFS80" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper81" unit="cm"  x="163.96" y="-507.8" z="0" />
+     <position name="posFieldShaper81" unit="cm"  x="163.95" y="-507.8" z="0" />
      <rotation name="rotFS81" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper82" unit="cm"  x="169.96" y="-507.8" z="0" />
+     <position name="posFieldShaper82" unit="cm"  x="169.95" y="-507.8" z="0" />
      <rotation name="rotFS82" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper83" unit="cm"  x="175.96" y="-507.8" z="0" />
+     <position name="posFieldShaper83" unit="cm"  x="175.95" y="-507.8" z="0" />
      <rotation name="rotFS83" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper84" unit="cm"  x="181.96" y="-507.8" z="0" />
+     <position name="posFieldShaper84" unit="cm"  x="181.95" y="-507.8" z="0" />
      <rotation name="rotFS84" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper85" unit="cm"  x="187.96" y="-507.8" z="0" />
+     <position name="posFieldShaper85" unit="cm"  x="187.95" y="-507.8" z="0" />
      <rotation name="rotFS85" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper86" unit="cm"  x="193.96" y="-507.8" z="0" />
+     <position name="posFieldShaper86" unit="cm"  x="193.95" y="-507.8" z="0" />
      <rotation name="rotFS86" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper87" unit="cm"  x="199.96" y="-507.8" z="0" />
+     <position name="posFieldShaper87" unit="cm"  x="199.95" y="-507.8" z="0" />
      <rotation name="rotFS87" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper88" unit="cm"  x="205.96" y="-507.8" z="0" />
+     <position name="posFieldShaper88" unit="cm"  x="205.95" y="-507.8" z="0" />
      <rotation name="rotFS88" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper89" unit="cm"  x="211.96" y="-507.8" z="0" />
+     <position name="posFieldShaper89" unit="cm"  x="211.95" y="-507.8" z="0" />
      <rotation name="rotFS89" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper90" unit="cm"  x="217.96" y="-507.8" z="0" />
+     <position name="posFieldShaper90" unit="cm"  x="217.95" y="-507.8" z="0" />
      <rotation name="rotFS90" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper91" unit="cm"  x="223.96" y="-507.8" z="0" />
+     <position name="posFieldShaper91" unit="cm"  x="223.95" y="-507.8" z="0" />
      <rotation name="rotFS91" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper92" unit="cm"  x="229.96" y="-507.8" z="0" />
+     <position name="posFieldShaper92" unit="cm"  x="229.95" y="-507.8" z="0" />
      <rotation name="rotFS92" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper93" unit="cm"  x="235.96" y="-507.8" z="0" />
+     <position name="posFieldShaper93" unit="cm"  x="235.95" y="-507.8" z="0" />
      <rotation name="rotFS93" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper94" unit="cm"  x="241.96" y="-507.8" z="0" />
+     <position name="posFieldShaper94" unit="cm"  x="241.95" y="-507.8" z="0" />
      <rotation name="rotFS94" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper95" unit="cm"  x="247.96" y="-507.8" z="0" />
+     <position name="posFieldShaper95" unit="cm"  x="247.95" y="-507.8" z="0" />
      <rotation name="rotFS95" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper96" unit="cm"  x="253.96" y="-507.8" z="0" />
+     <position name="posFieldShaper96" unit="cm"  x="253.95" y="-507.8" z="0" />
      <rotation name="rotFS96" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper97" unit="cm"  x="259.96" y="-507.8" z="0" />
+     <position name="posFieldShaper97" unit="cm"  x="259.95" y="-507.8" z="0" />
      <rotation name="rotFS97" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper98" unit="cm"  x="265.96" y="-507.8" z="0" />
+     <position name="posFieldShaper98" unit="cm"  x="265.95" y="-507.8" z="0" />
      <rotation name="rotFS98" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper99" unit="cm"  x="271.96" y="-507.8" z="0" />
+     <position name="posFieldShaper99" unit="cm"  x="271.95" y="-507.8" z="0" />
      <rotation name="rotFS99" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper100" unit="cm"  x="277.96" y="-507.8" z="0" />
+     <position name="posFieldShaper100" unit="cm"  x="277.95" y="-507.8" z="0" />
      <rotation name="rotFS100" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper101" unit="cm"  x="283.96" y="-507.8" z="0" />
+     <position name="posFieldShaper101" unit="cm"  x="283.95" y="-507.8" z="0" />
      <rotation name="rotFS101" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper102" unit="cm"  x="289.96" y="-507.8" z="0" />
+     <position name="posFieldShaper102" unit="cm"  x="289.95" y="-507.8" z="0" />
      <rotation name="rotFS102" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper103" unit="cm"  x="295.96" y="-507.8" z="0" />
+     <position name="posFieldShaper103" unit="cm"  x="295.95" y="-507.8" z="0" />
      <rotation name="rotFS103" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper104" unit="cm"  x="301.96" y="-507.8" z="0" />
+     <position name="posFieldShaper104" unit="cm"  x="301.95" y="-507.8" z="0" />
      <rotation name="rotFS104" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper105" unit="cm"  x="307.96" y="-507.8" z="0" />
+     <position name="posFieldShaper105" unit="cm"  x="307.95" y="-507.8" z="0" />
      <rotation name="rotFS105" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper106" unit="cm"  x="313.96" y="-507.8" z="0" />
+     <position name="posFieldShaper106" unit="cm"  x="313.95" y="-507.8" z="0" />
      <rotation name="rotFS106" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper107" unit="cm"  x="319.96" y="-507.8" z="0" />
+     <position name="posFieldShaper107" unit="cm"  x="319.95" y="-507.8" z="0" />
      <rotation name="rotFS107" unit="deg" x="0" y="0" z="90" />
   </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-0" unit="cm" x="-328.04" y="-337.5" z="-299.3018"/>
+   <position name="posGroundGrid-0" unit="cm" x="-328.05" y="-337.5" z="-299.3018"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-1" unit="cm" x="-328.04" y="-1.5" z="-299.3018"/>
+   <position name="posGroundGrid-1" unit="cm" x="-328.05" y="-1.5" z="-299.3018"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-2" unit="cm" x="-328.04" y="334.5" z="-299.3018"/>
+   <position name="posGroundGrid-2" unit="cm" x="-328.05" y="334.5" z="-299.3018"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-3" unit="cm" x="-328.04" y="-337.5" z="-1.50000000000006"/>
+   <position name="posGroundGrid-3" unit="cm" x="-328.05" y="-337.5" z="-1.50000000000006"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-4" unit="cm" x="-328.04" y="-1.5" z="-1.50000000000006"/>
+   <position name="posGroundGrid-4" unit="cm" x="-328.05" y="-1.5" z="-1.50000000000006"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-5" unit="cm" x="-328.04" y="334.5" z="-1.50000000000006"/>
+   <position name="posGroundGrid-5" unit="cm" x="-328.05" y="334.5" z="-1.50000000000006"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-6" unit="cm" x="-328.04" y="-337.5" z="296.3018"/>
+   <position name="posGroundGrid-6" unit="cm" x="-328.05" y="-337.5" z="296.3018"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-7" unit="cm" x="-328.04" y="-1.5" z="296.3018"/>
+   <position name="posGroundGrid-7" unit="cm" x="-328.05" y="-1.5" z="296.3018"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-8" unit="cm" x="-328.04" y="334.5" z="296.3018"/>
+   <position name="posGroundGrid-8" unit="cm" x="-328.05" y="334.5" z="296.3018"/>
       </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-0-0"/>
        <position name="posArapucaDouble0-Frame-0-0" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-465.2" 
 	 z="-261.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -1880,14 +1880,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-0"/>
        <position name="posOpArapucaDouble0-Frame-0-0" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-465.2" 
 	 z="-261.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-0-1"/>
        <position name="posArapucaDouble1-Frame-0-0" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-374.5" 
 	 z="-407.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -1895,14 +1895,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-1"/>
        <position name="posOpArapucaDouble1-Frame-0-0" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-374.5" 
 	 z="-407.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-0-2"/>
        <position name="posArapucaDouble2-Frame-0-0" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-300.5" 
 	 z="-190.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -1910,14 +1910,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-2"/>
        <position name="posOpArapucaDouble2-Frame-0-0" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-300.5" 
 	 z="-190.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-0-3"/>
        <position name="posArapucaDouble3-Frame-0-0" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-209.8" 
 	 z="-336.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -1925,14 +1925,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-3"/>
        <position name="posOpArapucaDouble3-Frame-0-0" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-209.8" 
 	 z="-336.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-1-0"/>
        <position name="posArapucaDouble0-Frame-0-1" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-465.2" 
 	 z="35.9999999999999"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -1940,14 +1940,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-0"/>
        <position name="posOpArapucaDouble0-Frame-0-1" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-465.2" 
 	 z="35.9999999999999"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-1-1"/>
        <position name="posArapucaDouble1-Frame-0-1" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-374.5" 
 	 z="-110"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -1955,14 +1955,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-1"/>
        <position name="posOpArapucaDouble1-Frame-0-1" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-374.5" 
 	 z="-110"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-1-2"/>
        <position name="posArapucaDouble2-Frame-0-1" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-300.5" 
 	 z="107"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -1970,14 +1970,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-2"/>
        <position name="posOpArapucaDouble2-Frame-0-1" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-300.5" 
 	 z="107"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-1-3"/>
        <position name="posArapucaDouble3-Frame-0-1" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-209.8" 
 	 z="-39.0000000000001"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -1985,14 +1985,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-3"/>
        <position name="posOpArapucaDouble3-Frame-0-1" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-209.8" 
 	 z="-39.0000000000001"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-2-0"/>
        <position name="posArapucaDouble0-Frame-0-2" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-465.2" 
 	 z="333.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -2000,14 +2000,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-0"/>
        <position name="posOpArapucaDouble0-Frame-0-2" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-465.2" 
 	 z="333.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-2-1"/>
        <position name="posArapucaDouble1-Frame-0-2" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-374.5" 
 	 z="187.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -2015,14 +2015,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-1"/>
        <position name="posOpArapucaDouble1-Frame-0-2" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-374.5" 
 	 z="187.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-2-2"/>
        <position name="posArapucaDouble2-Frame-0-2" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-300.5" 
 	 z="404.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -2030,14 +2030,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-2"/>
        <position name="posOpArapucaDouble2-Frame-0-2" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-300.5" 
 	 z="404.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-2-3"/>
        <position name="posArapucaDouble3-Frame-0-2" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-209.8" 
 	 z="258.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -2045,14 +2045,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-3"/>
        <position name="posOpArapucaDouble3-Frame-0-2" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-209.8" 
 	 z="258.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-0-0"/>
        <position name="posArapucaDouble0-Frame-1-0" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-129.2" 
 	 z="-261.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -2060,14 +2060,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-0"/>
        <position name="posOpArapucaDouble0-Frame-1-0" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-129.2" 
 	 z="-261.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-0-1"/>
        <position name="posArapucaDouble1-Frame-1-0" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-38.5" 
 	 z="-407.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -2075,14 +2075,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-1"/>
        <position name="posOpArapucaDouble1-Frame-1-0" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-38.5" 
 	 z="-407.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-0-2"/>
        <position name="posArapucaDouble2-Frame-1-0" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="35.5" 
 	 z="-190.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -2090,14 +2090,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-2"/>
        <position name="posOpArapucaDouble2-Frame-1-0" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="35.5" 
 	 z="-190.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-0-3"/>
        <position name="posArapucaDouble3-Frame-1-0" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="126.2" 
 	 z="-336.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -2105,14 +2105,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-3"/>
        <position name="posOpArapucaDouble3-Frame-1-0" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="126.2" 
 	 z="-336.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-1-0"/>
        <position name="posArapucaDouble0-Frame-1-1" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-129.2" 
 	 z="35.9999999999999"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -2120,14 +2120,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-0"/>
        <position name="posOpArapucaDouble0-Frame-1-1" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-129.2" 
 	 z="35.9999999999999"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-1-1"/>
        <position name="posArapucaDouble1-Frame-1-1" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-38.5" 
 	 z="-110"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -2135,14 +2135,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-1"/>
        <position name="posOpArapucaDouble1-Frame-1-1" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-38.5" 
 	 z="-110"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-1-2"/>
        <position name="posArapucaDouble2-Frame-1-1" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="35.5" 
 	 z="107"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -2150,14 +2150,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-2"/>
        <position name="posOpArapucaDouble2-Frame-1-1" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="35.5" 
 	 z="107"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-1-3"/>
        <position name="posArapucaDouble3-Frame-1-1" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="126.2" 
 	 z="-39.0000000000001"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -2165,14 +2165,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-3"/>
        <position name="posOpArapucaDouble3-Frame-1-1" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="126.2" 
 	 z="-39.0000000000001"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-2-0"/>
        <position name="posArapucaDouble0-Frame-1-2" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-129.2" 
 	 z="333.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -2180,14 +2180,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-0"/>
        <position name="posOpArapucaDouble0-Frame-1-2" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-129.2" 
 	 z="333.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-2-1"/>
        <position name="posArapucaDouble1-Frame-1-2" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="-38.5" 
 	 z="187.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -2195,14 +2195,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-1"/>
        <position name="posOpArapucaDouble1-Frame-1-2" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="-38.5" 
 	 z="187.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-2-2"/>
        <position name="posArapucaDouble2-Frame-1-2" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="35.5" 
 	 z="404.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -2210,14 +2210,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-2"/>
        <position name="posOpArapucaDouble2-Frame-1-2" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="35.5" 
 	 z="404.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-2-3"/>
        <position name="posArapucaDouble3-Frame-1-2" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="126.2" 
 	 z="258.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -2225,14 +2225,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-3"/>
        <position name="posOpArapucaDouble3-Frame-1-2" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="126.2" 
 	 z="258.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-0-0"/>
        <position name="posArapucaDouble0-Frame-2-0" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="206.8" 
 	 z="-261.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -2240,14 +2240,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-0"/>
        <position name="posOpArapucaDouble0-Frame-2-0" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="206.8" 
 	 z="-261.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-0-1"/>
        <position name="posArapucaDouble1-Frame-2-0" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="297.5" 
 	 z="-407.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -2255,14 +2255,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-1"/>
        <position name="posOpArapucaDouble1-Frame-2-0" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="297.5" 
 	 z="-407.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-0-2"/>
        <position name="posArapucaDouble2-Frame-2-0" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="371.5" 
 	 z="-190.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -2270,14 +2270,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-2"/>
        <position name="posOpArapucaDouble2-Frame-2-0" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="371.5" 
 	 z="-190.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-0-3"/>
        <position name="posArapucaDouble3-Frame-2-0" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="462.2" 
 	 z="-336.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -2285,14 +2285,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-3"/>
        <position name="posOpArapucaDouble3-Frame-2-0" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="462.2" 
 	 z="-336.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-1-0"/>
        <position name="posArapucaDouble0-Frame-2-1" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="206.8" 
 	 z="35.9999999999999"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -2300,14 +2300,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-0"/>
        <position name="posOpArapucaDouble0-Frame-2-1" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="206.8" 
 	 z="35.9999999999999"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-1-1"/>
        <position name="posArapucaDouble1-Frame-2-1" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="297.5" 
 	 z="-110"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -2315,14 +2315,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-1"/>
        <position name="posOpArapucaDouble1-Frame-2-1" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="297.5" 
 	 z="-110"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-1-2"/>
        <position name="posArapucaDouble2-Frame-2-1" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="371.5" 
 	 z="107"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -2330,14 +2330,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-2"/>
        <position name="posOpArapucaDouble2-Frame-2-1" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="371.5" 
 	 z="107"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-1-3"/>
        <position name="posArapucaDouble3-Frame-2-1" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="462.2" 
 	 z="-39.0000000000001"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -2345,14 +2345,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-3"/>
        <position name="posOpArapucaDouble3-Frame-2-1" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="462.2" 
 	 z="-39.0000000000001"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-2-0"/>
        <position name="posArapucaDouble0-Frame-2-2" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="206.8" 
 	 z="333.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -2360,14 +2360,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-0"/>
        <position name="posOpArapucaDouble0-Frame-2-2" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="206.8" 
 	 z="333.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-2-1"/>
        <position name="posArapucaDouble1-Frame-2-2" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="297.5" 
 	 z="187.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -2375,14 +2375,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-1"/>
        <position name="posOpArapucaDouble1-Frame-2-2" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="297.5" 
 	 z="187.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-2-2"/>
        <position name="posArapucaDouble2-Frame-2-2" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="371.5" 
 	 z="404.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -2390,14 +2390,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-2"/>
        <position name="posOpArapucaDouble2-Frame-2-2" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="371.5" 
 	 z="404.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-2-3"/>
        <position name="posArapucaDouble3-Frame-2-2" unit="cm" 
-         x="-328.04"
+         x="-328.05"
 	 y="462.2" 
 	 z="258.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -2405,7 +2405,7 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-3"/>
        <position name="posOpArapucaDouble3-Frame-2-2" unit="cm" 
-         x="-327.3"
+         x="-327.31"
 	 y="462.2" 
 	 z="258.8018"/>
      </physvol>
@@ -2445,7 +2445,7 @@
 
       <physvol>
         <volumeref ref="volDetEnclosure"/>
-	<position name="posDetEnclosure" unit="cm" x="50.04" y="0" z="448.2027"/>
+	<position name="posDetEnclosure" unit="cm" x="50.0500000000001" y="0" z="448.2027"/>
       </physvol>
 
     </volume>

--- a/dunecore/Geometry/gdml/dunevd10kt_3view_v3_refactored_1x8x6ref_nowires.gdml
+++ b/dunecore/Geometry/gdml/dunevd10kt_3view_v3_refactored_1x8x6ref_nowires.gdml
@@ -19,8 +19,7 @@
 
    <position name="posCryoInDetEnc"     unit="cm" x="-50.0000000000001" y="0" z="0"/>
    <position name="posCenter"           unit="cm" x="0" y="0" z="0"/>
-   <rotation name="rUWireAboutX"        unit="deg" x="150" y="0" z="0"/>
-   <rotation name="rVWireAboutX"        unit="deg" x="30" y="0" z="0"/>
+   <rotation name="rUWireAboutX"        unit="deg" x="131.63" y="0" z="0"/>
    <rotation name="rPlus90AboutX"       unit="deg" x="90" y="0" z="0"/>
    <rotation name="rPlus90AboutY"       unit="deg" x="0" y="90" z="0"/>
    <rotation name="rPlus90AboutXPlus90AboutY" unit="deg" x="90" y="90" z="0"/>
@@ -388,131 +387,131 @@
 </materials>
 <solids>
      <torus name="FieldShaperCorner" rmin="0.5" rmax="2.285" rtor="2.3" deltaphi="90" startphi="0" aunit="deg" lunit="cm"/>
-     <tube name="FieldShaperLongtube" rmin="0.5" rmax="2.285" z="896.52" deltaphi="360" startphi="0" aunit="deg" lunit="cm"/>
-     <tube name="FieldShaperLongtubeSlim" rmin="0.5" rmax="0.75" z="896.52" deltaphi="360" startphi="0" aunit="deg" lunit="cm"/>
-     <tube name="FieldShaperShorttube" rmin="0.5" rmax="2.285" z="1009.2036" deltaphi="360" startphi="0" aunit="deg" lunit="cm"/>
+     <tube name="FieldShaperLongtube" rmin="0.5" rmax="2.285" z="896.4054" deltaphi="360" startphi="0" aunit="deg" lunit="cm"/>
+     <tube name="FieldShaperLongtubeSlim" rmin="0.5" rmax="0.75" z="896.4054" deltaphi="360" startphi="0" aunit="deg" lunit="cm"/>
+     <tube name="FieldShaperShorttube" rmin="0.5" rmax="2.285" z="1011" deltaphi="360" startphi="0" aunit="deg" lunit="cm"/>
 
     <union name="FSunion1">
       <first ref="FieldShaperLongtube"/>
       <second ref="FieldShaperCorner"/>
-   		<position name="esquinapos1" unit="cm" x="-2.3" y="0" z="448.26"/>
+   		<position name="esquinapos1" unit="cm" x="-2.3" y="0" z="448.2027"/>
 		<rotation name="rot1" unit="deg" x="90" y="0" z="0" />
     </union>
 
     <union name="FSunion2">
       <first ref="FSunion1"/>
       <second ref="FieldShaperShorttube"/>
-   		<position name="esquinapos2" unit="cm" x="-506.9018" y="0" z="450.56"/>
+   		<position name="esquinapos2" unit="cm" x="-507.8" y="0" z="450.5027"/>
    		<rotation name="rot2" unit="deg" x="0" y="90" z="0" />
     </union>
 
     <union name="FSunion3">
       <first ref="FSunion2"/>
       <second ref="FieldShaperCorner"/>
-   		<position name="esquinapos3" unit="cm" x="-1011.5036" y="0" z="448.26"/>
+   		<position name="esquinapos3" unit="cm" x="-1013.3" y="0" z="448.2027"/>
 		<rotation name="rot3" unit="deg" x="90" y="270" z="0" />
     </union>
 
     <union name="FSunion4">
       <first ref="FSunion3"/>
       <second ref="FieldShaperLongtube"/>
-   		<position name="esquinapos4" unit="cm" x="-1013.8036" y="0" z="0"/>
+   		<position name="esquinapos4" unit="cm" x="-1015.6" y="0" z="0"/>
     </union>
 
     <union name="FSunion5">
       <first ref="FSunion4"/>
       <second ref="FieldShaperCorner"/>
-   		<position name="esquinapos5" unit="cm" x="-1011.5036" y="0" z="-448.26"/>
+   		<position name="esquinapos5" unit="cm" x="-1013.3" y="0" z="-448.2027"/>
 		<rotation name="rot5" unit="deg" x="90" y="180" z="0" />
     </union>
 
     <union name="FSunion6">
       <first ref="FSunion5"/>
       <second ref="FieldShaperShorttube"/>
-   		<position name="esquinapos6" unit="cm" x="-506.9018" y="0" z="-450.56"/>
+   		<position name="esquinapos6" unit="cm" x="-507.8" y="0" z="-450.5027"/>
 		<rotation name="rot6" unit="deg" x="0" y="90" z="0" />
     </union>
 
     <union name="FieldShaperSolid">
       <first ref="FSunion6"/>
       <second ref="FieldShaperCorner"/>
-   		<position name="esquinapos7" unit="cm" x="-2.3" y="0" z="-448.26"/>
+   		<position name="esquinapos7" unit="cm" x="-2.3" y="0" z="-448.2027"/>
 		<rotation name="rot7" unit="deg" x="90" y="90" z="0" />
     </union>
     
     <union name="FSunionSlim1">
       <first ref="FieldShaperLongtubeSlim"/>
       <second ref="FieldShaperCorner"/>
-   		<position name="esquinapos1" unit="cm" x="-2.3" y="0" z="448.26"/>
+   		<position name="esquinapos1" unit="cm" x="-2.3" y="0" z="448.2027"/>
 		<rotation name="rot1" unit="deg" x="90" y="0" z="0" />
     </union>
 
     <union name="FSunionSlim2">
       <first ref="FSunionSlim1"/>
       <second ref="FieldShaperShorttube"/>
-   		<position name="esquinapos2" unit="cm" x="-506.9018" y="0" z="450.56"/>
+   		<position name="esquinapos2" unit="cm" x="-507.8" y="0" z="450.5027"/>
    		<rotation name="rot2" unit="deg" x="0" y="90" z="0" />
     </union>
 
     <union name="FSunionSlim3">
       <first ref="FSunionSlim2"/>
       <second ref="FieldShaperCorner"/>
-   		<position name="esquinapos3" unit="cm" x="-1011.5036" y="0" z="448.26"/>
+   		<position name="esquinapos3" unit="cm" x="-1013.3" y="0" z="448.2027"/>
 		<rotation name="rot3" unit="deg" x="90" y="270" z="0" />
     </union>
 
     <union name="FSunionSlim4">
       <first ref="FSunionSlim3"/>
       <second ref="FieldShaperLongtubeSlim"/>
-   		<position name="esquinapos4" unit="cm" x="-1013.8036" y="0" z="0"/>
+   		<position name="esquinapos4" unit="cm" x="-1015.6" y="0" z="0"/>
     </union>
 
     <union name="FSunionSlim5">
       <first ref="FSunionSlim4"/>
       <second ref="FieldShaperCorner"/>
-   		<position name="esquinapos5" unit="cm" x="-1011.5036" y="0" z="-448.26"/>
+   		<position name="esquinapos5" unit="cm" x="-1013.3" y="0" z="-448.2027"/>
 		<rotation name="rot5" unit="deg" x="90" y="180" z="0" />
     </union>
 
     <union name="FSunionSlim6">
       <first ref="FSunionSlim5"/>
       <second ref="FieldShaperShorttube"/>
-   		<position name="esquinapos6" unit="cm" x="-506.9018" y="0" z="-450.56"/>
+   		<position name="esquinapos6" unit="cm" x="-507.8" y="0" z="-450.5027"/>
 		<rotation name="rot6" unit="deg" x="0" y="90" z="0" />
     </union>
 
     <union name="FieldShaperSolidSlim">
       <first ref="FSunionSlim6"/>
       <second ref="FieldShaperCorner"/>
-   		<position name="esquinapos7" unit="cm" x="-2.3" y="0" z="-448.26"/>
+   		<position name="esquinapos7" unit="cm" x="-2.3" y="0" z="-448.2027"/>
 		<rotation name="rot7" unit="deg" x="90" y="90" z="0" />
     </union>
     
 
    <box name="CRM"
       x="650.08" 
-      y="167.7006" 
-      z="148.92"
+      y="168" 
+      z="148.9009"
       lunit="cm"/>
    <box name="CRMUPlane" 
       x="0.02" 
-      y="167.7006" 
-      z="148.92"
+      y="168" 
+      z="148.9009"
       lunit="cm"/>
-   <box name="CRMVPlane" 
+   <box name="CRMYPlane" 
       x="0.02" 
-      y="167.7006" 
-      z="148.92"
+      y="168" 
+      z="148.9009"
       lunit="cm"/>
    <box name="CRMZPlane" 
       x="0.02"
-      y="167.7006"
-      z="148.92"
+      y="168"
+      z="148.9009"
       lunit="cm"/>
    <box name="CRMActive" 
       x="650"
-      y="167.7006"
-      z="148.92"
+      y="168"
+      z="148.9009"
       lunit="cm"/>
 
     <box name="ArapucaOut" lunit="cm"
@@ -560,28 +559,28 @@
 
     <box name="Cryostat" lunit="cm" 
       x="850.32" 
-      y="1209.4436" 
-      z="1096.76"/>
+      y="1211.24" 
+      z="1096.6454"/>
 
     <box name="ArgonInterior" lunit="cm" 
       x="850.08"
-      y="1209.2036"
-      z="1096.52"/>
+      y="1211"
+      z="1096.4054"/>
 
     <box name="GaseousArgon" lunit="cm" 
       x="100"
-      y="1209.2036"
-      z="1096.52"/>
+      y="1211"
+      z="1096.4054"/>
 
     <box name="ExternalAuxOut" lunit="cm" 
       x="850.08 - 100"
-      y="1209.2036 - 2*2.5 - 2*40"
-      z="1096.52"/>
+      y="1211 - 2*2.5 - 2*40"
+      z="1096.4054"/>
 
     <box name="ExternalAuxIn" lunit="cm" 
       x="850.08"
-      y="1020.3736"
-      z="1096.52 + 1"/>
+      y="1022.17"
+      z="1096.4054 + 1"/>
 
    <subtraction name="ExternalActive">
       <first ref="ExternalAuxOut"/>
@@ -597,8 +596,8 @@
 
     <box name="CathodeBlock" lunit="cm"
       x="4"
-      y="335.4012"
-      z="297.84" />
+      y="336"
+      z="297.8018" />
 
     <box name="CathodeVoid" lunit="cm"
       x="5"
@@ -688,8 +687,8 @@
 
     <box name="FoamPadBlock" lunit="cm"
       x="1010.32"
-      y="1369.4436"
-      z="1256.76" />
+      y="1371.24"
+      z="1256.6454" />
 
     <subtraction name="FoamPadding">
       <first ref="FoamPadBlock"/>
@@ -699,8 +698,8 @@
 
     <box name="SteelSupportBlock" lunit="cm"
       x="1210.32"
-      y="1569.4436"
-      z="1456.76" />
+      y="1571.24"
+      z="1456.6454" />
 
     <subtraction name="SteelSupport">
       <first ref="SteelSupportBlock"/>
@@ -710,14 +709,14 @@
 
     <box name="DetEnclosure" lunit="cm" 
       x="1310.32"
-      y="1769.4436"
-      z="1656.76"/>
+      y="1771.24"
+      z="1656.6454"/>
 
 
     <box name="World" lunit="cm" 
       x="9310.32" 
-      y="9769.4436" 
-      z="9656.76"/>
+      y="9771.24" 
+      z="9656.6454"/>
 </solids>
 <structure>
 <volume name="volFieldShaper">
@@ -742,9 +741,9 @@
      <materialref ref="LAr"/>
      <solidref ref="CRMUPlane"/>
    </volume>
-  <volume name="volTPCPlaneV">
+  <volume name="volTPCPlaneY">
     <materialref ref="LAr"/>
-    <solidref ref="CRMVPlane"/>
+    <solidref ref="CRMYPlane"/>
   </volume>
   <volume name="volTPCPlaneZ">
     <materialref ref="LAr"/>
@@ -765,7 +764,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volTPCPlaneV"/>
+       <volumeref ref="volTPCPlaneY"/>
        <position name="posPlaneY" unit="cm" 
          x="324.99" y="0" z="0"/>
        <rotationref ref="rIdentity"/>
@@ -781,7 +780,7 @@
        <position name="posAnodePlate" unit="cm" 
          x="325.03" y="0" z="0"/>
        <rotationref ref="rIdentity"/>
-     </physvol>
+     </physvol>    
      <physvol>
        <volumeref ref="volTPCActive"/>
        <position name="posActive" unit="cm" 
@@ -797,7 +796,7 @@
     <volume name="volGroundGrid">
       <materialref ref="STEEL_STAINLESS_Fe7Cr2Ni" />
       <solidref ref="CathodeGrid" />
-    </volume>
+    </volume>    
     <volume name="volGaseousArgon">
       <materialref ref="ArGas"/>
       <solidref ref="GaseousArgon"/>
@@ -1117,839 +1116,839 @@
       <physvol>
         <volumeref ref="volTPC"/>
 	<position name="posTPC-0" unit="cm"
-           x="0" y="-420.2515" z="-373.3"/>
+           x="0" y="-421" z="-373.25225"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC"/>
 	<position name="posTPC-1" unit="cm"
-           x="0" y="-252.5509" z="-373.3"/>
+           x="0" y="-253" z="-373.25225"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC"/>
 	<position name="posTPC-2" unit="cm"
-           x="0" y="-83.8503" z="-373.3"/>
+           x="0" y="-84" z="-373.25225"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC"/>
 	<position name="posTPC-3" unit="cm"
-           x="0" y="83.8503" z="-373.3"/>
+           x="0" y="84" z="-373.25225"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC"/>
 	<position name="posTPC-4" unit="cm"
-           x="0" y="252.5509" z="-373.3"/>
+           x="0" y="253" z="-373.25225"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC"/>
 	<position name="posTPC-5" unit="cm"
-           x="0" y="420.2515" z="-373.3"/>
+           x="0" y="421" z="-373.25225"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC"/>
 	<position name="posTPC-6" unit="cm"
-           x="0" y="-420.2515" z="-224.38"/>
+           x="0" y="-421" z="-224.35135"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC"/>
 	<position name="posTPC-7" unit="cm"
-           x="0" y="-252.5509" z="-224.38"/>
+           x="0" y="-253" z="-224.35135"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC"/>
 	<position name="posTPC-8" unit="cm"
-           x="0" y="-83.8503" z="-224.38"/>
+           x="0" y="-84" z="-224.35135"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC"/>
 	<position name="posTPC-9" unit="cm"
-           x="0" y="83.8503" z="-224.38"/>
+           x="0" y="84" z="-224.35135"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC"/>
 	<position name="posTPC-10" unit="cm"
-           x="0" y="252.5509" z="-224.38"/>
+           x="0" y="253" z="-224.35135"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC"/>
 	<position name="posTPC-11" unit="cm"
-           x="0" y="420.2515" z="-224.38"/>
+           x="0" y="421" z="-224.35135"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC"/>
 	<position name="posTPC-12" unit="cm"
-           x="0" y="-420.2515" z="-74.46"/>
+           x="0" y="-421" z="-74.45045"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC"/>
 	<position name="posTPC-13" unit="cm"
-           x="0" y="-252.5509" z="-74.46"/>
+           x="0" y="-253" z="-74.45045"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC"/>
 	<position name="posTPC-14" unit="cm"
-           x="0" y="-83.8503" z="-74.46"/>
+           x="0" y="-84" z="-74.45045"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC"/>
 	<position name="posTPC-15" unit="cm"
-           x="0" y="83.8503" z="-74.46"/>
+           x="0" y="84" z="-74.45045"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC"/>
 	<position name="posTPC-16" unit="cm"
-           x="0" y="252.5509" z="-74.46"/>
+           x="0" y="253" z="-74.45045"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC"/>
 	<position name="posTPC-17" unit="cm"
-           x="0" y="420.2515" z="-74.46"/>
+           x="0" y="421" z="-74.45045"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC"/>
 	<position name="posTPC-18" unit="cm"
-           x="0" y="-420.2515" z="74.46"/>
+           x="0" y="-421" z="74.45045"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC"/>
 	<position name="posTPC-19" unit="cm"
-           x="0" y="-252.5509" z="74.46"/>
+           x="0" y="-253" z="74.45045"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC"/>
 	<position name="posTPC-20" unit="cm"
-           x="0" y="-83.8503" z="74.46"/>
+           x="0" y="-84" z="74.45045"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC"/>
 	<position name="posTPC-21" unit="cm"
-           x="0" y="83.8503" z="74.46"/>
+           x="0" y="84" z="74.45045"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC"/>
 	<position name="posTPC-22" unit="cm"
-           x="0" y="252.5509" z="74.46"/>
+           x="0" y="253" z="74.45045"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC"/>
 	<position name="posTPC-23" unit="cm"
-           x="0" y="420.2515" z="74.46"/>
+           x="0" y="421" z="74.45045"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC"/>
 	<position name="posTPC-24" unit="cm"
-           x="0" y="-420.2515" z="224.38"/>
+           x="0" y="-421" z="224.35135"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC"/>
 	<position name="posTPC-25" unit="cm"
-           x="0" y="-252.5509" z="224.38"/>
+           x="0" y="-253" z="224.35135"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC"/>
 	<position name="posTPC-26" unit="cm"
-           x="0" y="-83.8503" z="224.38"/>
+           x="0" y="-84" z="224.35135"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC"/>
 	<position name="posTPC-27" unit="cm"
-           x="0" y="83.8503" z="224.38"/>
+           x="0" y="84" z="224.35135"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC"/>
 	<position name="posTPC-28" unit="cm"
-           x="0" y="252.5509" z="224.38"/>
+           x="0" y="253" z="224.35135"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC"/>
 	<position name="posTPC-29" unit="cm"
-           x="0" y="420.2515" z="224.38"/>
+           x="0" y="421" z="224.35135"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC"/>
 	<position name="posTPC-30" unit="cm"
-           x="0" y="-420.2515" z="373.3"/>
+           x="0" y="-421" z="373.25225"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC"/>
 	<position name="posTPC-31" unit="cm"
-           x="0" y="-252.5509" z="373.3"/>
+           x="0" y="-253" z="373.25225"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC"/>
 	<position name="posTPC-32" unit="cm"
-           x="0" y="-83.8503" z="373.3"/>
+           x="0" y="-84" z="373.25225"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC"/>
 	<position name="posTPC-33" unit="cm"
-           x="0" y="83.8503" z="373.3"/>
+           x="0" y="84" z="373.25225"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC"/>
 	<position name="posTPC-34" unit="cm"
-           x="0" y="252.5509" z="373.3"/>
+           x="0" y="253" z="373.25225"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC"/>
 	<position name="posTPC-35" unit="cm"
-           x="0" y="420.2515" z="373.3"/>
+           x="0" y="421" z="373.25225"/>
       </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper0" unit="cm"  x="-322.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper0" unit="cm"  x="-322.04" y="-507.8" z="0" />
      <rotation name="rotFS0" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper1" unit="cm"  x="-316.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper1" unit="cm"  x="-316.04" y="-507.8" z="0" />
      <rotation name="rotFS1" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper2" unit="cm"  x="-310.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper2" unit="cm"  x="-310.04" y="-507.8" z="0" />
      <rotation name="rotFS2" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper3" unit="cm"  x="-304.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper3" unit="cm"  x="-304.04" y="-507.8" z="0" />
      <rotation name="rotFS3" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper4" unit="cm"  x="-298.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper4" unit="cm"  x="-298.04" y="-507.8" z="0" />
      <rotation name="rotFS4" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper5" unit="cm"  x="-292.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper5" unit="cm"  x="-292.04" y="-507.8" z="0" />
      <rotation name="rotFS5" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper6" unit="cm"  x="-286.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper6" unit="cm"  x="-286.04" y="-507.8" z="0" />
      <rotation name="rotFS6" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper7" unit="cm"  x="-280.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper7" unit="cm"  x="-280.04" y="-507.8" z="0" />
      <rotation name="rotFS7" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper8" unit="cm"  x="-274.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper8" unit="cm"  x="-274.04" y="-507.8" z="0" />
      <rotation name="rotFS8" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper9" unit="cm"  x="-268.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper9" unit="cm"  x="-268.04" y="-507.8" z="0" />
      <rotation name="rotFS9" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper10" unit="cm"  x="-262.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper10" unit="cm"  x="-262.04" y="-507.8" z="0" />
      <rotation name="rotFS10" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper11" unit="cm"  x="-256.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper11" unit="cm"  x="-256.04" y="-507.8" z="0" />
      <rotation name="rotFS11" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper12" unit="cm"  x="-250.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper12" unit="cm"  x="-250.04" y="-507.8" z="0" />
      <rotation name="rotFS12" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper13" unit="cm"  x="-244.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper13" unit="cm"  x="-244.04" y="-507.8" z="0" />
      <rotation name="rotFS13" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper14" unit="cm"  x="-238.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper14" unit="cm"  x="-238.04" y="-507.8" z="0" />
      <rotation name="rotFS14" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper15" unit="cm"  x="-232.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper15" unit="cm"  x="-232.04" y="-507.8" z="0" />
      <rotation name="rotFS15" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper16" unit="cm"  x="-226.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper16" unit="cm"  x="-226.04" y="-507.8" z="0" />
      <rotation name="rotFS16" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper17" unit="cm"  x="-220.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper17" unit="cm"  x="-220.04" y="-507.8" z="0" />
      <rotation name="rotFS17" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper18" unit="cm"  x="-214.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper18" unit="cm"  x="-214.04" y="-507.8" z="0" />
      <rotation name="rotFS18" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper19" unit="cm"  x="-208.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper19" unit="cm"  x="-208.04" y="-507.8" z="0" />
      <rotation name="rotFS19" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper20" unit="cm"  x="-202.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper20" unit="cm"  x="-202.04" y="-507.8" z="0" />
      <rotation name="rotFS20" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper21" unit="cm"  x="-196.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper21" unit="cm"  x="-196.04" y="-507.8" z="0" />
      <rotation name="rotFS21" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper22" unit="cm"  x="-190.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper22" unit="cm"  x="-190.04" y="-507.8" z="0" />
      <rotation name="rotFS22" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper23" unit="cm"  x="-184.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper23" unit="cm"  x="-184.04" y="-507.8" z="0" />
      <rotation name="rotFS23" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper24" unit="cm"  x="-178.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper24" unit="cm"  x="-178.04" y="-507.8" z="0" />
      <rotation name="rotFS24" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper25" unit="cm"  x="-172.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper25" unit="cm"  x="-172.04" y="-507.8" z="0" />
      <rotation name="rotFS25" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper26" unit="cm"  x="-166.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper26" unit="cm"  x="-166.04" y="-507.8" z="0" />
      <rotation name="rotFS26" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper27" unit="cm"  x="-160.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper27" unit="cm"  x="-160.04" y="-507.8" z="0" />
      <rotation name="rotFS27" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper28" unit="cm"  x="-154.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper28" unit="cm"  x="-154.04" y="-507.8" z="0" />
      <rotation name="rotFS28" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper29" unit="cm"  x="-148.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper29" unit="cm"  x="-148.04" y="-507.8" z="0" />
      <rotation name="rotFS29" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper30" unit="cm"  x="-142.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper30" unit="cm"  x="-142.04" y="-507.8" z="0" />
      <rotation name="rotFS30" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper31" unit="cm"  x="-136.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper31" unit="cm"  x="-136.04" y="-507.8" z="0" />
      <rotation name="rotFS31" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper32" unit="cm"  x="-130.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper32" unit="cm"  x="-130.04" y="-507.8" z="0" />
      <rotation name="rotFS32" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper33" unit="cm"  x="-124.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper33" unit="cm"  x="-124.04" y="-507.8" z="0" />
      <rotation name="rotFS33" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper34" unit="cm"  x="-118.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper34" unit="cm"  x="-118.04" y="-507.8" z="0" />
      <rotation name="rotFS34" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper35" unit="cm"  x="-112.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper35" unit="cm"  x="-112.04" y="-507.8" z="0" />
      <rotation name="rotFS35" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper36" unit="cm"  x="-106.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper36" unit="cm"  x="-106.04" y="-507.8" z="0" />
      <rotation name="rotFS36" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper37" unit="cm"  x="-100.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper37" unit="cm"  x="-100.04" y="-507.8" z="0" />
      <rotation name="rotFS37" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper38" unit="cm"  x="-94.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper38" unit="cm"  x="-94.04" y="-507.8" z="0" />
      <rotation name="rotFS38" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper39" unit="cm"  x="-88.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper39" unit="cm"  x="-88.04" y="-507.8" z="0" />
      <rotation name="rotFS39" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper40" unit="cm"  x="-82.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper40" unit="cm"  x="-82.04" y="-507.8" z="0" />
      <rotation name="rotFS40" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper41" unit="cm"  x="-76.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper41" unit="cm"  x="-76.04" y="-507.8" z="0" />
      <rotation name="rotFS41" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper42" unit="cm"  x="-70.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper42" unit="cm"  x="-70.04" y="-507.8" z="0" />
      <rotation name="rotFS42" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper43" unit="cm"  x="-64.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper43" unit="cm"  x="-64.04" y="-507.8" z="0" />
      <rotation name="rotFS43" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper44" unit="cm"  x="-58.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper44" unit="cm"  x="-58.04" y="-507.8" z="0" />
      <rotation name="rotFS44" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper45" unit="cm"  x="-52.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper45" unit="cm"  x="-52.04" y="-507.8" z="0" />
      <rotation name="rotFS45" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper46" unit="cm"  x="-46.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper46" unit="cm"  x="-46.04" y="-507.8" z="0" />
      <rotation name="rotFS46" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper47" unit="cm"  x="-40.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper47" unit="cm"  x="-40.04" y="-507.8" z="0" />
      <rotation name="rotFS47" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper48" unit="cm"  x="-34.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper48" unit="cm"  x="-34.04" y="-507.8" z="0" />
      <rotation name="rotFS48" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper49" unit="cm"  x="-28.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper49" unit="cm"  x="-28.04" y="-507.8" z="0" />
      <rotation name="rotFS49" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper50" unit="cm"  x="-22.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper50" unit="cm"  x="-22.04" y="-507.8" z="0" />
      <rotation name="rotFS50" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper51" unit="cm"  x="-16.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper51" unit="cm"  x="-16.04" y="-507.8" z="0" />
      <rotation name="rotFS51" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper52" unit="cm"  x="-10.04" y="-506.9018" z="0" />
+     <position name="posFieldShaper52" unit="cm"  x="-10.04" y="-507.8" z="0" />
      <rotation name="rotFS52" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper53" unit="cm"  x="-4.04000000000001" y="-506.9018" z="0" />
+     <position name="posFieldShaper53" unit="cm"  x="-4.04000000000001" y="-507.8" z="0" />
      <rotation name="rotFS53" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper54" unit="cm"  x="1.95999999999999" y="-506.9018" z="0" />
+     <position name="posFieldShaper54" unit="cm"  x="1.95999999999999" y="-507.8" z="0" />
      <rotation name="rotFS54" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper55" unit="cm"  x="7.95999999999999" y="-506.9018" z="0" />
+     <position name="posFieldShaper55" unit="cm"  x="7.95999999999999" y="-507.8" z="0" />
      <rotation name="rotFS55" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper56" unit="cm"  x="13.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper56" unit="cm"  x="13.96" y="-507.8" z="0" />
      <rotation name="rotFS56" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper57" unit="cm"  x="19.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper57" unit="cm"  x="19.96" y="-507.8" z="0" />
      <rotation name="rotFS57" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper58" unit="cm"  x="25.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper58" unit="cm"  x="25.96" y="-507.8" z="0" />
      <rotation name="rotFS58" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper59" unit="cm"  x="31.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper59" unit="cm"  x="31.96" y="-507.8" z="0" />
      <rotation name="rotFS59" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper60" unit="cm"  x="37.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper60" unit="cm"  x="37.96" y="-507.8" z="0" />
      <rotation name="rotFS60" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper61" unit="cm"  x="43.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper61" unit="cm"  x="43.96" y="-507.8" z="0" />
      <rotation name="rotFS61" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper62" unit="cm"  x="49.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper62" unit="cm"  x="49.96" y="-507.8" z="0" />
      <rotation name="rotFS62" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper63" unit="cm"  x="55.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper63" unit="cm"  x="55.96" y="-507.8" z="0" />
      <rotation name="rotFS63" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper64" unit="cm"  x="61.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper64" unit="cm"  x="61.96" y="-507.8" z="0" />
      <rotation name="rotFS64" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper65" unit="cm"  x="67.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper65" unit="cm"  x="67.96" y="-507.8" z="0" />
      <rotation name="rotFS65" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper66" unit="cm"  x="73.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper66" unit="cm"  x="73.96" y="-507.8" z="0" />
      <rotation name="rotFS66" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper67" unit="cm"  x="79.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper67" unit="cm"  x="79.96" y="-507.8" z="0" />
      <rotation name="rotFS67" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper68" unit="cm"  x="85.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper68" unit="cm"  x="85.96" y="-507.8" z="0" />
      <rotation name="rotFS68" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper69" unit="cm"  x="91.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper69" unit="cm"  x="91.96" y="-507.8" z="0" />
      <rotation name="rotFS69" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper70" unit="cm"  x="97.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper70" unit="cm"  x="97.96" y="-507.8" z="0" />
      <rotation name="rotFS70" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper71" unit="cm"  x="103.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper71" unit="cm"  x="103.96" y="-507.8" z="0" />
      <rotation name="rotFS71" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper72" unit="cm"  x="109.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper72" unit="cm"  x="109.96" y="-507.8" z="0" />
      <rotation name="rotFS72" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper73" unit="cm"  x="115.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper73" unit="cm"  x="115.96" y="-507.8" z="0" />
      <rotation name="rotFS73" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper74" unit="cm"  x="121.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper74" unit="cm"  x="121.96" y="-507.8" z="0" />
      <rotation name="rotFS74" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper75" unit="cm"  x="127.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper75" unit="cm"  x="127.96" y="-507.8" z="0" />
      <rotation name="rotFS75" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper76" unit="cm"  x="133.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper76" unit="cm"  x="133.96" y="-507.8" z="0" />
      <rotation name="rotFS76" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper77" unit="cm"  x="139.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper77" unit="cm"  x="139.96" y="-507.8" z="0" />
      <rotation name="rotFS77" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper78" unit="cm"  x="145.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper78" unit="cm"  x="145.96" y="-507.8" z="0" />
      <rotation name="rotFS78" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper79" unit="cm"  x="151.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper79" unit="cm"  x="151.96" y="-507.8" z="0" />
      <rotation name="rotFS79" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper80" unit="cm"  x="157.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper80" unit="cm"  x="157.96" y="-507.8" z="0" />
      <rotation name="rotFS80" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper81" unit="cm"  x="163.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper81" unit="cm"  x="163.96" y="-507.8" z="0" />
      <rotation name="rotFS81" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper82" unit="cm"  x="169.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper82" unit="cm"  x="169.96" y="-507.8" z="0" />
      <rotation name="rotFS82" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper83" unit="cm"  x="175.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper83" unit="cm"  x="175.96" y="-507.8" z="0" />
      <rotation name="rotFS83" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper84" unit="cm"  x="181.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper84" unit="cm"  x="181.96" y="-507.8" z="0" />
      <rotation name="rotFS84" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper85" unit="cm"  x="187.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper85" unit="cm"  x="187.96" y="-507.8" z="0" />
      <rotation name="rotFS85" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper86" unit="cm"  x="193.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper86" unit="cm"  x="193.96" y="-507.8" z="0" />
      <rotation name="rotFS86" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper87" unit="cm"  x="199.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper87" unit="cm"  x="199.96" y="-507.8" z="0" />
      <rotation name="rotFS87" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper88" unit="cm"  x="205.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper88" unit="cm"  x="205.96" y="-507.8" z="0" />
      <rotation name="rotFS88" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper89" unit="cm"  x="211.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper89" unit="cm"  x="211.96" y="-507.8" z="0" />
      <rotation name="rotFS89" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper90" unit="cm"  x="217.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper90" unit="cm"  x="217.96" y="-507.8" z="0" />
      <rotation name="rotFS90" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper91" unit="cm"  x="223.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper91" unit="cm"  x="223.96" y="-507.8" z="0" />
      <rotation name="rotFS91" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper92" unit="cm"  x="229.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper92" unit="cm"  x="229.96" y="-507.8" z="0" />
      <rotation name="rotFS92" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper93" unit="cm"  x="235.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper93" unit="cm"  x="235.96" y="-507.8" z="0" />
      <rotation name="rotFS93" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper94" unit="cm"  x="241.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper94" unit="cm"  x="241.96" y="-507.8" z="0" />
      <rotation name="rotFS94" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper95" unit="cm"  x="247.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper95" unit="cm"  x="247.96" y="-507.8" z="0" />
      <rotation name="rotFS95" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper96" unit="cm"  x="253.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper96" unit="cm"  x="253.96" y="-507.8" z="0" />
      <rotation name="rotFS96" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper97" unit="cm"  x="259.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper97" unit="cm"  x="259.96" y="-507.8" z="0" />
      <rotation name="rotFS97" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper98" unit="cm"  x="265.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper98" unit="cm"  x="265.96" y="-507.8" z="0" />
      <rotation name="rotFS98" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper99" unit="cm"  x="271.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper99" unit="cm"  x="271.96" y="-507.8" z="0" />
      <rotation name="rotFS99" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper100" unit="cm"  x="277.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper100" unit="cm"  x="277.96" y="-507.8" z="0" />
      <rotation name="rotFS100" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper101" unit="cm"  x="283.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper101" unit="cm"  x="283.96" y="-507.8" z="0" />
      <rotation name="rotFS101" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper102" unit="cm"  x="289.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper102" unit="cm"  x="289.96" y="-507.8" z="0" />
      <rotation name="rotFS102" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper103" unit="cm"  x="295.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper103" unit="cm"  x="295.96" y="-507.8" z="0" />
      <rotation name="rotFS103" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper104" unit="cm"  x="301.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper104" unit="cm"  x="301.96" y="-507.8" z="0" />
      <rotation name="rotFS104" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper105" unit="cm"  x="307.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper105" unit="cm"  x="307.96" y="-507.8" z="0" />
      <rotation name="rotFS105" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper106" unit="cm"  x="313.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper106" unit="cm"  x="313.96" y="-507.8" z="0" />
      <rotation name="rotFS106" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper107" unit="cm"  x="319.96" y="-506.9018" z="0" />
+     <position name="posFieldShaper107" unit="cm"  x="319.96" y="-507.8" z="0" />
      <rotation name="rotFS107" unit="deg" x="0" y="0" z="90" />
   </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-0" unit="cm" x="-328.04" y="-336.9012" z="-299.34"/>
+   <position name="posGroundGrid-0" unit="cm" x="-328.04" y="-337.5" z="-299.3018"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-1" unit="cm" x="-328.04" y="-1.5" z="-299.34"/>
+   <position name="posGroundGrid-1" unit="cm" x="-328.04" y="-1.5" z="-299.3018"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-2" unit="cm" x="-328.04" y="333.9012" z="-299.34"/>
+   <position name="posGroundGrid-2" unit="cm" x="-328.04" y="334.5" z="-299.3018"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-3" unit="cm" x="-328.04" y="-336.9012" z="-1.5"/>
+   <position name="posGroundGrid-3" unit="cm" x="-328.04" y="-337.5" z="-1.50000000000006"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-4" unit="cm" x="-328.04" y="-1.5" z="-1.5"/>
+   <position name="posGroundGrid-4" unit="cm" x="-328.04" y="-1.5" z="-1.50000000000006"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-5" unit="cm" x="-328.04" y="333.9012" z="-1.5"/>
+   <position name="posGroundGrid-5" unit="cm" x="-328.04" y="334.5" z="-1.50000000000006"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-6" unit="cm" x="-328.04" y="-336.9012" z="296.34"/>
+   <position name="posGroundGrid-6" unit="cm" x="-328.04" y="-337.5" z="296.3018"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-7" unit="cm" x="-328.04" y="-1.5" z="296.34"/>
+   <position name="posGroundGrid-7" unit="cm" x="-328.04" y="-1.5" z="296.3018"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-8" unit="cm" x="-328.04" y="333.9012" z="296.34"/>
+   <position name="posGroundGrid-8" unit="cm" x="-328.04" y="334.5" z="296.3018"/>
       </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-0-0"/>
        <position name="posArapucaDouble0-Frame-0-0" unit="cm" 
          x="-328.04"
-	 y="-464.6012" 
-	 z="-261.84"/>
+	 y="-465.2" 
+	 z="-261.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-0"/>
        <position name="posOpArapucaDouble0-Frame-0-0" unit="cm" 
          x="-327.3"
-	 y="-464.6012" 
-	 z="-261.84"/>
+	 y="-465.2" 
+	 z="-261.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-0-1"/>
        <position name="posArapucaDouble1-Frame-0-0" unit="cm" 
          x="-328.04"
-	 y="-373.9012" 
-	 z="-407.84"/>
+	 y="-374.5" 
+	 z="-407.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-1"/>
        <position name="posOpArapucaDouble1-Frame-0-0" unit="cm" 
          x="-327.3"
-	 y="-373.9012" 
-	 z="-407.84"/>
+	 y="-374.5" 
+	 z="-407.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-0-2"/>
        <position name="posArapucaDouble2-Frame-0-0" unit="cm" 
          x="-328.04"
-	 y="-299.9012" 
-	 z="-190.84"/>
+	 y="-300.5" 
+	 z="-190.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-2"/>
        <position name="posOpArapucaDouble2-Frame-0-0" unit="cm" 
          x="-327.3"
-	 y="-299.9012" 
-	 z="-190.84"/>
+	 y="-300.5" 
+	 z="-190.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-0-3"/>
        <position name="posArapucaDouble3-Frame-0-0" unit="cm" 
          x="-328.04"
-	 y="-209.2012" 
-	 z="-336.84"/>
+	 y="-209.8" 
+	 z="-336.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-3"/>
        <position name="posOpArapucaDouble3-Frame-0-0" unit="cm" 
          x="-327.3"
-	 y="-209.2012" 
-	 z="-336.84"/>
+	 y="-209.8" 
+	 z="-336.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-1-0"/>
        <position name="posArapucaDouble0-Frame-0-1" unit="cm" 
          x="-328.04"
-	 y="-464.6012" 
-	 z="36"/>
+	 y="-465.2" 
+	 z="35.9999999999999"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-0"/>
        <position name="posOpArapucaDouble0-Frame-0-1" unit="cm" 
          x="-327.3"
-	 y="-464.6012" 
-	 z="36"/>
+	 y="-465.2" 
+	 z="35.9999999999999"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-1-1"/>
        <position name="posArapucaDouble1-Frame-0-1" unit="cm" 
          x="-328.04"
-	 y="-373.9012" 
+	 y="-374.5" 
 	 z="-110"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
@@ -1957,14 +1956,14 @@
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-1"/>
        <position name="posOpArapucaDouble1-Frame-0-1" unit="cm" 
          x="-327.3"
-	 y="-373.9012" 
+	 y="-374.5" 
 	 z="-110"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-1-2"/>
        <position name="posArapucaDouble2-Frame-0-1" unit="cm" 
          x="-328.04"
-	 y="-299.9012" 
+	 y="-300.5" 
 	 z="107"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
@@ -1972,90 +1971,90 @@
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-2"/>
        <position name="posOpArapucaDouble2-Frame-0-1" unit="cm" 
          x="-327.3"
-	 y="-299.9012" 
+	 y="-300.5" 
 	 z="107"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-1-3"/>
        <position name="posArapucaDouble3-Frame-0-1" unit="cm" 
          x="-328.04"
-	 y="-209.2012" 
-	 z="-39"/>
+	 y="-209.8" 
+	 z="-39.0000000000001"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-3"/>
        <position name="posOpArapucaDouble3-Frame-0-1" unit="cm" 
          x="-327.3"
-	 y="-209.2012" 
-	 z="-39"/>
+	 y="-209.8" 
+	 z="-39.0000000000001"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-2-0"/>
        <position name="posArapucaDouble0-Frame-0-2" unit="cm" 
          x="-328.04"
-	 y="-464.6012" 
-	 z="333.84"/>
+	 y="-465.2" 
+	 z="333.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-0"/>
        <position name="posOpArapucaDouble0-Frame-0-2" unit="cm" 
          x="-327.3"
-	 y="-464.6012" 
-	 z="333.84"/>
+	 y="-465.2" 
+	 z="333.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-2-1"/>
        <position name="posArapucaDouble1-Frame-0-2" unit="cm" 
          x="-328.04"
-	 y="-373.9012" 
-	 z="187.84"/>
+	 y="-374.5" 
+	 z="187.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-1"/>
        <position name="posOpArapucaDouble1-Frame-0-2" unit="cm" 
          x="-327.3"
-	 y="-373.9012" 
-	 z="187.84"/>
+	 y="-374.5" 
+	 z="187.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-2-2"/>
        <position name="posArapucaDouble2-Frame-0-2" unit="cm" 
          x="-328.04"
-	 y="-299.9012" 
-	 z="404.84"/>
+	 y="-300.5" 
+	 z="404.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-2"/>
        <position name="posOpArapucaDouble2-Frame-0-2" unit="cm" 
          x="-327.3"
-	 y="-299.9012" 
-	 z="404.84"/>
+	 y="-300.5" 
+	 z="404.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-2-3"/>
        <position name="posArapucaDouble3-Frame-0-2" unit="cm" 
          x="-328.04"
-	 y="-209.2012" 
-	 z="258.84"/>
+	 y="-209.8" 
+	 z="258.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-3"/>
        <position name="posOpArapucaDouble3-Frame-0-2" unit="cm" 
          x="-327.3"
-	 y="-209.2012" 
-	 z="258.84"/>
+	 y="-209.8" 
+	 z="258.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-0-0"/>
        <position name="posArapucaDouble0-Frame-1-0" unit="cm" 
          x="-328.04"
 	 y="-129.2" 
-	 z="-261.84"/>
+	 z="-261.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
@@ -2063,14 +2062,14 @@
        <position name="posOpArapucaDouble0-Frame-1-0" unit="cm" 
          x="-327.3"
 	 y="-129.2" 
-	 z="-261.84"/>
+	 z="-261.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-0-1"/>
        <position name="posArapucaDouble1-Frame-1-0" unit="cm" 
          x="-328.04"
 	 y="-38.5" 
-	 z="-407.84"/>
+	 z="-407.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
@@ -2078,14 +2077,14 @@
        <position name="posOpArapucaDouble1-Frame-1-0" unit="cm" 
          x="-327.3"
 	 y="-38.5" 
-	 z="-407.84"/>
+	 z="-407.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-0-2"/>
        <position name="posArapucaDouble2-Frame-1-0" unit="cm" 
          x="-328.04"
 	 y="35.5" 
-	 z="-190.84"/>
+	 z="-190.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
@@ -2093,14 +2092,14 @@
        <position name="posOpArapucaDouble2-Frame-1-0" unit="cm" 
          x="-327.3"
 	 y="35.5" 
-	 z="-190.84"/>
+	 z="-190.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-0-3"/>
        <position name="posArapucaDouble3-Frame-1-0" unit="cm" 
          x="-328.04"
 	 y="126.2" 
-	 z="-336.84"/>
+	 z="-336.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
@@ -2108,14 +2107,14 @@
        <position name="posOpArapucaDouble3-Frame-1-0" unit="cm" 
          x="-327.3"
 	 y="126.2" 
-	 z="-336.84"/>
+	 z="-336.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-1-0"/>
        <position name="posArapucaDouble0-Frame-1-1" unit="cm" 
          x="-328.04"
 	 y="-129.2" 
-	 z="36"/>
+	 z="35.9999999999999"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
@@ -2123,7 +2122,7 @@
        <position name="posOpArapucaDouble0-Frame-1-1" unit="cm" 
          x="-327.3"
 	 y="-129.2" 
-	 z="36"/>
+	 z="35.9999999999999"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-1-1"/>
@@ -2160,7 +2159,7 @@
        <position name="posArapucaDouble3-Frame-1-1" unit="cm" 
          x="-328.04"
 	 y="126.2" 
-	 z="-39"/>
+	 z="-39.0000000000001"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
@@ -2168,14 +2167,14 @@
        <position name="posOpArapucaDouble3-Frame-1-1" unit="cm" 
          x="-327.3"
 	 y="126.2" 
-	 z="-39"/>
+	 z="-39.0000000000001"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-2-0"/>
        <position name="posArapucaDouble0-Frame-1-2" unit="cm" 
          x="-328.04"
 	 y="-129.2" 
-	 z="333.84"/>
+	 z="333.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
@@ -2183,14 +2182,14 @@
        <position name="posOpArapucaDouble0-Frame-1-2" unit="cm" 
          x="-327.3"
 	 y="-129.2" 
-	 z="333.84"/>
+	 z="333.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-2-1"/>
        <position name="posArapucaDouble1-Frame-1-2" unit="cm" 
          x="-328.04"
 	 y="-38.5" 
-	 z="187.84"/>
+	 z="187.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
@@ -2198,14 +2197,14 @@
        <position name="posOpArapucaDouble1-Frame-1-2" unit="cm" 
          x="-327.3"
 	 y="-38.5" 
-	 z="187.84"/>
+	 z="187.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-2-2"/>
        <position name="posArapucaDouble2-Frame-1-2" unit="cm" 
          x="-328.04"
 	 y="35.5" 
-	 z="404.84"/>
+	 z="404.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
@@ -2213,14 +2212,14 @@
        <position name="posOpArapucaDouble2-Frame-1-2" unit="cm" 
          x="-327.3"
 	 y="35.5" 
-	 z="404.84"/>
+	 z="404.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-2-3"/>
        <position name="posArapucaDouble3-Frame-1-2" unit="cm" 
          x="-328.04"
 	 y="126.2" 
-	 z="258.84"/>
+	 z="258.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
@@ -2228,88 +2227,88 @@
        <position name="posOpArapucaDouble3-Frame-1-2" unit="cm" 
          x="-327.3"
 	 y="126.2" 
-	 z="258.84"/>
+	 z="258.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-0-0"/>
        <position name="posArapucaDouble0-Frame-2-0" unit="cm" 
          x="-328.04"
-	 y="206.2012" 
-	 z="-261.84"/>
+	 y="206.8" 
+	 z="-261.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-0"/>
        <position name="posOpArapucaDouble0-Frame-2-0" unit="cm" 
          x="-327.3"
-	 y="206.2012" 
-	 z="-261.84"/>
+	 y="206.8" 
+	 z="-261.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-0-1"/>
        <position name="posArapucaDouble1-Frame-2-0" unit="cm" 
          x="-328.04"
-	 y="296.9012" 
-	 z="-407.84"/>
+	 y="297.5" 
+	 z="-407.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-1"/>
        <position name="posOpArapucaDouble1-Frame-2-0" unit="cm" 
          x="-327.3"
-	 y="296.9012" 
-	 z="-407.84"/>
+	 y="297.5" 
+	 z="-407.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-0-2"/>
        <position name="posArapucaDouble2-Frame-2-0" unit="cm" 
          x="-328.04"
-	 y="370.9012" 
-	 z="-190.84"/>
+	 y="371.5" 
+	 z="-190.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-2"/>
        <position name="posOpArapucaDouble2-Frame-2-0" unit="cm" 
          x="-327.3"
-	 y="370.9012" 
-	 z="-190.84"/>
+	 y="371.5" 
+	 z="-190.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-0-3"/>
        <position name="posArapucaDouble3-Frame-2-0" unit="cm" 
          x="-328.04"
-	 y="461.6012" 
-	 z="-336.84"/>
+	 y="462.2" 
+	 z="-336.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-3"/>
        <position name="posOpArapucaDouble3-Frame-2-0" unit="cm" 
          x="-327.3"
-	 y="461.6012" 
-	 z="-336.84"/>
+	 y="462.2" 
+	 z="-336.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-1-0"/>
        <position name="posArapucaDouble0-Frame-2-1" unit="cm" 
          x="-328.04"
-	 y="206.2012" 
-	 z="36"/>
+	 y="206.8" 
+	 z="35.9999999999999"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-0"/>
        <position name="posOpArapucaDouble0-Frame-2-1" unit="cm" 
          x="-327.3"
-	 y="206.2012" 
-	 z="36"/>
+	 y="206.8" 
+	 z="35.9999999999999"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-1-1"/>
        <position name="posArapucaDouble1-Frame-2-1" unit="cm" 
          x="-328.04"
-	 y="296.9012" 
+	 y="297.5" 
 	 z="-110"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
@@ -2317,14 +2316,14 @@
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-1"/>
        <position name="posOpArapucaDouble1-Frame-2-1" unit="cm" 
          x="-327.3"
-	 y="296.9012" 
+	 y="297.5" 
 	 z="-110"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-1-2"/>
        <position name="posArapucaDouble2-Frame-2-1" unit="cm" 
          x="-328.04"
-	 y="370.9012" 
+	 y="371.5" 
 	 z="107"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
@@ -2332,83 +2331,83 @@
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-2"/>
        <position name="posOpArapucaDouble2-Frame-2-1" unit="cm" 
          x="-327.3"
-	 y="370.9012" 
+	 y="371.5" 
 	 z="107"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-1-3"/>
        <position name="posArapucaDouble3-Frame-2-1" unit="cm" 
          x="-328.04"
-	 y="461.6012" 
-	 z="-39"/>
+	 y="462.2" 
+	 z="-39.0000000000001"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-3"/>
        <position name="posOpArapucaDouble3-Frame-2-1" unit="cm" 
          x="-327.3"
-	 y="461.6012" 
-	 z="-39"/>
+	 y="462.2" 
+	 z="-39.0000000000001"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-2-0"/>
        <position name="posArapucaDouble0-Frame-2-2" unit="cm" 
          x="-328.04"
-	 y="206.2012" 
-	 z="333.84"/>
+	 y="206.8" 
+	 z="333.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-0"/>
        <position name="posOpArapucaDouble0-Frame-2-2" unit="cm" 
          x="-327.3"
-	 y="206.2012" 
-	 z="333.84"/>
+	 y="206.8" 
+	 z="333.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-2-1"/>
        <position name="posArapucaDouble1-Frame-2-2" unit="cm" 
          x="-328.04"
-	 y="296.9012" 
-	 z="187.84"/>
+	 y="297.5" 
+	 z="187.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-1"/>
        <position name="posOpArapucaDouble1-Frame-2-2" unit="cm" 
          x="-327.3"
-	 y="296.9012" 
-	 z="187.84"/>
+	 y="297.5" 
+	 z="187.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-2-2"/>
        <position name="posArapucaDouble2-Frame-2-2" unit="cm" 
          x="-328.04"
-	 y="370.9012" 
-	 z="404.84"/>
+	 y="371.5" 
+	 z="404.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-2"/>
        <position name="posOpArapucaDouble2-Frame-2-2" unit="cm" 
          x="-327.3"
-	 y="370.9012" 
-	 z="404.84"/>
+	 y="371.5" 
+	 z="404.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-2-3"/>
        <position name="posArapucaDouble3-Frame-2-2" unit="cm" 
          x="-328.04"
-	 y="461.6012" 
-	 z="258.84"/>
+	 y="462.2" 
+	 z="258.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-3"/>
        <position name="posOpArapucaDouble3-Frame-2-2" unit="cm" 
          x="-327.3"
-	 y="461.6012" 
-	 z="258.84"/>
+	 y="462.2" 
+	 z="258.8018"/>
      </physvol>
     </volume>
 
@@ -2446,7 +2445,7 @@
 
       <physvol>
         <volumeref ref="volDetEnclosure"/>
-	<position name="posDetEnclosure" unit="cm" x="50.04" y="0" z="448.26"/>
+	<position name="posDetEnclosure" unit="cm" x="50.04" y="0" z="448.2027"/>
       </physvol>
 
     </volume>

--- a/dunecore/Geometry/gdml/dunevd10kt_3view_v3_refactored_1x8x6ref_nowires.gdml
+++ b/dunecore/Geometry/gdml/dunevd10kt_3view_v3_refactored_1x8x6ref_nowires.gdml
@@ -508,6 +508,11 @@
       y="168"
       z="148.9009"
       lunit="cm"/>
+   <box name="AnodePlate" 
+      x="0.02/2."
+      y="168"
+      z="148.9009"
+      lunit="cm"/>
    <box name="CRMActive" 
       x="650"
       y="168"
@@ -752,7 +757,7 @@
      
    <volume name="volAnodePlate">
      <materialref ref="vm2000"/>
-     <solidref ref="CRMZPlane"/>
+     <solidref ref="AnodePlate"/>
   </volume>
    <volume name="volTPC">
      <materialref ref="LAr"/>
@@ -760,25 +765,25 @@
        <physvol>
        <volumeref ref="volTPCPlaneU"/>
        <position name="posPlaneU" unit="cm" 
-         x="324.98" y="0" z="0"/>
+         x="324.99" y="0" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volTPCPlaneY"/>
        <position name="posPlaneY" unit="cm" 
-         x="325" y="0" z="0"/>
+         x="325.01" y="0" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volTPCPlaneZ"/>
        <position name="posPlaneZ" unit="cm" 
-         x="325.02" y="0" z="0"/>
+         x="325.03" y="0" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volAnodePlate"/>
        <position name="posAnodePlate" unit="cm" 
-         x="325.04" y="0" z="0"/>
+         x="325.045" y="0" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>    
      <physvol>
@@ -1835,44 +1840,44 @@
   </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-0" unit="cm" x="-328.05" y="-337.5" z="-299.3018"/>
+   <position name="posGroundGrid-0" unit="cm" x="-328.04" y="-337.5" z="-299.3018"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-1" unit="cm" x="-328.05" y="-1.5" z="-299.3018"/>
+   <position name="posGroundGrid-1" unit="cm" x="-328.04" y="-1.5" z="-299.3018"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-2" unit="cm" x="-328.05" y="334.5" z="-299.3018"/>
+   <position name="posGroundGrid-2" unit="cm" x="-328.04" y="334.5" z="-299.3018"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-3" unit="cm" x="-328.05" y="-337.5" z="-1.50000000000006"/>
+   <position name="posGroundGrid-3" unit="cm" x="-328.04" y="-337.5" z="-1.50000000000006"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-4" unit="cm" x="-328.05" y="-1.5" z="-1.50000000000006"/>
+   <position name="posGroundGrid-4" unit="cm" x="-328.04" y="-1.5" z="-1.50000000000006"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-5" unit="cm" x="-328.05" y="334.5" z="-1.50000000000006"/>
+   <position name="posGroundGrid-5" unit="cm" x="-328.04" y="334.5" z="-1.50000000000006"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-6" unit="cm" x="-328.05" y="-337.5" z="296.3018"/>
+   <position name="posGroundGrid-6" unit="cm" x="-328.04" y="-337.5" z="296.3018"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-7" unit="cm" x="-328.05" y="-1.5" z="296.3018"/>
+   <position name="posGroundGrid-7" unit="cm" x="-328.04" y="-1.5" z="296.3018"/>
       </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-8" unit="cm" x="-328.05" y="334.5" z="296.3018"/>
+   <position name="posGroundGrid-8" unit="cm" x="-328.04" y="334.5" z="296.3018"/>
       </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-0-0"/>
        <position name="posArapucaDouble0-Frame-0-0" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-465.2" 
 	 z="-261.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -1880,14 +1885,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-0"/>
        <position name="posOpArapucaDouble0-Frame-0-0" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-465.2" 
 	 z="-261.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-0-1"/>
        <position name="posArapucaDouble1-Frame-0-0" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-374.5" 
 	 z="-407.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -1895,14 +1900,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-1"/>
        <position name="posOpArapucaDouble1-Frame-0-0" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-374.5" 
 	 z="-407.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-0-2"/>
        <position name="posArapucaDouble2-Frame-0-0" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-300.5" 
 	 z="-190.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -1910,14 +1915,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-2"/>
        <position name="posOpArapucaDouble2-Frame-0-0" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-300.5" 
 	 z="-190.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-0-3"/>
        <position name="posArapucaDouble3-Frame-0-0" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-209.8" 
 	 z="-336.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -1925,14 +1930,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-3"/>
        <position name="posOpArapucaDouble3-Frame-0-0" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-209.8" 
 	 z="-336.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-1-0"/>
        <position name="posArapucaDouble0-Frame-0-1" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-465.2" 
 	 z="35.9999999999999"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -1940,14 +1945,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-0"/>
        <position name="posOpArapucaDouble0-Frame-0-1" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-465.2" 
 	 z="35.9999999999999"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-1-1"/>
        <position name="posArapucaDouble1-Frame-0-1" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-374.5" 
 	 z="-110"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -1955,14 +1960,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-1"/>
        <position name="posOpArapucaDouble1-Frame-0-1" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-374.5" 
 	 z="-110"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-1-2"/>
        <position name="posArapucaDouble2-Frame-0-1" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-300.5" 
 	 z="107"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -1970,14 +1975,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-2"/>
        <position name="posOpArapucaDouble2-Frame-0-1" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-300.5" 
 	 z="107"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-1-3"/>
        <position name="posArapucaDouble3-Frame-0-1" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-209.8" 
 	 z="-39.0000000000001"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -1985,14 +1990,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-3"/>
        <position name="posOpArapucaDouble3-Frame-0-1" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-209.8" 
 	 z="-39.0000000000001"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-2-0"/>
        <position name="posArapucaDouble0-Frame-0-2" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-465.2" 
 	 z="333.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -2000,14 +2005,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-0"/>
        <position name="posOpArapucaDouble0-Frame-0-2" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-465.2" 
 	 z="333.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-2-1"/>
        <position name="posArapucaDouble1-Frame-0-2" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-374.5" 
 	 z="187.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -2015,14 +2020,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-1"/>
        <position name="posOpArapucaDouble1-Frame-0-2" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-374.5" 
 	 z="187.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-2-2"/>
        <position name="posArapucaDouble2-Frame-0-2" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-300.5" 
 	 z="404.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -2030,14 +2035,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-2"/>
        <position name="posOpArapucaDouble2-Frame-0-2" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-300.5" 
 	 z="404.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-2-3"/>
        <position name="posArapucaDouble3-Frame-0-2" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-209.8" 
 	 z="258.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -2045,14 +2050,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-3"/>
        <position name="posOpArapucaDouble3-Frame-0-2" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-209.8" 
 	 z="258.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-0-0"/>
        <position name="posArapucaDouble0-Frame-1-0" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-129.2" 
 	 z="-261.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -2060,14 +2065,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-0"/>
        <position name="posOpArapucaDouble0-Frame-1-0" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-129.2" 
 	 z="-261.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-0-1"/>
        <position name="posArapucaDouble1-Frame-1-0" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-38.5" 
 	 z="-407.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -2075,14 +2080,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-1"/>
        <position name="posOpArapucaDouble1-Frame-1-0" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-38.5" 
 	 z="-407.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-0-2"/>
        <position name="posArapucaDouble2-Frame-1-0" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="35.5" 
 	 z="-190.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -2090,14 +2095,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-2"/>
        <position name="posOpArapucaDouble2-Frame-1-0" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="35.5" 
 	 z="-190.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-0-3"/>
        <position name="posArapucaDouble3-Frame-1-0" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="126.2" 
 	 z="-336.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -2105,14 +2110,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-3"/>
        <position name="posOpArapucaDouble3-Frame-1-0" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="126.2" 
 	 z="-336.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-1-0"/>
        <position name="posArapucaDouble0-Frame-1-1" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-129.2" 
 	 z="35.9999999999999"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -2120,14 +2125,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-0"/>
        <position name="posOpArapucaDouble0-Frame-1-1" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-129.2" 
 	 z="35.9999999999999"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-1-1"/>
        <position name="posArapucaDouble1-Frame-1-1" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-38.5" 
 	 z="-110"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -2135,14 +2140,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-1"/>
        <position name="posOpArapucaDouble1-Frame-1-1" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-38.5" 
 	 z="-110"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-1-2"/>
        <position name="posArapucaDouble2-Frame-1-1" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="35.5" 
 	 z="107"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -2150,14 +2155,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-2"/>
        <position name="posOpArapucaDouble2-Frame-1-1" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="35.5" 
 	 z="107"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-1-3"/>
        <position name="posArapucaDouble3-Frame-1-1" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="126.2" 
 	 z="-39.0000000000001"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -2165,14 +2170,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-3"/>
        <position name="posOpArapucaDouble3-Frame-1-1" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="126.2" 
 	 z="-39.0000000000001"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-2-0"/>
        <position name="posArapucaDouble0-Frame-1-2" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-129.2" 
 	 z="333.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -2180,14 +2185,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-0"/>
        <position name="posOpArapucaDouble0-Frame-1-2" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-129.2" 
 	 z="333.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-2-1"/>
        <position name="posArapucaDouble1-Frame-1-2" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="-38.5" 
 	 z="187.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -2195,14 +2200,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-1"/>
        <position name="posOpArapucaDouble1-Frame-1-2" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="-38.5" 
 	 z="187.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-2-2"/>
        <position name="posArapucaDouble2-Frame-1-2" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="35.5" 
 	 z="404.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -2210,14 +2215,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-2"/>
        <position name="posOpArapucaDouble2-Frame-1-2" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="35.5" 
 	 z="404.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-2-3"/>
        <position name="posArapucaDouble3-Frame-1-2" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="126.2" 
 	 z="258.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -2225,14 +2230,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-3"/>
        <position name="posOpArapucaDouble3-Frame-1-2" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="126.2" 
 	 z="258.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-0-0"/>
        <position name="posArapucaDouble0-Frame-2-0" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="206.8" 
 	 z="-261.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -2240,14 +2245,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-0"/>
        <position name="posOpArapucaDouble0-Frame-2-0" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="206.8" 
 	 z="-261.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-0-1"/>
        <position name="posArapucaDouble1-Frame-2-0" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="297.5" 
 	 z="-407.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -2255,14 +2260,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-1"/>
        <position name="posOpArapucaDouble1-Frame-2-0" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="297.5" 
 	 z="-407.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-0-2"/>
        <position name="posArapucaDouble2-Frame-2-0" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="371.5" 
 	 z="-190.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -2270,14 +2275,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-2"/>
        <position name="posOpArapucaDouble2-Frame-2-0" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="371.5" 
 	 z="-190.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-0-3"/>
        <position name="posArapucaDouble3-Frame-2-0" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="462.2" 
 	 z="-336.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -2285,14 +2290,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-3"/>
        <position name="posOpArapucaDouble3-Frame-2-0" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="462.2" 
 	 z="-336.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-1-0"/>
        <position name="posArapucaDouble0-Frame-2-1" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="206.8" 
 	 z="35.9999999999999"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -2300,14 +2305,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-0"/>
        <position name="posOpArapucaDouble0-Frame-2-1" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="206.8" 
 	 z="35.9999999999999"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-1-1"/>
        <position name="posArapucaDouble1-Frame-2-1" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="297.5" 
 	 z="-110"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -2315,14 +2320,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-1"/>
        <position name="posOpArapucaDouble1-Frame-2-1" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="297.5" 
 	 z="-110"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-1-2"/>
        <position name="posArapucaDouble2-Frame-2-1" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="371.5" 
 	 z="107"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -2330,14 +2335,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-2"/>
        <position name="posOpArapucaDouble2-Frame-2-1" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="371.5" 
 	 z="107"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-1-3"/>
        <position name="posArapucaDouble3-Frame-2-1" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="462.2" 
 	 z="-39.0000000000001"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -2345,14 +2350,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-3"/>
        <position name="posOpArapucaDouble3-Frame-2-1" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="462.2" 
 	 z="-39.0000000000001"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-2-0"/>
        <position name="posArapucaDouble0-Frame-2-2" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="206.8" 
 	 z="333.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -2360,14 +2365,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-0"/>
        <position name="posOpArapucaDouble0-Frame-2-2" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="206.8" 
 	 z="333.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-2-1"/>
        <position name="posArapucaDouble1-Frame-2-2" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="297.5" 
 	 z="187.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -2375,14 +2380,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-1"/>
        <position name="posOpArapucaDouble1-Frame-2-2" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="297.5" 
 	 z="187.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-2-2"/>
        <position name="posArapucaDouble2-Frame-2-2" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="371.5" 
 	 z="404.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -2390,14 +2395,14 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-2"/>
        <position name="posOpArapucaDouble2-Frame-2-2" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="371.5" 
 	 z="404.8018"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-2-3"/>
        <position name="posArapucaDouble3-Frame-2-2" unit="cm" 
-         x="-328.05"
+         x="-328.04"
 	 y="462.2" 
 	 z="258.8018"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
@@ -2405,7 +2410,7 @@
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-3"/>
        <position name="posOpArapucaDouble3-Frame-2-2" unit="cm" 
-         x="-327.31"
+         x="-327.3"
 	 y="462.2" 
 	 z="258.8018"/>
      </physvol>

--- a/dunecore/Geometry/gdml/generate_dunevd10kt_3view_30deg_v3_refactored.pl
+++ b/dunecore/Geometry/gdml/generate_dunevd10kt_3view_30deg_v3_refactored.pl
@@ -30,11 +30,14 @@
 #                       Collection pitch = 5.1 mm (4.89 mm in v2)
 #                       Induction pitch = 7.65 mm (7.335 mm in v2) 
 #                       Reference for changes: https://indico.fnal.gov/event/53111/timetable/
-#             May 2022: Inclusion of anode plate on top of the 3 wire planes as requested by the background TF.
-#             In order to achieve it without overlaps, the 3 wire planes x positions were shifted downwards by
-#             1*$padWidth = 0.02 cm. Currently the material of this plate is set to vm2000 so that no aditional
-#             geometry (ReflAnode) is needed to obtain optical fast simulation.
-#             TO DO: include perforated PCB in the gdml (see LEMs in dual phase gdml) 
+#           May 2022: Inclusion of anode plate on top of the 3 wire planes as requested by the background TF.
+#           In order to achieve it without overlaps, the TPC drift size was increased by 
+#           1*$padWidth = 0.02 cm. In this way, the relative distances of the 3 wire planes to the cathode plane
+#           remain the same. Other impacts are (all in drift direction): Argon volume from 850.08 to 850.1 cm,
+#           Detector enclosure from 1310.32 to 1310.34 cm, TPC origin from 50.04 to 50.05 cm, and TPC dimension
+#           from 650.08 to 650.1 cm. Currently the material of this plate is set to vm2000 so that no additional
+#           geometry (ReflAnode) is needed to obtain optical fast simulation.
+#           TO DO: include perforated PCB in the gdml (see LEMs in dual phase gdml) 
 #
 #################################################################################
 
@@ -198,7 +201,7 @@ $driftTPCActive  = 650.0;
 
 # model anode strips as wires of some diameter
 $padWidth          = 0.02;
-$ReadoutPlane      = $nViews * $padWidth; # 3 readout planes (no space b/w)!
+$ReadoutPlane      = (1+$nViews) * $padWidth; # 3 readout planes (no space b/w) + space for anode plate!
 
 ##################################################################
 ############## Parameters for TPC and inner volume ###############
@@ -880,7 +883,7 @@ print TPC <<EOF;
   </volume>
 EOF
 
-#$posUplane[0] = 0.5*$TPC_x - 2.5*$padWidth;       
+#$posUplane[0] = 0.5*$TPC_x - 2.5*$padWidth; #the original positions without the anode plate are commented
 $posUplane[0] = 0.5*$TPC_x - 3.5*$padWidth;
 $posUplane[1] = 0;
 $posUplane[2] = 0;
@@ -903,7 +906,6 @@ $posAnodePlate[2] = 0;
 $posTPCActive[0] = -$ReadoutPlane/2;
 $posTPCActive[1] = 0;
 $posTPCActive[2] = 0;
-
 
 #wrap up the TPC file
 print TPC <<EOF;
@@ -1402,6 +1404,7 @@ EOF
 $CathodePosX =-$OriginXSet+50+(-1-$NFieldShapers*0.5)*$FieldShaperSeparation;
 $CathodePosY = -0.5*$Argon_y + $yLArBuffer + 0.5*$widthCathode;
 $CathodePosZ = -0.5*$Argon_z + $zLArBuffer + 0.5*$lengthCathode;
+
 $idx = 0;
   if ( $Cathode_switch eq "on" )
   {

--- a/dunecore/Geometry/gdml/generate_dunevd10kt_3view_v3_refactored.pl
+++ b/dunecore/Geometry/gdml/generate_dunevd10kt_3view_v3_refactored.pl
@@ -26,8 +26,11 @@
 #	      Mar 2022: Cathode included
 #
 #    V3     May 2022: Inclusion of anode plate on top of the 3 wire planes as requested by the background TF.
-#           In order to achieve it without overlaps, the 3 wire planes x positions were shifted downwards by
-#           1*$padWidth = 0.02 cm. Currently the material of this plate is set to vm2000 so that no aditional
+#           In order to achieve it without overlaps, the TPC drift size was increased by 
+#           1*$padWidth = 0.02 cm. In this way, the relative distances of the 3 wire planes to the cathode plane
+#           remain the same. Other impacts are (all in drift direction): Argon volume from 850.08 to 850.1 cm,
+#           Detector enclosure from 1310.32 to 1310.34 cm, TPC origin from 50.04 to 50.05 cm, and TPC dimension
+#           from 650.08 to 650.1 cm. Currently the material of this plate is set to vm2000 so that no additional
 #           geometry (ReflAnode) is needed to obtain optical fast simulation.
 #           TO DO: include perforated PCB in the gdml (see LEMs in dual phase gdml) 
 #
@@ -190,7 +193,7 @@ $driftTPCActive  = 650.0;
 
 # model anode strips as wires of some diameter
 $padWidth          = 0.02;
-$ReadoutPlane      = $nViews * $padWidth; # 3 readout planes (no space b/w)!
+$ReadoutPlane      = (1+$nViews) * $padWidth; # 3 readout planes (no space b/w) + space for anode plate!
 
 ##################################################################
 ############## Parameters for TPC and inner volume ###############
@@ -850,7 +853,7 @@ print TPC <<EOF;
   </volume>
 EOF
        
-#$posUplane[0] = 0.5*$TPC_x - 2.5*$padWidth;
+#$posUplane[0] = 0.5*$TPC_x - 2.5*$padWidth; #the original positions without the anode plate are commented
 $posUplane[0] = 0.5*$TPC_x - 3.5*$padWidth;
 $posUplane[1] = 0;
 $posUplane[2] = 0;
@@ -870,11 +873,9 @@ $posAnodePlate[0] = 0.5*$TPC_x - 0.5*$padWidth;
 $posAnodePlate[1] = 0; 
 $posAnodePlate[2] = 0;
 
-
 $posTPCActive[0] = -$ReadoutPlane/2;
 $posTPCActive[1] = 0;
 $posTPCActive[2] = 0;
-
 
 #wrap up the TPC file
 print TPC <<EOF;
@@ -1374,6 +1375,7 @@ EOF
 $CathodePosX =-$OriginXSet+50+(-1-$NFieldShapers*0.5)*$FieldShaperSeparation;
 $CathodePosY = -0.5*$Argon_y + $yLArBuffer + 0.5*$widthCathode;
 $CathodePosZ = -0.5*$Argon_z + $zLArBuffer + 0.5*$lengthCathode;
+
 $idx = 0;
   if ( $Cathode_switch eq "on" )
   {

--- a/dunecore/Geometry/gdml/generate_dunevd10kt_3view_v3_refactored.pl
+++ b/dunecore/Geometry/gdml/generate_dunevd10kt_3view_v3_refactored.pl
@@ -26,11 +26,14 @@
 #	      Mar 2022: Cathode included
 #
 #    V3     May 2022: Inclusion of anode plate on top of the 3 wire planes as requested by the background TF.
-#           In order to achieve it without overlaps, the TPC drift size was increased by 
-#           1*$padWidth = 0.02 cm. In this way, the relative distances of the 3 wire planes to the cathode plane
-#           remain the same. Other impacts are (all in drift direction): Argon volume from 850.08 to 850.1 cm,
-#           Detector enclosure from 1310.32 to 1310.34 cm, TPC origin from 50.04 to 50.05 cm, and TPC dimension
-#           from 650.08 to 650.1 cm. Currently the material of this plate is set to vm2000 so that no additional
+#           In order to avoid overlaps, the TPC drift size was increased by 1*$padWidth = 0.02 cm. Also, 
+#           a small displacement downwards (upwards) in the TPC (cathode) was included to keep cathode and 
+#           wireplanes in their original positions (world origin remains vertically centered on active TPC). 
+#           This change uses parameters: $nplate=1 and $tpc_x_disp, that should both be set to zero (or 
+#           deleted) if the anode plate is no longer needed. Other impacts are (all in drift direction): 
+#           Argon volume from 850.08 to 850.1 cm, Detector enclosure from 1310.32 to 1310.34 cm, TPC 
+#           origin from 50.04 to 50.05 cm, and TPC dimension from 650.08 to 650.1 cm. Currently the 
+#           material of this plate is set to vm2000 so that no additional
 #           geometry (ReflAnode) is needed to obtain optical fast simulation.
 #           TO DO: include perforated PCB in the gdml (see LEMs in dual phase gdml) 
 #
@@ -192,8 +195,10 @@ $lengthTPCActive = $nCRM_z * $lengthCRM + $nCRM_z * $borderCRP; # around 6000 fo
 $driftTPCActive  = 650.0;
 
 # model anode strips as wires of some diameter
+$nplate            = 1; #use 0 if the anode plate is no longer needed
 $padWidth          = 0.02;
-$ReadoutPlane      = (1+$nViews) * $padWidth; # 3 readout planes (no space b/w) + space for anode plate!
+$tpc_x_disp        = $padWidth/2.; #displacement to maintain cathode and wire planes in their original positions when including the anode plate --> Change to 0 if no longer needed
+$ReadoutPlane      = ($nplate+$nViews) * $padWidth; # 3 readout planes (no space b/w) + space for anode plate!
 
 ##################################################################
 ############## Parameters for TPC and inner volume ###############
@@ -681,6 +686,11 @@ print TPC <<EOF;
       y="$TPCActive_y"
       z="$TPCActive_z"
       lunit="cm"/>
+   <box name="AnodePlate" 
+      x="$padWidth/2."
+      y="$TPCActive_y"
+      z="$TPCActive_z"
+      lunit="cm"/>
    <box name="CRMActive" 
       x="$TPCActive_x"
       y="$TPCActive_y"
@@ -846,7 +856,7 @@ print TPC <<EOF;
      
    <volume name="volAnodePlate">
      <materialref ref="vm2000"/>
-     <solidref ref="CRMZPlane"/>
+     <solidref ref="AnodePlate"/>
 EOF
 
 print TPC <<EOF;
@@ -854,22 +864,22 @@ print TPC <<EOF;
 EOF
        
 #$posUplane[0] = 0.5*$TPC_x - 2.5*$padWidth; #the original positions without the anode plate are commented
-$posUplane[0] = 0.5*$TPC_x - 3.5*$padWidth;
+$posUplane[0] = 0.5*$TPC_x - 3.5*$padWidth + $tpc_x_disp;
 $posUplane[1] = 0;
 $posUplane[2] = 0;
 
 #$posYplane[0] = 0.5*$TPC_x - 1.5*$padWidth;
-$posYplane[0] = 0.5*$TPC_x - 2.5*$padWidth;
+$posYplane[0] = 0.5*$TPC_x - 2.5*$padWidth + $tpc_x_disp;
 $posYplane[1] = 0;
 $posYplane[2] = 0;
 
 #$posZplane[0] = 0.5*$TPC_x - 0.5*$padWidth;
-$posZplane[0] = 0.5*$TPC_x - 1.5*$padWidth;
+$posZplane[0] = 0.5*$TPC_x - 1.5*$padWidth + $tpc_x_disp;
 $posZplane[1] = 0; 
 $posZplane[2] = 0;
 
 #to simulate backgrounds from anode
-$posAnodePlate[0] = 0.5*$TPC_x - 0.5*$padWidth;
+$posAnodePlate[0] = 0.5*$TPC_x - 0.5*$padWidth + $tpc_x_disp/2;
 $posAnodePlate[1] = 0; 
 $posAnodePlate[2] = 0;
 
@@ -1372,7 +1382,7 @@ EOF
   }
 
 
-$CathodePosX =-$OriginXSet+50+(-1-$NFieldShapers*0.5)*$FieldShaperSeparation;
+$CathodePosX =-$OriginXSet+50+(-1-$NFieldShapers*0.5)*$FieldShaperSeparation + $tpc_x_disp;
 $CathodePosY = -0.5*$Argon_y + $yLArBuffer + 0.5*$widthCathode;
 $CathodePosZ = -0.5*$Argon_z + $zLArBuffer + 0.5*$lengthCathode;
 

--- a/dunecore/Geometry/gdml/generate_dunevd10kt_3view_v3_refactored.pl
+++ b/dunecore/Geometry/gdml/generate_dunevd10kt_3view_v3_refactored.pl
@@ -3,7 +3,7 @@
 #
 #
 #  First attempt to make a GDML fragment generator for the DUNE vertical drift 
-#  10kt detector geometry with 3 views: +/- Xdeg for induction and 90 deg collection
+#  10kt detector geometry with 3 views (2 orthogonal + induction at angle)
 #  The lower chamber is not added yet. 
 #  !!!NOTE!!!: the readout is on a positive Y plane (drift along horizontal X)
 #              due to current reco limitations)
@@ -17,24 +17,19 @@
 #           VG: Added defs to enable use in the refactored sim framework
 #           VG: 23.02.21 Adjust plane dimensions to fit a given number of ch per side
 #           VG: 23.02.21 Group CRUs in CRPs
-#           VG: 02.03.21 The length for the ROP is force to be the lenght
-#                        given by nch_collection x pitch_collection
-#    V2:    Laura Paulucci (lpaulucc@fnal.gov): Sept 2021 PDS added. 
+#    V2     Laura Paulucci (lpaulucc@fnal.gov): Sept 2021 PDS added. 
 #             Use option -pds=1 for backup design (membrane only coverage).
 #             Default (pds=0) is the reference design (~4-pi).
 #             This is linked with a larger geometry to account for photon propagation, generate it with -k=4.
 #             Field Cage is turned on with reference and backup designs to match PDS option.
 #	      For not including the pds, please use option -pds=-1
 #	      Mar 2022: Cathode included
-#    V3:      Apr 2022: Pitch and number of channels changed. 
-#                       Collection pitch = 5.1 mm (4.89 mm in v2)
-#                       Induction pitch = 7.65 mm (7.335 mm in v2) 
-#                       Reference for changes: https://indico.fnal.gov/event/53111/timetable/
-#             May 2022: Inclusion of anode plate on top of the 3 wire planes as requested by the background TF.
-#             In order to achieve it without overlaps, the 3 wire planes x positions were shifted downwards by
-#             1*$padWidth = 0.02 cm. Currently the material of this plate is set to vm2000 so that no aditional
-#             geometry (ReflAnode) is needed to obtain optical fast simulation.
-#             TO DO: include perforated PCB in the gdml (see LEMs in dual phase gdml) 
+#
+#    V3     May 2022: Inclusion of anode plate on top of the 3 wire planes as requested by the background TF.
+#           In order to achieve it without overlaps, the 3 wire planes x positions were shifted downwards by
+#           1*$padWidth = 0.02 cm. Currently the material of this plate is set to vm2000 so that no aditional
+#           geometry (ReflAnode) is needed to obtain optical fast simulation.
+#           TO DO: include perforated PCB in the gdml (see LEMs in dual phase gdml) 
 #
 #################################################################################
 
@@ -57,8 +52,8 @@ Math::BigFloat->precision(-16);
 GetOptions( "help|h" => \$help,
 	    "suffix|s:s" => \$suffix,
 	    "output|o:s" => \$output,
-	    "wires|w:s" => \$wires,  
-            "workspace|k:s" => \$wkspc,
+	    "wires|w:s" => \$wires,
+	    "workspace|k:s" => \$wkspc,
             "pdsconfig|pds:s" => \$pdsconfig);
 
 my $FieldCage_switch="on";
@@ -124,28 +119,24 @@ $basename="_";
 #$lengthPCBActive  = 150.0; # cm
 
 # views and channel counts
-%nChans = ('Ind1', 286, 'Ind1Bot', 96, 'Ind2', 286, 'Col', 292);
+%nChans = ('Ind1', 256, 'Ind1Bot', 128, 'Ind2', 320, 'Col', 288);
 $nViews = keys %nChans;
 #print "$nViews %nChans\n";
 
 # first induction view
-$wirePitchU      = 0.765;  # cm
-$wireAngleU      = 150.0;   # deg
+$wirePitchU      = 0.8695;  # cm
+$wireAngleU      = 131.63;  #-48.37;  # deg
 
 # second induction view
-$wirePitchV      = 0.765;  # cm
-$wireAngleV      = 30.0;    # deg
-
+$wirePitchY      = 0.525;
+$widthPCBActive  = 168.00;   #$wirePitchY * $nChans{'Ind2'};
 
 # last collection view
-$wirePitchZ      = 0.51;   # cm
-
-# force length to be equal to collection nch x pitch
-$lengthPCBActive = $wirePitchZ * $nChans{'Col'};
-$widthPCBActive  = 167.7006;
+$wirePitchZ      = 0.517;
+$lengthPCBActive = 148.9009; #$wirePitchZ * $nChans{'Col'};
 
 #
-$borderCRM       = 0.0;     # border space aroud each CRM 
+$borderCRM       = 0.0;      # border space aroud each CRM 
 
 $widthCRM_active  = $widthPCBActive;  
 $lengthCRM_active = $lengthPCBActive; 
@@ -184,11 +175,12 @@ if( $workspace == 3 )
 if( $workspace == 4 )
 {
     $nCRM_x = 4 * 2;
+#   $nCRM_z = 3 * 2;
     $nCRM_z = 7 * 2;
 }
 
 
-# calculate tpc area based on number of CRMs and their dimensions
+# calculate tpc area based on number of CRMs and their dimensions 
 # each CRP should have a 2x2 CRMs
 $widthTPCActive  = $nCRM_x * $widthCRM + $nCRM_x * $borderCRP;  # around 1200 for full module
 $lengthTPCActive = $nCRM_z * $lengthCRM + $nCRM_z * $borderCRP; # around 6000 for full module
@@ -427,7 +419,6 @@ print DEF <<EOF;
    <position name="posCryoInDetEnc"     unit="cm" x="$posCryoInDetEnc_x" y="0" z="0"/>
    <position name="posCenter"           unit="cm" x="0" y="0" z="0"/>
    <rotation name="rUWireAboutX"        unit="deg" x="$wireAngleU" y="0" z="0"/>
-   <rotation name="rVWireAboutX"        unit="deg" x="$wireAngleV" y="0" z="0"/>
    <rotation name="rPlus90AboutX"       unit="deg" x="90" y="0" z="0"/>
    <rotation name="rPlus90AboutY"       unit="deg" x="0" y="90" z="0"/>
    <rotation name="rPlus90AboutXPlus90AboutY" unit="deg" x="90" y="90" z="0"/>
@@ -576,12 +567,12 @@ sub gen_Wires
     if( $dirp[1] < 0 ){
 	$orig[1] = $width;
     }
-
+  
     #print "origin    : @orig\n";
     #print "pitch dir : @dirp\n";
     #print "wire dir  : @dirw\n";
     #print "$length x $width cm2\n";
-
+    
     # gen wires
     my @winfo  = ();
     my $offset = $pitch/2;
@@ -654,16 +645,11 @@ print TPC <<EOF;
 EOF
 
     # compute wires for 1st induction
-    my @winfoU = ();
-    my @winfoV = ();
+    my @winfo = ();
     if( $wires_on == 1 ){
-	@winfoU = gen_Wires( $TPCActive_z, 0, # force length
-			     $nChans{'Ind1'}, $nChans{'Ind1Bot'}, 
-			     $wirePitchU, $wireAngleU, $padWidth );
-	@winfoV = gen_Wires( $TPCActive_z, 0, # force length
-			     $nChans{'Ind2'}, $nChans{'Ind1Bot'}, 
-			     $wirePitchV, $wireAngleV, $padWidth );
-
+	@winfo = gen_Wires( 0, 0, # $TPCActive_y,
+			    $nChans{'Ind1'}, $nChans{'Ind1Bot'}, 
+			    $wirePitchU, $wireAngleU, $padWidth );
     }
 
     # All the TPC solids save the wires.
@@ -682,7 +668,7 @@ print TPC <<EOF;
       y="$TPCActive_y" 
       z="$TPCActive_z"
       lunit="cm"/>
-   <box name="CRMVPlane" 
+   <box name="CRMYPlane" 
       x="$padWidth" 
       y="$TPCActive_y" 
       z="$TPCActive_z"
@@ -702,7 +688,7 @@ EOF
 #++++++++++++++++++++++++++++ Wire Solids ++++++++++++++++++++++++++++++
 if($wires_on==1){
 	    
-    foreach my $wire (@winfoU) {
+    foreach my $wire (@winfo) {
 	my $wid = $wire->[0];
 	my $wln = $wire->[3];
 print TPC <<EOF;
@@ -713,21 +699,13 @@ print TPC <<EOF;
       aunit="deg" lunit="cm"/>
 EOF
     }
-
-    foreach my $wire (@winfoV) {
-	my $wid = $wire->[0];
-	my $wln = $wire->[3];
-print TPC <<EOF;
-   <tube name="CRMWireV$wid"
-      rmax="0.5*$padWidth"
-      z="$wln"               
-      deltaphi="360"
-      aunit="deg" lunit="cm"/>
-EOF
-    }
-
     
 print TPC <<EOF;
+   <tube name="CRMWireY"
+      rmax="0.5*$padWidth"
+      z="$TPCActive_z"               
+      deltaphi="360" 
+      aunit="deg" lunit="cm"/>
    <tube name="CRMWireZ"
       rmax="0.5*$padWidth"
       z="$TPCActive_y"               
@@ -755,7 +733,7 @@ EOF
 
 if($wires_on==1) 
 {
-    foreach my $wire (@winfoU) 
+    foreach my $wire (@winfo) 
     {
 	my $wid = $wire->[0];
 print TPC <<EOF;
@@ -766,18 +744,11 @@ print TPC <<EOF;
 EOF
     }
 
-    foreach my $wire (@winfoV) 
-    {
-	my $wid = $wire->[0];
 print TPC <<EOF;
-    <volume name="volTPCWireV$wid">
+    <volume name="volTPCWireY">
       <materialref ref="Copper_Beryllium_alloy25"/>
-      <solidref ref="CRMWireV$wid"/>
+      <solidref ref="CRMWireY"/>
     </volume>
-EOF
-    }
-
-print TPC <<EOF;
     <volume name="volTPCWireZ">
       <materialref ref="Copper_Beryllium_alloy25"/>
       <solidref ref="CRMWireZ"/>
@@ -797,7 +768,7 @@ if ($wires_on==1) # add wires to U plane
     my $offsetZ = 0; #-0.5 * $TPCActive_z;
     my $offsetY = 0; #-0.5 * $TPCActive_y;
 
-    foreach my $wire (@winfoU) {
+    foreach my $wire (@winfo) {
 	my $wid  = $wire->[0];
 	my $zpos = $wire->[1] + $offsetZ;
 	my $ypos = $wire->[2] + $offsetY;
@@ -816,30 +787,28 @@ EOF
 
 # 2nd induction plane
 print TPC <<EOF;
-  <volume name="volTPCPlaneV">
+  <volume name="volTPCPlaneY">
     <materialref ref="LAr"/>
-    <solidref ref="CRMVPlane"/>
+    <solidref ref="CRMYPlane"/>
 EOF
 
-if ($wires_on==1) # add wires to V plane (plane with wires reading y position)
-  {
-          # the coordinates were computed with a corner at (0,0)
-    # so we need to move to plane coordinates
-    my $offsetZ = 0; #-0.5 * $TPCActive_z;
-    my $offsetY = 0; #-0.5 * $TPCActive_y;
-
-    foreach my $wire (@winfoV) {
-	my $wid  = $wire->[0];
-	my $zpos = $wire->[1] + $offsetZ;
-	my $ypos = $wire->[2] + $offsetY;
+if ($wires_on==1) # add wires to Y plane (plane with wires reading y position)
+{
+    for(my $i=0;$i<$nChans{'Ind2'};++$i)
+    {
+	#my $ypos = -0.5 * $TPCActive_y + ($i+0.5)*$wirePitchY + 0.5*$padWidth;
+	my $ypos = ($i + 0.5 - $nChans{'Ind2'}/2)*$wirePitchY;
+	if( (0.5 * $TPCActive_y - abs($ypos)) < 0 ){
+	    die "Cannot place wire $i in view Y, as plane is too small\n";
+	}
 print TPC <<EOF;
-     <physvol>
-       <volumeref ref="volTPCWireV$wid"/> 
-       <position name="posWireV$wid" unit="cm" x="0" y="$ypos" z="$zpos"/>
-       <rotationref ref="rVWireAboutX"/> 
-     </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY$i" unit="cm" x="0" y="$ypos" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
 EOF
-    }
+   }
 }
 print TPC <<EOF;
   </volume>
@@ -853,9 +822,9 @@ print TPC <<EOF;
 EOF
 if ($wires_on==1) # add wires to Z plane (plane with wires reading z position)
    {
-       for($i=0;$i<$nChans{'Col'};++$i)
+       for(my $i=0;$i<$nChans{'Col'};++$i)
        {
-	  #my $zpos = -0.5 * $TPCActive_z + ($i+0.5)*$wirePitchZ + 0.5*$padWidth;
+	   #my $zpos = -0.5 * $TPCActive_z + ($i+0.5)*$wirePitchZ + 0.5*$padWidth;
 	   my $zpos = ($i + 0.5 - $nChans{'Col'}/2)*$wirePitchZ;
 	   if( (0.5 * $TPCActive_z - abs($zpos)) < 0 ){
 	       die "Cannot place wire $i in view Z, as plane is too small\n";
@@ -876,19 +845,20 @@ print TPC <<EOF;
      <materialref ref="vm2000"/>
      <solidref ref="CRMZPlane"/>
 EOF
+
 print TPC <<EOF;
   </volume>
 EOF
-
-#$posUplane[0] = 0.5*$TPC_x - 2.5*$padWidth;       
+       
+#$posUplane[0] = 0.5*$TPC_x - 2.5*$padWidth;
 $posUplane[0] = 0.5*$TPC_x - 3.5*$padWidth;
 $posUplane[1] = 0;
 $posUplane[2] = 0;
 
-#$posVplane[0] = 0.5*$TPC_x - 1.5*$padWidth;
-$posVplane[0] = 0.5*$TPC_x - 2.5*$padWidth;
-$posVplane[1] = 0;
-$posVplane[2] = 0;
+#$posYplane[0] = 0.5*$TPC_x - 1.5*$padWidth;
+$posYplane[0] = 0.5*$TPC_x - 2.5*$padWidth;
+$posYplane[1] = 0;
+$posYplane[2] = 0;
 
 #$posZplane[0] = 0.5*$TPC_x - 0.5*$padWidth;
 $posZplane[0] = 0.5*$TPC_x - 1.5*$padWidth;
@@ -899,6 +869,7 @@ $posZplane[2] = 0;
 $posAnodePlate[0] = 0.5*$TPC_x - 0.5*$padWidth;
 $posAnodePlate[1] = 0; 
 $posAnodePlate[2] = 0;
+
 
 $posTPCActive[0] = -$ReadoutPlane/2;
 $posTPCActive[1] = 0;
@@ -917,9 +888,9 @@ print TPC <<EOF;
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volTPCPlaneV"/>
+       <volumeref ref="volTPCPlaneY"/>
        <position name="posPlaneY" unit="cm" 
-         x="$posVplane[0]" y="$posVplane[1]" z="$posVplane[2]"/>
+         x="$posYplane[0]" y="$posYplane[1]" z="$posYplane[2]"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
@@ -933,7 +904,7 @@ print TPC <<EOF;
        <position name="posAnodePlate" unit="cm" 
          x="$posAnodePlate[0]" y="$posAnodePlate[1]" z="$posAnodePlate[2]"/>
        <rotationref ref="rIdentity"/>
-     </physvol>
+     </physvol>    
      <physvol>
        <volumeref ref="volTPCActive"/>
        <position name="posActive" unit="cm" 
@@ -942,6 +913,7 @@ print TPC <<EOF;
      </physvol>
    </volume>
 EOF
+## x="@{[$posTPCActive[0]+$padWidth]}" y="$posTPCActive[1]" z="$posTPCActive[2]"/>
 
 print TPC <<EOF;
  </structure>
@@ -1167,7 +1139,7 @@ print CRYO <<EOF;
 
 </solids>
 EOF
-
+    
 #PDS
 #Double sided detectors should only be included when both top and bottom volumes become available
 #Optical sensitive volumes cannot be rotated because Larsoft cannot pick up the rotation when obtinaing the lengths needed for the semi-analytic model --> two acceptance windows for single sided lateral and cathode
@@ -1228,7 +1200,7 @@ print CRYO <<EOF;
     <volume name="volGroundGrid">
       <materialref ref="STEEL_STAINLESS_Fe7Cr2Ni" />
       <solidref ref="CathodeGrid" />
-    </volume>
+    </volume>    
     <volume name="volGaseousArgon">
       <materialref ref="ArGas"/>
       <solidref ref="GaseousArgon"/>
@@ -1422,7 +1394,7 @@ EOF
        $CathodePosY = -0.5*$Argon_y + $yLArBuffer + 0.5*$widthCathode;
   }
   }
-
+  
 if ($pdsconfig == 0) {  #4-pi PDS converage
 
 #for placing the Arapucas over the cathode
@@ -1464,7 +1436,7 @@ for($j=0;$j<$nCRM_z/2;$j++){#nCRM will give the collumn number (1 collumn per fr
 }
 
 }
-  
+
  print CRYO <<EOF;
     </volume>
 </structure>
@@ -1963,7 +1935,7 @@ EOF
 print "Some of the principal parameters for this TPC geometry (unit cm unless noted otherwise)\n";
 print " CRM active area       : $widthCRM_active x $lengthCRM_active\n";
 print " CRM total area        : $widthCRM x $lengthCRM\n";
-print " Wire pitch in U, V, Z : $wirePitchU, $wirePitchV, $wirePitchZ\n";
+print " Wire pitch in U, Y, Z : $wirePitchU, $wirePitchY, $wirePitchZ\n";
 print " TPC active volume  : $driftTPCActive x $widthTPCActive x $lengthTPCActive\n";
 print " Argon volume       : ($Argon_x, $Argon_y, $Argon_z) \n"; 
 print " Argon buffer       : ($xLArBuffer, $yLArBuffer, $zLArBuffer) \n"; 


### PR DESCRIPTION
The background TF requested an anode volume to use as source of backgrounds. The new v3 geometries (3view and 3view_30deg) include an anode plate on top of the 3 wire planes. In order to achieve this without overlaps, the 3 wire planes x positions were shifted downwards by 1*$padWidth = 0.02 cm. Currently the material of this plate is set to vm2000 so that no additional geometry (ReflAnode) is needed to obtain optical fast simulation, allowing this file to be deleted in the future. If additional changes are needed please let me know.