### PR TITLE
new VD v3 geo (backgrounds from anode)

### DIFF
--- a/dunecore/Geometry/gdml/dunevd10kt_3view_30deg_v3_refactored_1x8x14ref.gdml
+++ b/dunecore/Geometry/gdml/dunevd10kt_3view_30deg_v3_refactored_1x8x14ref.gdml
@@ -490,7 +490,7 @@
     
 
    <box name="CRM"
-      x="650.1" 
+      x="650.08" 
       y="167.7006" 
       z="148.92"
       lunit="cm"/>
@@ -506,11 +506,6 @@
       lunit="cm"/>
    <box name="CRMZPlane" 
       x="0.02"
-      y="167.7006"
-      z="148.92"
-      lunit="cm"/>
-   <box name="AnodePlate" 
-      x="0.02/2."
       y="167.7006"
       z="148.92"
       lunit="cm"/>
@@ -3429,27 +3424,27 @@
 
 
     <box name="Cryostat" lunit="cm" 
-      x="850.34" 
+      x="850.32" 
       y="1545.8448" 
       z="2292.12"/>
 
     <box name="ArgonInterior" lunit="cm" 
-      x="850.1"
+      x="850.08"
       y="1545.6048"
       z="2291.88"/>
 
     <box name="GaseousArgon" lunit="cm" 
-      x="100"
+      x="100 - 0.02"
       y="1545.6048"
       z="2291.88"/>
 
     <box name="ExternalAuxOut" lunit="cm" 
-      x="850.1 - 100"
+      x="850.08 - 100"
       y="1545.6048 - 2*2.5 - 2*40"
       z="2291.88"/>
 
     <box name="ExternalAuxIn" lunit="cm" 
-      x="850.1"
+      x="850.08"
       y="1356.7748"
       z="2291.88 + 1"/>
 
@@ -3556,8 +3551,14 @@
       <position name="posCathodeSub16" x="0" y="122.525" z="108.5" unit="cm"/>
     </subtraction>
 
+   <box name="AnodePlate" 
+      x="0.02/2."
+      y="335.4012"
+      z="297.84"
+      lunit="cm"/>
+
     <box name="FoamPadBlock" lunit="cm"
-      x="1010.34"
+      x="1010.32"
       y="1705.8448"
       z="2452.12" />
 
@@ -3568,7 +3569,7 @@
     </subtraction>
 
     <box name="SteelSupportBlock" lunit="cm"
-      x="1210.34"
+      x="1210.32"
       y="1905.8448"
       z="2652.12" />
 
@@ -3579,13 +3580,13 @@
     </subtraction>
 
     <box name="DetEnclosure" lunit="cm" 
-      x="1310.34"
+      x="1310.32"
       y="2105.8448"
       z="2852.12"/>
 
 
     <box name="World" lunit="cm" 
-      x="9310.34" 
+      x="9310.32" 
       y="10105.8448" 
       z="10852.12"/>
 </solids>
@@ -10232,11 +10233,6 @@
          <rotationref ref="rPlus90AboutX"/>
        </physvol>
   </volume>
-     
-   <volume name="volAnodePlate">
-     <materialref ref="vm2000"/>
-     <solidref ref="AnodePlate"/>
-  </volume>
    <volume name="volTPC">
      <materialref ref="LAr"/>
        <solidref ref="CRM"/>
@@ -10259,15 +10255,9 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volAnodePlate"/>
-       <position name="posAnodePlate" unit="cm" 
-         x="325.045" y="0" z="0"/>
-       <rotationref ref="rIdentity"/>
-     </physvol>
-     <physvol>
        <volumeref ref="volTPCActive"/>
        <position name="posActive" unit="cm" 
-        x="-0.05" y="" z="0"/>
+        x="-0.04" y="" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
    </volume>
@@ -10279,6 +10269,10 @@
     <volume name="volGroundGrid">
       <materialref ref="STEEL_STAINLESS_Fe7Cr2Ni" />
       <solidref ref="CathodeGrid" />
+    </volume>
+    <volume name="volAnodePlate">
+     <materialref ref="vm2000"/>
+     <solidref ref="AnodePlate"/>
     </volume>
     <volume name="volGaseousArgon">
       <materialref ref="ArGas"/>
@@ -11642,7 +11636,7 @@
       <solidref ref="Cryostat" />
       <physvol>
         <volumeref ref="volGaseousArgon"/>
-        <position name="posGaseousArgon" unit="cm" x="375.05" y="0" z="0"/>
+        <position name="posGaseousArgon" unit="cm" x="375.04" y="0" z="0"/>
       </physvol>
       <physvol>
         <volumeref ref="volSteelShell"/>
@@ -12214,542 +12208,542 @@
       </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper0" unit="cm"  x="-322.05" y="-675.1024" z="0" />
+     <position name="posFieldShaper0" unit="cm"  x="-322.04" y="-675.1024" z="0" />
      <rotation name="rotFS0" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper1" unit="cm"  x="-316.05" y="-675.1024" z="0" />
+     <position name="posFieldShaper1" unit="cm"  x="-316.04" y="-675.1024" z="0" />
      <rotation name="rotFS1" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper2" unit="cm"  x="-310.05" y="-675.1024" z="0" />
+     <position name="posFieldShaper2" unit="cm"  x="-310.04" y="-675.1024" z="0" />
      <rotation name="rotFS2" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper3" unit="cm"  x="-304.05" y="-675.1024" z="0" />
+     <position name="posFieldShaper3" unit="cm"  x="-304.04" y="-675.1024" z="0" />
      <rotation name="rotFS3" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper4" unit="cm"  x="-298.05" y="-675.1024" z="0" />
+     <position name="posFieldShaper4" unit="cm"  x="-298.04" y="-675.1024" z="0" />
      <rotation name="rotFS4" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper5" unit="cm"  x="-292.05" y="-675.1024" z="0" />
+     <position name="posFieldShaper5" unit="cm"  x="-292.04" y="-675.1024" z="0" />
      <rotation name="rotFS5" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper6" unit="cm"  x="-286.05" y="-675.1024" z="0" />
+     <position name="posFieldShaper6" unit="cm"  x="-286.04" y="-675.1024" z="0" />
      <rotation name="rotFS6" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper7" unit="cm"  x="-280.05" y="-675.1024" z="0" />
+     <position name="posFieldShaper7" unit="cm"  x="-280.04" y="-675.1024" z="0" />
      <rotation name="rotFS7" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper8" unit="cm"  x="-274.05" y="-675.1024" z="0" />
+     <position name="posFieldShaper8" unit="cm"  x="-274.04" y="-675.1024" z="0" />
      <rotation name="rotFS8" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper9" unit="cm"  x="-268.05" y="-675.1024" z="0" />
+     <position name="posFieldShaper9" unit="cm"  x="-268.04" y="-675.1024" z="0" />
      <rotation name="rotFS9" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper10" unit="cm"  x="-262.05" y="-675.1024" z="0" />
+     <position name="posFieldShaper10" unit="cm"  x="-262.04" y="-675.1024" z="0" />
      <rotation name="rotFS10" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper11" unit="cm"  x="-256.05" y="-675.1024" z="0" />
+     <position name="posFieldShaper11" unit="cm"  x="-256.04" y="-675.1024" z="0" />
      <rotation name="rotFS11" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper12" unit="cm"  x="-250.05" y="-675.1024" z="0" />
+     <position name="posFieldShaper12" unit="cm"  x="-250.04" y="-675.1024" z="0" />
      <rotation name="rotFS12" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper13" unit="cm"  x="-244.05" y="-675.1024" z="0" />
+     <position name="posFieldShaper13" unit="cm"  x="-244.04" y="-675.1024" z="0" />
      <rotation name="rotFS13" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper14" unit="cm"  x="-238.05" y="-675.1024" z="0" />
+     <position name="posFieldShaper14" unit="cm"  x="-238.04" y="-675.1024" z="0" />
      <rotation name="rotFS14" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper15" unit="cm"  x="-232.05" y="-675.1024" z="0" />
+     <position name="posFieldShaper15" unit="cm"  x="-232.04" y="-675.1024" z="0" />
      <rotation name="rotFS15" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper16" unit="cm"  x="-226.05" y="-675.1024" z="0" />
+     <position name="posFieldShaper16" unit="cm"  x="-226.04" y="-675.1024" z="0" />
      <rotation name="rotFS16" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper17" unit="cm"  x="-220.05" y="-675.1024" z="0" />
+     <position name="posFieldShaper17" unit="cm"  x="-220.04" y="-675.1024" z="0" />
      <rotation name="rotFS17" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper18" unit="cm"  x="-214.05" y="-675.1024" z="0" />
+     <position name="posFieldShaper18" unit="cm"  x="-214.04" y="-675.1024" z="0" />
      <rotation name="rotFS18" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper19" unit="cm"  x="-208.05" y="-675.1024" z="0" />
+     <position name="posFieldShaper19" unit="cm"  x="-208.04" y="-675.1024" z="0" />
      <rotation name="rotFS19" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper20" unit="cm"  x="-202.05" y="-675.1024" z="0" />
+     <position name="posFieldShaper20" unit="cm"  x="-202.04" y="-675.1024" z="0" />
      <rotation name="rotFS20" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper21" unit="cm"  x="-196.05" y="-675.1024" z="0" />
+     <position name="posFieldShaper21" unit="cm"  x="-196.04" y="-675.1024" z="0" />
      <rotation name="rotFS21" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper22" unit="cm"  x="-190.05" y="-675.1024" z="0" />
+     <position name="posFieldShaper22" unit="cm"  x="-190.04" y="-675.1024" z="0" />
      <rotation name="rotFS22" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper23" unit="cm"  x="-184.05" y="-675.1024" z="0" />
+     <position name="posFieldShaper23" unit="cm"  x="-184.04" y="-675.1024" z="0" />
      <rotation name="rotFS23" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper24" unit="cm"  x="-178.05" y="-675.1024" z="0" />
+     <position name="posFieldShaper24" unit="cm"  x="-178.04" y="-675.1024" z="0" />
      <rotation name="rotFS24" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper25" unit="cm"  x="-172.05" y="-675.1024" z="0" />
+     <position name="posFieldShaper25" unit="cm"  x="-172.04" y="-675.1024" z="0" />
      <rotation name="rotFS25" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper26" unit="cm"  x="-166.05" y="-675.1024" z="0" />
+     <position name="posFieldShaper26" unit="cm"  x="-166.04" y="-675.1024" z="0" />
      <rotation name="rotFS26" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper27" unit="cm"  x="-160.05" y="-675.1024" z="0" />
+     <position name="posFieldShaper27" unit="cm"  x="-160.04" y="-675.1024" z="0" />
      <rotation name="rotFS27" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper28" unit="cm"  x="-154.05" y="-675.1024" z="0" />
+     <position name="posFieldShaper28" unit="cm"  x="-154.04" y="-675.1024" z="0" />
      <rotation name="rotFS28" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper29" unit="cm"  x="-148.05" y="-675.1024" z="0" />
+     <position name="posFieldShaper29" unit="cm"  x="-148.04" y="-675.1024" z="0" />
      <rotation name="rotFS29" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper30" unit="cm"  x="-142.05" y="-675.1024" z="0" />
+     <position name="posFieldShaper30" unit="cm"  x="-142.04" y="-675.1024" z="0" />
      <rotation name="rotFS30" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper31" unit="cm"  x="-136.05" y="-675.1024" z="0" />
+     <position name="posFieldShaper31" unit="cm"  x="-136.04" y="-675.1024" z="0" />
      <rotation name="rotFS31" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper32" unit="cm"  x="-130.05" y="-675.1024" z="0" />
+     <position name="posFieldShaper32" unit="cm"  x="-130.04" y="-675.1024" z="0" />
      <rotation name="rotFS32" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper33" unit="cm"  x="-124.05" y="-675.1024" z="0" />
+     <position name="posFieldShaper33" unit="cm"  x="-124.04" y="-675.1024" z="0" />
      <rotation name="rotFS33" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper34" unit="cm"  x="-118.05" y="-675.1024" z="0" />
+     <position name="posFieldShaper34" unit="cm"  x="-118.04" y="-675.1024" z="0" />
      <rotation name="rotFS34" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper35" unit="cm"  x="-112.05" y="-675.1024" z="0" />
+     <position name="posFieldShaper35" unit="cm"  x="-112.04" y="-675.1024" z="0" />
      <rotation name="rotFS35" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper36" unit="cm"  x="-106.05" y="-675.1024" z="0" />
+     <position name="posFieldShaper36" unit="cm"  x="-106.04" y="-675.1024" z="0" />
      <rotation name="rotFS36" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper37" unit="cm"  x="-100.05" y="-675.1024" z="0" />
+     <position name="posFieldShaper37" unit="cm"  x="-100.04" y="-675.1024" z="0" />
      <rotation name="rotFS37" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper38" unit="cm"  x="-94.0500000000001" y="-675.1024" z="0" />
+     <position name="posFieldShaper38" unit="cm"  x="-94.04" y="-675.1024" z="0" />
      <rotation name="rotFS38" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper39" unit="cm"  x="-88.0500000000001" y="-675.1024" z="0" />
+     <position name="posFieldShaper39" unit="cm"  x="-88.04" y="-675.1024" z="0" />
      <rotation name="rotFS39" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper40" unit="cm"  x="-82.0500000000001" y="-675.1024" z="0" />
+     <position name="posFieldShaper40" unit="cm"  x="-82.04" y="-675.1024" z="0" />
      <rotation name="rotFS40" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper41" unit="cm"  x="-76.0500000000001" y="-675.1024" z="0" />
+     <position name="posFieldShaper41" unit="cm"  x="-76.04" y="-675.1024" z="0" />
      <rotation name="rotFS41" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper42" unit="cm"  x="-70.0500000000001" y="-675.1024" z="0" />
+     <position name="posFieldShaper42" unit="cm"  x="-70.04" y="-675.1024" z="0" />
      <rotation name="rotFS42" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper43" unit="cm"  x="-64.0500000000001" y="-675.1024" z="0" />
+     <position name="posFieldShaper43" unit="cm"  x="-64.04" y="-675.1024" z="0" />
      <rotation name="rotFS43" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper44" unit="cm"  x="-58.0500000000001" y="-675.1024" z="0" />
+     <position name="posFieldShaper44" unit="cm"  x="-58.04" y="-675.1024" z="0" />
      <rotation name="rotFS44" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper45" unit="cm"  x="-52.0500000000001" y="-675.1024" z="0" />
+     <position name="posFieldShaper45" unit="cm"  x="-52.04" y="-675.1024" z="0" />
      <rotation name="rotFS45" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper46" unit="cm"  x="-46.0500000000001" y="-675.1024" z="0" />
+     <position name="posFieldShaper46" unit="cm"  x="-46.04" y="-675.1024" z="0" />
      <rotation name="rotFS46" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper47" unit="cm"  x="-40.0500000000001" y="-675.1024" z="0" />
+     <position name="posFieldShaper47" unit="cm"  x="-40.04" y="-675.1024" z="0" />
      <rotation name="rotFS47" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper48" unit="cm"  x="-34.0500000000001" y="-675.1024" z="0" />
+     <position name="posFieldShaper48" unit="cm"  x="-34.04" y="-675.1024" z="0" />
      <rotation name="rotFS48" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper49" unit="cm"  x="-28.0500000000001" y="-675.1024" z="0" />
+     <position name="posFieldShaper49" unit="cm"  x="-28.04" y="-675.1024" z="0" />
      <rotation name="rotFS49" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper50" unit="cm"  x="-22.0500000000001" y="-675.1024" z="0" />
+     <position name="posFieldShaper50" unit="cm"  x="-22.04" y="-675.1024" z="0" />
      <rotation name="rotFS50" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper51" unit="cm"  x="-16.0500000000001" y="-675.1024" z="0" />
+     <position name="posFieldShaper51" unit="cm"  x="-16.04" y="-675.1024" z="0" />
      <rotation name="rotFS51" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper52" unit="cm"  x="-10.0500000000001" y="-675.1024" z="0" />
+     <position name="posFieldShaper52" unit="cm"  x="-10.04" y="-675.1024" z="0" />
      <rotation name="rotFS52" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper53" unit="cm"  x="-4.05000000000005" y="-675.1024" z="0" />
+     <position name="posFieldShaper53" unit="cm"  x="-4.04000000000001" y="-675.1024" z="0" />
      <rotation name="rotFS53" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper54" unit="cm"  x="1.94999999999995" y="-675.1024" z="0" />
+     <position name="posFieldShaper54" unit="cm"  x="1.95999999999999" y="-675.1024" z="0" />
      <rotation name="rotFS54" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper55" unit="cm"  x="7.94999999999995" y="-675.1024" z="0" />
+     <position name="posFieldShaper55" unit="cm"  x="7.95999999999999" y="-675.1024" z="0" />
      <rotation name="rotFS55" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper56" unit="cm"  x="13.9499999999999" y="-675.1024" z="0" />
+     <position name="posFieldShaper56" unit="cm"  x="13.96" y="-675.1024" z="0" />
      <rotation name="rotFS56" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper57" unit="cm"  x="19.9499999999999" y="-675.1024" z="0" />
+     <position name="posFieldShaper57" unit="cm"  x="19.96" y="-675.1024" z="0" />
      <rotation name="rotFS57" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper58" unit="cm"  x="25.9499999999999" y="-675.1024" z="0" />
+     <position name="posFieldShaper58" unit="cm"  x="25.96" y="-675.1024" z="0" />
      <rotation name="rotFS58" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper59" unit="cm"  x="31.9499999999999" y="-675.1024" z="0" />
+     <position name="posFieldShaper59" unit="cm"  x="31.96" y="-675.1024" z="0" />
      <rotation name="rotFS59" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper60" unit="cm"  x="37.9499999999999" y="-675.1024" z="0" />
+     <position name="posFieldShaper60" unit="cm"  x="37.96" y="-675.1024" z="0" />
      <rotation name="rotFS60" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper61" unit="cm"  x="43.9499999999999" y="-675.1024" z="0" />
+     <position name="posFieldShaper61" unit="cm"  x="43.96" y="-675.1024" z="0" />
      <rotation name="rotFS61" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper62" unit="cm"  x="49.9499999999999" y="-675.1024" z="0" />
+     <position name="posFieldShaper62" unit="cm"  x="49.96" y="-675.1024" z="0" />
      <rotation name="rotFS62" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper63" unit="cm"  x="55.9499999999999" y="-675.1024" z="0" />
+     <position name="posFieldShaper63" unit="cm"  x="55.96" y="-675.1024" z="0" />
      <rotation name="rotFS63" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper64" unit="cm"  x="61.9499999999999" y="-675.1024" z="0" />
+     <position name="posFieldShaper64" unit="cm"  x="61.96" y="-675.1024" z="0" />
      <rotation name="rotFS64" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper65" unit="cm"  x="67.9499999999999" y="-675.1024" z="0" />
+     <position name="posFieldShaper65" unit="cm"  x="67.96" y="-675.1024" z="0" />
      <rotation name="rotFS65" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper66" unit="cm"  x="73.9499999999999" y="-675.1024" z="0" />
+     <position name="posFieldShaper66" unit="cm"  x="73.96" y="-675.1024" z="0" />
      <rotation name="rotFS66" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper67" unit="cm"  x="79.9499999999999" y="-675.1024" z="0" />
+     <position name="posFieldShaper67" unit="cm"  x="79.96" y="-675.1024" z="0" />
      <rotation name="rotFS67" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper68" unit="cm"  x="85.9499999999999" y="-675.1024" z="0" />
+     <position name="posFieldShaper68" unit="cm"  x="85.96" y="-675.1024" z="0" />
      <rotation name="rotFS68" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper69" unit="cm"  x="91.9499999999999" y="-675.1024" z="0" />
+     <position name="posFieldShaper69" unit="cm"  x="91.96" y="-675.1024" z="0" />
      <rotation name="rotFS69" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper70" unit="cm"  x="97.9499999999999" y="-675.1024" z="0" />
+     <position name="posFieldShaper70" unit="cm"  x="97.96" y="-675.1024" z="0" />
      <rotation name="rotFS70" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper71" unit="cm"  x="103.95" y="-675.1024" z="0" />
+     <position name="posFieldShaper71" unit="cm"  x="103.96" y="-675.1024" z="0" />
      <rotation name="rotFS71" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper72" unit="cm"  x="109.95" y="-675.1024" z="0" />
+     <position name="posFieldShaper72" unit="cm"  x="109.96" y="-675.1024" z="0" />
      <rotation name="rotFS72" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper73" unit="cm"  x="115.95" y="-675.1024" z="0" />
+     <position name="posFieldShaper73" unit="cm"  x="115.96" y="-675.1024" z="0" />
      <rotation name="rotFS73" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper74" unit="cm"  x="121.95" y="-675.1024" z="0" />
+     <position name="posFieldShaper74" unit="cm"  x="121.96" y="-675.1024" z="0" />
      <rotation name="rotFS74" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper75" unit="cm"  x="127.95" y="-675.1024" z="0" />
+     <position name="posFieldShaper75" unit="cm"  x="127.96" y="-675.1024" z="0" />
      <rotation name="rotFS75" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper76" unit="cm"  x="133.95" y="-675.1024" z="0" />
+     <position name="posFieldShaper76" unit="cm"  x="133.96" y="-675.1024" z="0" />
      <rotation name="rotFS76" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper77" unit="cm"  x="139.95" y="-675.1024" z="0" />
+     <position name="posFieldShaper77" unit="cm"  x="139.96" y="-675.1024" z="0" />
      <rotation name="rotFS77" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper78" unit="cm"  x="145.95" y="-675.1024" z="0" />
+     <position name="posFieldShaper78" unit="cm"  x="145.96" y="-675.1024" z="0" />
      <rotation name="rotFS78" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper79" unit="cm"  x="151.95" y="-675.1024" z="0" />
+     <position name="posFieldShaper79" unit="cm"  x="151.96" y="-675.1024" z="0" />
      <rotation name="rotFS79" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper80" unit="cm"  x="157.95" y="-675.1024" z="0" />
+     <position name="posFieldShaper80" unit="cm"  x="157.96" y="-675.1024" z="0" />
      <rotation name="rotFS80" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper81" unit="cm"  x="163.95" y="-675.1024" z="0" />
+     <position name="posFieldShaper81" unit="cm"  x="163.96" y="-675.1024" z="0" />
      <rotation name="rotFS81" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper82" unit="cm"  x="169.95" y="-675.1024" z="0" />
+     <position name="posFieldShaper82" unit="cm"  x="169.96" y="-675.1024" z="0" />
      <rotation name="rotFS82" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper83" unit="cm"  x="175.95" y="-675.1024" z="0" />
+     <position name="posFieldShaper83" unit="cm"  x="175.96" y="-675.1024" z="0" />
      <rotation name="rotFS83" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper84" unit="cm"  x="181.95" y="-675.1024" z="0" />
+     <position name="posFieldShaper84" unit="cm"  x="181.96" y="-675.1024" z="0" />
      <rotation name="rotFS84" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper85" unit="cm"  x="187.95" y="-675.1024" z="0" />
+     <position name="posFieldShaper85" unit="cm"  x="187.96" y="-675.1024" z="0" />
      <rotation name="rotFS85" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper86" unit="cm"  x="193.95" y="-675.1024" z="0" />
+     <position name="posFieldShaper86" unit="cm"  x="193.96" y="-675.1024" z="0" />
      <rotation name="rotFS86" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper87" unit="cm"  x="199.95" y="-675.1024" z="0" />
+     <position name="posFieldShaper87" unit="cm"  x="199.96" y="-675.1024" z="0" />
      <rotation name="rotFS87" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper88" unit="cm"  x="205.95" y="-675.1024" z="0" />
+     <position name="posFieldShaper88" unit="cm"  x="205.96" y="-675.1024" z="0" />
      <rotation name="rotFS88" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper89" unit="cm"  x="211.95" y="-675.1024" z="0" />
+     <position name="posFieldShaper89" unit="cm"  x="211.96" y="-675.1024" z="0" />
      <rotation name="rotFS89" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper90" unit="cm"  x="217.95" y="-675.1024" z="0" />
+     <position name="posFieldShaper90" unit="cm"  x="217.96" y="-675.1024" z="0" />
      <rotation name="rotFS90" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper91" unit="cm"  x="223.95" y="-675.1024" z="0" />
+     <position name="posFieldShaper91" unit="cm"  x="223.96" y="-675.1024" z="0" />
      <rotation name="rotFS91" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper92" unit="cm"  x="229.95" y="-675.1024" z="0" />
+     <position name="posFieldShaper92" unit="cm"  x="229.96" y="-675.1024" z="0" />
      <rotation name="rotFS92" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper93" unit="cm"  x="235.95" y="-675.1024" z="0" />
+     <position name="posFieldShaper93" unit="cm"  x="235.96" y="-675.1024" z="0" />
      <rotation name="rotFS93" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper94" unit="cm"  x="241.95" y="-675.1024" z="0" />
+     <position name="posFieldShaper94" unit="cm"  x="241.96" y="-675.1024" z="0" />
      <rotation name="rotFS94" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper95" unit="cm"  x="247.95" y="-675.1024" z="0" />
+     <position name="posFieldShaper95" unit="cm"  x="247.96" y="-675.1024" z="0" />
      <rotation name="rotFS95" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper96" unit="cm"  x="253.95" y="-675.1024" z="0" />
+     <position name="posFieldShaper96" unit="cm"  x="253.96" y="-675.1024" z="0" />
      <rotation name="rotFS96" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper97" unit="cm"  x="259.95" y="-675.1024" z="0" />
+     <position name="posFieldShaper97" unit="cm"  x="259.96" y="-675.1024" z="0" />
      <rotation name="rotFS97" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper98" unit="cm"  x="265.95" y="-675.1024" z="0" />
+     <position name="posFieldShaper98" unit="cm"  x="265.96" y="-675.1024" z="0" />
      <rotation name="rotFS98" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper99" unit="cm"  x="271.95" y="-675.1024" z="0" />
+     <position name="posFieldShaper99" unit="cm"  x="271.96" y="-675.1024" z="0" />
      <rotation name="rotFS99" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper100" unit="cm"  x="277.95" y="-675.1024" z="0" />
+     <position name="posFieldShaper100" unit="cm"  x="277.96" y="-675.1024" z="0" />
      <rotation name="rotFS100" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper101" unit="cm"  x="283.95" y="-675.1024" z="0" />
+     <position name="posFieldShaper101" unit="cm"  x="283.96" y="-675.1024" z="0" />
      <rotation name="rotFS101" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper102" unit="cm"  x="289.95" y="-675.1024" z="0" />
+     <position name="posFieldShaper102" unit="cm"  x="289.96" y="-675.1024" z="0" />
      <rotation name="rotFS102" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper103" unit="cm"  x="295.95" y="-675.1024" z="0" />
+     <position name="posFieldShaper103" unit="cm"  x="295.96" y="-675.1024" z="0" />
      <rotation name="rotFS103" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper104" unit="cm"  x="301.95" y="-675.1024" z="0" />
+     <position name="posFieldShaper104" unit="cm"  x="301.96" y="-675.1024" z="0" />
      <rotation name="rotFS104" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper105" unit="cm"  x="307.95" y="-675.1024" z="0" />
+     <position name="posFieldShaper105" unit="cm"  x="307.96" y="-675.1024" z="0" />
      <rotation name="rotFS105" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper106" unit="cm"  x="313.95" y="-675.1024" z="0" />
+     <position name="posFieldShaper106" unit="cm"  x="313.96" y="-675.1024" z="0" />
      <rotation name="rotFS106" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper107" unit="cm"  x="319.95" y="-675.1024" z="0" />
+     <position name="posFieldShaper107" unit="cm"  x="319.96" y="-675.1024" z="0" />
      <rotation name="rotFS107" unit="deg" x="0" y="0" z="90" />
   </physvol>
       <physvol>
@@ -12757,113 +12751,253 @@
    <position name="posGroundGrid-0" unit="cm" x="-328.04" y="-505.1018" z="-897.02"/>
       </physvol>
       <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-0" unit="cm" x="325.045" y="-505.1018" z="-897.02"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-1" unit="cm" x="-328.04" y="-169.7006" z="-897.02"/>
       </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-1" unit="cm" x="325.045" y="-169.7006" z="-897.02"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
       <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-2" unit="cm" x="-328.04" y="165.7006" z="-897.02"/>
       </physvol>
       <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-2" unit="cm" x="325.045" y="165.7006" z="-897.02"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-3" unit="cm" x="-328.04" y="501.1018" z="-897.02"/>
       </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-3" unit="cm" x="325.045" y="501.1018" z="-897.02"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
       <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-4" unit="cm" x="-328.04" y="-505.1018" z="-599.18"/>
       </physvol>
       <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-4" unit="cm" x="325.045" y="-505.1018" z="-599.18"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-5" unit="cm" x="-328.04" y="-169.7006" z="-599.18"/>
       </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-5" unit="cm" x="325.045" y="-169.7006" z="-599.18"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
       <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-6" unit="cm" x="-328.04" y="165.7006" z="-599.18"/>
       </physvol>
       <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-6" unit="cm" x="325.045" y="165.7006" z="-599.18"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-7" unit="cm" x="-328.04" y="501.1018" z="-599.18"/>
       </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-7" unit="cm" x="325.045" y="501.1018" z="-599.18"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
       <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-8" unit="cm" x="-328.04" y="-505.1018" z="-301.34"/>
       </physvol>
       <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-8" unit="cm" x="325.045" y="-505.1018" z="-301.34"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-9" unit="cm" x="-328.04" y="-169.7006" z="-301.34"/>
       </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-9" unit="cm" x="325.045" y="-169.7006" z="-301.34"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
       <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-10" unit="cm" x="-328.04" y="165.7006" z="-301.34"/>
       </physvol>
       <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-10" unit="cm" x="325.045" y="165.7006" z="-301.34"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-11" unit="cm" x="-328.04" y="501.1018" z="-301.34"/>
       </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-11" unit="cm" x="325.045" y="501.1018" z="-301.34"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
       <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-12" unit="cm" x="-328.04" y="-505.1018" z="-3.49999999999989"/>
       </physvol>
       <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-12" unit="cm" x="325.045" y="-505.1018" z="-3.49999999999989"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-13" unit="cm" x="-328.04" y="-169.7006" z="-3.49999999999989"/>
       </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-13" unit="cm" x="325.045" y="-169.7006" z="-3.49999999999989"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
       <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-14" unit="cm" x="-328.04" y="165.7006" z="-3.49999999999989"/>
       </physvol>
       <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-14" unit="cm" x="325.045" y="165.7006" z="-3.49999999999989"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-15" unit="cm" x="-328.04" y="501.1018" z="-3.49999999999989"/>
       </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-15" unit="cm" x="325.045" y="501.1018" z="-3.49999999999989"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
       <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-16" unit="cm" x="-328.04" y="-505.1018" z="294.34"/>
       </physvol>
       <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-16" unit="cm" x="325.045" y="-505.1018" z="294.34"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-17" unit="cm" x="-328.04" y="-169.7006" z="294.34"/>
       </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-17" unit="cm" x="325.045" y="-169.7006" z="294.34"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
       <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-18" unit="cm" x="-328.04" y="165.7006" z="294.34"/>
       </physvol>
       <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-18" unit="cm" x="325.045" y="165.7006" z="294.34"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-19" unit="cm" x="-328.04" y="501.1018" z="294.34"/>
       </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-19" unit="cm" x="325.045" y="501.1018" z="294.34"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
       <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-20" unit="cm" x="-328.04" y="-505.1018" z="592.18"/>
       </physvol>
       <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-20" unit="cm" x="325.045" y="-505.1018" z="592.18"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-21" unit="cm" x="-328.04" y="-169.7006" z="592.18"/>
       </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-21" unit="cm" x="325.045" y="-169.7006" z="592.18"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
       <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-22" unit="cm" x="-328.04" y="165.7006" z="592.18"/>
       </physvol>
       <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-22" unit="cm" x="325.045" y="165.7006" z="592.18"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-23" unit="cm" x="-328.04" y="501.1018" z="592.18"/>
       </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-23" unit="cm" x="325.045" y="501.1018" z="592.18"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
       <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-24" unit="cm" x="-328.04" y="-505.1018" z="890.02"/>
       </physvol>
       <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-24" unit="cm" x="325.045" y="-505.1018" z="890.02"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-25" unit="cm" x="-328.04" y="-169.7006" z="890.02"/>
       </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-25" unit="cm" x="325.045" y="-169.7006" z="890.02"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
       <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-26" unit="cm" x="-328.04" y="165.7006" z="890.02"/>
       </physvol>
       <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-26" unit="cm" x="325.045" y="165.7006" z="890.02"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-27" unit="cm" x="-328.04" y="501.1018" z="890.02"/>
       </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-27" unit="cm" x="325.045" y="501.1018" z="890.02"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
      <physvol>
        <volumeref ref="volArapucaDouble_0-0-0"/>
        <position name="posArapucaDouble0-Frame-0-0" unit="cm" 
@@ -15420,7 +15554,7 @@
 
       <physvol>
         <volumeref ref="volDetEnclosure"/>
-	<position name="posDetEnclosure" unit="cm" x="50.0500000000001" y="-1.13686837721616e-13" z="1045.94"/>
+	<position name="posDetEnclosure" unit="cm" x="50.04" y="-1.13686837721616e-13" z="1045.94"/>
       </physvol>
 
     </volume>

--- a/dunecore/Geometry/gdml/dunevd10kt_3view_30deg_v3_refactored_1x8x14ref_nowires.gdml
+++ b/dunecore/Geometry/gdml/dunevd10kt_3view_30deg_v3_refactored_1x8x14ref_nowires.gdml
@@ -490,7 +490,7 @@
     
 
    <box name="CRM"
-      x="650.1" 
+      x="650.08" 
       y="167.7006" 
       z="148.92"
       lunit="cm"/>
@@ -506,11 +506,6 @@
       lunit="cm"/>
    <box name="CRMZPlane" 
       x="0.02"
-      y="167.7006"
-      z="148.92"
-      lunit="cm"/>
-   <box name="AnodePlate" 
-      x="0.02/2."
       y="167.7006"
       z="148.92"
       lunit="cm"/>
@@ -564,27 +559,27 @@
 
 
     <box name="Cryostat" lunit="cm" 
-      x="850.34" 
+      x="850.32" 
       y="1545.8448" 
       z="2292.12"/>
 
     <box name="ArgonInterior" lunit="cm" 
-      x="850.1"
+      x="850.08"
       y="1545.6048"
       z="2291.88"/>
 
     <box name="GaseousArgon" lunit="cm" 
-      x="100"
+      x="100 - 0.02"
       y="1545.6048"
       z="2291.88"/>
 
     <box name="ExternalAuxOut" lunit="cm" 
-      x="850.1 - 100"
+      x="850.08 - 100"
       y="1545.6048 - 2*2.5 - 2*40"
       z="2291.88"/>
 
     <box name="ExternalAuxIn" lunit="cm" 
-      x="850.1"
+      x="850.08"
       y="1356.7748"
       z="2291.88 + 1"/>
 
@@ -691,8 +686,14 @@
       <position name="posCathodeSub16" x="0" y="122.525" z="108.5" unit="cm"/>
     </subtraction>
 
+   <box name="AnodePlate" 
+      x="0.02/2."
+      y="335.4012"
+      z="297.84"
+      lunit="cm"/>
+
     <box name="FoamPadBlock" lunit="cm"
-      x="1010.34"
+      x="1010.32"
       y="1705.8448"
       z="2452.12" />
 
@@ -703,7 +704,7 @@
     </subtraction>
 
     <box name="SteelSupportBlock" lunit="cm"
-      x="1210.34"
+      x="1210.32"
       y="1905.8448"
       z="2652.12" />
 
@@ -714,13 +715,13 @@
     </subtraction>
 
     <box name="DetEnclosure" lunit="cm" 
-      x="1310.34"
+      x="1310.32"
       y="2105.8448"
       z="2852.12"/>
 
 
     <box name="World" lunit="cm" 
-      x="9310.34" 
+      x="9310.32" 
       y="10105.8448" 
       z="10852.12"/>
 </solids>
@@ -755,11 +756,6 @@
     <materialref ref="LAr"/>
     <solidref ref="CRMZPlane"/>
   </volume>
-     
-   <volume name="volAnodePlate">
-     <materialref ref="vm2000"/>
-     <solidref ref="AnodePlate"/>
-  </volume>
    <volume name="volTPC">
      <materialref ref="LAr"/>
        <solidref ref="CRM"/>
@@ -782,15 +778,9 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volAnodePlate"/>
-       <position name="posAnodePlate" unit="cm" 
-         x="325.045" y="0" z="0"/>
-       <rotationref ref="rIdentity"/>
-     </physvol>
-     <physvol>
        <volumeref ref="volTPCActive"/>
        <position name="posActive" unit="cm" 
-        x="-0.05" y="" z="0"/>
+        x="-0.04" y="" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
    </volume>
@@ -802,6 +792,10 @@
     <volume name="volGroundGrid">
       <materialref ref="STEEL_STAINLESS_Fe7Cr2Ni" />
       <solidref ref="CathodeGrid" />
+    </volume>
+    <volume name="volAnodePlate">
+     <materialref ref="vm2000"/>
+     <solidref ref="AnodePlate"/>
     </volume>
     <volume name="volGaseousArgon">
       <materialref ref="ArGas"/>
@@ -2165,7 +2159,7 @@
       <solidref ref="Cryostat" />
       <physvol>
         <volumeref ref="volGaseousArgon"/>
-        <position name="posGaseousArgon" unit="cm" x="375.05" y="0" z="0"/>
+        <position name="posGaseousArgon" unit="cm" x="375.04" y="0" z="0"/>
       </physvol>
       <physvol>
         <volumeref ref="volSteelShell"/>
@@ -2737,542 +2731,542 @@
       </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper0" unit="cm"  x="-322.05" y="-675.1024" z="0" />
+     <position name="posFieldShaper0" unit="cm"  x="-322.04" y="-675.1024" z="0" />
      <rotation name="rotFS0" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper1" unit="cm"  x="-316.05" y="-675.1024" z="0" />
+     <position name="posFieldShaper1" unit="cm"  x="-316.04" y="-675.1024" z="0" />
      <rotation name="rotFS1" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper2" unit="cm"  x="-310.05" y="-675.1024" z="0" />
+     <position name="posFieldShaper2" unit="cm"  x="-310.04" y="-675.1024" z="0" />
      <rotation name="rotFS2" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper3" unit="cm"  x="-304.05" y="-675.1024" z="0" />
+     <position name="posFieldShaper3" unit="cm"  x="-304.04" y="-675.1024" z="0" />
      <rotation name="rotFS3" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper4" unit="cm"  x="-298.05" y="-675.1024" z="0" />
+     <position name="posFieldShaper4" unit="cm"  x="-298.04" y="-675.1024" z="0" />
      <rotation name="rotFS4" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper5" unit="cm"  x="-292.05" y="-675.1024" z="0" />
+     <position name="posFieldShaper5" unit="cm"  x="-292.04" y="-675.1024" z="0" />
      <rotation name="rotFS5" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper6" unit="cm"  x="-286.05" y="-675.1024" z="0" />
+     <position name="posFieldShaper6" unit="cm"  x="-286.04" y="-675.1024" z="0" />
      <rotation name="rotFS6" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper7" unit="cm"  x="-280.05" y="-675.1024" z="0" />
+     <position name="posFieldShaper7" unit="cm"  x="-280.04" y="-675.1024" z="0" />
      <rotation name="rotFS7" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper8" unit="cm"  x="-274.05" y="-675.1024" z="0" />
+     <position name="posFieldShaper8" unit="cm"  x="-274.04" y="-675.1024" z="0" />
      <rotation name="rotFS8" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper9" unit="cm"  x="-268.05" y="-675.1024" z="0" />
+     <position name="posFieldShaper9" unit="cm"  x="-268.04" y="-675.1024" z="0" />
      <rotation name="rotFS9" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper10" unit="cm"  x="-262.05" y="-675.1024" z="0" />
+     <position name="posFieldShaper10" unit="cm"  x="-262.04" y="-675.1024" z="0" />
      <rotation name="rotFS10" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper11" unit="cm"  x="-256.05" y="-675.1024" z="0" />
+     <position name="posFieldShaper11" unit="cm"  x="-256.04" y="-675.1024" z="0" />
      <rotation name="rotFS11" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper12" unit="cm"  x="-250.05" y="-675.1024" z="0" />
+     <position name="posFieldShaper12" unit="cm"  x="-250.04" y="-675.1024" z="0" />
      <rotation name="rotFS12" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper13" unit="cm"  x="-244.05" y="-675.1024" z="0" />
+     <position name="posFieldShaper13" unit="cm"  x="-244.04" y="-675.1024" z="0" />
      <rotation name="rotFS13" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper14" unit="cm"  x="-238.05" y="-675.1024" z="0" />
+     <position name="posFieldShaper14" unit="cm"  x="-238.04" y="-675.1024" z="0" />
      <rotation name="rotFS14" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper15" unit="cm"  x="-232.05" y="-675.1024" z="0" />
+     <position name="posFieldShaper15" unit="cm"  x="-232.04" y="-675.1024" z="0" />
      <rotation name="rotFS15" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper16" unit="cm"  x="-226.05" y="-675.1024" z="0" />
+     <position name="posFieldShaper16" unit="cm"  x="-226.04" y="-675.1024" z="0" />
      <rotation name="rotFS16" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper17" unit="cm"  x="-220.05" y="-675.1024" z="0" />
+     <position name="posFieldShaper17" unit="cm"  x="-220.04" y="-675.1024" z="0" />
      <rotation name="rotFS17" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper18" unit="cm"  x="-214.05" y="-675.1024" z="0" />
+     <position name="posFieldShaper18" unit="cm"  x="-214.04" y="-675.1024" z="0" />
      <rotation name="rotFS18" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper19" unit="cm"  x="-208.05" y="-675.1024" z="0" />
+     <position name="posFieldShaper19" unit="cm"  x="-208.04" y="-675.1024" z="0" />
      <rotation name="rotFS19" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper20" unit="cm"  x="-202.05" y="-675.1024" z="0" />
+     <position name="posFieldShaper20" unit="cm"  x="-202.04" y="-675.1024" z="0" />
      <rotation name="rotFS20" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper21" unit="cm"  x="-196.05" y="-675.1024" z="0" />
+     <position name="posFieldShaper21" unit="cm"  x="-196.04" y="-675.1024" z="0" />
      <rotation name="rotFS21" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper22" unit="cm"  x="-190.05" y="-675.1024" z="0" />
+     <position name="posFieldShaper22" unit="cm"  x="-190.04" y="-675.1024" z="0" />
      <rotation name="rotFS22" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper23" unit="cm"  x="-184.05" y="-675.1024" z="0" />
+     <position name="posFieldShaper23" unit="cm"  x="-184.04" y="-675.1024" z="0" />
      <rotation name="rotFS23" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper24" unit="cm"  x="-178.05" y="-675.1024" z="0" />
+     <position name="posFieldShaper24" unit="cm"  x="-178.04" y="-675.1024" z="0" />
      <rotation name="rotFS24" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper25" unit="cm"  x="-172.05" y="-675.1024" z="0" />
+     <position name="posFieldShaper25" unit="cm"  x="-172.04" y="-675.1024" z="0" />
      <rotation name="rotFS25" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper26" unit="cm"  x="-166.05" y="-675.1024" z="0" />
+     <position name="posFieldShaper26" unit="cm"  x="-166.04" y="-675.1024" z="0" />
      <rotation name="rotFS26" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper27" unit="cm"  x="-160.05" y="-675.1024" z="0" />
+     <position name="posFieldShaper27" unit="cm"  x="-160.04" y="-675.1024" z="0" />
      <rotation name="rotFS27" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper28" unit="cm"  x="-154.05" y="-675.1024" z="0" />
+     <position name="posFieldShaper28" unit="cm"  x="-154.04" y="-675.1024" z="0" />
      <rotation name="rotFS28" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper29" unit="cm"  x="-148.05" y="-675.1024" z="0" />
+     <position name="posFieldShaper29" unit="cm"  x="-148.04" y="-675.1024" z="0" />
      <rotation name="rotFS29" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper30" unit="cm"  x="-142.05" y="-675.1024" z="0" />
+     <position name="posFieldShaper30" unit="cm"  x="-142.04" y="-675.1024" z="0" />
      <rotation name="rotFS30" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper31" unit="cm"  x="-136.05" y="-675.1024" z="0" />
+     <position name="posFieldShaper31" unit="cm"  x="-136.04" y="-675.1024" z="0" />
      <rotation name="rotFS31" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper32" unit="cm"  x="-130.05" y="-675.1024" z="0" />
+     <position name="posFieldShaper32" unit="cm"  x="-130.04" y="-675.1024" z="0" />
      <rotation name="rotFS32" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper33" unit="cm"  x="-124.05" y="-675.1024" z="0" />
+     <position name="posFieldShaper33" unit="cm"  x="-124.04" y="-675.1024" z="0" />
      <rotation name="rotFS33" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper34" unit="cm"  x="-118.05" y="-675.1024" z="0" />
+     <position name="posFieldShaper34" unit="cm"  x="-118.04" y="-675.1024" z="0" />
      <rotation name="rotFS34" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper35" unit="cm"  x="-112.05" y="-675.1024" z="0" />
+     <position name="posFieldShaper35" unit="cm"  x="-112.04" y="-675.1024" z="0" />
      <rotation name="rotFS35" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper36" unit="cm"  x="-106.05" y="-675.1024" z="0" />
+     <position name="posFieldShaper36" unit="cm"  x="-106.04" y="-675.1024" z="0" />
      <rotation name="rotFS36" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper37" unit="cm"  x="-100.05" y="-675.1024" z="0" />
+     <position name="posFieldShaper37" unit="cm"  x="-100.04" y="-675.1024" z="0" />
      <rotation name="rotFS37" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper38" unit="cm"  x="-94.0500000000001" y="-675.1024" z="0" />
+     <position name="posFieldShaper38" unit="cm"  x="-94.04" y="-675.1024" z="0" />
      <rotation name="rotFS38" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper39" unit="cm"  x="-88.0500000000001" y="-675.1024" z="0" />
+     <position name="posFieldShaper39" unit="cm"  x="-88.04" y="-675.1024" z="0" />
      <rotation name="rotFS39" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper40" unit="cm"  x="-82.0500000000001" y="-675.1024" z="0" />
+     <position name="posFieldShaper40" unit="cm"  x="-82.04" y="-675.1024" z="0" />
      <rotation name="rotFS40" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper41" unit="cm"  x="-76.0500000000001" y="-675.1024" z="0" />
+     <position name="posFieldShaper41" unit="cm"  x="-76.04" y="-675.1024" z="0" />
      <rotation name="rotFS41" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper42" unit="cm"  x="-70.0500000000001" y="-675.1024" z="0" />
+     <position name="posFieldShaper42" unit="cm"  x="-70.04" y="-675.1024" z="0" />
      <rotation name="rotFS42" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper43" unit="cm"  x="-64.0500000000001" y="-675.1024" z="0" />
+     <position name="posFieldShaper43" unit="cm"  x="-64.04" y="-675.1024" z="0" />
      <rotation name="rotFS43" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper44" unit="cm"  x="-58.0500000000001" y="-675.1024" z="0" />
+     <position name="posFieldShaper44" unit="cm"  x="-58.04" y="-675.1024" z="0" />
      <rotation name="rotFS44" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper45" unit="cm"  x="-52.0500000000001" y="-675.1024" z="0" />
+     <position name="posFieldShaper45" unit="cm"  x="-52.04" y="-675.1024" z="0" />
      <rotation name="rotFS45" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper46" unit="cm"  x="-46.0500000000001" y="-675.1024" z="0" />
+     <position name="posFieldShaper46" unit="cm"  x="-46.04" y="-675.1024" z="0" />
      <rotation name="rotFS46" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper47" unit="cm"  x="-40.0500000000001" y="-675.1024" z="0" />
+     <position name="posFieldShaper47" unit="cm"  x="-40.04" y="-675.1024" z="0" />
      <rotation name="rotFS47" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper48" unit="cm"  x="-34.0500000000001" y="-675.1024" z="0" />
+     <position name="posFieldShaper48" unit="cm"  x="-34.04" y="-675.1024" z="0" />
      <rotation name="rotFS48" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper49" unit="cm"  x="-28.0500000000001" y="-675.1024" z="0" />
+     <position name="posFieldShaper49" unit="cm"  x="-28.04" y="-675.1024" z="0" />
      <rotation name="rotFS49" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper50" unit="cm"  x="-22.0500000000001" y="-675.1024" z="0" />
+     <position name="posFieldShaper50" unit="cm"  x="-22.04" y="-675.1024" z="0" />
      <rotation name="rotFS50" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper51" unit="cm"  x="-16.0500000000001" y="-675.1024" z="0" />
+     <position name="posFieldShaper51" unit="cm"  x="-16.04" y="-675.1024" z="0" />
      <rotation name="rotFS51" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper52" unit="cm"  x="-10.0500000000001" y="-675.1024" z="0" />
+     <position name="posFieldShaper52" unit="cm"  x="-10.04" y="-675.1024" z="0" />
      <rotation name="rotFS52" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper53" unit="cm"  x="-4.05000000000005" y="-675.1024" z="0" />
+     <position name="posFieldShaper53" unit="cm"  x="-4.04000000000001" y="-675.1024" z="0" />
      <rotation name="rotFS53" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper54" unit="cm"  x="1.94999999999995" y="-675.1024" z="0" />
+     <position name="posFieldShaper54" unit="cm"  x="1.95999999999999" y="-675.1024" z="0" />
      <rotation name="rotFS54" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper55" unit="cm"  x="7.94999999999995" y="-675.1024" z="0" />
+     <position name="posFieldShaper55" unit="cm"  x="7.95999999999999" y="-675.1024" z="0" />
      <rotation name="rotFS55" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper56" unit="cm"  x="13.9499999999999" y="-675.1024" z="0" />
+     <position name="posFieldShaper56" unit="cm"  x="13.96" y="-675.1024" z="0" />
      <rotation name="rotFS56" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper57" unit="cm"  x="19.9499999999999" y="-675.1024" z="0" />
+     <position name="posFieldShaper57" unit="cm"  x="19.96" y="-675.1024" z="0" />
      <rotation name="rotFS57" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper58" unit="cm"  x="25.9499999999999" y="-675.1024" z="0" />
+     <position name="posFieldShaper58" unit="cm"  x="25.96" y="-675.1024" z="0" />
      <rotation name="rotFS58" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper59" unit="cm"  x="31.9499999999999" y="-675.1024" z="0" />
+     <position name="posFieldShaper59" unit="cm"  x="31.96" y="-675.1024" z="0" />
      <rotation name="rotFS59" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper60" unit="cm"  x="37.9499999999999" y="-675.1024" z="0" />
+     <position name="posFieldShaper60" unit="cm"  x="37.96" y="-675.1024" z="0" />
      <rotation name="rotFS60" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper61" unit="cm"  x="43.9499999999999" y="-675.1024" z="0" />
+     <position name="posFieldShaper61" unit="cm"  x="43.96" y="-675.1024" z="0" />
      <rotation name="rotFS61" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper62" unit="cm"  x="49.9499999999999" y="-675.1024" z="0" />
+     <position name="posFieldShaper62" unit="cm"  x="49.96" y="-675.1024" z="0" />
      <rotation name="rotFS62" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper63" unit="cm"  x="55.9499999999999" y="-675.1024" z="0" />
+     <position name="posFieldShaper63" unit="cm"  x="55.96" y="-675.1024" z="0" />
      <rotation name="rotFS63" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper64" unit="cm"  x="61.9499999999999" y="-675.1024" z="0" />
+     <position name="posFieldShaper64" unit="cm"  x="61.96" y="-675.1024" z="0" />
      <rotation name="rotFS64" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper65" unit="cm"  x="67.9499999999999" y="-675.1024" z="0" />
+     <position name="posFieldShaper65" unit="cm"  x="67.96" y="-675.1024" z="0" />
      <rotation name="rotFS65" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper66" unit="cm"  x="73.9499999999999" y="-675.1024" z="0" />
+     <position name="posFieldShaper66" unit="cm"  x="73.96" y="-675.1024" z="0" />
      <rotation name="rotFS66" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper67" unit="cm"  x="79.9499999999999" y="-675.1024" z="0" />
+     <position name="posFieldShaper67" unit="cm"  x="79.96" y="-675.1024" z="0" />
      <rotation name="rotFS67" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper68" unit="cm"  x="85.9499999999999" y="-675.1024" z="0" />
+     <position name="posFieldShaper68" unit="cm"  x="85.96" y="-675.1024" z="0" />
      <rotation name="rotFS68" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper69" unit="cm"  x="91.9499999999999" y="-675.1024" z="0" />
+     <position name="posFieldShaper69" unit="cm"  x="91.96" y="-675.1024" z="0" />
      <rotation name="rotFS69" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper70" unit="cm"  x="97.9499999999999" y="-675.1024" z="0" />
+     <position name="posFieldShaper70" unit="cm"  x="97.96" y="-675.1024" z="0" />
      <rotation name="rotFS70" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper71" unit="cm"  x="103.95" y="-675.1024" z="0" />
+     <position name="posFieldShaper71" unit="cm"  x="103.96" y="-675.1024" z="0" />
      <rotation name="rotFS71" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper72" unit="cm"  x="109.95" y="-675.1024" z="0" />
+     <position name="posFieldShaper72" unit="cm"  x="109.96" y="-675.1024" z="0" />
      <rotation name="rotFS72" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper73" unit="cm"  x="115.95" y="-675.1024" z="0" />
+     <position name="posFieldShaper73" unit="cm"  x="115.96" y="-675.1024" z="0" />
      <rotation name="rotFS73" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper74" unit="cm"  x="121.95" y="-675.1024" z="0" />
+     <position name="posFieldShaper74" unit="cm"  x="121.96" y="-675.1024" z="0" />
      <rotation name="rotFS74" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper75" unit="cm"  x="127.95" y="-675.1024" z="0" />
+     <position name="posFieldShaper75" unit="cm"  x="127.96" y="-675.1024" z="0" />
      <rotation name="rotFS75" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper76" unit="cm"  x="133.95" y="-675.1024" z="0" />
+     <position name="posFieldShaper76" unit="cm"  x="133.96" y="-675.1024" z="0" />
      <rotation name="rotFS76" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper77" unit="cm"  x="139.95" y="-675.1024" z="0" />
+     <position name="posFieldShaper77" unit="cm"  x="139.96" y="-675.1024" z="0" />
      <rotation name="rotFS77" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper78" unit="cm"  x="145.95" y="-675.1024" z="0" />
+     <position name="posFieldShaper78" unit="cm"  x="145.96" y="-675.1024" z="0" />
      <rotation name="rotFS78" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper79" unit="cm"  x="151.95" y="-675.1024" z="0" />
+     <position name="posFieldShaper79" unit="cm"  x="151.96" y="-675.1024" z="0" />
      <rotation name="rotFS79" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper80" unit="cm"  x="157.95" y="-675.1024" z="0" />
+     <position name="posFieldShaper80" unit="cm"  x="157.96" y="-675.1024" z="0" />
      <rotation name="rotFS80" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper81" unit="cm"  x="163.95" y="-675.1024" z="0" />
+     <position name="posFieldShaper81" unit="cm"  x="163.96" y="-675.1024" z="0" />
      <rotation name="rotFS81" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper82" unit="cm"  x="169.95" y="-675.1024" z="0" />
+     <position name="posFieldShaper82" unit="cm"  x="169.96" y="-675.1024" z="0" />
      <rotation name="rotFS82" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper83" unit="cm"  x="175.95" y="-675.1024" z="0" />
+     <position name="posFieldShaper83" unit="cm"  x="175.96" y="-675.1024" z="0" />
      <rotation name="rotFS83" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper84" unit="cm"  x="181.95" y="-675.1024" z="0" />
+     <position name="posFieldShaper84" unit="cm"  x="181.96" y="-675.1024" z="0" />
      <rotation name="rotFS84" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper85" unit="cm"  x="187.95" y="-675.1024" z="0" />
+     <position name="posFieldShaper85" unit="cm"  x="187.96" y="-675.1024" z="0" />
      <rotation name="rotFS85" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper86" unit="cm"  x="193.95" y="-675.1024" z="0" />
+     <position name="posFieldShaper86" unit="cm"  x="193.96" y="-675.1024" z="0" />
      <rotation name="rotFS86" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper87" unit="cm"  x="199.95" y="-675.1024" z="0" />
+     <position name="posFieldShaper87" unit="cm"  x="199.96" y="-675.1024" z="0" />
      <rotation name="rotFS87" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper88" unit="cm"  x="205.95" y="-675.1024" z="0" />
+     <position name="posFieldShaper88" unit="cm"  x="205.96" y="-675.1024" z="0" />
      <rotation name="rotFS88" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper89" unit="cm"  x="211.95" y="-675.1024" z="0" />
+     <position name="posFieldShaper89" unit="cm"  x="211.96" y="-675.1024" z="0" />
      <rotation name="rotFS89" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper90" unit="cm"  x="217.95" y="-675.1024" z="0" />
+     <position name="posFieldShaper90" unit="cm"  x="217.96" y="-675.1024" z="0" />
      <rotation name="rotFS90" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper91" unit="cm"  x="223.95" y="-675.1024" z="0" />
+     <position name="posFieldShaper91" unit="cm"  x="223.96" y="-675.1024" z="0" />
      <rotation name="rotFS91" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper92" unit="cm"  x="229.95" y="-675.1024" z="0" />
+     <position name="posFieldShaper92" unit="cm"  x="229.96" y="-675.1024" z="0" />
      <rotation name="rotFS92" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper93" unit="cm"  x="235.95" y="-675.1024" z="0" />
+     <position name="posFieldShaper93" unit="cm"  x="235.96" y="-675.1024" z="0" />
      <rotation name="rotFS93" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper94" unit="cm"  x="241.95" y="-675.1024" z="0" />
+     <position name="posFieldShaper94" unit="cm"  x="241.96" y="-675.1024" z="0" />
      <rotation name="rotFS94" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper95" unit="cm"  x="247.95" y="-675.1024" z="0" />
+     <position name="posFieldShaper95" unit="cm"  x="247.96" y="-675.1024" z="0" />
      <rotation name="rotFS95" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper96" unit="cm"  x="253.95" y="-675.1024" z="0" />
+     <position name="posFieldShaper96" unit="cm"  x="253.96" y="-675.1024" z="0" />
      <rotation name="rotFS96" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper97" unit="cm"  x="259.95" y="-675.1024" z="0" />
+     <position name="posFieldShaper97" unit="cm"  x="259.96" y="-675.1024" z="0" />
      <rotation name="rotFS97" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper98" unit="cm"  x="265.95" y="-675.1024" z="0" />
+     <position name="posFieldShaper98" unit="cm"  x="265.96" y="-675.1024" z="0" />
      <rotation name="rotFS98" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper99" unit="cm"  x="271.95" y="-675.1024" z="0" />
+     <position name="posFieldShaper99" unit="cm"  x="271.96" y="-675.1024" z="0" />
      <rotation name="rotFS99" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper100" unit="cm"  x="277.95" y="-675.1024" z="0" />
+     <position name="posFieldShaper100" unit="cm"  x="277.96" y="-675.1024" z="0" />
      <rotation name="rotFS100" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper101" unit="cm"  x="283.95" y="-675.1024" z="0" />
+     <position name="posFieldShaper101" unit="cm"  x="283.96" y="-675.1024" z="0" />
      <rotation name="rotFS101" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper102" unit="cm"  x="289.95" y="-675.1024" z="0" />
+     <position name="posFieldShaper102" unit="cm"  x="289.96" y="-675.1024" z="0" />
      <rotation name="rotFS102" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper103" unit="cm"  x="295.95" y="-675.1024" z="0" />
+     <position name="posFieldShaper103" unit="cm"  x="295.96" y="-675.1024" z="0" />
      <rotation name="rotFS103" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper104" unit="cm"  x="301.95" y="-675.1024" z="0" />
+     <position name="posFieldShaper104" unit="cm"  x="301.96" y="-675.1024" z="0" />
      <rotation name="rotFS104" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper105" unit="cm"  x="307.95" y="-675.1024" z="0" />
+     <position name="posFieldShaper105" unit="cm"  x="307.96" y="-675.1024" z="0" />
      <rotation name="rotFS105" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper106" unit="cm"  x="313.95" y="-675.1024" z="0" />
+     <position name="posFieldShaper106" unit="cm"  x="313.96" y="-675.1024" z="0" />
      <rotation name="rotFS106" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper107" unit="cm"  x="319.95" y="-675.1024" z="0" />
+     <position name="posFieldShaper107" unit="cm"  x="319.96" y="-675.1024" z="0" />
      <rotation name="rotFS107" unit="deg" x="0" y="0" z="90" />
   </physvol>
       <physvol>
@@ -3280,113 +3274,253 @@
    <position name="posGroundGrid-0" unit="cm" x="-328.04" y="-505.1018" z="-897.02"/>
       </physvol>
       <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-0" unit="cm" x="325.045" y="-505.1018" z="-897.02"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-1" unit="cm" x="-328.04" y="-169.7006" z="-897.02"/>
       </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-1" unit="cm" x="325.045" y="-169.7006" z="-897.02"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
       <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-2" unit="cm" x="-328.04" y="165.7006" z="-897.02"/>
       </physvol>
       <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-2" unit="cm" x="325.045" y="165.7006" z="-897.02"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-3" unit="cm" x="-328.04" y="501.1018" z="-897.02"/>
       </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-3" unit="cm" x="325.045" y="501.1018" z="-897.02"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
       <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-4" unit="cm" x="-328.04" y="-505.1018" z="-599.18"/>
       </physvol>
       <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-4" unit="cm" x="325.045" y="-505.1018" z="-599.18"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-5" unit="cm" x="-328.04" y="-169.7006" z="-599.18"/>
       </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-5" unit="cm" x="325.045" y="-169.7006" z="-599.18"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
       <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-6" unit="cm" x="-328.04" y="165.7006" z="-599.18"/>
       </physvol>
       <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-6" unit="cm" x="325.045" y="165.7006" z="-599.18"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-7" unit="cm" x="-328.04" y="501.1018" z="-599.18"/>
       </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-7" unit="cm" x="325.045" y="501.1018" z="-599.18"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
       <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-8" unit="cm" x="-328.04" y="-505.1018" z="-301.34"/>
       </physvol>
       <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-8" unit="cm" x="325.045" y="-505.1018" z="-301.34"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-9" unit="cm" x="-328.04" y="-169.7006" z="-301.34"/>
       </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-9" unit="cm" x="325.045" y="-169.7006" z="-301.34"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
       <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-10" unit="cm" x="-328.04" y="165.7006" z="-301.34"/>
       </physvol>
       <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-10" unit="cm" x="325.045" y="165.7006" z="-301.34"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-11" unit="cm" x="-328.04" y="501.1018" z="-301.34"/>
       </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-11" unit="cm" x="325.045" y="501.1018" z="-301.34"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
       <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-12" unit="cm" x="-328.04" y="-505.1018" z="-3.49999999999989"/>
       </physvol>
       <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-12" unit="cm" x="325.045" y="-505.1018" z="-3.49999999999989"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-13" unit="cm" x="-328.04" y="-169.7006" z="-3.49999999999989"/>
       </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-13" unit="cm" x="325.045" y="-169.7006" z="-3.49999999999989"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
       <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-14" unit="cm" x="-328.04" y="165.7006" z="-3.49999999999989"/>
       </physvol>
       <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-14" unit="cm" x="325.045" y="165.7006" z="-3.49999999999989"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-15" unit="cm" x="-328.04" y="501.1018" z="-3.49999999999989"/>
       </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-15" unit="cm" x="325.045" y="501.1018" z="-3.49999999999989"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
       <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-16" unit="cm" x="-328.04" y="-505.1018" z="294.34"/>
       </physvol>
       <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-16" unit="cm" x="325.045" y="-505.1018" z="294.34"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-17" unit="cm" x="-328.04" y="-169.7006" z="294.34"/>
       </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-17" unit="cm" x="325.045" y="-169.7006" z="294.34"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
       <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-18" unit="cm" x="-328.04" y="165.7006" z="294.34"/>
       </physvol>
       <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-18" unit="cm" x="325.045" y="165.7006" z="294.34"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-19" unit="cm" x="-328.04" y="501.1018" z="294.34"/>
       </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-19" unit="cm" x="325.045" y="501.1018" z="294.34"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
       <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-20" unit="cm" x="-328.04" y="-505.1018" z="592.18"/>
       </physvol>
       <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-20" unit="cm" x="325.045" y="-505.1018" z="592.18"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-21" unit="cm" x="-328.04" y="-169.7006" z="592.18"/>
       </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-21" unit="cm" x="325.045" y="-169.7006" z="592.18"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
       <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-22" unit="cm" x="-328.04" y="165.7006" z="592.18"/>
       </physvol>
       <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-22" unit="cm" x="325.045" y="165.7006" z="592.18"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-23" unit="cm" x="-328.04" y="501.1018" z="592.18"/>
       </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-23" unit="cm" x="325.045" y="501.1018" z="592.18"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
       <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-24" unit="cm" x="-328.04" y="-505.1018" z="890.02"/>
       </physvol>
       <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-24" unit="cm" x="325.045" y="-505.1018" z="890.02"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-25" unit="cm" x="-328.04" y="-169.7006" z="890.02"/>
       </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-25" unit="cm" x="325.045" y="-169.7006" z="890.02"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
       <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-26" unit="cm" x="-328.04" y="165.7006" z="890.02"/>
       </physvol>
       <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-26" unit="cm" x="325.045" y="165.7006" z="890.02"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-27" unit="cm" x="-328.04" y="501.1018" z="890.02"/>
       </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-27" unit="cm" x="325.045" y="501.1018" z="890.02"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
      <physvol>
        <volumeref ref="volArapucaDouble_0-0-0"/>
        <position name="posArapucaDouble0-Frame-0-0" unit="cm" 
@@ -5943,7 +6077,7 @@
 
       <physvol>
         <volumeref ref="volDetEnclosure"/>
-	<position name="posDetEnclosure" unit="cm" x="50.0500000000001" y="-1.13686837721616e-13" z="1045.94"/>
+	<position name="posDetEnclosure" unit="cm" x="50.04" y="-1.13686837721616e-13" z="1045.94"/>
       </physvol>
 
     </volume>

--- a/dunecore/Geometry/gdml/dunevd10kt_3view_30deg_v3_refactored_1x8x6ref.gdml
+++ b/dunecore/Geometry/gdml/dunevd10kt_3view_30deg_v3_refactored_1x8x6ref.gdml
@@ -490,7 +490,7 @@
     
 
    <box name="CRM"
-      x="650.1" 
+      x="650.08" 
       y="167.7006" 
       z="148.92"
       lunit="cm"/>
@@ -506,11 +506,6 @@
       lunit="cm"/>
    <box name="CRMZPlane" 
       x="0.02"
-      y="167.7006"
-      z="148.92"
-      lunit="cm"/>
-   <box name="AnodePlate" 
-      x="0.02/2."
       y="167.7006"
       z="148.92"
       lunit="cm"/>
@@ -3429,27 +3424,27 @@
 
 
     <box name="Cryostat" lunit="cm" 
-      x="850.34" 
+      x="850.32" 
       y="1209.4436" 
       z="1096.76"/>
 
     <box name="ArgonInterior" lunit="cm" 
-      x="850.1"
+      x="850.08"
       y="1209.2036"
       z="1096.52"/>
 
     <box name="GaseousArgon" lunit="cm" 
-      x="100"
+      x="100 - 0.02"
       y="1209.2036"
       z="1096.52"/>
 
     <box name="ExternalAuxOut" lunit="cm" 
-      x="850.1 - 100"
+      x="850.08 - 100"
       y="1209.2036 - 2*2.5 - 2*40"
       z="1096.52"/>
 
     <box name="ExternalAuxIn" lunit="cm" 
-      x="850.1"
+      x="850.08"
       y="1020.3736"
       z="1096.52 + 1"/>
 
@@ -3556,8 +3551,14 @@
       <position name="posCathodeSub16" x="0" y="122.525" z="108.5" unit="cm"/>
     </subtraction>
 
+   <box name="AnodePlate" 
+      x="0.02/2."
+      y="335.4012"
+      z="297.84"
+      lunit="cm"/>
+
     <box name="FoamPadBlock" lunit="cm"
-      x="1010.34"
+      x="1010.32"
       y="1369.4436"
       z="1256.76" />
 
@@ -3568,7 +3569,7 @@
     </subtraction>
 
     <box name="SteelSupportBlock" lunit="cm"
-      x="1210.34"
+      x="1210.32"
       y="1569.4436"
       z="1456.76" />
 
@@ -3579,13 +3580,13 @@
     </subtraction>
 
     <box name="DetEnclosure" lunit="cm" 
-      x="1310.34"
+      x="1310.32"
       y="1769.4436"
       z="1656.76"/>
 
 
     <box name="World" lunit="cm" 
-      x="9310.34" 
+      x="9310.32" 
       y="9769.4436" 
       z="9656.76"/>
 </solids>
@@ -10232,11 +10233,6 @@
          <rotationref ref="rPlus90AboutX"/>
        </physvol>
   </volume>
-     
-   <volume name="volAnodePlate">
-     <materialref ref="vm2000"/>
-     <solidref ref="AnodePlate"/>
-  </volume>
    <volume name="volTPC">
      <materialref ref="LAr"/>
        <solidref ref="CRM"/>
@@ -10259,15 +10255,9 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volAnodePlate"/>
-       <position name="posAnodePlate" unit="cm" 
-         x="325.045" y="0" z="0"/>
-       <rotationref ref="rIdentity"/>
-     </physvol>
-     <physvol>
        <volumeref ref="volTPCActive"/>
        <position name="posActive" unit="cm" 
-        x="-0.05" y="" z="0"/>
+        x="-0.04" y="" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
    </volume>
@@ -10279,6 +10269,10 @@
     <volume name="volGroundGrid">
       <materialref ref="STEEL_STAINLESS_Fe7Cr2Ni" />
       <solidref ref="CathodeGrid" />
+    </volume>
+    <volume name="volAnodePlate">
+     <materialref ref="vm2000"/>
+     <solidref ref="AnodePlate"/>
     </volume>
     <volume name="volGaseousArgon">
       <materialref ref="ArGas"/>
@@ -10586,7 +10580,7 @@
       <solidref ref="Cryostat" />
       <physvol>
         <volumeref ref="volGaseousArgon"/>
-        <position name="posGaseousArgon" unit="cm" x="375.05" y="0" z="0"/>
+        <position name="posGaseousArgon" unit="cm" x="375.04" y="0" z="0"/>
       </physvol>
       <physvol>
         <volumeref ref="volSteelShell"/>
@@ -10778,542 +10772,542 @@
       </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper0" unit="cm"  x="-322.05" y="-506.9018" z="0" />
+     <position name="posFieldShaper0" unit="cm"  x="-322.04" y="-506.9018" z="0" />
      <rotation name="rotFS0" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper1" unit="cm"  x="-316.05" y="-506.9018" z="0" />
+     <position name="posFieldShaper1" unit="cm"  x="-316.04" y="-506.9018" z="0" />
      <rotation name="rotFS1" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper2" unit="cm"  x="-310.05" y="-506.9018" z="0" />
+     <position name="posFieldShaper2" unit="cm"  x="-310.04" y="-506.9018" z="0" />
      <rotation name="rotFS2" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper3" unit="cm"  x="-304.05" y="-506.9018" z="0" />
+     <position name="posFieldShaper3" unit="cm"  x="-304.04" y="-506.9018" z="0" />
      <rotation name="rotFS3" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper4" unit="cm"  x="-298.05" y="-506.9018" z="0" />
+     <position name="posFieldShaper4" unit="cm"  x="-298.04" y="-506.9018" z="0" />
      <rotation name="rotFS4" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper5" unit="cm"  x="-292.05" y="-506.9018" z="0" />
+     <position name="posFieldShaper5" unit="cm"  x="-292.04" y="-506.9018" z="0" />
      <rotation name="rotFS5" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper6" unit="cm"  x="-286.05" y="-506.9018" z="0" />
+     <position name="posFieldShaper6" unit="cm"  x="-286.04" y="-506.9018" z="0" />
      <rotation name="rotFS6" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper7" unit="cm"  x="-280.05" y="-506.9018" z="0" />
+     <position name="posFieldShaper7" unit="cm"  x="-280.04" y="-506.9018" z="0" />
      <rotation name="rotFS7" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper8" unit="cm"  x="-274.05" y="-506.9018" z="0" />
+     <position name="posFieldShaper8" unit="cm"  x="-274.04" y="-506.9018" z="0" />
      <rotation name="rotFS8" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper9" unit="cm"  x="-268.05" y="-506.9018" z="0" />
+     <position name="posFieldShaper9" unit="cm"  x="-268.04" y="-506.9018" z="0" />
      <rotation name="rotFS9" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper10" unit="cm"  x="-262.05" y="-506.9018" z="0" />
+     <position name="posFieldShaper10" unit="cm"  x="-262.04" y="-506.9018" z="0" />
      <rotation name="rotFS10" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper11" unit="cm"  x="-256.05" y="-506.9018" z="0" />
+     <position name="posFieldShaper11" unit="cm"  x="-256.04" y="-506.9018" z="0" />
      <rotation name="rotFS11" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper12" unit="cm"  x="-250.05" y="-506.9018" z="0" />
+     <position name="posFieldShaper12" unit="cm"  x="-250.04" y="-506.9018" z="0" />
      <rotation name="rotFS12" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper13" unit="cm"  x="-244.05" y="-506.9018" z="0" />
+     <position name="posFieldShaper13" unit="cm"  x="-244.04" y="-506.9018" z="0" />
      <rotation name="rotFS13" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper14" unit="cm"  x="-238.05" y="-506.9018" z="0" />
+     <position name="posFieldShaper14" unit="cm"  x="-238.04" y="-506.9018" z="0" />
      <rotation name="rotFS14" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper15" unit="cm"  x="-232.05" y="-506.9018" z="0" />
+     <position name="posFieldShaper15" unit="cm"  x="-232.04" y="-506.9018" z="0" />
      <rotation name="rotFS15" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper16" unit="cm"  x="-226.05" y="-506.9018" z="0" />
+     <position name="posFieldShaper16" unit="cm"  x="-226.04" y="-506.9018" z="0" />
      <rotation name="rotFS16" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper17" unit="cm"  x="-220.05" y="-506.9018" z="0" />
+     <position name="posFieldShaper17" unit="cm"  x="-220.04" y="-506.9018" z="0" />
      <rotation name="rotFS17" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper18" unit="cm"  x="-214.05" y="-506.9018" z="0" />
+     <position name="posFieldShaper18" unit="cm"  x="-214.04" y="-506.9018" z="0" />
      <rotation name="rotFS18" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper19" unit="cm"  x="-208.05" y="-506.9018" z="0" />
+     <position name="posFieldShaper19" unit="cm"  x="-208.04" y="-506.9018" z="0" />
      <rotation name="rotFS19" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper20" unit="cm"  x="-202.05" y="-506.9018" z="0" />
+     <position name="posFieldShaper20" unit="cm"  x="-202.04" y="-506.9018" z="0" />
      <rotation name="rotFS20" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper21" unit="cm"  x="-196.05" y="-506.9018" z="0" />
+     <position name="posFieldShaper21" unit="cm"  x="-196.04" y="-506.9018" z="0" />
      <rotation name="rotFS21" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper22" unit="cm"  x="-190.05" y="-506.9018" z="0" />
+     <position name="posFieldShaper22" unit="cm"  x="-190.04" y="-506.9018" z="0" />
      <rotation name="rotFS22" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper23" unit="cm"  x="-184.05" y="-506.9018" z="0" />
+     <position name="posFieldShaper23" unit="cm"  x="-184.04" y="-506.9018" z="0" />
      <rotation name="rotFS23" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper24" unit="cm"  x="-178.05" y="-506.9018" z="0" />
+     <position name="posFieldShaper24" unit="cm"  x="-178.04" y="-506.9018" z="0" />
      <rotation name="rotFS24" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper25" unit="cm"  x="-172.05" y="-506.9018" z="0" />
+     <position name="posFieldShaper25" unit="cm"  x="-172.04" y="-506.9018" z="0" />
      <rotation name="rotFS25" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper26" unit="cm"  x="-166.05" y="-506.9018" z="0" />
+     <position name="posFieldShaper26" unit="cm"  x="-166.04" y="-506.9018" z="0" />
      <rotation name="rotFS26" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper27" unit="cm"  x="-160.05" y="-506.9018" z="0" />
+     <position name="posFieldShaper27" unit="cm"  x="-160.04" y="-506.9018" z="0" />
      <rotation name="rotFS27" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper28" unit="cm"  x="-154.05" y="-506.9018" z="0" />
+     <position name="posFieldShaper28" unit="cm"  x="-154.04" y="-506.9018" z="0" />
      <rotation name="rotFS28" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper29" unit="cm"  x="-148.05" y="-506.9018" z="0" />
+     <position name="posFieldShaper29" unit="cm"  x="-148.04" y="-506.9018" z="0" />
      <rotation name="rotFS29" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper30" unit="cm"  x="-142.05" y="-506.9018" z="0" />
+     <position name="posFieldShaper30" unit="cm"  x="-142.04" y="-506.9018" z="0" />
      <rotation name="rotFS30" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper31" unit="cm"  x="-136.05" y="-506.9018" z="0" />
+     <position name="posFieldShaper31" unit="cm"  x="-136.04" y="-506.9018" z="0" />
      <rotation name="rotFS31" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper32" unit="cm"  x="-130.05" y="-506.9018" z="0" />
+     <position name="posFieldShaper32" unit="cm"  x="-130.04" y="-506.9018" z="0" />
      <rotation name="rotFS32" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper33" unit="cm"  x="-124.05" y="-506.9018" z="0" />
+     <position name="posFieldShaper33" unit="cm"  x="-124.04" y="-506.9018" z="0" />
      <rotation name="rotFS33" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper34" unit="cm"  x="-118.05" y="-506.9018" z="0" />
+     <position name="posFieldShaper34" unit="cm"  x="-118.04" y="-506.9018" z="0" />
      <rotation name="rotFS34" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper35" unit="cm"  x="-112.05" y="-506.9018" z="0" />
+     <position name="posFieldShaper35" unit="cm"  x="-112.04" y="-506.9018" z="0" />
      <rotation name="rotFS35" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper36" unit="cm"  x="-106.05" y="-506.9018" z="0" />
+     <position name="posFieldShaper36" unit="cm"  x="-106.04" y="-506.9018" z="0" />
      <rotation name="rotFS36" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper37" unit="cm"  x="-100.05" y="-506.9018" z="0" />
+     <position name="posFieldShaper37" unit="cm"  x="-100.04" y="-506.9018" z="0" />
      <rotation name="rotFS37" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper38" unit="cm"  x="-94.0500000000001" y="-506.9018" z="0" />
+     <position name="posFieldShaper38" unit="cm"  x="-94.04" y="-506.9018" z="0" />
      <rotation name="rotFS38" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper39" unit="cm"  x="-88.0500000000001" y="-506.9018" z="0" />
+     <position name="posFieldShaper39" unit="cm"  x="-88.04" y="-506.9018" z="0" />
      <rotation name="rotFS39" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper40" unit="cm"  x="-82.0500000000001" y="-506.9018" z="0" />
+     <position name="posFieldShaper40" unit="cm"  x="-82.04" y="-506.9018" z="0" />
      <rotation name="rotFS40" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper41" unit="cm"  x="-76.0500000000001" y="-506.9018" z="0" />
+     <position name="posFieldShaper41" unit="cm"  x="-76.04" y="-506.9018" z="0" />
      <rotation name="rotFS41" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper42" unit="cm"  x="-70.0500000000001" y="-506.9018" z="0" />
+     <position name="posFieldShaper42" unit="cm"  x="-70.04" y="-506.9018" z="0" />
      <rotation name="rotFS42" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper43" unit="cm"  x="-64.0500000000001" y="-506.9018" z="0" />
+     <position name="posFieldShaper43" unit="cm"  x="-64.04" y="-506.9018" z="0" />
      <rotation name="rotFS43" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper44" unit="cm"  x="-58.0500000000001" y="-506.9018" z="0" />
+     <position name="posFieldShaper44" unit="cm"  x="-58.04" y="-506.9018" z="0" />
      <rotation name="rotFS44" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper45" unit="cm"  x="-52.0500000000001" y="-506.9018" z="0" />
+     <position name="posFieldShaper45" unit="cm"  x="-52.04" y="-506.9018" z="0" />
      <rotation name="rotFS45" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper46" unit="cm"  x="-46.0500000000001" y="-506.9018" z="0" />
+     <position name="posFieldShaper46" unit="cm"  x="-46.04" y="-506.9018" z="0" />
      <rotation name="rotFS46" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper47" unit="cm"  x="-40.0500000000001" y="-506.9018" z="0" />
+     <position name="posFieldShaper47" unit="cm"  x="-40.04" y="-506.9018" z="0" />
      <rotation name="rotFS47" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper48" unit="cm"  x="-34.0500000000001" y="-506.9018" z="0" />
+     <position name="posFieldShaper48" unit="cm"  x="-34.04" y="-506.9018" z="0" />
      <rotation name="rotFS48" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper49" unit="cm"  x="-28.0500000000001" y="-506.9018" z="0" />
+     <position name="posFieldShaper49" unit="cm"  x="-28.04" y="-506.9018" z="0" />
      <rotation name="rotFS49" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper50" unit="cm"  x="-22.0500000000001" y="-506.9018" z="0" />
+     <position name="posFieldShaper50" unit="cm"  x="-22.04" y="-506.9018" z="0" />
      <rotation name="rotFS50" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper51" unit="cm"  x="-16.0500000000001" y="-506.9018" z="0" />
+     <position name="posFieldShaper51" unit="cm"  x="-16.04" y="-506.9018" z="0" />
      <rotation name="rotFS51" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper52" unit="cm"  x="-10.0500000000001" y="-506.9018" z="0" />
+     <position name="posFieldShaper52" unit="cm"  x="-10.04" y="-506.9018" z="0" />
      <rotation name="rotFS52" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper53" unit="cm"  x="-4.05000000000005" y="-506.9018" z="0" />
+     <position name="posFieldShaper53" unit="cm"  x="-4.04000000000001" y="-506.9018" z="0" />
      <rotation name="rotFS53" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper54" unit="cm"  x="1.94999999999995" y="-506.9018" z="0" />
+     <position name="posFieldShaper54" unit="cm"  x="1.95999999999999" y="-506.9018" z="0" />
      <rotation name="rotFS54" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper55" unit="cm"  x="7.94999999999995" y="-506.9018" z="0" />
+     <position name="posFieldShaper55" unit="cm"  x="7.95999999999999" y="-506.9018" z="0" />
      <rotation name="rotFS55" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper56" unit="cm"  x="13.9499999999999" y="-506.9018" z="0" />
+     <position name="posFieldShaper56" unit="cm"  x="13.96" y="-506.9018" z="0" />
      <rotation name="rotFS56" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper57" unit="cm"  x="19.9499999999999" y="-506.9018" z="0" />
+     <position name="posFieldShaper57" unit="cm"  x="19.96" y="-506.9018" z="0" />
      <rotation name="rotFS57" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper58" unit="cm"  x="25.9499999999999" y="-506.9018" z="0" />
+     <position name="posFieldShaper58" unit="cm"  x="25.96" y="-506.9018" z="0" />
      <rotation name="rotFS58" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper59" unit="cm"  x="31.9499999999999" y="-506.9018" z="0" />
+     <position name="posFieldShaper59" unit="cm"  x="31.96" y="-506.9018" z="0" />
      <rotation name="rotFS59" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper60" unit="cm"  x="37.9499999999999" y="-506.9018" z="0" />
+     <position name="posFieldShaper60" unit="cm"  x="37.96" y="-506.9018" z="0" />
      <rotation name="rotFS60" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper61" unit="cm"  x="43.9499999999999" y="-506.9018" z="0" />
+     <position name="posFieldShaper61" unit="cm"  x="43.96" y="-506.9018" z="0" />
      <rotation name="rotFS61" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper62" unit="cm"  x="49.9499999999999" y="-506.9018" z="0" />
+     <position name="posFieldShaper62" unit="cm"  x="49.96" y="-506.9018" z="0" />
      <rotation name="rotFS62" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper63" unit="cm"  x="55.9499999999999" y="-506.9018" z="0" />
+     <position name="posFieldShaper63" unit="cm"  x="55.96" y="-506.9018" z="0" />
      <rotation name="rotFS63" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper64" unit="cm"  x="61.9499999999999" y="-506.9018" z="0" />
+     <position name="posFieldShaper64" unit="cm"  x="61.96" y="-506.9018" z="0" />
      <rotation name="rotFS64" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper65" unit="cm"  x="67.9499999999999" y="-506.9018" z="0" />
+     <position name="posFieldShaper65" unit="cm"  x="67.96" y="-506.9018" z="0" />
      <rotation name="rotFS65" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper66" unit="cm"  x="73.9499999999999" y="-506.9018" z="0" />
+     <position name="posFieldShaper66" unit="cm"  x="73.96" y="-506.9018" z="0" />
      <rotation name="rotFS66" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper67" unit="cm"  x="79.9499999999999" y="-506.9018" z="0" />
+     <position name="posFieldShaper67" unit="cm"  x="79.96" y="-506.9018" z="0" />
      <rotation name="rotFS67" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper68" unit="cm"  x="85.9499999999999" y="-506.9018" z="0" />
+     <position name="posFieldShaper68" unit="cm"  x="85.96" y="-506.9018" z="0" />
      <rotation name="rotFS68" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper69" unit="cm"  x="91.9499999999999" y="-506.9018" z="0" />
+     <position name="posFieldShaper69" unit="cm"  x="91.96" y="-506.9018" z="0" />
      <rotation name="rotFS69" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper70" unit="cm"  x="97.9499999999999" y="-506.9018" z="0" />
+     <position name="posFieldShaper70" unit="cm"  x="97.96" y="-506.9018" z="0" />
      <rotation name="rotFS70" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper71" unit="cm"  x="103.95" y="-506.9018" z="0" />
+     <position name="posFieldShaper71" unit="cm"  x="103.96" y="-506.9018" z="0" />
      <rotation name="rotFS71" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper72" unit="cm"  x="109.95" y="-506.9018" z="0" />
+     <position name="posFieldShaper72" unit="cm"  x="109.96" y="-506.9018" z="0" />
      <rotation name="rotFS72" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper73" unit="cm"  x="115.95" y="-506.9018" z="0" />
+     <position name="posFieldShaper73" unit="cm"  x="115.96" y="-506.9018" z="0" />
      <rotation name="rotFS73" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper74" unit="cm"  x="121.95" y="-506.9018" z="0" />
+     <position name="posFieldShaper74" unit="cm"  x="121.96" y="-506.9018" z="0" />
      <rotation name="rotFS74" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper75" unit="cm"  x="127.95" y="-506.9018" z="0" />
+     <position name="posFieldShaper75" unit="cm"  x="127.96" y="-506.9018" z="0" />
      <rotation name="rotFS75" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper76" unit="cm"  x="133.95" y="-506.9018" z="0" />
+     <position name="posFieldShaper76" unit="cm"  x="133.96" y="-506.9018" z="0" />
      <rotation name="rotFS76" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper77" unit="cm"  x="139.95" y="-506.9018" z="0" />
+     <position name="posFieldShaper77" unit="cm"  x="139.96" y="-506.9018" z="0" />
      <rotation name="rotFS77" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper78" unit="cm"  x="145.95" y="-506.9018" z="0" />
+     <position name="posFieldShaper78" unit="cm"  x="145.96" y="-506.9018" z="0" />
      <rotation name="rotFS78" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper79" unit="cm"  x="151.95" y="-506.9018" z="0" />
+     <position name="posFieldShaper79" unit="cm"  x="151.96" y="-506.9018" z="0" />
      <rotation name="rotFS79" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper80" unit="cm"  x="157.95" y="-506.9018" z="0" />
+     <position name="posFieldShaper80" unit="cm"  x="157.96" y="-506.9018" z="0" />
      <rotation name="rotFS80" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper81" unit="cm"  x="163.95" y="-506.9018" z="0" />
+     <position name="posFieldShaper81" unit="cm"  x="163.96" y="-506.9018" z="0" />
      <rotation name="rotFS81" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper82" unit="cm"  x="169.95" y="-506.9018" z="0" />
+     <position name="posFieldShaper82" unit="cm"  x="169.96" y="-506.9018" z="0" />
      <rotation name="rotFS82" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper83" unit="cm"  x="175.95" y="-506.9018" z="0" />
+     <position name="posFieldShaper83" unit="cm"  x="175.96" y="-506.9018" z="0" />
      <rotation name="rotFS83" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper84" unit="cm"  x="181.95" y="-506.9018" z="0" />
+     <position name="posFieldShaper84" unit="cm"  x="181.96" y="-506.9018" z="0" />
      <rotation name="rotFS84" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper85" unit="cm"  x="187.95" y="-506.9018" z="0" />
+     <position name="posFieldShaper85" unit="cm"  x="187.96" y="-506.9018" z="0" />
      <rotation name="rotFS85" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper86" unit="cm"  x="193.95" y="-506.9018" z="0" />
+     <position name="posFieldShaper86" unit="cm"  x="193.96" y="-506.9018" z="0" />
      <rotation name="rotFS86" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper87" unit="cm"  x="199.95" y="-506.9018" z="0" />
+     <position name="posFieldShaper87" unit="cm"  x="199.96" y="-506.9018" z="0" />
      <rotation name="rotFS87" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper88" unit="cm"  x="205.95" y="-506.9018" z="0" />
+     <position name="posFieldShaper88" unit="cm"  x="205.96" y="-506.9018" z="0" />
      <rotation name="rotFS88" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper89" unit="cm"  x="211.95" y="-506.9018" z="0" />
+     <position name="posFieldShaper89" unit="cm"  x="211.96" y="-506.9018" z="0" />
      <rotation name="rotFS89" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper90" unit="cm"  x="217.95" y="-506.9018" z="0" />
+     <position name="posFieldShaper90" unit="cm"  x="217.96" y="-506.9018" z="0" />
      <rotation name="rotFS90" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper91" unit="cm"  x="223.95" y="-506.9018" z="0" />
+     <position name="posFieldShaper91" unit="cm"  x="223.96" y="-506.9018" z="0" />
      <rotation name="rotFS91" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper92" unit="cm"  x="229.95" y="-506.9018" z="0" />
+     <position name="posFieldShaper92" unit="cm"  x="229.96" y="-506.9018" z="0" />
      <rotation name="rotFS92" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper93" unit="cm"  x="235.95" y="-506.9018" z="0" />
+     <position name="posFieldShaper93" unit="cm"  x="235.96" y="-506.9018" z="0" />
      <rotation name="rotFS93" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper94" unit="cm"  x="241.95" y="-506.9018" z="0" />
+     <position name="posFieldShaper94" unit="cm"  x="241.96" y="-506.9018" z="0" />
      <rotation name="rotFS94" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper95" unit="cm"  x="247.95" y="-506.9018" z="0" />
+     <position name="posFieldShaper95" unit="cm"  x="247.96" y="-506.9018" z="0" />
      <rotation name="rotFS95" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper96" unit="cm"  x="253.95" y="-506.9018" z="0" />
+     <position name="posFieldShaper96" unit="cm"  x="253.96" y="-506.9018" z="0" />
      <rotation name="rotFS96" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper97" unit="cm"  x="259.95" y="-506.9018" z="0" />
+     <position name="posFieldShaper97" unit="cm"  x="259.96" y="-506.9018" z="0" />
      <rotation name="rotFS97" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper98" unit="cm"  x="265.95" y="-506.9018" z="0" />
+     <position name="posFieldShaper98" unit="cm"  x="265.96" y="-506.9018" z="0" />
      <rotation name="rotFS98" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper99" unit="cm"  x="271.95" y="-506.9018" z="0" />
+     <position name="posFieldShaper99" unit="cm"  x="271.96" y="-506.9018" z="0" />
      <rotation name="rotFS99" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper100" unit="cm"  x="277.95" y="-506.9018" z="0" />
+     <position name="posFieldShaper100" unit="cm"  x="277.96" y="-506.9018" z="0" />
      <rotation name="rotFS100" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper101" unit="cm"  x="283.95" y="-506.9018" z="0" />
+     <position name="posFieldShaper101" unit="cm"  x="283.96" y="-506.9018" z="0" />
      <rotation name="rotFS101" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper102" unit="cm"  x="289.95" y="-506.9018" z="0" />
+     <position name="posFieldShaper102" unit="cm"  x="289.96" y="-506.9018" z="0" />
      <rotation name="rotFS102" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper103" unit="cm"  x="295.95" y="-506.9018" z="0" />
+     <position name="posFieldShaper103" unit="cm"  x="295.96" y="-506.9018" z="0" />
      <rotation name="rotFS103" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper104" unit="cm"  x="301.95" y="-506.9018" z="0" />
+     <position name="posFieldShaper104" unit="cm"  x="301.96" y="-506.9018" z="0" />
      <rotation name="rotFS104" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper105" unit="cm"  x="307.95" y="-506.9018" z="0" />
+     <position name="posFieldShaper105" unit="cm"  x="307.96" y="-506.9018" z="0" />
      <rotation name="rotFS105" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper106" unit="cm"  x="313.95" y="-506.9018" z="0" />
+     <position name="posFieldShaper106" unit="cm"  x="313.96" y="-506.9018" z="0" />
      <rotation name="rotFS106" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper107" unit="cm"  x="319.95" y="-506.9018" z="0" />
+     <position name="posFieldShaper107" unit="cm"  x="319.96" y="-506.9018" z="0" />
      <rotation name="rotFS107" unit="deg" x="0" y="0" z="90" />
   </physvol>
       <physvol>
@@ -11321,37 +11315,82 @@
    <position name="posGroundGrid-0" unit="cm" x="-328.04" y="-336.9012" z="-299.34"/>
       </physvol>
       <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-0" unit="cm" x="325.045" y="-336.9012" z="-299.34"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-1" unit="cm" x="-328.04" y="-1.5" z="-299.34"/>
       </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-1" unit="cm" x="325.045" y="-1.5" z="-299.34"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
       <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-2" unit="cm" x="-328.04" y="333.9012" z="-299.34"/>
       </physvol>
       <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-2" unit="cm" x="325.045" y="333.9012" z="-299.34"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-3" unit="cm" x="-328.04" y="-336.9012" z="-1.5"/>
       </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-3" unit="cm" x="325.045" y="-336.9012" z="-1.5"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
       <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-4" unit="cm" x="-328.04" y="-1.5" z="-1.5"/>
       </physvol>
       <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-4" unit="cm" x="325.045" y="-1.5" z="-1.5"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-5" unit="cm" x="-328.04" y="333.9012" z="-1.5"/>
       </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-5" unit="cm" x="325.045" y="333.9012" z="-1.5"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
       <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-6" unit="cm" x="-328.04" y="-336.9012" z="296.34"/>
       </physvol>
       <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-6" unit="cm" x="325.045" y="-336.9012" z="296.34"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-7" unit="cm" x="-328.04" y="-1.5" z="296.34"/>
       </physvol>
       <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-7" unit="cm" x="325.045" y="-1.5" z="296.34"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-8" unit="cm" x="-328.04" y="333.9012" z="296.34"/>
       </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-8" unit="cm" x="325.045" y="333.9012" z="296.34"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
      <physvol>
        <volumeref ref="volArapucaDouble_0-0-0"/>
        <position name="posArapucaDouble0-Frame-0-0" unit="cm" 
@@ -11928,7 +11967,7 @@
 
       <physvol>
         <volumeref ref="volDetEnclosure"/>
-	<position name="posDetEnclosure" unit="cm" x="50.0500000000001" y="0" z="448.26"/>
+	<position name="posDetEnclosure" unit="cm" x="50.04" y="0" z="448.26"/>
       </physvol>
 
     </volume>

--- a/dunecore/Geometry/gdml/dunevd10kt_3view_30deg_v3_refactored_1x8x6ref_nowires.gdml
+++ b/dunecore/Geometry/gdml/dunevd10kt_3view_30deg_v3_refactored_1x8x6ref_nowires.gdml
@@ -490,7 +490,7 @@
     
 
    <box name="CRM"
-      x="650.1" 
+      x="650.08" 
       y="167.7006" 
       z="148.92"
       lunit="cm"/>
@@ -506,11 +506,6 @@
       lunit="cm"/>
    <box name="CRMZPlane" 
       x="0.02"
-      y="167.7006"
-      z="148.92"
-      lunit="cm"/>
-   <box name="AnodePlate" 
-      x="0.02/2."
       y="167.7006"
       z="148.92"
       lunit="cm"/>
@@ -564,27 +559,27 @@
 
 
     <box name="Cryostat" lunit="cm" 
-      x="850.34" 
+      x="850.32" 
       y="1209.4436" 
       z="1096.76"/>
 
     <box name="ArgonInterior" lunit="cm" 
-      x="850.1"
+      x="850.08"
       y="1209.2036"
       z="1096.52"/>
 
     <box name="GaseousArgon" lunit="cm" 
-      x="100"
+      x="100 - 0.02"
       y="1209.2036"
       z="1096.52"/>
 
     <box name="ExternalAuxOut" lunit="cm" 
-      x="850.1 - 100"
+      x="850.08 - 100"
       y="1209.2036 - 2*2.5 - 2*40"
       z="1096.52"/>
 
     <box name="ExternalAuxIn" lunit="cm" 
-      x="850.1"
+      x="850.08"
       y="1020.3736"
       z="1096.52 + 1"/>
 
@@ -691,8 +686,14 @@
       <position name="posCathodeSub16" x="0" y="122.525" z="108.5" unit="cm"/>
     </subtraction>
 
+   <box name="AnodePlate" 
+      x="0.02/2."
+      y="335.4012"
+      z="297.84"
+      lunit="cm"/>
+
     <box name="FoamPadBlock" lunit="cm"
-      x="1010.34"
+      x="1010.32"
       y="1369.4436"
       z="1256.76" />
 
@@ -703,7 +704,7 @@
     </subtraction>
 
     <box name="SteelSupportBlock" lunit="cm"
-      x="1210.34"
+      x="1210.32"
       y="1569.4436"
       z="1456.76" />
 
@@ -714,13 +715,13 @@
     </subtraction>
 
     <box name="DetEnclosure" lunit="cm" 
-      x="1310.34"
+      x="1310.32"
       y="1769.4436"
       z="1656.76"/>
 
 
     <box name="World" lunit="cm" 
-      x="9310.34" 
+      x="9310.32" 
       y="9769.4436" 
       z="9656.76"/>
 </solids>
@@ -755,11 +756,6 @@
     <materialref ref="LAr"/>
     <solidref ref="CRMZPlane"/>
   </volume>
-     
-   <volume name="volAnodePlate">
-     <materialref ref="vm2000"/>
-     <solidref ref="AnodePlate"/>
-  </volume>
    <volume name="volTPC">
      <materialref ref="LAr"/>
        <solidref ref="CRM"/>
@@ -782,15 +778,9 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volAnodePlate"/>
-       <position name="posAnodePlate" unit="cm" 
-         x="325.045" y="0" z="0"/>
-       <rotationref ref="rIdentity"/>
-     </physvol>
-     <physvol>
        <volumeref ref="volTPCActive"/>
        <position name="posActive" unit="cm" 
-        x="-0.05" y="" z="0"/>
+        x="-0.04" y="" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
    </volume>
@@ -802,6 +792,10 @@
     <volume name="volGroundGrid">
       <materialref ref="STEEL_STAINLESS_Fe7Cr2Ni" />
       <solidref ref="CathodeGrid" />
+    </volume>
+    <volume name="volAnodePlate">
+     <materialref ref="vm2000"/>
+     <solidref ref="AnodePlate"/>
     </volume>
     <volume name="volGaseousArgon">
       <materialref ref="ArGas"/>
@@ -1109,7 +1103,7 @@
       <solidref ref="Cryostat" />
       <physvol>
         <volumeref ref="volGaseousArgon"/>
-        <position name="posGaseousArgon" unit="cm" x="375.05" y="0" z="0"/>
+        <position name="posGaseousArgon" unit="cm" x="375.04" y="0" z="0"/>
       </physvol>
       <physvol>
         <volumeref ref="volSteelShell"/>
@@ -1301,542 +1295,542 @@
       </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper0" unit="cm"  x="-322.05" y="-506.9018" z="0" />
+     <position name="posFieldShaper0" unit="cm"  x="-322.04" y="-506.9018" z="0" />
      <rotation name="rotFS0" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper1" unit="cm"  x="-316.05" y="-506.9018" z="0" />
+     <position name="posFieldShaper1" unit="cm"  x="-316.04" y="-506.9018" z="0" />
      <rotation name="rotFS1" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper2" unit="cm"  x="-310.05" y="-506.9018" z="0" />
+     <position name="posFieldShaper2" unit="cm"  x="-310.04" y="-506.9018" z="0" />
      <rotation name="rotFS2" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper3" unit="cm"  x="-304.05" y="-506.9018" z="0" />
+     <position name="posFieldShaper3" unit="cm"  x="-304.04" y="-506.9018" z="0" />
      <rotation name="rotFS3" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper4" unit="cm"  x="-298.05" y="-506.9018" z="0" />
+     <position name="posFieldShaper4" unit="cm"  x="-298.04" y="-506.9018" z="0" />
      <rotation name="rotFS4" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper5" unit="cm"  x="-292.05" y="-506.9018" z="0" />
+     <position name="posFieldShaper5" unit="cm"  x="-292.04" y="-506.9018" z="0" />
      <rotation name="rotFS5" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper6" unit="cm"  x="-286.05" y="-506.9018" z="0" />
+     <position name="posFieldShaper6" unit="cm"  x="-286.04" y="-506.9018" z="0" />
      <rotation name="rotFS6" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper7" unit="cm"  x="-280.05" y="-506.9018" z="0" />
+     <position name="posFieldShaper7" unit="cm"  x="-280.04" y="-506.9018" z="0" />
      <rotation name="rotFS7" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper8" unit="cm"  x="-274.05" y="-506.9018" z="0" />
+     <position name="posFieldShaper8" unit="cm"  x="-274.04" y="-506.9018" z="0" />
      <rotation name="rotFS8" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper9" unit="cm"  x="-268.05" y="-506.9018" z="0" />
+     <position name="posFieldShaper9" unit="cm"  x="-268.04" y="-506.9018" z="0" />
      <rotation name="rotFS9" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper10" unit="cm"  x="-262.05" y="-506.9018" z="0" />
+     <position name="posFieldShaper10" unit="cm"  x="-262.04" y="-506.9018" z="0" />
      <rotation name="rotFS10" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper11" unit="cm"  x="-256.05" y="-506.9018" z="0" />
+     <position name="posFieldShaper11" unit="cm"  x="-256.04" y="-506.9018" z="0" />
      <rotation name="rotFS11" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper12" unit="cm"  x="-250.05" y="-506.9018" z="0" />
+     <position name="posFieldShaper12" unit="cm"  x="-250.04" y="-506.9018" z="0" />
      <rotation name="rotFS12" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper13" unit="cm"  x="-244.05" y="-506.9018" z="0" />
+     <position name="posFieldShaper13" unit="cm"  x="-244.04" y="-506.9018" z="0" />
      <rotation name="rotFS13" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper14" unit="cm"  x="-238.05" y="-506.9018" z="0" />
+     <position name="posFieldShaper14" unit="cm"  x="-238.04" y="-506.9018" z="0" />
      <rotation name="rotFS14" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper15" unit="cm"  x="-232.05" y="-506.9018" z="0" />
+     <position name="posFieldShaper15" unit="cm"  x="-232.04" y="-506.9018" z="0" />
      <rotation name="rotFS15" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper16" unit="cm"  x="-226.05" y="-506.9018" z="0" />
+     <position name="posFieldShaper16" unit="cm"  x="-226.04" y="-506.9018" z="0" />
      <rotation name="rotFS16" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper17" unit="cm"  x="-220.05" y="-506.9018" z="0" />
+     <position name="posFieldShaper17" unit="cm"  x="-220.04" y="-506.9018" z="0" />
      <rotation name="rotFS17" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper18" unit="cm"  x="-214.05" y="-506.9018" z="0" />
+     <position name="posFieldShaper18" unit="cm"  x="-214.04" y="-506.9018" z="0" />
      <rotation name="rotFS18" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper19" unit="cm"  x="-208.05" y="-506.9018" z="0" />
+     <position name="posFieldShaper19" unit="cm"  x="-208.04" y="-506.9018" z="0" />
      <rotation name="rotFS19" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper20" unit="cm"  x="-202.05" y="-506.9018" z="0" />
+     <position name="posFieldShaper20" unit="cm"  x="-202.04" y="-506.9018" z="0" />
      <rotation name="rotFS20" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper21" unit="cm"  x="-196.05" y="-506.9018" z="0" />
+     <position name="posFieldShaper21" unit="cm"  x="-196.04" y="-506.9018" z="0" />
      <rotation name="rotFS21" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper22" unit="cm"  x="-190.05" y="-506.9018" z="0" />
+     <position name="posFieldShaper22" unit="cm"  x="-190.04" y="-506.9018" z="0" />
      <rotation name="rotFS22" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper23" unit="cm"  x="-184.05" y="-506.9018" z="0" />
+     <position name="posFieldShaper23" unit="cm"  x="-184.04" y="-506.9018" z="0" />
      <rotation name="rotFS23" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper24" unit="cm"  x="-178.05" y="-506.9018" z="0" />
+     <position name="posFieldShaper24" unit="cm"  x="-178.04" y="-506.9018" z="0" />
      <rotation name="rotFS24" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper25" unit="cm"  x="-172.05" y="-506.9018" z="0" />
+     <position name="posFieldShaper25" unit="cm"  x="-172.04" y="-506.9018" z="0" />
      <rotation name="rotFS25" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper26" unit="cm"  x="-166.05" y="-506.9018" z="0" />
+     <position name="posFieldShaper26" unit="cm"  x="-166.04" y="-506.9018" z="0" />
      <rotation name="rotFS26" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper27" unit="cm"  x="-160.05" y="-506.9018" z="0" />
+     <position name="posFieldShaper27" unit="cm"  x="-160.04" y="-506.9018" z="0" />
      <rotation name="rotFS27" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper28" unit="cm"  x="-154.05" y="-506.9018" z="0" />
+     <position name="posFieldShaper28" unit="cm"  x="-154.04" y="-506.9018" z="0" />
      <rotation name="rotFS28" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper29" unit="cm"  x="-148.05" y="-506.9018" z="0" />
+     <position name="posFieldShaper29" unit="cm"  x="-148.04" y="-506.9018" z="0" />
      <rotation name="rotFS29" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper30" unit="cm"  x="-142.05" y="-506.9018" z="0" />
+     <position name="posFieldShaper30" unit="cm"  x="-142.04" y="-506.9018" z="0" />
      <rotation name="rotFS30" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper31" unit="cm"  x="-136.05" y="-506.9018" z="0" />
+     <position name="posFieldShaper31" unit="cm"  x="-136.04" y="-506.9018" z="0" />
      <rotation name="rotFS31" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper32" unit="cm"  x="-130.05" y="-506.9018" z="0" />
+     <position name="posFieldShaper32" unit="cm"  x="-130.04" y="-506.9018" z="0" />
      <rotation name="rotFS32" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper33" unit="cm"  x="-124.05" y="-506.9018" z="0" />
+     <position name="posFieldShaper33" unit="cm"  x="-124.04" y="-506.9018" z="0" />
      <rotation name="rotFS33" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper34" unit="cm"  x="-118.05" y="-506.9018" z="0" />
+     <position name="posFieldShaper34" unit="cm"  x="-118.04" y="-506.9018" z="0" />
      <rotation name="rotFS34" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper35" unit="cm"  x="-112.05" y="-506.9018" z="0" />
+     <position name="posFieldShaper35" unit="cm"  x="-112.04" y="-506.9018" z="0" />
      <rotation name="rotFS35" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper36" unit="cm"  x="-106.05" y="-506.9018" z="0" />
+     <position name="posFieldShaper36" unit="cm"  x="-106.04" y="-506.9018" z="0" />
      <rotation name="rotFS36" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper37" unit="cm"  x="-100.05" y="-506.9018" z="0" />
+     <position name="posFieldShaper37" unit="cm"  x="-100.04" y="-506.9018" z="0" />
      <rotation name="rotFS37" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper38" unit="cm"  x="-94.0500000000001" y="-506.9018" z="0" />
+     <position name="posFieldShaper38" unit="cm"  x="-94.04" y="-506.9018" z="0" />
      <rotation name="rotFS38" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper39" unit="cm"  x="-88.0500000000001" y="-506.9018" z="0" />
+     <position name="posFieldShaper39" unit="cm"  x="-88.04" y="-506.9018" z="0" />
      <rotation name="rotFS39" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper40" unit="cm"  x="-82.0500000000001" y="-506.9018" z="0" />
+     <position name="posFieldShaper40" unit="cm"  x="-82.04" y="-506.9018" z="0" />
      <rotation name="rotFS40" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper41" unit="cm"  x="-76.0500000000001" y="-506.9018" z="0" />
+     <position name="posFieldShaper41" unit="cm"  x="-76.04" y="-506.9018" z="0" />
      <rotation name="rotFS41" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper42" unit="cm"  x="-70.0500000000001" y="-506.9018" z="0" />
+     <position name="posFieldShaper42" unit="cm"  x="-70.04" y="-506.9018" z="0" />
      <rotation name="rotFS42" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper43" unit="cm"  x="-64.0500000000001" y="-506.9018" z="0" />
+     <position name="posFieldShaper43" unit="cm"  x="-64.04" y="-506.9018" z="0" />
      <rotation name="rotFS43" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper44" unit="cm"  x="-58.0500000000001" y="-506.9018" z="0" />
+     <position name="posFieldShaper44" unit="cm"  x="-58.04" y="-506.9018" z="0" />
      <rotation name="rotFS44" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper45" unit="cm"  x="-52.0500000000001" y="-506.9018" z="0" />
+     <position name="posFieldShaper45" unit="cm"  x="-52.04" y="-506.9018" z="0" />
      <rotation name="rotFS45" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper46" unit="cm"  x="-46.0500000000001" y="-506.9018" z="0" />
+     <position name="posFieldShaper46" unit="cm"  x="-46.04" y="-506.9018" z="0" />
      <rotation name="rotFS46" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper47" unit="cm"  x="-40.0500000000001" y="-506.9018" z="0" />
+     <position name="posFieldShaper47" unit="cm"  x="-40.04" y="-506.9018" z="0" />
      <rotation name="rotFS47" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper48" unit="cm"  x="-34.0500000000001" y="-506.9018" z="0" />
+     <position name="posFieldShaper48" unit="cm"  x="-34.04" y="-506.9018" z="0" />
      <rotation name="rotFS48" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper49" unit="cm"  x="-28.0500000000001" y="-506.9018" z="0" />
+     <position name="posFieldShaper49" unit="cm"  x="-28.04" y="-506.9018" z="0" />
      <rotation name="rotFS49" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper50" unit="cm"  x="-22.0500000000001" y="-506.9018" z="0" />
+     <position name="posFieldShaper50" unit="cm"  x="-22.04" y="-506.9018" z="0" />
      <rotation name="rotFS50" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper51" unit="cm"  x="-16.0500000000001" y="-506.9018" z="0" />
+     <position name="posFieldShaper51" unit="cm"  x="-16.04" y="-506.9018" z="0" />
      <rotation name="rotFS51" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper52" unit="cm"  x="-10.0500000000001" y="-506.9018" z="0" />
+     <position name="posFieldShaper52" unit="cm"  x="-10.04" y="-506.9018" z="0" />
      <rotation name="rotFS52" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper53" unit="cm"  x="-4.05000000000005" y="-506.9018" z="0" />
+     <position name="posFieldShaper53" unit="cm"  x="-4.04000000000001" y="-506.9018" z="0" />
      <rotation name="rotFS53" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper54" unit="cm"  x="1.94999999999995" y="-506.9018" z="0" />
+     <position name="posFieldShaper54" unit="cm"  x="1.95999999999999" y="-506.9018" z="0" />
      <rotation name="rotFS54" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper55" unit="cm"  x="7.94999999999995" y="-506.9018" z="0" />
+     <position name="posFieldShaper55" unit="cm"  x="7.95999999999999" y="-506.9018" z="0" />
      <rotation name="rotFS55" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper56" unit="cm"  x="13.9499999999999" y="-506.9018" z="0" />
+     <position name="posFieldShaper56" unit="cm"  x="13.96" y="-506.9018" z="0" />
      <rotation name="rotFS56" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper57" unit="cm"  x="19.9499999999999" y="-506.9018" z="0" />
+     <position name="posFieldShaper57" unit="cm"  x="19.96" y="-506.9018" z="0" />
      <rotation name="rotFS57" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper58" unit="cm"  x="25.9499999999999" y="-506.9018" z="0" />
+     <position name="posFieldShaper58" unit="cm"  x="25.96" y="-506.9018" z="0" />
      <rotation name="rotFS58" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper59" unit="cm"  x="31.9499999999999" y="-506.9018" z="0" />
+     <position name="posFieldShaper59" unit="cm"  x="31.96" y="-506.9018" z="0" />
      <rotation name="rotFS59" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper60" unit="cm"  x="37.9499999999999" y="-506.9018" z="0" />
+     <position name="posFieldShaper60" unit="cm"  x="37.96" y="-506.9018" z="0" />
      <rotation name="rotFS60" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper61" unit="cm"  x="43.9499999999999" y="-506.9018" z="0" />
+     <position name="posFieldShaper61" unit="cm"  x="43.96" y="-506.9018" z="0" />
      <rotation name="rotFS61" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper62" unit="cm"  x="49.9499999999999" y="-506.9018" z="0" />
+     <position name="posFieldShaper62" unit="cm"  x="49.96" y="-506.9018" z="0" />
      <rotation name="rotFS62" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper63" unit="cm"  x="55.9499999999999" y="-506.9018" z="0" />
+     <position name="posFieldShaper63" unit="cm"  x="55.96" y="-506.9018" z="0" />
      <rotation name="rotFS63" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper64" unit="cm"  x="61.9499999999999" y="-506.9018" z="0" />
+     <position name="posFieldShaper64" unit="cm"  x="61.96" y="-506.9018" z="0" />
      <rotation name="rotFS64" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper65" unit="cm"  x="67.9499999999999" y="-506.9018" z="0" />
+     <position name="posFieldShaper65" unit="cm"  x="67.96" y="-506.9018" z="0" />
      <rotation name="rotFS65" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper66" unit="cm"  x="73.9499999999999" y="-506.9018" z="0" />
+     <position name="posFieldShaper66" unit="cm"  x="73.96" y="-506.9018" z="0" />
      <rotation name="rotFS66" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper67" unit="cm"  x="79.9499999999999" y="-506.9018" z="0" />
+     <position name="posFieldShaper67" unit="cm"  x="79.96" y="-506.9018" z="0" />
      <rotation name="rotFS67" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper68" unit="cm"  x="85.9499999999999" y="-506.9018" z="0" />
+     <position name="posFieldShaper68" unit="cm"  x="85.96" y="-506.9018" z="0" />
      <rotation name="rotFS68" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper69" unit="cm"  x="91.9499999999999" y="-506.9018" z="0" />
+     <position name="posFieldShaper69" unit="cm"  x="91.96" y="-506.9018" z="0" />
      <rotation name="rotFS69" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper70" unit="cm"  x="97.9499999999999" y="-506.9018" z="0" />
+     <position name="posFieldShaper70" unit="cm"  x="97.96" y="-506.9018" z="0" />
      <rotation name="rotFS70" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper71" unit="cm"  x="103.95" y="-506.9018" z="0" />
+     <position name="posFieldShaper71" unit="cm"  x="103.96" y="-506.9018" z="0" />
      <rotation name="rotFS71" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper72" unit="cm"  x="109.95" y="-506.9018" z="0" />
+     <position name="posFieldShaper72" unit="cm"  x="109.96" y="-506.9018" z="0" />
      <rotation name="rotFS72" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper73" unit="cm"  x="115.95" y="-506.9018" z="0" />
+     <position name="posFieldShaper73" unit="cm"  x="115.96" y="-506.9018" z="0" />
      <rotation name="rotFS73" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper74" unit="cm"  x="121.95" y="-506.9018" z="0" />
+     <position name="posFieldShaper74" unit="cm"  x="121.96" y="-506.9018" z="0" />
      <rotation name="rotFS74" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper75" unit="cm"  x="127.95" y="-506.9018" z="0" />
+     <position name="posFieldShaper75" unit="cm"  x="127.96" y="-506.9018" z="0" />
      <rotation name="rotFS75" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper76" unit="cm"  x="133.95" y="-506.9018" z="0" />
+     <position name="posFieldShaper76" unit="cm"  x="133.96" y="-506.9018" z="0" />
      <rotation name="rotFS76" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper77" unit="cm"  x="139.95" y="-506.9018" z="0" />
+     <position name="posFieldShaper77" unit="cm"  x="139.96" y="-506.9018" z="0" />
      <rotation name="rotFS77" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper78" unit="cm"  x="145.95" y="-506.9018" z="0" />
+     <position name="posFieldShaper78" unit="cm"  x="145.96" y="-506.9018" z="0" />
      <rotation name="rotFS78" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper79" unit="cm"  x="151.95" y="-506.9018" z="0" />
+     <position name="posFieldShaper79" unit="cm"  x="151.96" y="-506.9018" z="0" />
      <rotation name="rotFS79" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper80" unit="cm"  x="157.95" y="-506.9018" z="0" />
+     <position name="posFieldShaper80" unit="cm"  x="157.96" y="-506.9018" z="0" />
      <rotation name="rotFS80" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper81" unit="cm"  x="163.95" y="-506.9018" z="0" />
+     <position name="posFieldShaper81" unit="cm"  x="163.96" y="-506.9018" z="0" />
      <rotation name="rotFS81" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper82" unit="cm"  x="169.95" y="-506.9018" z="0" />
+     <position name="posFieldShaper82" unit="cm"  x="169.96" y="-506.9018" z="0" />
      <rotation name="rotFS82" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper83" unit="cm"  x="175.95" y="-506.9018" z="0" />
+     <position name="posFieldShaper83" unit="cm"  x="175.96" y="-506.9018" z="0" />
      <rotation name="rotFS83" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper84" unit="cm"  x="181.95" y="-506.9018" z="0" />
+     <position name="posFieldShaper84" unit="cm"  x="181.96" y="-506.9018" z="0" />
      <rotation name="rotFS84" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper85" unit="cm"  x="187.95" y="-506.9018" z="0" />
+     <position name="posFieldShaper85" unit="cm"  x="187.96" y="-506.9018" z="0" />
      <rotation name="rotFS85" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper86" unit="cm"  x="193.95" y="-506.9018" z="0" />
+     <position name="posFieldShaper86" unit="cm"  x="193.96" y="-506.9018" z="0" />
      <rotation name="rotFS86" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper87" unit="cm"  x="199.95" y="-506.9018" z="0" />
+     <position name="posFieldShaper87" unit="cm"  x="199.96" y="-506.9018" z="0" />
      <rotation name="rotFS87" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper88" unit="cm"  x="205.95" y="-506.9018" z="0" />
+     <position name="posFieldShaper88" unit="cm"  x="205.96" y="-506.9018" z="0" />
      <rotation name="rotFS88" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper89" unit="cm"  x="211.95" y="-506.9018" z="0" />
+     <position name="posFieldShaper89" unit="cm"  x="211.96" y="-506.9018" z="0" />
      <rotation name="rotFS89" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper90" unit="cm"  x="217.95" y="-506.9018" z="0" />
+     <position name="posFieldShaper90" unit="cm"  x="217.96" y="-506.9018" z="0" />
      <rotation name="rotFS90" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper91" unit="cm"  x="223.95" y="-506.9018" z="0" />
+     <position name="posFieldShaper91" unit="cm"  x="223.96" y="-506.9018" z="0" />
      <rotation name="rotFS91" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper92" unit="cm"  x="229.95" y="-506.9018" z="0" />
+     <position name="posFieldShaper92" unit="cm"  x="229.96" y="-506.9018" z="0" />
      <rotation name="rotFS92" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper93" unit="cm"  x="235.95" y="-506.9018" z="0" />
+     <position name="posFieldShaper93" unit="cm"  x="235.96" y="-506.9018" z="0" />
      <rotation name="rotFS93" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper94" unit="cm"  x="241.95" y="-506.9018" z="0" />
+     <position name="posFieldShaper94" unit="cm"  x="241.96" y="-506.9018" z="0" />
      <rotation name="rotFS94" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper95" unit="cm"  x="247.95" y="-506.9018" z="0" />
+     <position name="posFieldShaper95" unit="cm"  x="247.96" y="-506.9018" z="0" />
      <rotation name="rotFS95" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper96" unit="cm"  x="253.95" y="-506.9018" z="0" />
+     <position name="posFieldShaper96" unit="cm"  x="253.96" y="-506.9018" z="0" />
      <rotation name="rotFS96" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper97" unit="cm"  x="259.95" y="-506.9018" z="0" />
+     <position name="posFieldShaper97" unit="cm"  x="259.96" y="-506.9018" z="0" />
      <rotation name="rotFS97" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper98" unit="cm"  x="265.95" y="-506.9018" z="0" />
+     <position name="posFieldShaper98" unit="cm"  x="265.96" y="-506.9018" z="0" />
      <rotation name="rotFS98" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper99" unit="cm"  x="271.95" y="-506.9018" z="0" />
+     <position name="posFieldShaper99" unit="cm"  x="271.96" y="-506.9018" z="0" />
      <rotation name="rotFS99" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper100" unit="cm"  x="277.95" y="-506.9018" z="0" />
+     <position name="posFieldShaper100" unit="cm"  x="277.96" y="-506.9018" z="0" />
      <rotation name="rotFS100" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper101" unit="cm"  x="283.95" y="-506.9018" z="0" />
+     <position name="posFieldShaper101" unit="cm"  x="283.96" y="-506.9018" z="0" />
      <rotation name="rotFS101" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper102" unit="cm"  x="289.95" y="-506.9018" z="0" />
+     <position name="posFieldShaper102" unit="cm"  x="289.96" y="-506.9018" z="0" />
      <rotation name="rotFS102" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper103" unit="cm"  x="295.95" y="-506.9018" z="0" />
+     <position name="posFieldShaper103" unit="cm"  x="295.96" y="-506.9018" z="0" />
      <rotation name="rotFS103" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper104" unit="cm"  x="301.95" y="-506.9018" z="0" />
+     <position name="posFieldShaper104" unit="cm"  x="301.96" y="-506.9018" z="0" />
      <rotation name="rotFS104" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper105" unit="cm"  x="307.95" y="-506.9018" z="0" />
+     <position name="posFieldShaper105" unit="cm"  x="307.96" y="-506.9018" z="0" />
      <rotation name="rotFS105" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper106" unit="cm"  x="313.95" y="-506.9018" z="0" />
+     <position name="posFieldShaper106" unit="cm"  x="313.96" y="-506.9018" z="0" />
      <rotation name="rotFS106" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper107" unit="cm"  x="319.95" y="-506.9018" z="0" />
+     <position name="posFieldShaper107" unit="cm"  x="319.96" y="-506.9018" z="0" />
      <rotation name="rotFS107" unit="deg" x="0" y="0" z="90" />
   </physvol>
       <physvol>
@@ -1844,37 +1838,82 @@
    <position name="posGroundGrid-0" unit="cm" x="-328.04" y="-336.9012" z="-299.34"/>
       </physvol>
       <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-0" unit="cm" x="325.045" y="-336.9012" z="-299.34"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-1" unit="cm" x="-328.04" y="-1.5" z="-299.34"/>
       </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-1" unit="cm" x="325.045" y="-1.5" z="-299.34"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
       <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-2" unit="cm" x="-328.04" y="333.9012" z="-299.34"/>
       </physvol>
       <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-2" unit="cm" x="325.045" y="333.9012" z="-299.34"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-3" unit="cm" x="-328.04" y="-336.9012" z="-1.5"/>
       </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-3" unit="cm" x="325.045" y="-336.9012" z="-1.5"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
       <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-4" unit="cm" x="-328.04" y="-1.5" z="-1.5"/>
       </physvol>
       <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-4" unit="cm" x="325.045" y="-1.5" z="-1.5"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-5" unit="cm" x="-328.04" y="333.9012" z="-1.5"/>
       </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-5" unit="cm" x="325.045" y="333.9012" z="-1.5"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
       <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-6" unit="cm" x="-328.04" y="-336.9012" z="296.34"/>
       </physvol>
       <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-6" unit="cm" x="325.045" y="-336.9012" z="296.34"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-7" unit="cm" x="-328.04" y="-1.5" z="296.34"/>
       </physvol>
       <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-7" unit="cm" x="325.045" y="-1.5" z="296.34"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-8" unit="cm" x="-328.04" y="333.9012" z="296.34"/>
       </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-8" unit="cm" x="325.045" y="333.9012" z="296.34"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
      <physvol>
        <volumeref ref="volArapucaDouble_0-0-0"/>
        <position name="posArapucaDouble0-Frame-0-0" unit="cm" 
@@ -2451,7 +2490,7 @@
 
       <physvol>
         <volumeref ref="volDetEnclosure"/>
-	<position name="posDetEnclosure" unit="cm" x="50.0500000000001" y="0" z="448.26"/>
+	<position name="posDetEnclosure" unit="cm" x="50.04" y="0" z="448.26"/>
       </physvol>
 
     </volume>

--- a/dunecore/Geometry/gdml/dunevd10kt_3view_v3_refactored_1x8x14ref.gdml
+++ b/dunecore/Geometry/gdml/dunevd10kt_3view_v3_refactored_1x8x14ref.gdml
@@ -489,7 +489,7 @@
     
 
    <box name="CRM"
-      x="650.1" 
+      x="650.08" 
       y="168" 
       z="148.9009"
       lunit="cm"/>
@@ -505,11 +505,6 @@
       lunit="cm"/>
    <box name="CRMZPlane" 
       x="0.02"
-      y="168"
-      z="148.9009"
-      lunit="cm"/>
-   <box name="AnodePlate" 
-      x="0.02/2."
       y="168"
       z="148.9009"
       lunit="cm"/>
@@ -1853,27 +1848,27 @@
 
 
     <box name="Cryostat" lunit="cm" 
-      x="850.34" 
+      x="850.32" 
       y="1548.24" 
       z="2291.8526"/>
 
     <box name="ArgonInterior" lunit="cm" 
-      x="850.1"
+      x="850.08"
       y="1548"
       z="2291.6126"/>
 
     <box name="GaseousArgon" lunit="cm" 
-      x="100"
+      x="100 - 0.02"
       y="1548"
       z="2291.6126"/>
 
     <box name="ExternalAuxOut" lunit="cm" 
-      x="850.1 - 100"
+      x="850.08 - 100"
       y="1548 - 2*2.5 - 2*40"
       z="2291.6126"/>
 
     <box name="ExternalAuxIn" lunit="cm" 
-      x="850.1"
+      x="850.08"
       y="1359.17"
       z="2291.6126 + 1"/>
 
@@ -1980,8 +1975,14 @@
       <position name="posCathodeSub16" x="0" y="122.525" z="108.5" unit="cm"/>
     </subtraction>
 
+   <box name="AnodePlate" 
+      x="0.02/2."
+      y="336"
+      z="297.8018"
+      lunit="cm"/>
+
     <box name="FoamPadBlock" lunit="cm"
-      x="1010.34"
+      x="1010.32"
       y="1708.24"
       z="2451.8526" />
 
@@ -1992,7 +1993,7 @@
     </subtraction>
 
     <box name="SteelSupportBlock" lunit="cm"
-      x="1210.34"
+      x="1210.32"
       y="1908.24"
       z="2651.8526" />
 
@@ -2003,13 +2004,13 @@
     </subtraction>
 
     <box name="DetEnclosure" lunit="cm" 
-      x="1310.34"
+      x="1310.32"
       y="2108.24"
       z="2851.8526"/>
 
 
     <box name="World" lunit="cm" 
-      x="9310.34" 
+      x="9310.32" 
       y="10108.24" 
       z="10851.8526"/>
 </solids>
@@ -7396,11 +7397,6 @@
          <rotationref ref="rPlus90AboutX"/>
        </physvol>
   </volume>
-     
-   <volume name="volAnodePlate">
-     <materialref ref="vm2000"/>
-     <solidref ref="AnodePlate"/>
-  </volume>
    <volume name="volTPC">
      <materialref ref="LAr"/>
        <solidref ref="CRM"/>
@@ -7423,15 +7419,9 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volAnodePlate"/>
-       <position name="posAnodePlate" unit="cm" 
-         x="325.045" y="0" z="0"/>
-       <rotationref ref="rIdentity"/>
-     </physvol>    
-     <physvol>
        <volumeref ref="volTPCActive"/>
        <position name="posActive" unit="cm" 
-        x="-0.05" y="" z="0"/>
+        x="-0.04" y="" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
    </volume>
@@ -7444,6 +7434,10 @@
       <materialref ref="STEEL_STAINLESS_Fe7Cr2Ni" />
       <solidref ref="CathodeGrid" />
     </volume>    
+    <volume name="volAnodePlate">
+     <materialref ref="vm2000"/>
+     <solidref ref="AnodePlate"/>
+    </volume>
     <volume name="volGaseousArgon">
       <materialref ref="ArGas"/>
       <solidref ref="GaseousArgon"/>
@@ -8806,7 +8800,7 @@
       <solidref ref="Cryostat" />
       <physvol>
         <volumeref ref="volGaseousArgon"/>
-        <position name="posGaseousArgon" unit="cm" x="375.05" y="0" z="0"/>
+        <position name="posGaseousArgon" unit="cm" x="375.04" y="0" z="0"/>
       </physvol>
       <physvol>
         <volumeref ref="volSteelShell"/>
@@ -9378,656 +9372,824 @@
       </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper0" unit="cm"  x="-322.05" y="-676.3" z="0" />
+     <position name="posFieldShaper0" unit="cm"  x="-322.04" y="-676.3" z="0" />
      <rotation name="rotFS0" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper1" unit="cm"  x="-316.05" y="-676.3" z="0" />
+     <position name="posFieldShaper1" unit="cm"  x="-316.04" y="-676.3" z="0" />
      <rotation name="rotFS1" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper2" unit="cm"  x="-310.05" y="-676.3" z="0" />
+     <position name="posFieldShaper2" unit="cm"  x="-310.04" y="-676.3" z="0" />
      <rotation name="rotFS2" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper3" unit="cm"  x="-304.05" y="-676.3" z="0" />
+     <position name="posFieldShaper3" unit="cm"  x="-304.04" y="-676.3" z="0" />
      <rotation name="rotFS3" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper4" unit="cm"  x="-298.05" y="-676.3" z="0" />
+     <position name="posFieldShaper4" unit="cm"  x="-298.04" y="-676.3" z="0" />
      <rotation name="rotFS4" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper5" unit="cm"  x="-292.05" y="-676.3" z="0" />
+     <position name="posFieldShaper5" unit="cm"  x="-292.04" y="-676.3" z="0" />
      <rotation name="rotFS5" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper6" unit="cm"  x="-286.05" y="-676.3" z="0" />
+     <position name="posFieldShaper6" unit="cm"  x="-286.04" y="-676.3" z="0" />
      <rotation name="rotFS6" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper7" unit="cm"  x="-280.05" y="-676.3" z="0" />
+     <position name="posFieldShaper7" unit="cm"  x="-280.04" y="-676.3" z="0" />
      <rotation name="rotFS7" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper8" unit="cm"  x="-274.05" y="-676.3" z="0" />
+     <position name="posFieldShaper8" unit="cm"  x="-274.04" y="-676.3" z="0" />
      <rotation name="rotFS8" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper9" unit="cm"  x="-268.05" y="-676.3" z="0" />
+     <position name="posFieldShaper9" unit="cm"  x="-268.04" y="-676.3" z="0" />
      <rotation name="rotFS9" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper10" unit="cm"  x="-262.05" y="-676.3" z="0" />
+     <position name="posFieldShaper10" unit="cm"  x="-262.04" y="-676.3" z="0" />
      <rotation name="rotFS10" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper11" unit="cm"  x="-256.05" y="-676.3" z="0" />
+     <position name="posFieldShaper11" unit="cm"  x="-256.04" y="-676.3" z="0" />
      <rotation name="rotFS11" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper12" unit="cm"  x="-250.05" y="-676.3" z="0" />
+     <position name="posFieldShaper12" unit="cm"  x="-250.04" y="-676.3" z="0" />
      <rotation name="rotFS12" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper13" unit="cm"  x="-244.05" y="-676.3" z="0" />
+     <position name="posFieldShaper13" unit="cm"  x="-244.04" y="-676.3" z="0" />
      <rotation name="rotFS13" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper14" unit="cm"  x="-238.05" y="-676.3" z="0" />
+     <position name="posFieldShaper14" unit="cm"  x="-238.04" y="-676.3" z="0" />
      <rotation name="rotFS14" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper15" unit="cm"  x="-232.05" y="-676.3" z="0" />
+     <position name="posFieldShaper15" unit="cm"  x="-232.04" y="-676.3" z="0" />
      <rotation name="rotFS15" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper16" unit="cm"  x="-226.05" y="-676.3" z="0" />
+     <position name="posFieldShaper16" unit="cm"  x="-226.04" y="-676.3" z="0" />
      <rotation name="rotFS16" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper17" unit="cm"  x="-220.05" y="-676.3" z="0" />
+     <position name="posFieldShaper17" unit="cm"  x="-220.04" y="-676.3" z="0" />
      <rotation name="rotFS17" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper18" unit="cm"  x="-214.05" y="-676.3" z="0" />
+     <position name="posFieldShaper18" unit="cm"  x="-214.04" y="-676.3" z="0" />
      <rotation name="rotFS18" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper19" unit="cm"  x="-208.05" y="-676.3" z="0" />
+     <position name="posFieldShaper19" unit="cm"  x="-208.04" y="-676.3" z="0" />
      <rotation name="rotFS19" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper20" unit="cm"  x="-202.05" y="-676.3" z="0" />
+     <position name="posFieldShaper20" unit="cm"  x="-202.04" y="-676.3" z="0" />
      <rotation name="rotFS20" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper21" unit="cm"  x="-196.05" y="-676.3" z="0" />
+     <position name="posFieldShaper21" unit="cm"  x="-196.04" y="-676.3" z="0" />
      <rotation name="rotFS21" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper22" unit="cm"  x="-190.05" y="-676.3" z="0" />
+     <position name="posFieldShaper22" unit="cm"  x="-190.04" y="-676.3" z="0" />
      <rotation name="rotFS22" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper23" unit="cm"  x="-184.05" y="-676.3" z="0" />
+     <position name="posFieldShaper23" unit="cm"  x="-184.04" y="-676.3" z="0" />
      <rotation name="rotFS23" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper24" unit="cm"  x="-178.05" y="-676.3" z="0" />
+     <position name="posFieldShaper24" unit="cm"  x="-178.04" y="-676.3" z="0" />
      <rotation name="rotFS24" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper25" unit="cm"  x="-172.05" y="-676.3" z="0" />
+     <position name="posFieldShaper25" unit="cm"  x="-172.04" y="-676.3" z="0" />
      <rotation name="rotFS25" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper26" unit="cm"  x="-166.05" y="-676.3" z="0" />
+     <position name="posFieldShaper26" unit="cm"  x="-166.04" y="-676.3" z="0" />
      <rotation name="rotFS26" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper27" unit="cm"  x="-160.05" y="-676.3" z="0" />
+     <position name="posFieldShaper27" unit="cm"  x="-160.04" y="-676.3" z="0" />
      <rotation name="rotFS27" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper28" unit="cm"  x="-154.05" y="-676.3" z="0" />
+     <position name="posFieldShaper28" unit="cm"  x="-154.04" y="-676.3" z="0" />
      <rotation name="rotFS28" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper29" unit="cm"  x="-148.05" y="-676.3" z="0" />
+     <position name="posFieldShaper29" unit="cm"  x="-148.04" y="-676.3" z="0" />
      <rotation name="rotFS29" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper30" unit="cm"  x="-142.05" y="-676.3" z="0" />
+     <position name="posFieldShaper30" unit="cm"  x="-142.04" y="-676.3" z="0" />
      <rotation name="rotFS30" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper31" unit="cm"  x="-136.05" y="-676.3" z="0" />
+     <position name="posFieldShaper31" unit="cm"  x="-136.04" y="-676.3" z="0" />
      <rotation name="rotFS31" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper32" unit="cm"  x="-130.05" y="-676.3" z="0" />
+     <position name="posFieldShaper32" unit="cm"  x="-130.04" y="-676.3" z="0" />
      <rotation name="rotFS32" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper33" unit="cm"  x="-124.05" y="-676.3" z="0" />
+     <position name="posFieldShaper33" unit="cm"  x="-124.04" y="-676.3" z="0" />
      <rotation name="rotFS33" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper34" unit="cm"  x="-118.05" y="-676.3" z="0" />
+     <position name="posFieldShaper34" unit="cm"  x="-118.04" y="-676.3" z="0" />
      <rotation name="rotFS34" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper35" unit="cm"  x="-112.05" y="-676.3" z="0" />
+     <position name="posFieldShaper35" unit="cm"  x="-112.04" y="-676.3" z="0" />
      <rotation name="rotFS35" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper36" unit="cm"  x="-106.05" y="-676.3" z="0" />
+     <position name="posFieldShaper36" unit="cm"  x="-106.04" y="-676.3" z="0" />
      <rotation name="rotFS36" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper37" unit="cm"  x="-100.05" y="-676.3" z="0" />
+     <position name="posFieldShaper37" unit="cm"  x="-100.04" y="-676.3" z="0" />
      <rotation name="rotFS37" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper38" unit="cm"  x="-94.0500000000001" y="-676.3" z="0" />
+     <position name="posFieldShaper38" unit="cm"  x="-94.04" y="-676.3" z="0" />
      <rotation name="rotFS38" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper39" unit="cm"  x="-88.0500000000001" y="-676.3" z="0" />
+     <position name="posFieldShaper39" unit="cm"  x="-88.04" y="-676.3" z="0" />
      <rotation name="rotFS39" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper40" unit="cm"  x="-82.0500000000001" y="-676.3" z="0" />
+     <position name="posFieldShaper40" unit="cm"  x="-82.04" y="-676.3" z="0" />
      <rotation name="rotFS40" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper41" unit="cm"  x="-76.0500000000001" y="-676.3" z="0" />
+     <position name="posFieldShaper41" unit="cm"  x="-76.04" y="-676.3" z="0" />
      <rotation name="rotFS41" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper42" unit="cm"  x="-70.0500000000001" y="-676.3" z="0" />
+     <position name="posFieldShaper42" unit="cm"  x="-70.04" y="-676.3" z="0" />
      <rotation name="rotFS42" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper43" unit="cm"  x="-64.0500000000001" y="-676.3" z="0" />
+     <position name="posFieldShaper43" unit="cm"  x="-64.04" y="-676.3" z="0" />
      <rotation name="rotFS43" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper44" unit="cm"  x="-58.0500000000001" y="-676.3" z="0" />
+     <position name="posFieldShaper44" unit="cm"  x="-58.04" y="-676.3" z="0" />
      <rotation name="rotFS44" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper45" unit="cm"  x="-52.0500000000001" y="-676.3" z="0" />
+     <position name="posFieldShaper45" unit="cm"  x="-52.04" y="-676.3" z="0" />
      <rotation name="rotFS45" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper46" unit="cm"  x="-46.0500000000001" y="-676.3" z="0" />
+     <position name="posFieldShaper46" unit="cm"  x="-46.04" y="-676.3" z="0" />
      <rotation name="rotFS46" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper47" unit="cm"  x="-40.0500000000001" y="-676.3" z="0" />
+     <position name="posFieldShaper47" unit="cm"  x="-40.04" y="-676.3" z="0" />
      <rotation name="rotFS47" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper48" unit="cm"  x="-34.0500000000001" y="-676.3" z="0" />
+     <position name="posFieldShaper48" unit="cm"  x="-34.04" y="-676.3" z="0" />
      <rotation name="rotFS48" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper49" unit="cm"  x="-28.0500000000001" y="-676.3" z="0" />
+     <position name="posFieldShaper49" unit="cm"  x="-28.04" y="-676.3" z="0" />
      <rotation name="rotFS49" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper50" unit="cm"  x="-22.0500000000001" y="-676.3" z="0" />
+     <position name="posFieldShaper50" unit="cm"  x="-22.04" y="-676.3" z="0" />
      <rotation name="rotFS50" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper51" unit="cm"  x="-16.0500000000001" y="-676.3" z="0" />
+     <position name="posFieldShaper51" unit="cm"  x="-16.04" y="-676.3" z="0" />
      <rotation name="rotFS51" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper52" unit="cm"  x="-10.0500000000001" y="-676.3" z="0" />
+     <position name="posFieldShaper52" unit="cm"  x="-10.04" y="-676.3" z="0" />
      <rotation name="rotFS52" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper53" unit="cm"  x="-4.05000000000005" y="-676.3" z="0" />
+     <position name="posFieldShaper53" unit="cm"  x="-4.04000000000001" y="-676.3" z="0" />
      <rotation name="rotFS53" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper54" unit="cm"  x="1.94999999999995" y="-676.3" z="0" />
+     <position name="posFieldShaper54" unit="cm"  x="1.95999999999999" y="-676.3" z="0" />
      <rotation name="rotFS54" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper55" unit="cm"  x="7.94999999999995" y="-676.3" z="0" />
+     <position name="posFieldShaper55" unit="cm"  x="7.95999999999999" y="-676.3" z="0" />
      <rotation name="rotFS55" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper56" unit="cm"  x="13.9499999999999" y="-676.3" z="0" />
+     <position name="posFieldShaper56" unit="cm"  x="13.96" y="-676.3" z="0" />
      <rotation name="rotFS56" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper57" unit="cm"  x="19.9499999999999" y="-676.3" z="0" />
+     <position name="posFieldShaper57" unit="cm"  x="19.96" y="-676.3" z="0" />
      <rotation name="rotFS57" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper58" unit="cm"  x="25.9499999999999" y="-676.3" z="0" />
+     <position name="posFieldShaper58" unit="cm"  x="25.96" y="-676.3" z="0" />
      <rotation name="rotFS58" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper59" unit="cm"  x="31.9499999999999" y="-676.3" z="0" />
+     <position name="posFieldShaper59" unit="cm"  x="31.96" y="-676.3" z="0" />
      <rotation name="rotFS59" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper60" unit="cm"  x="37.9499999999999" y="-676.3" z="0" />
+     <position name="posFieldShaper60" unit="cm"  x="37.96" y="-676.3" z="0" />
      <rotation name="rotFS60" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper61" unit="cm"  x="43.9499999999999" y="-676.3" z="0" />
+     <position name="posFieldShaper61" unit="cm"  x="43.96" y="-676.3" z="0" />
      <rotation name="rotFS61" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper62" unit="cm"  x="49.9499999999999" y="-676.3" z="0" />
+     <position name="posFieldShaper62" unit="cm"  x="49.96" y="-676.3" z="0" />
      <rotation name="rotFS62" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper63" unit="cm"  x="55.9499999999999" y="-676.3" z="0" />
+     <position name="posFieldShaper63" unit="cm"  x="55.96" y="-676.3" z="0" />
      <rotation name="rotFS63" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper64" unit="cm"  x="61.9499999999999" y="-676.3" z="0" />
+     <position name="posFieldShaper64" unit="cm"  x="61.96" y="-676.3" z="0" />
      <rotation name="rotFS64" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper65" unit="cm"  x="67.9499999999999" y="-676.3" z="0" />
+     <position name="posFieldShaper65" unit="cm"  x="67.96" y="-676.3" z="0" />
      <rotation name="rotFS65" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper66" unit="cm"  x="73.9499999999999" y="-676.3" z="0" />
+     <position name="posFieldShaper66" unit="cm"  x="73.96" y="-676.3" z="0" />
      <rotation name="rotFS66" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper67" unit="cm"  x="79.9499999999999" y="-676.3" z="0" />
+     <position name="posFieldShaper67" unit="cm"  x="79.96" y="-676.3" z="0" />
      <rotation name="rotFS67" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper68" unit="cm"  x="85.9499999999999" y="-676.3" z="0" />
+     <position name="posFieldShaper68" unit="cm"  x="85.96" y="-676.3" z="0" />
      <rotation name="rotFS68" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper69" unit="cm"  x="91.9499999999999" y="-676.3" z="0" />
+     <position name="posFieldShaper69" unit="cm"  x="91.96" y="-676.3" z="0" />
      <rotation name="rotFS69" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper70" unit="cm"  x="97.9499999999999" y="-676.3" z="0" />
+     <position name="posFieldShaper70" unit="cm"  x="97.96" y="-676.3" z="0" />
      <rotation name="rotFS70" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper71" unit="cm"  x="103.95" y="-676.3" z="0" />
+     <position name="posFieldShaper71" unit="cm"  x="103.96" y="-676.3" z="0" />
      <rotation name="rotFS71" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper72" unit="cm"  x="109.95" y="-676.3" z="0" />
+     <position name="posFieldShaper72" unit="cm"  x="109.96" y="-676.3" z="0" />
      <rotation name="rotFS72" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper73" unit="cm"  x="115.95" y="-676.3" z="0" />
+     <position name="posFieldShaper73" unit="cm"  x="115.96" y="-676.3" z="0" />
      <rotation name="rotFS73" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper74" unit="cm"  x="121.95" y="-676.3" z="0" />
+     <position name="posFieldShaper74" unit="cm"  x="121.96" y="-676.3" z="0" />
      <rotation name="rotFS74" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper75" unit="cm"  x="127.95" y="-676.3" z="0" />
+     <position name="posFieldShaper75" unit="cm"  x="127.96" y="-676.3" z="0" />
      <rotation name="rotFS75" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper76" unit="cm"  x="133.95" y="-676.3" z="0" />
+     <position name="posFieldShaper76" unit="cm"  x="133.96" y="-676.3" z="0" />
      <rotation name="rotFS76" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper77" unit="cm"  x="139.95" y="-676.3" z="0" />
+     <position name="posFieldShaper77" unit="cm"  x="139.96" y="-676.3" z="0" />
      <rotation name="rotFS77" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper78" unit="cm"  x="145.95" y="-676.3" z="0" />
+     <position name="posFieldShaper78" unit="cm"  x="145.96" y="-676.3" z="0" />
      <rotation name="rotFS78" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper79" unit="cm"  x="151.95" y="-676.3" z="0" />
+     <position name="posFieldShaper79" unit="cm"  x="151.96" y="-676.3" z="0" />
      <rotation name="rotFS79" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper80" unit="cm"  x="157.95" y="-676.3" z="0" />
+     <position name="posFieldShaper80" unit="cm"  x="157.96" y="-676.3" z="0" />
      <rotation name="rotFS80" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper81" unit="cm"  x="163.95" y="-676.3" z="0" />
+     <position name="posFieldShaper81" unit="cm"  x="163.96" y="-676.3" z="0" />
      <rotation name="rotFS81" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper82" unit="cm"  x="169.95" y="-676.3" z="0" />
+     <position name="posFieldShaper82" unit="cm"  x="169.96" y="-676.3" z="0" />
      <rotation name="rotFS82" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper83" unit="cm"  x="175.95" y="-676.3" z="0" />
+     <position name="posFieldShaper83" unit="cm"  x="175.96" y="-676.3" z="0" />
      <rotation name="rotFS83" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper84" unit="cm"  x="181.95" y="-676.3" z="0" />
+     <position name="posFieldShaper84" unit="cm"  x="181.96" y="-676.3" z="0" />
      <rotation name="rotFS84" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper85" unit="cm"  x="187.95" y="-676.3" z="0" />
+     <position name="posFieldShaper85" unit="cm"  x="187.96" y="-676.3" z="0" />
      <rotation name="rotFS85" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper86" unit="cm"  x="193.95" y="-676.3" z="0" />
+     <position name="posFieldShaper86" unit="cm"  x="193.96" y="-676.3" z="0" />
      <rotation name="rotFS86" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper87" unit="cm"  x="199.95" y="-676.3" z="0" />
+     <position name="posFieldShaper87" unit="cm"  x="199.96" y="-676.3" z="0" />
      <rotation name="rotFS87" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper88" unit="cm"  x="205.95" y="-676.3" z="0" />
+     <position name="posFieldShaper88" unit="cm"  x="205.96" y="-676.3" z="0" />
      <rotation name="rotFS88" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper89" unit="cm"  x="211.95" y="-676.3" z="0" />
+     <position name="posFieldShaper89" unit="cm"  x="211.96" y="-676.3" z="0" />
      <rotation name="rotFS89" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper90" unit="cm"  x="217.95" y="-676.3" z="0" />
+     <position name="posFieldShaper90" unit="cm"  x="217.96" y="-676.3" z="0" />
      <rotation name="rotFS90" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper91" unit="cm"  x="223.95" y="-676.3" z="0" />
+     <position name="posFieldShaper91" unit="cm"  x="223.96" y="-676.3" z="0" />
      <rotation name="rotFS91" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper92" unit="cm"  x="229.95" y="-676.3" z="0" />
+     <position name="posFieldShaper92" unit="cm"  x="229.96" y="-676.3" z="0" />
      <rotation name="rotFS92" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper93" unit="cm"  x="235.95" y="-676.3" z="0" />
+     <position name="posFieldShaper93" unit="cm"  x="235.96" y="-676.3" z="0" />
      <rotation name="rotFS93" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper94" unit="cm"  x="241.95" y="-676.3" z="0" />
+     <position name="posFieldShaper94" unit="cm"  x="241.96" y="-676.3" z="0" />
      <rotation name="rotFS94" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper95" unit="cm"  x="247.95" y="-676.3" z="0" />
+     <position name="posFieldShaper95" unit="cm"  x="247.96" y="-676.3" z="0" />
      <rotation name="rotFS95" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper96" unit="cm"  x="253.95" y="-676.3" z="0" />
+     <position name="posFieldShaper96" unit="cm"  x="253.96" y="-676.3" z="0" />
      <rotation name="rotFS96" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper97" unit="cm"  x="259.95" y="-676.3" z="0" />
+     <position name="posFieldShaper97" unit="cm"  x="259.96" y="-676.3" z="0" />
      <rotation name="rotFS97" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper98" unit="cm"  x="265.95" y="-676.3" z="0" />
+     <position name="posFieldShaper98" unit="cm"  x="265.96" y="-676.3" z="0" />
      <rotation name="rotFS98" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper99" unit="cm"  x="271.95" y="-676.3" z="0" />
+     <position name="posFieldShaper99" unit="cm"  x="271.96" y="-676.3" z="0" />
      <rotation name="rotFS99" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper100" unit="cm"  x="277.95" y="-676.3" z="0" />
+     <position name="posFieldShaper100" unit="cm"  x="277.96" y="-676.3" z="0" />
      <rotation name="rotFS100" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper101" unit="cm"  x="283.95" y="-676.3" z="0" />
+     <position name="posFieldShaper101" unit="cm"  x="283.96" y="-676.3" z="0" />
      <rotation name="rotFS101" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper102" unit="cm"  x="289.95" y="-676.3" z="0" />
+     <position name="posFieldShaper102" unit="cm"  x="289.96" y="-676.3" z="0" />
      <rotation name="rotFS102" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper103" unit="cm"  x="295.95" y="-676.3" z="0" />
+     <position name="posFieldShaper103" unit="cm"  x="295.96" y="-676.3" z="0" />
      <rotation name="rotFS103" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper104" unit="cm"  x="301.95" y="-676.3" z="0" />
+     <position name="posFieldShaper104" unit="cm"  x="301.96" y="-676.3" z="0" />
      <rotation name="rotFS104" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper105" unit="cm"  x="307.95" y="-676.3" z="0" />
+     <position name="posFieldShaper105" unit="cm"  x="307.96" y="-676.3" z="0" />
      <rotation name="rotFS105" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper106" unit="cm"  x="313.95" y="-676.3" z="0" />
+     <position name="posFieldShaper106" unit="cm"  x="313.96" y="-676.3" z="0" />
      <rotation name="rotFS106" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper107" unit="cm"  x="319.95" y="-676.3" z="0" />
+     <position name="posFieldShaper107" unit="cm"  x="319.96" y="-676.3" z="0" />
      <rotation name="rotFS107" unit="deg" x="0" y="0" z="90" />
   </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-0" unit="cm" x="-328.04" y="-506" z="-896.9054"/>
       </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-0" unit="cm" 
+         x="325.045" y="-506" z="-896.9054"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
       <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-1" unit="cm" x="-328.04" y="-170" z="-896.9054"/>
       </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-1" unit="cm" 
+         x="325.045" y="-170" z="-896.9054"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
       <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-2" unit="cm" x="-328.04" y="166" z="-896.9054"/>
       </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-2" unit="cm" 
+         x="325.045" y="166" z="-896.9054"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
       <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-3" unit="cm" x="-328.04" y="502" z="-896.9054"/>
       </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-3" unit="cm" 
+         x="325.045" y="502" z="-896.9054"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
       <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-4" unit="cm" x="-328.04" y="-506" z="-599.1036"/>
       </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-4" unit="cm" 
+         x="325.045" y="-506" z="-599.1036"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
       <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-5" unit="cm" x="-328.04" y="-170" z="-599.1036"/>
       </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-5" unit="cm" 
+         x="325.045" y="-170" z="-599.1036"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
       <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-6" unit="cm" x="-328.04" y="166" z="-599.1036"/>
       </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-6" unit="cm" 
+         x="325.045" y="166" z="-599.1036"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
       <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-7" unit="cm" x="-328.04" y="502" z="-599.1036"/>
       </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-7" unit="cm" 
+         x="325.045" y="502" z="-599.1036"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
       <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-8" unit="cm" x="-328.04" y="-506" z="-301.3018"/>
       </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-8" unit="cm" 
+         x="325.045" y="-506" z="-301.3018"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
       <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-9" unit="cm" x="-328.04" y="-170" z="-301.3018"/>
       </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-9" unit="cm" 
+         x="325.045" y="-170" z="-301.3018"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
       <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-10" unit="cm" x="-328.04" y="166" z="-301.3018"/>
       </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-10" unit="cm" 
+         x="325.045" y="166" z="-301.3018"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
       <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-11" unit="cm" x="-328.04" y="502" z="-301.3018"/>
       </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-11" unit="cm" 
+         x="325.045" y="502" z="-301.3018"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
       <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-12" unit="cm" x="-328.04" y="-506" z="-3.49999999999989"/>
       </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-12" unit="cm" 
+         x="325.045" y="-506" z="-3.49999999999989"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
       <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-13" unit="cm" x="-328.04" y="-170" z="-3.49999999999989"/>
       </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-13" unit="cm" 
+         x="325.045" y="-170" z="-3.49999999999989"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
       <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-14" unit="cm" x="-328.04" y="166" z="-3.49999999999989"/>
       </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-14" unit="cm" 
+         x="325.045" y="166" z="-3.49999999999989"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
       <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-15" unit="cm" x="-328.04" y="502" z="-3.49999999999989"/>
       </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-15" unit="cm" 
+         x="325.045" y="502" z="-3.49999999999989"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
       <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-16" unit="cm" x="-328.04" y="-506" z="294.3018"/>
       </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-16" unit="cm" 
+         x="325.045" y="-506" z="294.3018"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
       <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-17" unit="cm" x="-328.04" y="-170" z="294.3018"/>
       </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-17" unit="cm" 
+         x="325.045" y="-170" z="294.3018"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
       <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-18" unit="cm" x="-328.04" y="166" z="294.3018"/>
       </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-18" unit="cm" 
+         x="325.045" y="166" z="294.3018"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
       <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-19" unit="cm" x="-328.04" y="502" z="294.3018"/>
       </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-19" unit="cm" 
+         x="325.045" y="502" z="294.3018"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
       <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-20" unit="cm" x="-328.04" y="-506" z="592.1036"/>
       </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-20" unit="cm" 
+         x="325.045" y="-506" z="592.1036"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
       <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-21" unit="cm" x="-328.04" y="-170" z="592.1036"/>
       </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-21" unit="cm" 
+         x="325.045" y="-170" z="592.1036"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
       <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-22" unit="cm" x="-328.04" y="166" z="592.1036"/>
       </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-22" unit="cm" 
+         x="325.045" y="166" z="592.1036"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
       <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-23" unit="cm" x="-328.04" y="502" z="592.1036"/>
       </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-23" unit="cm" 
+         x="325.045" y="502" z="592.1036"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
       <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-24" unit="cm" x="-328.04" y="-506" z="889.9054"/>
       </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-24" unit="cm" 
+         x="325.045" y="-506" z="889.9054"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
       <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-25" unit="cm" x="-328.04" y="-170" z="889.9054"/>
       </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-25" unit="cm" 
+         x="325.045" y="-170" z="889.9054"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
       <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-26" unit="cm" x="-328.04" y="166" z="889.9054"/>
       </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-26" unit="cm" 
+         x="325.045" y="166" z="889.9054"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
       <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-27" unit="cm" x="-328.04" y="502" z="889.9054"/>
       </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-27" unit="cm" 
+         x="325.045" y="502" z="889.9054"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
      <physvol>
        <volumeref ref="volArapucaDouble_0-0-0"/>
        <position name="posArapucaDouble0-Frame-0-0" unit="cm" 
@@ -12584,7 +12746,7 @@
 
       <physvol>
         <volumeref ref="volDetEnclosure"/>
-	<position name="posDetEnclosure" unit="cm" x="50.0500000000001" y="-1.13686837721616e-13" z="1045.8063"/>
+	<position name="posDetEnclosure" unit="cm" x="50.04" y="-1.13686837721616e-13" z="1045.8063"/>
       </physvol>
 
     </volume>

--- a/dunecore/Geometry/gdml/dunevd10kt_3view_v3_refactored_1x8x14ref_nowires.gdml
+++ b/dunecore/Geometry/gdml/dunevd10kt_3view_v3_refactored_1x8x14ref_nowires.gdml
@@ -489,7 +489,7 @@
     
 
    <box name="CRM"
-      x="650.1" 
+      x="650.08" 
       y="168" 
       z="148.9009"
       lunit="cm"/>
@@ -505,11 +505,6 @@
       lunit="cm"/>
    <box name="CRMZPlane" 
       x="0.02"
-      y="168"
-      z="148.9009"
-      lunit="cm"/>
-   <box name="AnodePlate" 
-      x="0.02/2."
       y="168"
       z="148.9009"
       lunit="cm"/>
@@ -563,27 +558,27 @@
 
 
     <box name="Cryostat" lunit="cm" 
-      x="850.34" 
+      x="850.32" 
       y="1548.24" 
       z="2291.8526"/>
 
     <box name="ArgonInterior" lunit="cm" 
-      x="850.1"
+      x="850.08"
       y="1548"
       z="2291.6126"/>
 
     <box name="GaseousArgon" lunit="cm" 
-      x="100"
+      x="100 - 0.02"
       y="1548"
       z="2291.6126"/>
 
     <box name="ExternalAuxOut" lunit="cm" 
-      x="850.1 - 100"
+      x="850.08 - 100"
       y="1548 - 2*2.5 - 2*40"
       z="2291.6126"/>
 
     <box name="ExternalAuxIn" lunit="cm" 
-      x="850.1"
+      x="850.08"
       y="1359.17"
       z="2291.6126 + 1"/>
 
@@ -690,8 +685,14 @@
       <position name="posCathodeSub16" x="0" y="122.525" z="108.5" unit="cm"/>
     </subtraction>
 
+   <box name="AnodePlate" 
+      x="0.02/2."
+      y="336"
+      z="297.8018"
+      lunit="cm"/>
+
     <box name="FoamPadBlock" lunit="cm"
-      x="1010.34"
+      x="1010.32"
       y="1708.24"
       z="2451.8526" />
 
@@ -702,7 +703,7 @@
     </subtraction>
 
     <box name="SteelSupportBlock" lunit="cm"
-      x="1210.34"
+      x="1210.32"
       y="1908.24"
       z="2651.8526" />
 
@@ -713,13 +714,13 @@
     </subtraction>
 
     <box name="DetEnclosure" lunit="cm" 
-      x="1310.34"
+      x="1310.32"
       y="2108.24"
       z="2851.8526"/>
 
 
     <box name="World" lunit="cm" 
-      x="9310.34" 
+      x="9310.32" 
       y="10108.24" 
       z="10851.8526"/>
 </solids>
@@ -754,11 +755,6 @@
     <materialref ref="LAr"/>
     <solidref ref="CRMZPlane"/>
   </volume>
-     
-   <volume name="volAnodePlate">
-     <materialref ref="vm2000"/>
-     <solidref ref="AnodePlate"/>
-  </volume>
    <volume name="volTPC">
      <materialref ref="LAr"/>
        <solidref ref="CRM"/>
@@ -781,15 +777,9 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volAnodePlate"/>
-       <position name="posAnodePlate" unit="cm" 
-         x="325.045" y="0" z="0"/>
-       <rotationref ref="rIdentity"/>
-     </physvol>    
-     <physvol>
        <volumeref ref="volTPCActive"/>
        <position name="posActive" unit="cm" 
-        x="-0.05" y="" z="0"/>
+        x="-0.04" y="" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
    </volume>
@@ -802,6 +792,10 @@
       <materialref ref="STEEL_STAINLESS_Fe7Cr2Ni" />
       <solidref ref="CathodeGrid" />
     </volume>    
+    <volume name="volAnodePlate">
+     <materialref ref="vm2000"/>
+     <solidref ref="AnodePlate"/>
+    </volume>
     <volume name="volGaseousArgon">
       <materialref ref="ArGas"/>
       <solidref ref="GaseousArgon"/>
@@ -2164,7 +2158,7 @@
       <solidref ref="Cryostat" />
       <physvol>
         <volumeref ref="volGaseousArgon"/>
-        <position name="posGaseousArgon" unit="cm" x="375.05" y="0" z="0"/>
+        <position name="posGaseousArgon" unit="cm" x="375.04" y="0" z="0"/>
       </physvol>
       <physvol>
         <volumeref ref="volSteelShell"/>
@@ -2736,656 +2730,824 @@
       </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper0" unit="cm"  x="-322.05" y="-676.3" z="0" />
+     <position name="posFieldShaper0" unit="cm"  x="-322.04" y="-676.3" z="0" />
      <rotation name="rotFS0" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper1" unit="cm"  x="-316.05" y="-676.3" z="0" />
+     <position name="posFieldShaper1" unit="cm"  x="-316.04" y="-676.3" z="0" />
      <rotation name="rotFS1" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper2" unit="cm"  x="-310.05" y="-676.3" z="0" />
+     <position name="posFieldShaper2" unit="cm"  x="-310.04" y="-676.3" z="0" />
      <rotation name="rotFS2" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper3" unit="cm"  x="-304.05" y="-676.3" z="0" />
+     <position name="posFieldShaper3" unit="cm"  x="-304.04" y="-676.3" z="0" />
      <rotation name="rotFS3" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper4" unit="cm"  x="-298.05" y="-676.3" z="0" />
+     <position name="posFieldShaper4" unit="cm"  x="-298.04" y="-676.3" z="0" />
      <rotation name="rotFS4" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper5" unit="cm"  x="-292.05" y="-676.3" z="0" />
+     <position name="posFieldShaper5" unit="cm"  x="-292.04" y="-676.3" z="0" />
      <rotation name="rotFS5" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper6" unit="cm"  x="-286.05" y="-676.3" z="0" />
+     <position name="posFieldShaper6" unit="cm"  x="-286.04" y="-676.3" z="0" />
      <rotation name="rotFS6" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper7" unit="cm"  x="-280.05" y="-676.3" z="0" />
+     <position name="posFieldShaper7" unit="cm"  x="-280.04" y="-676.3" z="0" />
      <rotation name="rotFS7" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper8" unit="cm"  x="-274.05" y="-676.3" z="0" />
+     <position name="posFieldShaper8" unit="cm"  x="-274.04" y="-676.3" z="0" />
      <rotation name="rotFS8" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper9" unit="cm"  x="-268.05" y="-676.3" z="0" />
+     <position name="posFieldShaper9" unit="cm"  x="-268.04" y="-676.3" z="0" />
      <rotation name="rotFS9" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper10" unit="cm"  x="-262.05" y="-676.3" z="0" />
+     <position name="posFieldShaper10" unit="cm"  x="-262.04" y="-676.3" z="0" />
      <rotation name="rotFS10" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper11" unit="cm"  x="-256.05" y="-676.3" z="0" />
+     <position name="posFieldShaper11" unit="cm"  x="-256.04" y="-676.3" z="0" />
      <rotation name="rotFS11" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper12" unit="cm"  x="-250.05" y="-676.3" z="0" />
+     <position name="posFieldShaper12" unit="cm"  x="-250.04" y="-676.3" z="0" />
      <rotation name="rotFS12" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper13" unit="cm"  x="-244.05" y="-676.3" z="0" />
+     <position name="posFieldShaper13" unit="cm"  x="-244.04" y="-676.3" z="0" />
      <rotation name="rotFS13" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper14" unit="cm"  x="-238.05" y="-676.3" z="0" />
+     <position name="posFieldShaper14" unit="cm"  x="-238.04" y="-676.3" z="0" />
      <rotation name="rotFS14" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper15" unit="cm"  x="-232.05" y="-676.3" z="0" />
+     <position name="posFieldShaper15" unit="cm"  x="-232.04" y="-676.3" z="0" />
      <rotation name="rotFS15" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper16" unit="cm"  x="-226.05" y="-676.3" z="0" />
+     <position name="posFieldShaper16" unit="cm"  x="-226.04" y="-676.3" z="0" />
      <rotation name="rotFS16" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper17" unit="cm"  x="-220.05" y="-676.3" z="0" />
+     <position name="posFieldShaper17" unit="cm"  x="-220.04" y="-676.3" z="0" />
      <rotation name="rotFS17" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper18" unit="cm"  x="-214.05" y="-676.3" z="0" />
+     <position name="posFieldShaper18" unit="cm"  x="-214.04" y="-676.3" z="0" />
      <rotation name="rotFS18" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper19" unit="cm"  x="-208.05" y="-676.3" z="0" />
+     <position name="posFieldShaper19" unit="cm"  x="-208.04" y="-676.3" z="0" />
      <rotation name="rotFS19" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper20" unit="cm"  x="-202.05" y="-676.3" z="0" />
+     <position name="posFieldShaper20" unit="cm"  x="-202.04" y="-676.3" z="0" />
      <rotation name="rotFS20" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper21" unit="cm"  x="-196.05" y="-676.3" z="0" />
+     <position name="posFieldShaper21" unit="cm"  x="-196.04" y="-676.3" z="0" />
      <rotation name="rotFS21" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper22" unit="cm"  x="-190.05" y="-676.3" z="0" />
+     <position name="posFieldShaper22" unit="cm"  x="-190.04" y="-676.3" z="0" />
      <rotation name="rotFS22" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper23" unit="cm"  x="-184.05" y="-676.3" z="0" />
+     <position name="posFieldShaper23" unit="cm"  x="-184.04" y="-676.3" z="0" />
      <rotation name="rotFS23" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper24" unit="cm"  x="-178.05" y="-676.3" z="0" />
+     <position name="posFieldShaper24" unit="cm"  x="-178.04" y="-676.3" z="0" />
      <rotation name="rotFS24" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper25" unit="cm"  x="-172.05" y="-676.3" z="0" />
+     <position name="posFieldShaper25" unit="cm"  x="-172.04" y="-676.3" z="0" />
      <rotation name="rotFS25" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper26" unit="cm"  x="-166.05" y="-676.3" z="0" />
+     <position name="posFieldShaper26" unit="cm"  x="-166.04" y="-676.3" z="0" />
      <rotation name="rotFS26" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper27" unit="cm"  x="-160.05" y="-676.3" z="0" />
+     <position name="posFieldShaper27" unit="cm"  x="-160.04" y="-676.3" z="0" />
      <rotation name="rotFS27" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper28" unit="cm"  x="-154.05" y="-676.3" z="0" />
+     <position name="posFieldShaper28" unit="cm"  x="-154.04" y="-676.3" z="0" />
      <rotation name="rotFS28" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper29" unit="cm"  x="-148.05" y="-676.3" z="0" />
+     <position name="posFieldShaper29" unit="cm"  x="-148.04" y="-676.3" z="0" />
      <rotation name="rotFS29" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper30" unit="cm"  x="-142.05" y="-676.3" z="0" />
+     <position name="posFieldShaper30" unit="cm"  x="-142.04" y="-676.3" z="0" />
      <rotation name="rotFS30" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper31" unit="cm"  x="-136.05" y="-676.3" z="0" />
+     <position name="posFieldShaper31" unit="cm"  x="-136.04" y="-676.3" z="0" />
      <rotation name="rotFS31" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper32" unit="cm"  x="-130.05" y="-676.3" z="0" />
+     <position name="posFieldShaper32" unit="cm"  x="-130.04" y="-676.3" z="0" />
      <rotation name="rotFS32" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper33" unit="cm"  x="-124.05" y="-676.3" z="0" />
+     <position name="posFieldShaper33" unit="cm"  x="-124.04" y="-676.3" z="0" />
      <rotation name="rotFS33" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper34" unit="cm"  x="-118.05" y="-676.3" z="0" />
+     <position name="posFieldShaper34" unit="cm"  x="-118.04" y="-676.3" z="0" />
      <rotation name="rotFS34" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper35" unit="cm"  x="-112.05" y="-676.3" z="0" />
+     <position name="posFieldShaper35" unit="cm"  x="-112.04" y="-676.3" z="0" />
      <rotation name="rotFS35" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper36" unit="cm"  x="-106.05" y="-676.3" z="0" />
+     <position name="posFieldShaper36" unit="cm"  x="-106.04" y="-676.3" z="0" />
      <rotation name="rotFS36" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper37" unit="cm"  x="-100.05" y="-676.3" z="0" />
+     <position name="posFieldShaper37" unit="cm"  x="-100.04" y="-676.3" z="0" />
      <rotation name="rotFS37" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper38" unit="cm"  x="-94.0500000000001" y="-676.3" z="0" />
+     <position name="posFieldShaper38" unit="cm"  x="-94.04" y="-676.3" z="0" />
      <rotation name="rotFS38" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper39" unit="cm"  x="-88.0500000000001" y="-676.3" z="0" />
+     <position name="posFieldShaper39" unit="cm"  x="-88.04" y="-676.3" z="0" />
      <rotation name="rotFS39" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper40" unit="cm"  x="-82.0500000000001" y="-676.3" z="0" />
+     <position name="posFieldShaper40" unit="cm"  x="-82.04" y="-676.3" z="0" />
      <rotation name="rotFS40" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper41" unit="cm"  x="-76.0500000000001" y="-676.3" z="0" />
+     <position name="posFieldShaper41" unit="cm"  x="-76.04" y="-676.3" z="0" />
      <rotation name="rotFS41" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper42" unit="cm"  x="-70.0500000000001" y="-676.3" z="0" />
+     <position name="posFieldShaper42" unit="cm"  x="-70.04" y="-676.3" z="0" />
      <rotation name="rotFS42" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper43" unit="cm"  x="-64.0500000000001" y="-676.3" z="0" />
+     <position name="posFieldShaper43" unit="cm"  x="-64.04" y="-676.3" z="0" />
      <rotation name="rotFS43" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper44" unit="cm"  x="-58.0500000000001" y="-676.3" z="0" />
+     <position name="posFieldShaper44" unit="cm"  x="-58.04" y="-676.3" z="0" />
      <rotation name="rotFS44" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper45" unit="cm"  x="-52.0500000000001" y="-676.3" z="0" />
+     <position name="posFieldShaper45" unit="cm"  x="-52.04" y="-676.3" z="0" />
      <rotation name="rotFS45" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper46" unit="cm"  x="-46.0500000000001" y="-676.3" z="0" />
+     <position name="posFieldShaper46" unit="cm"  x="-46.04" y="-676.3" z="0" />
      <rotation name="rotFS46" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper47" unit="cm"  x="-40.0500000000001" y="-676.3" z="0" />
+     <position name="posFieldShaper47" unit="cm"  x="-40.04" y="-676.3" z="0" />
      <rotation name="rotFS47" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper48" unit="cm"  x="-34.0500000000001" y="-676.3" z="0" />
+     <position name="posFieldShaper48" unit="cm"  x="-34.04" y="-676.3" z="0" />
      <rotation name="rotFS48" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper49" unit="cm"  x="-28.0500000000001" y="-676.3" z="0" />
+     <position name="posFieldShaper49" unit="cm"  x="-28.04" y="-676.3" z="0" />
      <rotation name="rotFS49" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper50" unit="cm"  x="-22.0500000000001" y="-676.3" z="0" />
+     <position name="posFieldShaper50" unit="cm"  x="-22.04" y="-676.3" z="0" />
      <rotation name="rotFS50" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper51" unit="cm"  x="-16.0500000000001" y="-676.3" z="0" />
+     <position name="posFieldShaper51" unit="cm"  x="-16.04" y="-676.3" z="0" />
      <rotation name="rotFS51" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper52" unit="cm"  x="-10.0500000000001" y="-676.3" z="0" />
+     <position name="posFieldShaper52" unit="cm"  x="-10.04" y="-676.3" z="0" />
      <rotation name="rotFS52" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper53" unit="cm"  x="-4.05000000000005" y="-676.3" z="0" />
+     <position name="posFieldShaper53" unit="cm"  x="-4.04000000000001" y="-676.3" z="0" />
      <rotation name="rotFS53" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper54" unit="cm"  x="1.94999999999995" y="-676.3" z="0" />
+     <position name="posFieldShaper54" unit="cm"  x="1.95999999999999" y="-676.3" z="0" />
      <rotation name="rotFS54" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper55" unit="cm"  x="7.94999999999995" y="-676.3" z="0" />
+     <position name="posFieldShaper55" unit="cm"  x="7.95999999999999" y="-676.3" z="0" />
      <rotation name="rotFS55" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper56" unit="cm"  x="13.9499999999999" y="-676.3" z="0" />
+     <position name="posFieldShaper56" unit="cm"  x="13.96" y="-676.3" z="0" />
      <rotation name="rotFS56" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper57" unit="cm"  x="19.9499999999999" y="-676.3" z="0" />
+     <position name="posFieldShaper57" unit="cm"  x="19.96" y="-676.3" z="0" />
      <rotation name="rotFS57" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper58" unit="cm"  x="25.9499999999999" y="-676.3" z="0" />
+     <position name="posFieldShaper58" unit="cm"  x="25.96" y="-676.3" z="0" />
      <rotation name="rotFS58" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper59" unit="cm"  x="31.9499999999999" y="-676.3" z="0" />
+     <position name="posFieldShaper59" unit="cm"  x="31.96" y="-676.3" z="0" />
      <rotation name="rotFS59" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper60" unit="cm"  x="37.9499999999999" y="-676.3" z="0" />
+     <position name="posFieldShaper60" unit="cm"  x="37.96" y="-676.3" z="0" />
      <rotation name="rotFS60" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper61" unit="cm"  x="43.9499999999999" y="-676.3" z="0" />
+     <position name="posFieldShaper61" unit="cm"  x="43.96" y="-676.3" z="0" />
      <rotation name="rotFS61" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper62" unit="cm"  x="49.9499999999999" y="-676.3" z="0" />
+     <position name="posFieldShaper62" unit="cm"  x="49.96" y="-676.3" z="0" />
      <rotation name="rotFS62" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper63" unit="cm"  x="55.9499999999999" y="-676.3" z="0" />
+     <position name="posFieldShaper63" unit="cm"  x="55.96" y="-676.3" z="0" />
      <rotation name="rotFS63" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper64" unit="cm"  x="61.9499999999999" y="-676.3" z="0" />
+     <position name="posFieldShaper64" unit="cm"  x="61.96" y="-676.3" z="0" />
      <rotation name="rotFS64" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper65" unit="cm"  x="67.9499999999999" y="-676.3" z="0" />
+     <position name="posFieldShaper65" unit="cm"  x="67.96" y="-676.3" z="0" />
      <rotation name="rotFS65" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper66" unit="cm"  x="73.9499999999999" y="-676.3" z="0" />
+     <position name="posFieldShaper66" unit="cm"  x="73.96" y="-676.3" z="0" />
      <rotation name="rotFS66" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper67" unit="cm"  x="79.9499999999999" y="-676.3" z="0" />
+     <position name="posFieldShaper67" unit="cm"  x="79.96" y="-676.3" z="0" />
      <rotation name="rotFS67" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper68" unit="cm"  x="85.9499999999999" y="-676.3" z="0" />
+     <position name="posFieldShaper68" unit="cm"  x="85.96" y="-676.3" z="0" />
      <rotation name="rotFS68" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper69" unit="cm"  x="91.9499999999999" y="-676.3" z="0" />
+     <position name="posFieldShaper69" unit="cm"  x="91.96" y="-676.3" z="0" />
      <rotation name="rotFS69" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper70" unit="cm"  x="97.9499999999999" y="-676.3" z="0" />
+     <position name="posFieldShaper70" unit="cm"  x="97.96" y="-676.3" z="0" />
      <rotation name="rotFS70" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper71" unit="cm"  x="103.95" y="-676.3" z="0" />
+     <position name="posFieldShaper71" unit="cm"  x="103.96" y="-676.3" z="0" />
      <rotation name="rotFS71" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper72" unit="cm"  x="109.95" y="-676.3" z="0" />
+     <position name="posFieldShaper72" unit="cm"  x="109.96" y="-676.3" z="0" />
      <rotation name="rotFS72" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper73" unit="cm"  x="115.95" y="-676.3" z="0" />
+     <position name="posFieldShaper73" unit="cm"  x="115.96" y="-676.3" z="0" />
      <rotation name="rotFS73" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper74" unit="cm"  x="121.95" y="-676.3" z="0" />
+     <position name="posFieldShaper74" unit="cm"  x="121.96" y="-676.3" z="0" />
      <rotation name="rotFS74" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper75" unit="cm"  x="127.95" y="-676.3" z="0" />
+     <position name="posFieldShaper75" unit="cm"  x="127.96" y="-676.3" z="0" />
      <rotation name="rotFS75" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper76" unit="cm"  x="133.95" y="-676.3" z="0" />
+     <position name="posFieldShaper76" unit="cm"  x="133.96" y="-676.3" z="0" />
      <rotation name="rotFS76" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper77" unit="cm"  x="139.95" y="-676.3" z="0" />
+     <position name="posFieldShaper77" unit="cm"  x="139.96" y="-676.3" z="0" />
      <rotation name="rotFS77" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper78" unit="cm"  x="145.95" y="-676.3" z="0" />
+     <position name="posFieldShaper78" unit="cm"  x="145.96" y="-676.3" z="0" />
      <rotation name="rotFS78" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper79" unit="cm"  x="151.95" y="-676.3" z="0" />
+     <position name="posFieldShaper79" unit="cm"  x="151.96" y="-676.3" z="0" />
      <rotation name="rotFS79" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper80" unit="cm"  x="157.95" y="-676.3" z="0" />
+     <position name="posFieldShaper80" unit="cm"  x="157.96" y="-676.3" z="0" />
      <rotation name="rotFS80" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper81" unit="cm"  x="163.95" y="-676.3" z="0" />
+     <position name="posFieldShaper81" unit="cm"  x="163.96" y="-676.3" z="0" />
      <rotation name="rotFS81" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper82" unit="cm"  x="169.95" y="-676.3" z="0" />
+     <position name="posFieldShaper82" unit="cm"  x="169.96" y="-676.3" z="0" />
      <rotation name="rotFS82" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper83" unit="cm"  x="175.95" y="-676.3" z="0" />
+     <position name="posFieldShaper83" unit="cm"  x="175.96" y="-676.3" z="0" />
      <rotation name="rotFS83" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper84" unit="cm"  x="181.95" y="-676.3" z="0" />
+     <position name="posFieldShaper84" unit="cm"  x="181.96" y="-676.3" z="0" />
      <rotation name="rotFS84" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper85" unit="cm"  x="187.95" y="-676.3" z="0" />
+     <position name="posFieldShaper85" unit="cm"  x="187.96" y="-676.3" z="0" />
      <rotation name="rotFS85" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper86" unit="cm"  x="193.95" y="-676.3" z="0" />
+     <position name="posFieldShaper86" unit="cm"  x="193.96" y="-676.3" z="0" />
      <rotation name="rotFS86" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper87" unit="cm"  x="199.95" y="-676.3" z="0" />
+     <position name="posFieldShaper87" unit="cm"  x="199.96" y="-676.3" z="0" />
      <rotation name="rotFS87" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper88" unit="cm"  x="205.95" y="-676.3" z="0" />
+     <position name="posFieldShaper88" unit="cm"  x="205.96" y="-676.3" z="0" />
      <rotation name="rotFS88" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper89" unit="cm"  x="211.95" y="-676.3" z="0" />
+     <position name="posFieldShaper89" unit="cm"  x="211.96" y="-676.3" z="0" />
      <rotation name="rotFS89" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper90" unit="cm"  x="217.95" y="-676.3" z="0" />
+     <position name="posFieldShaper90" unit="cm"  x="217.96" y="-676.3" z="0" />
      <rotation name="rotFS90" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper91" unit="cm"  x="223.95" y="-676.3" z="0" />
+     <position name="posFieldShaper91" unit="cm"  x="223.96" y="-676.3" z="0" />
      <rotation name="rotFS91" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper92" unit="cm"  x="229.95" y="-676.3" z="0" />
+     <position name="posFieldShaper92" unit="cm"  x="229.96" y="-676.3" z="0" />
      <rotation name="rotFS92" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper93" unit="cm"  x="235.95" y="-676.3" z="0" />
+     <position name="posFieldShaper93" unit="cm"  x="235.96" y="-676.3" z="0" />
      <rotation name="rotFS93" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper94" unit="cm"  x="241.95" y="-676.3" z="0" />
+     <position name="posFieldShaper94" unit="cm"  x="241.96" y="-676.3" z="0" />
      <rotation name="rotFS94" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper95" unit="cm"  x="247.95" y="-676.3" z="0" />
+     <position name="posFieldShaper95" unit="cm"  x="247.96" y="-676.3" z="0" />
      <rotation name="rotFS95" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper96" unit="cm"  x="253.95" y="-676.3" z="0" />
+     <position name="posFieldShaper96" unit="cm"  x="253.96" y="-676.3" z="0" />
      <rotation name="rotFS96" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper97" unit="cm"  x="259.95" y="-676.3" z="0" />
+     <position name="posFieldShaper97" unit="cm"  x="259.96" y="-676.3" z="0" />
      <rotation name="rotFS97" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper98" unit="cm"  x="265.95" y="-676.3" z="0" />
+     <position name="posFieldShaper98" unit="cm"  x="265.96" y="-676.3" z="0" />
      <rotation name="rotFS98" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper99" unit="cm"  x="271.95" y="-676.3" z="0" />
+     <position name="posFieldShaper99" unit="cm"  x="271.96" y="-676.3" z="0" />
      <rotation name="rotFS99" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper100" unit="cm"  x="277.95" y="-676.3" z="0" />
+     <position name="posFieldShaper100" unit="cm"  x="277.96" y="-676.3" z="0" />
      <rotation name="rotFS100" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper101" unit="cm"  x="283.95" y="-676.3" z="0" />
+     <position name="posFieldShaper101" unit="cm"  x="283.96" y="-676.3" z="0" />
      <rotation name="rotFS101" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper102" unit="cm"  x="289.95" y="-676.3" z="0" />
+     <position name="posFieldShaper102" unit="cm"  x="289.96" y="-676.3" z="0" />
      <rotation name="rotFS102" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper103" unit="cm"  x="295.95" y="-676.3" z="0" />
+     <position name="posFieldShaper103" unit="cm"  x="295.96" y="-676.3" z="0" />
      <rotation name="rotFS103" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper104" unit="cm"  x="301.95" y="-676.3" z="0" />
+     <position name="posFieldShaper104" unit="cm"  x="301.96" y="-676.3" z="0" />
      <rotation name="rotFS104" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper105" unit="cm"  x="307.95" y="-676.3" z="0" />
+     <position name="posFieldShaper105" unit="cm"  x="307.96" y="-676.3" z="0" />
      <rotation name="rotFS105" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper106" unit="cm"  x="313.95" y="-676.3" z="0" />
+     <position name="posFieldShaper106" unit="cm"  x="313.96" y="-676.3" z="0" />
      <rotation name="rotFS106" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper107" unit="cm"  x="319.95" y="-676.3" z="0" />
+     <position name="posFieldShaper107" unit="cm"  x="319.96" y="-676.3" z="0" />
      <rotation name="rotFS107" unit="deg" x="0" y="0" z="90" />
   </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-0" unit="cm" x="-328.04" y="-506" z="-896.9054"/>
       </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-0" unit="cm" 
+         x="325.045" y="-506" z="-896.9054"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
       <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-1" unit="cm" x="-328.04" y="-170" z="-896.9054"/>
       </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-1" unit="cm" 
+         x="325.045" y="-170" z="-896.9054"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
       <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-2" unit="cm" x="-328.04" y="166" z="-896.9054"/>
       </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-2" unit="cm" 
+         x="325.045" y="166" z="-896.9054"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
       <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-3" unit="cm" x="-328.04" y="502" z="-896.9054"/>
       </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-3" unit="cm" 
+         x="325.045" y="502" z="-896.9054"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
       <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-4" unit="cm" x="-328.04" y="-506" z="-599.1036"/>
       </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-4" unit="cm" 
+         x="325.045" y="-506" z="-599.1036"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
       <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-5" unit="cm" x="-328.04" y="-170" z="-599.1036"/>
       </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-5" unit="cm" 
+         x="325.045" y="-170" z="-599.1036"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
       <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-6" unit="cm" x="-328.04" y="166" z="-599.1036"/>
       </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-6" unit="cm" 
+         x="325.045" y="166" z="-599.1036"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
       <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-7" unit="cm" x="-328.04" y="502" z="-599.1036"/>
       </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-7" unit="cm" 
+         x="325.045" y="502" z="-599.1036"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
       <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-8" unit="cm" x="-328.04" y="-506" z="-301.3018"/>
       </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-8" unit="cm" 
+         x="325.045" y="-506" z="-301.3018"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
       <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-9" unit="cm" x="-328.04" y="-170" z="-301.3018"/>
       </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-9" unit="cm" 
+         x="325.045" y="-170" z="-301.3018"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
       <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-10" unit="cm" x="-328.04" y="166" z="-301.3018"/>
       </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-10" unit="cm" 
+         x="325.045" y="166" z="-301.3018"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
       <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-11" unit="cm" x="-328.04" y="502" z="-301.3018"/>
       </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-11" unit="cm" 
+         x="325.045" y="502" z="-301.3018"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
       <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-12" unit="cm" x="-328.04" y="-506" z="-3.49999999999989"/>
       </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-12" unit="cm" 
+         x="325.045" y="-506" z="-3.49999999999989"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
       <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-13" unit="cm" x="-328.04" y="-170" z="-3.49999999999989"/>
       </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-13" unit="cm" 
+         x="325.045" y="-170" z="-3.49999999999989"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
       <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-14" unit="cm" x="-328.04" y="166" z="-3.49999999999989"/>
       </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-14" unit="cm" 
+         x="325.045" y="166" z="-3.49999999999989"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
       <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-15" unit="cm" x="-328.04" y="502" z="-3.49999999999989"/>
       </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-15" unit="cm" 
+         x="325.045" y="502" z="-3.49999999999989"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
       <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-16" unit="cm" x="-328.04" y="-506" z="294.3018"/>
       </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-16" unit="cm" 
+         x="325.045" y="-506" z="294.3018"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
       <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-17" unit="cm" x="-328.04" y="-170" z="294.3018"/>
       </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-17" unit="cm" 
+         x="325.045" y="-170" z="294.3018"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
       <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-18" unit="cm" x="-328.04" y="166" z="294.3018"/>
       </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-18" unit="cm" 
+         x="325.045" y="166" z="294.3018"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
       <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-19" unit="cm" x="-328.04" y="502" z="294.3018"/>
       </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-19" unit="cm" 
+         x="325.045" y="502" z="294.3018"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
       <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-20" unit="cm" x="-328.04" y="-506" z="592.1036"/>
       </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-20" unit="cm" 
+         x="325.045" y="-506" z="592.1036"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
       <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-21" unit="cm" x="-328.04" y="-170" z="592.1036"/>
       </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-21" unit="cm" 
+         x="325.045" y="-170" z="592.1036"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
       <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-22" unit="cm" x="-328.04" y="166" z="592.1036"/>
       </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-22" unit="cm" 
+         x="325.045" y="166" z="592.1036"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
       <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-23" unit="cm" x="-328.04" y="502" z="592.1036"/>
       </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-23" unit="cm" 
+         x="325.045" y="502" z="592.1036"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
       <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-24" unit="cm" x="-328.04" y="-506" z="889.9054"/>
       </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-24" unit="cm" 
+         x="325.045" y="-506" z="889.9054"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
       <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-25" unit="cm" x="-328.04" y="-170" z="889.9054"/>
       </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-25" unit="cm" 
+         x="325.045" y="-170" z="889.9054"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
       <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-26" unit="cm" x="-328.04" y="166" z="889.9054"/>
       </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-26" unit="cm" 
+         x="325.045" y="166" z="889.9054"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
       <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-27" unit="cm" x="-328.04" y="502" z="889.9054"/>
       </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-27" unit="cm" 
+         x="325.045" y="502" z="889.9054"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
      <physvol>
        <volumeref ref="volArapucaDouble_0-0-0"/>
        <position name="posArapucaDouble0-Frame-0-0" unit="cm" 
@@ -5942,7 +6104,7 @@
 
       <physvol>
         <volumeref ref="volDetEnclosure"/>
-	<position name="posDetEnclosure" unit="cm" x="50.0500000000001" y="-1.13686837721616e-13" z="1045.8063"/>
+	<position name="posDetEnclosure" unit="cm" x="50.04" y="-1.13686837721616e-13" z="1045.8063"/>
       </physvol>
 
     </volume>

--- a/dunecore/Geometry/gdml/dunevd10kt_3view_v3_refactored_1x8x6ref.gdml
+++ b/dunecore/Geometry/gdml/dunevd10kt_3view_v3_refactored_1x8x6ref.gdml
@@ -489,7 +489,7 @@
     
 
    <box name="CRM"
-      x="650.1" 
+      x="650.08" 
       y="168" 
       z="148.9009"
       lunit="cm"/>
@@ -505,11 +505,6 @@
       lunit="cm"/>
    <box name="CRMZPlane" 
       x="0.02"
-      y="168"
-      z="148.9009"
-      lunit="cm"/>
-   <box name="AnodePlate" 
-      x="0.02/2."
       y="168"
       z="148.9009"
       lunit="cm"/>
@@ -1853,27 +1848,27 @@
 
 
     <box name="Cryostat" lunit="cm" 
-      x="850.34" 
+      x="850.32" 
       y="1211.24" 
       z="1096.6454"/>
 
     <box name="ArgonInterior" lunit="cm" 
-      x="850.1"
+      x="850.08"
       y="1211"
       z="1096.4054"/>
 
     <box name="GaseousArgon" lunit="cm" 
-      x="100"
+      x="100 - 0.02"
       y="1211"
       z="1096.4054"/>
 
     <box name="ExternalAuxOut" lunit="cm" 
-      x="850.1 - 100"
+      x="850.08 - 100"
       y="1211 - 2*2.5 - 2*40"
       z="1096.4054"/>
 
     <box name="ExternalAuxIn" lunit="cm" 
-      x="850.1"
+      x="850.08"
       y="1022.17"
       z="1096.4054 + 1"/>
 
@@ -1980,8 +1975,14 @@
       <position name="posCathodeSub16" x="0" y="122.525" z="108.5" unit="cm"/>
     </subtraction>
 
+   <box name="AnodePlate" 
+      x="0.02/2."
+      y="336"
+      z="297.8018"
+      lunit="cm"/>
+
     <box name="FoamPadBlock" lunit="cm"
-      x="1010.34"
+      x="1010.32"
       y="1371.24"
       z="1256.6454" />
 
@@ -1992,7 +1993,7 @@
     </subtraction>
 
     <box name="SteelSupportBlock" lunit="cm"
-      x="1210.34"
+      x="1210.32"
       y="1571.24"
       z="1456.6454" />
 
@@ -2003,13 +2004,13 @@
     </subtraction>
 
     <box name="DetEnclosure" lunit="cm" 
-      x="1310.34"
+      x="1310.32"
       y="1771.24"
       z="1656.6454"/>
 
 
     <box name="World" lunit="cm" 
-      x="9310.34" 
+      x="9310.32" 
       y="9771.24" 
       z="9656.6454"/>
 </solids>
@@ -7396,11 +7397,6 @@
          <rotationref ref="rPlus90AboutX"/>
        </physvol>
   </volume>
-     
-   <volume name="volAnodePlate">
-     <materialref ref="vm2000"/>
-     <solidref ref="AnodePlate"/>
-  </volume>
    <volume name="volTPC">
      <materialref ref="LAr"/>
        <solidref ref="CRM"/>
@@ -7423,15 +7419,9 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volAnodePlate"/>
-       <position name="posAnodePlate" unit="cm" 
-         x="325.045" y="0" z="0"/>
-       <rotationref ref="rIdentity"/>
-     </physvol>    
-     <physvol>
        <volumeref ref="volTPCActive"/>
        <position name="posActive" unit="cm" 
-        x="-0.05" y="" z="0"/>
+        x="-0.04" y="" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
    </volume>
@@ -7444,6 +7434,10 @@
       <materialref ref="STEEL_STAINLESS_Fe7Cr2Ni" />
       <solidref ref="CathodeGrid" />
     </volume>    
+    <volume name="volAnodePlate">
+     <materialref ref="vm2000"/>
+     <solidref ref="AnodePlate"/>
+    </volume>
     <volume name="volGaseousArgon">
       <materialref ref="ArGas"/>
       <solidref ref="GaseousArgon"/>
@@ -7750,7 +7744,7 @@
       <solidref ref="Cryostat" />
       <physvol>
         <volumeref ref="volGaseousArgon"/>
-        <position name="posGaseousArgon" unit="cm" x="375.05" y="0" z="0"/>
+        <position name="posGaseousArgon" unit="cm" x="375.04" y="0" z="0"/>
       </physvol>
       <physvol>
         <volumeref ref="volSteelShell"/>
@@ -7942,580 +7936,634 @@
       </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper0" unit="cm"  x="-322.05" y="-507.8" z="0" />
+     <position name="posFieldShaper0" unit="cm"  x="-322.04" y="-507.8" z="0" />
      <rotation name="rotFS0" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper1" unit="cm"  x="-316.05" y="-507.8" z="0" />
+     <position name="posFieldShaper1" unit="cm"  x="-316.04" y="-507.8" z="0" />
      <rotation name="rotFS1" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper2" unit="cm"  x="-310.05" y="-507.8" z="0" />
+     <position name="posFieldShaper2" unit="cm"  x="-310.04" y="-507.8" z="0" />
      <rotation name="rotFS2" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper3" unit="cm"  x="-304.05" y="-507.8" z="0" />
+     <position name="posFieldShaper3" unit="cm"  x="-304.04" y="-507.8" z="0" />
      <rotation name="rotFS3" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper4" unit="cm"  x="-298.05" y="-507.8" z="0" />
+     <position name="posFieldShaper4" unit="cm"  x="-298.04" y="-507.8" z="0" />
      <rotation name="rotFS4" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper5" unit="cm"  x="-292.05" y="-507.8" z="0" />
+     <position name="posFieldShaper5" unit="cm"  x="-292.04" y="-507.8" z="0" />
      <rotation name="rotFS5" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper6" unit="cm"  x="-286.05" y="-507.8" z="0" />
+     <position name="posFieldShaper6" unit="cm"  x="-286.04" y="-507.8" z="0" />
      <rotation name="rotFS6" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper7" unit="cm"  x="-280.05" y="-507.8" z="0" />
+     <position name="posFieldShaper7" unit="cm"  x="-280.04" y="-507.8" z="0" />
      <rotation name="rotFS7" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper8" unit="cm"  x="-274.05" y="-507.8" z="0" />
+     <position name="posFieldShaper8" unit="cm"  x="-274.04" y="-507.8" z="0" />
      <rotation name="rotFS8" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper9" unit="cm"  x="-268.05" y="-507.8" z="0" />
+     <position name="posFieldShaper9" unit="cm"  x="-268.04" y="-507.8" z="0" />
      <rotation name="rotFS9" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper10" unit="cm"  x="-262.05" y="-507.8" z="0" />
+     <position name="posFieldShaper10" unit="cm"  x="-262.04" y="-507.8" z="0" />
      <rotation name="rotFS10" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper11" unit="cm"  x="-256.05" y="-507.8" z="0" />
+     <position name="posFieldShaper11" unit="cm"  x="-256.04" y="-507.8" z="0" />
      <rotation name="rotFS11" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper12" unit="cm"  x="-250.05" y="-507.8" z="0" />
+     <position name="posFieldShaper12" unit="cm"  x="-250.04" y="-507.8" z="0" />
      <rotation name="rotFS12" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper13" unit="cm"  x="-244.05" y="-507.8" z="0" />
+     <position name="posFieldShaper13" unit="cm"  x="-244.04" y="-507.8" z="0" />
      <rotation name="rotFS13" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper14" unit="cm"  x="-238.05" y="-507.8" z="0" />
+     <position name="posFieldShaper14" unit="cm"  x="-238.04" y="-507.8" z="0" />
      <rotation name="rotFS14" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper15" unit="cm"  x="-232.05" y="-507.8" z="0" />
+     <position name="posFieldShaper15" unit="cm"  x="-232.04" y="-507.8" z="0" />
      <rotation name="rotFS15" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper16" unit="cm"  x="-226.05" y="-507.8" z="0" />
+     <position name="posFieldShaper16" unit="cm"  x="-226.04" y="-507.8" z="0" />
      <rotation name="rotFS16" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper17" unit="cm"  x="-220.05" y="-507.8" z="0" />
+     <position name="posFieldShaper17" unit="cm"  x="-220.04" y="-507.8" z="0" />
      <rotation name="rotFS17" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper18" unit="cm"  x="-214.05" y="-507.8" z="0" />
+     <position name="posFieldShaper18" unit="cm"  x="-214.04" y="-507.8" z="0" />
      <rotation name="rotFS18" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper19" unit="cm"  x="-208.05" y="-507.8" z="0" />
+     <position name="posFieldShaper19" unit="cm"  x="-208.04" y="-507.8" z="0" />
      <rotation name="rotFS19" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper20" unit="cm"  x="-202.05" y="-507.8" z="0" />
+     <position name="posFieldShaper20" unit="cm"  x="-202.04" y="-507.8" z="0" />
      <rotation name="rotFS20" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper21" unit="cm"  x="-196.05" y="-507.8" z="0" />
+     <position name="posFieldShaper21" unit="cm"  x="-196.04" y="-507.8" z="0" />
      <rotation name="rotFS21" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper22" unit="cm"  x="-190.05" y="-507.8" z="0" />
+     <position name="posFieldShaper22" unit="cm"  x="-190.04" y="-507.8" z="0" />
      <rotation name="rotFS22" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper23" unit="cm"  x="-184.05" y="-507.8" z="0" />
+     <position name="posFieldShaper23" unit="cm"  x="-184.04" y="-507.8" z="0" />
      <rotation name="rotFS23" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper24" unit="cm"  x="-178.05" y="-507.8" z="0" />
+     <position name="posFieldShaper24" unit="cm"  x="-178.04" y="-507.8" z="0" />
      <rotation name="rotFS24" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper25" unit="cm"  x="-172.05" y="-507.8" z="0" />
+     <position name="posFieldShaper25" unit="cm"  x="-172.04" y="-507.8" z="0" />
      <rotation name="rotFS25" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper26" unit="cm"  x="-166.05" y="-507.8" z="0" />
+     <position name="posFieldShaper26" unit="cm"  x="-166.04" y="-507.8" z="0" />
      <rotation name="rotFS26" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper27" unit="cm"  x="-160.05" y="-507.8" z="0" />
+     <position name="posFieldShaper27" unit="cm"  x="-160.04" y="-507.8" z="0" />
      <rotation name="rotFS27" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper28" unit="cm"  x="-154.05" y="-507.8" z="0" />
+     <position name="posFieldShaper28" unit="cm"  x="-154.04" y="-507.8" z="0" />
      <rotation name="rotFS28" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper29" unit="cm"  x="-148.05" y="-507.8" z="0" />
+     <position name="posFieldShaper29" unit="cm"  x="-148.04" y="-507.8" z="0" />
      <rotation name="rotFS29" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper30" unit="cm"  x="-142.05" y="-507.8" z="0" />
+     <position name="posFieldShaper30" unit="cm"  x="-142.04" y="-507.8" z="0" />
      <rotation name="rotFS30" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper31" unit="cm"  x="-136.05" y="-507.8" z="0" />
+     <position name="posFieldShaper31" unit="cm"  x="-136.04" y="-507.8" z="0" />
      <rotation name="rotFS31" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper32" unit="cm"  x="-130.05" y="-507.8" z="0" />
+     <position name="posFieldShaper32" unit="cm"  x="-130.04" y="-507.8" z="0" />
      <rotation name="rotFS32" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper33" unit="cm"  x="-124.05" y="-507.8" z="0" />
+     <position name="posFieldShaper33" unit="cm"  x="-124.04" y="-507.8" z="0" />
      <rotation name="rotFS33" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper34" unit="cm"  x="-118.05" y="-507.8" z="0" />
+     <position name="posFieldShaper34" unit="cm"  x="-118.04" y="-507.8" z="0" />
      <rotation name="rotFS34" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper35" unit="cm"  x="-112.05" y="-507.8" z="0" />
+     <position name="posFieldShaper35" unit="cm"  x="-112.04" y="-507.8" z="0" />
      <rotation name="rotFS35" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper36" unit="cm"  x="-106.05" y="-507.8" z="0" />
+     <position name="posFieldShaper36" unit="cm"  x="-106.04" y="-507.8" z="0" />
      <rotation name="rotFS36" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper37" unit="cm"  x="-100.05" y="-507.8" z="0" />
+     <position name="posFieldShaper37" unit="cm"  x="-100.04" y="-507.8" z="0" />
      <rotation name="rotFS37" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper38" unit="cm"  x="-94.0500000000001" y="-507.8" z="0" />
+     <position name="posFieldShaper38" unit="cm"  x="-94.04" y="-507.8" z="0" />
      <rotation name="rotFS38" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper39" unit="cm"  x="-88.0500000000001" y="-507.8" z="0" />
+     <position name="posFieldShaper39" unit="cm"  x="-88.04" y="-507.8" z="0" />
      <rotation name="rotFS39" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper40" unit="cm"  x="-82.0500000000001" y="-507.8" z="0" />
+     <position name="posFieldShaper40" unit="cm"  x="-82.04" y="-507.8" z="0" />
      <rotation name="rotFS40" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper41" unit="cm"  x="-76.0500000000001" y="-507.8" z="0" />
+     <position name="posFieldShaper41" unit="cm"  x="-76.04" y="-507.8" z="0" />
      <rotation name="rotFS41" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper42" unit="cm"  x="-70.0500000000001" y="-507.8" z="0" />
+     <position name="posFieldShaper42" unit="cm"  x="-70.04" y="-507.8" z="0" />
      <rotation name="rotFS42" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper43" unit="cm"  x="-64.0500000000001" y="-507.8" z="0" />
+     <position name="posFieldShaper43" unit="cm"  x="-64.04" y="-507.8" z="0" />
      <rotation name="rotFS43" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper44" unit="cm"  x="-58.0500000000001" y="-507.8" z="0" />
+     <position name="posFieldShaper44" unit="cm"  x="-58.04" y="-507.8" z="0" />
      <rotation name="rotFS44" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper45" unit="cm"  x="-52.0500000000001" y="-507.8" z="0" />
+     <position name="posFieldShaper45" unit="cm"  x="-52.04" y="-507.8" z="0" />
      <rotation name="rotFS45" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper46" unit="cm"  x="-46.0500000000001" y="-507.8" z="0" />
+     <position name="posFieldShaper46" unit="cm"  x="-46.04" y="-507.8" z="0" />
      <rotation name="rotFS46" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper47" unit="cm"  x="-40.0500000000001" y="-507.8" z="0" />
+     <position name="posFieldShaper47" unit="cm"  x="-40.04" y="-507.8" z="0" />
      <rotation name="rotFS47" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper48" unit="cm"  x="-34.0500000000001" y="-507.8" z="0" />
+     <position name="posFieldShaper48" unit="cm"  x="-34.04" y="-507.8" z="0" />
      <rotation name="rotFS48" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper49" unit="cm"  x="-28.0500000000001" y="-507.8" z="0" />
+     <position name="posFieldShaper49" unit="cm"  x="-28.04" y="-507.8" z="0" />
      <rotation name="rotFS49" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper50" unit="cm"  x="-22.0500000000001" y="-507.8" z="0" />
+     <position name="posFieldShaper50" unit="cm"  x="-22.04" y="-507.8" z="0" />
      <rotation name="rotFS50" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper51" unit="cm"  x="-16.0500000000001" y="-507.8" z="0" />
+     <position name="posFieldShaper51" unit="cm"  x="-16.04" y="-507.8" z="0" />
      <rotation name="rotFS51" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper52" unit="cm"  x="-10.0500000000001" y="-507.8" z="0" />
+     <position name="posFieldShaper52" unit="cm"  x="-10.04" y="-507.8" z="0" />
      <rotation name="rotFS52" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper53" unit="cm"  x="-4.05000000000005" y="-507.8" z="0" />
+     <position name="posFieldShaper53" unit="cm"  x="-4.04000000000001" y="-507.8" z="0" />
      <rotation name="rotFS53" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper54" unit="cm"  x="1.94999999999995" y="-507.8" z="0" />
+     <position name="posFieldShaper54" unit="cm"  x="1.95999999999999" y="-507.8" z="0" />
      <rotation name="rotFS54" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper55" unit="cm"  x="7.94999999999995" y="-507.8" z="0" />
+     <position name="posFieldShaper55" unit="cm"  x="7.95999999999999" y="-507.8" z="0" />
      <rotation name="rotFS55" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper56" unit="cm"  x="13.9499999999999" y="-507.8" z="0" />
+     <position name="posFieldShaper56" unit="cm"  x="13.96" y="-507.8" z="0" />
      <rotation name="rotFS56" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper57" unit="cm"  x="19.9499999999999" y="-507.8" z="0" />
+     <position name="posFieldShaper57" unit="cm"  x="19.96" y="-507.8" z="0" />
      <rotation name="rotFS57" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper58" unit="cm"  x="25.9499999999999" y="-507.8" z="0" />
+     <position name="posFieldShaper58" unit="cm"  x="25.96" y="-507.8" z="0" />
      <rotation name="rotFS58" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper59" unit="cm"  x="31.9499999999999" y="-507.8" z="0" />
+     <position name="posFieldShaper59" unit="cm"  x="31.96" y="-507.8" z="0" />
      <rotation name="rotFS59" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper60" unit="cm"  x="37.9499999999999" y="-507.8" z="0" />
+     <position name="posFieldShaper60" unit="cm"  x="37.96" y="-507.8" z="0" />
      <rotation name="rotFS60" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper61" unit="cm"  x="43.9499999999999" y="-507.8" z="0" />
+     <position name="posFieldShaper61" unit="cm"  x="43.96" y="-507.8" z="0" />
      <rotation name="rotFS61" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper62" unit="cm"  x="49.9499999999999" y="-507.8" z="0" />
+     <position name="posFieldShaper62" unit="cm"  x="49.96" y="-507.8" z="0" />
      <rotation name="rotFS62" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper63" unit="cm"  x="55.9499999999999" y="-507.8" z="0" />
+     <position name="posFieldShaper63" unit="cm"  x="55.96" y="-507.8" z="0" />
      <rotation name="rotFS63" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper64" unit="cm"  x="61.9499999999999" y="-507.8" z="0" />
+     <position name="posFieldShaper64" unit="cm"  x="61.96" y="-507.8" z="0" />
      <rotation name="rotFS64" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper65" unit="cm"  x="67.9499999999999" y="-507.8" z="0" />
+     <position name="posFieldShaper65" unit="cm"  x="67.96" y="-507.8" z="0" />
      <rotation name="rotFS65" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper66" unit="cm"  x="73.9499999999999" y="-507.8" z="0" />
+     <position name="posFieldShaper66" unit="cm"  x="73.96" y="-507.8" z="0" />
      <rotation name="rotFS66" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper67" unit="cm"  x="79.9499999999999" y="-507.8" z="0" />
+     <position name="posFieldShaper67" unit="cm"  x="79.96" y="-507.8" z="0" />
      <rotation name="rotFS67" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper68" unit="cm"  x="85.9499999999999" y="-507.8" z="0" />
+     <position name="posFieldShaper68" unit="cm"  x="85.96" y="-507.8" z="0" />
      <rotation name="rotFS68" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper69" unit="cm"  x="91.9499999999999" y="-507.8" z="0" />
+     <position name="posFieldShaper69" unit="cm"  x="91.96" y="-507.8" z="0" />
      <rotation name="rotFS69" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper70" unit="cm"  x="97.9499999999999" y="-507.8" z="0" />
+     <position name="posFieldShaper70" unit="cm"  x="97.96" y="-507.8" z="0" />
      <rotation name="rotFS70" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper71" unit="cm"  x="103.95" y="-507.8" z="0" />
+     <position name="posFieldShaper71" unit="cm"  x="103.96" y="-507.8" z="0" />
      <rotation name="rotFS71" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper72" unit="cm"  x="109.95" y="-507.8" z="0" />
+     <position name="posFieldShaper72" unit="cm"  x="109.96" y="-507.8" z="0" />
      <rotation name="rotFS72" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper73" unit="cm"  x="115.95" y="-507.8" z="0" />
+     <position name="posFieldShaper73" unit="cm"  x="115.96" y="-507.8" z="0" />
      <rotation name="rotFS73" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper74" unit="cm"  x="121.95" y="-507.8" z="0" />
+     <position name="posFieldShaper74" unit="cm"  x="121.96" y="-507.8" z="0" />
      <rotation name="rotFS74" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper75" unit="cm"  x="127.95" y="-507.8" z="0" />
+     <position name="posFieldShaper75" unit="cm"  x="127.96" y="-507.8" z="0" />
      <rotation name="rotFS75" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper76" unit="cm"  x="133.95" y="-507.8" z="0" />
+     <position name="posFieldShaper76" unit="cm"  x="133.96" y="-507.8" z="0" />
      <rotation name="rotFS76" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper77" unit="cm"  x="139.95" y="-507.8" z="0" />
+     <position name="posFieldShaper77" unit="cm"  x="139.96" y="-507.8" z="0" />
      <rotation name="rotFS77" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper78" unit="cm"  x="145.95" y="-507.8" z="0" />
+     <position name="posFieldShaper78" unit="cm"  x="145.96" y="-507.8" z="0" />
      <rotation name="rotFS78" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper79" unit="cm"  x="151.95" y="-507.8" z="0" />
+     <position name="posFieldShaper79" unit="cm"  x="151.96" y="-507.8" z="0" />
      <rotation name="rotFS79" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper80" unit="cm"  x="157.95" y="-507.8" z="0" />
+     <position name="posFieldShaper80" unit="cm"  x="157.96" y="-507.8" z="0" />
      <rotation name="rotFS80" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper81" unit="cm"  x="163.95" y="-507.8" z="0" />
+     <position name="posFieldShaper81" unit="cm"  x="163.96" y="-507.8" z="0" />
      <rotation name="rotFS81" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper82" unit="cm"  x="169.95" y="-507.8" z="0" />
+     <position name="posFieldShaper82" unit="cm"  x="169.96" y="-507.8" z="0" />
      <rotation name="rotFS82" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper83" unit="cm"  x="175.95" y="-507.8" z="0" />
+     <position name="posFieldShaper83" unit="cm"  x="175.96" y="-507.8" z="0" />
      <rotation name="rotFS83" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper84" unit="cm"  x="181.95" y="-507.8" z="0" />
+     <position name="posFieldShaper84" unit="cm"  x="181.96" y="-507.8" z="0" />
      <rotation name="rotFS84" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper85" unit="cm"  x="187.95" y="-507.8" z="0" />
+     <position name="posFieldShaper85" unit="cm"  x="187.96" y="-507.8" z="0" />
      <rotation name="rotFS85" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper86" unit="cm"  x="193.95" y="-507.8" z="0" />
+     <position name="posFieldShaper86" unit="cm"  x="193.96" y="-507.8" z="0" />
      <rotation name="rotFS86" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper87" unit="cm"  x="199.95" y="-507.8" z="0" />
+     <position name="posFieldShaper87" unit="cm"  x="199.96" y="-507.8" z="0" />
      <rotation name="rotFS87" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper88" unit="cm"  x="205.95" y="-507.8" z="0" />
+     <position name="posFieldShaper88" unit="cm"  x="205.96" y="-507.8" z="0" />
      <rotation name="rotFS88" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper89" unit="cm"  x="211.95" y="-507.8" z="0" />
+     <position name="posFieldShaper89" unit="cm"  x="211.96" y="-507.8" z="0" />
      <rotation name="rotFS89" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper90" unit="cm"  x="217.95" y="-507.8" z="0" />
+     <position name="posFieldShaper90" unit="cm"  x="217.96" y="-507.8" z="0" />
      <rotation name="rotFS90" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper91" unit="cm"  x="223.95" y="-507.8" z="0" />
+     <position name="posFieldShaper91" unit="cm"  x="223.96" y="-507.8" z="0" />
      <rotation name="rotFS91" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper92" unit="cm"  x="229.95" y="-507.8" z="0" />
+     <position name="posFieldShaper92" unit="cm"  x="229.96" y="-507.8" z="0" />
      <rotation name="rotFS92" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper93" unit="cm"  x="235.95" y="-507.8" z="0" />
+     <position name="posFieldShaper93" unit="cm"  x="235.96" y="-507.8" z="0" />
      <rotation name="rotFS93" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper94" unit="cm"  x="241.95" y="-507.8" z="0" />
+     <position name="posFieldShaper94" unit="cm"  x="241.96" y="-507.8" z="0" />
      <rotation name="rotFS94" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper95" unit="cm"  x="247.95" y="-507.8" z="0" />
+     <position name="posFieldShaper95" unit="cm"  x="247.96" y="-507.8" z="0" />
      <rotation name="rotFS95" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper96" unit="cm"  x="253.95" y="-507.8" z="0" />
+     <position name="posFieldShaper96" unit="cm"  x="253.96" y="-507.8" z="0" />
      <rotation name="rotFS96" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper97" unit="cm"  x="259.95" y="-507.8" z="0" />
+     <position name="posFieldShaper97" unit="cm"  x="259.96" y="-507.8" z="0" />
      <rotation name="rotFS97" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper98" unit="cm"  x="265.95" y="-507.8" z="0" />
+     <position name="posFieldShaper98" unit="cm"  x="265.96" y="-507.8" z="0" />
      <rotation name="rotFS98" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper99" unit="cm"  x="271.95" y="-507.8" z="0" />
+     <position name="posFieldShaper99" unit="cm"  x="271.96" y="-507.8" z="0" />
      <rotation name="rotFS99" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper100" unit="cm"  x="277.95" y="-507.8" z="0" />
+     <position name="posFieldShaper100" unit="cm"  x="277.96" y="-507.8" z="0" />
      <rotation name="rotFS100" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper101" unit="cm"  x="283.95" y="-507.8" z="0" />
+     <position name="posFieldShaper101" unit="cm"  x="283.96" y="-507.8" z="0" />
      <rotation name="rotFS101" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper102" unit="cm"  x="289.95" y="-507.8" z="0" />
+     <position name="posFieldShaper102" unit="cm"  x="289.96" y="-507.8" z="0" />
      <rotation name="rotFS102" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper103" unit="cm"  x="295.95" y="-507.8" z="0" />
+     <position name="posFieldShaper103" unit="cm"  x="295.96" y="-507.8" z="0" />
      <rotation name="rotFS103" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper104" unit="cm"  x="301.95" y="-507.8" z="0" />
+     <position name="posFieldShaper104" unit="cm"  x="301.96" y="-507.8" z="0" />
      <rotation name="rotFS104" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper105" unit="cm"  x="307.95" y="-507.8" z="0" />
+     <position name="posFieldShaper105" unit="cm"  x="307.96" y="-507.8" z="0" />
      <rotation name="rotFS105" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper106" unit="cm"  x="313.95" y="-507.8" z="0" />
+     <position name="posFieldShaper106" unit="cm"  x="313.96" y="-507.8" z="0" />
      <rotation name="rotFS106" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper107" unit="cm"  x="319.95" y="-507.8" z="0" />
+     <position name="posFieldShaper107" unit="cm"  x="319.96" y="-507.8" z="0" />
      <rotation name="rotFS107" unit="deg" x="0" y="0" z="90" />
   </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-0" unit="cm" x="-328.04" y="-337.5" z="-299.3018"/>
       </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-0" unit="cm" 
+         x="325.045" y="-337.5" z="-299.3018"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
       <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-1" unit="cm" x="-328.04" y="-1.5" z="-299.3018"/>
       </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-1" unit="cm" 
+         x="325.045" y="-1.5" z="-299.3018"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
       <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-2" unit="cm" x="-328.04" y="334.5" z="-299.3018"/>
       </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-2" unit="cm" 
+         x="325.045" y="334.5" z="-299.3018"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
       <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-3" unit="cm" x="-328.04" y="-337.5" z="-1.50000000000006"/>
       </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-3" unit="cm" 
+         x="325.045" y="-337.5" z="-1.50000000000006"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
       <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-4" unit="cm" x="-328.04" y="-1.5" z="-1.50000000000006"/>
       </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-4" unit="cm" 
+         x="325.045" y="-1.5" z="-1.50000000000006"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
       <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-5" unit="cm" x="-328.04" y="334.5" z="-1.50000000000006"/>
       </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-5" unit="cm" 
+         x="325.045" y="334.5" z="-1.50000000000006"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
       <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-6" unit="cm" x="-328.04" y="-337.5" z="296.3018"/>
       </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-6" unit="cm" 
+         x="325.045" y="-337.5" z="296.3018"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
       <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-7" unit="cm" x="-328.04" y="-1.5" z="296.3018"/>
       </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-7" unit="cm" 
+         x="325.045" y="-1.5" z="296.3018"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
       <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-8" unit="cm" x="-328.04" y="334.5" z="296.3018"/>
       </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-8" unit="cm" 
+         x="325.045" y="334.5" z="296.3018"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
      <physvol>
        <volumeref ref="volArapucaDouble_0-0-0"/>
        <position name="posArapucaDouble0-Frame-0-0" unit="cm" 
@@ -9092,7 +9140,7 @@
 
       <physvol>
         <volumeref ref="volDetEnclosure"/>
-	<position name="posDetEnclosure" unit="cm" x="50.0500000000001" y="0" z="448.2027"/>
+	<position name="posDetEnclosure" unit="cm" x="50.04" y="0" z="448.2027"/>
       </physvol>
 
     </volume>

--- a/dunecore/Geometry/gdml/dunevd10kt_3view_v3_refactored_1x8x6ref_nowires.gdml
+++ b/dunecore/Geometry/gdml/dunevd10kt_3view_v3_refactored_1x8x6ref_nowires.gdml
@@ -489,7 +489,7 @@
     
 
    <box name="CRM"
-      x="650.1" 
+      x="650.08" 
       y="168" 
       z="148.9009"
       lunit="cm"/>
@@ -505,11 +505,6 @@
       lunit="cm"/>
    <box name="CRMZPlane" 
       x="0.02"
-      y="168"
-      z="148.9009"
-      lunit="cm"/>
-   <box name="AnodePlate" 
-      x="0.02/2."
       y="168"
       z="148.9009"
       lunit="cm"/>
@@ -563,27 +558,27 @@
 
 
     <box name="Cryostat" lunit="cm" 
-      x="850.34" 
+      x="850.32" 
       y="1211.24" 
       z="1096.6454"/>
 
     <box name="ArgonInterior" lunit="cm" 
-      x="850.1"
+      x="850.08"
       y="1211"
       z="1096.4054"/>
 
     <box name="GaseousArgon" lunit="cm" 
-      x="100"
+      x="100 - 0.02"
       y="1211"
       z="1096.4054"/>
 
     <box name="ExternalAuxOut" lunit="cm" 
-      x="850.1 - 100"
+      x="850.08 - 100"
       y="1211 - 2*2.5 - 2*40"
       z="1096.4054"/>
 
     <box name="ExternalAuxIn" lunit="cm" 
-      x="850.1"
+      x="850.08"
       y="1022.17"
       z="1096.4054 + 1"/>
 
@@ -690,8 +685,14 @@
       <position name="posCathodeSub16" x="0" y="122.525" z="108.5" unit="cm"/>
     </subtraction>
 
+   <box name="AnodePlate" 
+      x="0.02/2."
+      y="336"
+      z="297.8018"
+      lunit="cm"/>
+
     <box name="FoamPadBlock" lunit="cm"
-      x="1010.34"
+      x="1010.32"
       y="1371.24"
       z="1256.6454" />
 
@@ -702,7 +703,7 @@
     </subtraction>
 
     <box name="SteelSupportBlock" lunit="cm"
-      x="1210.34"
+      x="1210.32"
       y="1571.24"
       z="1456.6454" />
 
@@ -713,13 +714,13 @@
     </subtraction>
 
     <box name="DetEnclosure" lunit="cm" 
-      x="1310.34"
+      x="1310.32"
       y="1771.24"
       z="1656.6454"/>
 
 
     <box name="World" lunit="cm" 
-      x="9310.34" 
+      x="9310.32" 
       y="9771.24" 
       z="9656.6454"/>
 </solids>
@@ -754,11 +755,6 @@
     <materialref ref="LAr"/>
     <solidref ref="CRMZPlane"/>
   </volume>
-     
-   <volume name="volAnodePlate">
-     <materialref ref="vm2000"/>
-     <solidref ref="AnodePlate"/>
-  </volume>
    <volume name="volTPC">
      <materialref ref="LAr"/>
        <solidref ref="CRM"/>
@@ -781,15 +777,9 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volAnodePlate"/>
-       <position name="posAnodePlate" unit="cm" 
-         x="325.045" y="0" z="0"/>
-       <rotationref ref="rIdentity"/>
-     </physvol>    
-     <physvol>
        <volumeref ref="volTPCActive"/>
        <position name="posActive" unit="cm" 
-        x="-0.05" y="" z="0"/>
+        x="-0.04" y="" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
    </volume>
@@ -802,6 +792,10 @@
       <materialref ref="STEEL_STAINLESS_Fe7Cr2Ni" />
       <solidref ref="CathodeGrid" />
     </volume>    
+    <volume name="volAnodePlate">
+     <materialref ref="vm2000"/>
+     <solidref ref="AnodePlate"/>
+    </volume>
     <volume name="volGaseousArgon">
       <materialref ref="ArGas"/>
       <solidref ref="GaseousArgon"/>
@@ -1108,7 +1102,7 @@
       <solidref ref="Cryostat" />
       <physvol>
         <volumeref ref="volGaseousArgon"/>
-        <position name="posGaseousArgon" unit="cm" x="375.05" y="0" z="0"/>
+        <position name="posGaseousArgon" unit="cm" x="375.04" y="0" z="0"/>
       </physvol>
       <physvol>
         <volumeref ref="volSteelShell"/>
@@ -1300,580 +1294,634 @@
       </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper0" unit="cm"  x="-322.05" y="-507.8" z="0" />
+     <position name="posFieldShaper0" unit="cm"  x="-322.04" y="-507.8" z="0" />
      <rotation name="rotFS0" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper1" unit="cm"  x="-316.05" y="-507.8" z="0" />
+     <position name="posFieldShaper1" unit="cm"  x="-316.04" y="-507.8" z="0" />
      <rotation name="rotFS1" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper2" unit="cm"  x="-310.05" y="-507.8" z="0" />
+     <position name="posFieldShaper2" unit="cm"  x="-310.04" y="-507.8" z="0" />
      <rotation name="rotFS2" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper3" unit="cm"  x="-304.05" y="-507.8" z="0" />
+     <position name="posFieldShaper3" unit="cm"  x="-304.04" y="-507.8" z="0" />
      <rotation name="rotFS3" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper4" unit="cm"  x="-298.05" y="-507.8" z="0" />
+     <position name="posFieldShaper4" unit="cm"  x="-298.04" y="-507.8" z="0" />
      <rotation name="rotFS4" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper5" unit="cm"  x="-292.05" y="-507.8" z="0" />
+     <position name="posFieldShaper5" unit="cm"  x="-292.04" y="-507.8" z="0" />
      <rotation name="rotFS5" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper6" unit="cm"  x="-286.05" y="-507.8" z="0" />
+     <position name="posFieldShaper6" unit="cm"  x="-286.04" y="-507.8" z="0" />
      <rotation name="rotFS6" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper7" unit="cm"  x="-280.05" y="-507.8" z="0" />
+     <position name="posFieldShaper7" unit="cm"  x="-280.04" y="-507.8" z="0" />
      <rotation name="rotFS7" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper8" unit="cm"  x="-274.05" y="-507.8" z="0" />
+     <position name="posFieldShaper8" unit="cm"  x="-274.04" y="-507.8" z="0" />
      <rotation name="rotFS8" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper9" unit="cm"  x="-268.05" y="-507.8" z="0" />
+     <position name="posFieldShaper9" unit="cm"  x="-268.04" y="-507.8" z="0" />
      <rotation name="rotFS9" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper10" unit="cm"  x="-262.05" y="-507.8" z="0" />
+     <position name="posFieldShaper10" unit="cm"  x="-262.04" y="-507.8" z="0" />
      <rotation name="rotFS10" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper11" unit="cm"  x="-256.05" y="-507.8" z="0" />
+     <position name="posFieldShaper11" unit="cm"  x="-256.04" y="-507.8" z="0" />
      <rotation name="rotFS11" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper12" unit="cm"  x="-250.05" y="-507.8" z="0" />
+     <position name="posFieldShaper12" unit="cm"  x="-250.04" y="-507.8" z="0" />
      <rotation name="rotFS12" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper13" unit="cm"  x="-244.05" y="-507.8" z="0" />
+     <position name="posFieldShaper13" unit="cm"  x="-244.04" y="-507.8" z="0" />
      <rotation name="rotFS13" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper14" unit="cm"  x="-238.05" y="-507.8" z="0" />
+     <position name="posFieldShaper14" unit="cm"  x="-238.04" y="-507.8" z="0" />
      <rotation name="rotFS14" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper15" unit="cm"  x="-232.05" y="-507.8" z="0" />
+     <position name="posFieldShaper15" unit="cm"  x="-232.04" y="-507.8" z="0" />
      <rotation name="rotFS15" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper16" unit="cm"  x="-226.05" y="-507.8" z="0" />
+     <position name="posFieldShaper16" unit="cm"  x="-226.04" y="-507.8" z="0" />
      <rotation name="rotFS16" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper17" unit="cm"  x="-220.05" y="-507.8" z="0" />
+     <position name="posFieldShaper17" unit="cm"  x="-220.04" y="-507.8" z="0" />
      <rotation name="rotFS17" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper18" unit="cm"  x="-214.05" y="-507.8" z="0" />
+     <position name="posFieldShaper18" unit="cm"  x="-214.04" y="-507.8" z="0" />
      <rotation name="rotFS18" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper19" unit="cm"  x="-208.05" y="-507.8" z="0" />
+     <position name="posFieldShaper19" unit="cm"  x="-208.04" y="-507.8" z="0" />
      <rotation name="rotFS19" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper20" unit="cm"  x="-202.05" y="-507.8" z="0" />
+     <position name="posFieldShaper20" unit="cm"  x="-202.04" y="-507.8" z="0" />
      <rotation name="rotFS20" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper21" unit="cm"  x="-196.05" y="-507.8" z="0" />
+     <position name="posFieldShaper21" unit="cm"  x="-196.04" y="-507.8" z="0" />
      <rotation name="rotFS21" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper22" unit="cm"  x="-190.05" y="-507.8" z="0" />
+     <position name="posFieldShaper22" unit="cm"  x="-190.04" y="-507.8" z="0" />
      <rotation name="rotFS22" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper23" unit="cm"  x="-184.05" y="-507.8" z="0" />
+     <position name="posFieldShaper23" unit="cm"  x="-184.04" y="-507.8" z="0" />
      <rotation name="rotFS23" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper24" unit="cm"  x="-178.05" y="-507.8" z="0" />
+     <position name="posFieldShaper24" unit="cm"  x="-178.04" y="-507.8" z="0" />
      <rotation name="rotFS24" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper25" unit="cm"  x="-172.05" y="-507.8" z="0" />
+     <position name="posFieldShaper25" unit="cm"  x="-172.04" y="-507.8" z="0" />
      <rotation name="rotFS25" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper26" unit="cm"  x="-166.05" y="-507.8" z="0" />
+     <position name="posFieldShaper26" unit="cm"  x="-166.04" y="-507.8" z="0" />
      <rotation name="rotFS26" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper27" unit="cm"  x="-160.05" y="-507.8" z="0" />
+     <position name="posFieldShaper27" unit="cm"  x="-160.04" y="-507.8" z="0" />
      <rotation name="rotFS27" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper28" unit="cm"  x="-154.05" y="-507.8" z="0" />
+     <position name="posFieldShaper28" unit="cm"  x="-154.04" y="-507.8" z="0" />
      <rotation name="rotFS28" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper29" unit="cm"  x="-148.05" y="-507.8" z="0" />
+     <position name="posFieldShaper29" unit="cm"  x="-148.04" y="-507.8" z="0" />
      <rotation name="rotFS29" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper30" unit="cm"  x="-142.05" y="-507.8" z="0" />
+     <position name="posFieldShaper30" unit="cm"  x="-142.04" y="-507.8" z="0" />
      <rotation name="rotFS30" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper31" unit="cm"  x="-136.05" y="-507.8" z="0" />
+     <position name="posFieldShaper31" unit="cm"  x="-136.04" y="-507.8" z="0" />
      <rotation name="rotFS31" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper32" unit="cm"  x="-130.05" y="-507.8" z="0" />
+     <position name="posFieldShaper32" unit="cm"  x="-130.04" y="-507.8" z="0" />
      <rotation name="rotFS32" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper33" unit="cm"  x="-124.05" y="-507.8" z="0" />
+     <position name="posFieldShaper33" unit="cm"  x="-124.04" y="-507.8" z="0" />
      <rotation name="rotFS33" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper34" unit="cm"  x="-118.05" y="-507.8" z="0" />
+     <position name="posFieldShaper34" unit="cm"  x="-118.04" y="-507.8" z="0" />
      <rotation name="rotFS34" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper35" unit="cm"  x="-112.05" y="-507.8" z="0" />
+     <position name="posFieldShaper35" unit="cm"  x="-112.04" y="-507.8" z="0" />
      <rotation name="rotFS35" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper36" unit="cm"  x="-106.05" y="-507.8" z="0" />
+     <position name="posFieldShaper36" unit="cm"  x="-106.04" y="-507.8" z="0" />
      <rotation name="rotFS36" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper37" unit="cm"  x="-100.05" y="-507.8" z="0" />
+     <position name="posFieldShaper37" unit="cm"  x="-100.04" y="-507.8" z="0" />
      <rotation name="rotFS37" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper38" unit="cm"  x="-94.0500000000001" y="-507.8" z="0" />
+     <position name="posFieldShaper38" unit="cm"  x="-94.04" y="-507.8" z="0" />
      <rotation name="rotFS38" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper39" unit="cm"  x="-88.0500000000001" y="-507.8" z="0" />
+     <position name="posFieldShaper39" unit="cm"  x="-88.04" y="-507.8" z="0" />
      <rotation name="rotFS39" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper40" unit="cm"  x="-82.0500000000001" y="-507.8" z="0" />
+     <position name="posFieldShaper40" unit="cm"  x="-82.04" y="-507.8" z="0" />
      <rotation name="rotFS40" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper41" unit="cm"  x="-76.0500000000001" y="-507.8" z="0" />
+     <position name="posFieldShaper41" unit="cm"  x="-76.04" y="-507.8" z="0" />
      <rotation name="rotFS41" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper42" unit="cm"  x="-70.0500000000001" y="-507.8" z="0" />
+     <position name="posFieldShaper42" unit="cm"  x="-70.04" y="-507.8" z="0" />
      <rotation name="rotFS42" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper43" unit="cm"  x="-64.0500000000001" y="-507.8" z="0" />
+     <position name="posFieldShaper43" unit="cm"  x="-64.04" y="-507.8" z="0" />
      <rotation name="rotFS43" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper44" unit="cm"  x="-58.0500000000001" y="-507.8" z="0" />
+     <position name="posFieldShaper44" unit="cm"  x="-58.04" y="-507.8" z="0" />
      <rotation name="rotFS44" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper45" unit="cm"  x="-52.0500000000001" y="-507.8" z="0" />
+     <position name="posFieldShaper45" unit="cm"  x="-52.04" y="-507.8" z="0" />
      <rotation name="rotFS45" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper46" unit="cm"  x="-46.0500000000001" y="-507.8" z="0" />
+     <position name="posFieldShaper46" unit="cm"  x="-46.04" y="-507.8" z="0" />
      <rotation name="rotFS46" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper47" unit="cm"  x="-40.0500000000001" y="-507.8" z="0" />
+     <position name="posFieldShaper47" unit="cm"  x="-40.04" y="-507.8" z="0" />
      <rotation name="rotFS47" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper48" unit="cm"  x="-34.0500000000001" y="-507.8" z="0" />
+     <position name="posFieldShaper48" unit="cm"  x="-34.04" y="-507.8" z="0" />
      <rotation name="rotFS48" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper49" unit="cm"  x="-28.0500000000001" y="-507.8" z="0" />
+     <position name="posFieldShaper49" unit="cm"  x="-28.04" y="-507.8" z="0" />
      <rotation name="rotFS49" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper50" unit="cm"  x="-22.0500000000001" y="-507.8" z="0" />
+     <position name="posFieldShaper50" unit="cm"  x="-22.04" y="-507.8" z="0" />
      <rotation name="rotFS50" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper51" unit="cm"  x="-16.0500000000001" y="-507.8" z="0" />
+     <position name="posFieldShaper51" unit="cm"  x="-16.04" y="-507.8" z="0" />
      <rotation name="rotFS51" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper52" unit="cm"  x="-10.0500000000001" y="-507.8" z="0" />
+     <position name="posFieldShaper52" unit="cm"  x="-10.04" y="-507.8" z="0" />
      <rotation name="rotFS52" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper53" unit="cm"  x="-4.05000000000005" y="-507.8" z="0" />
+     <position name="posFieldShaper53" unit="cm"  x="-4.04000000000001" y="-507.8" z="0" />
      <rotation name="rotFS53" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper54" unit="cm"  x="1.94999999999995" y="-507.8" z="0" />
+     <position name="posFieldShaper54" unit="cm"  x="1.95999999999999" y="-507.8" z="0" />
      <rotation name="rotFS54" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper55" unit="cm"  x="7.94999999999995" y="-507.8" z="0" />
+     <position name="posFieldShaper55" unit="cm"  x="7.95999999999999" y="-507.8" z="0" />
      <rotation name="rotFS55" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper56" unit="cm"  x="13.9499999999999" y="-507.8" z="0" />
+     <position name="posFieldShaper56" unit="cm"  x="13.96" y="-507.8" z="0" />
      <rotation name="rotFS56" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper57" unit="cm"  x="19.9499999999999" y="-507.8" z="0" />
+     <position name="posFieldShaper57" unit="cm"  x="19.96" y="-507.8" z="0" />
      <rotation name="rotFS57" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper58" unit="cm"  x="25.9499999999999" y="-507.8" z="0" />
+     <position name="posFieldShaper58" unit="cm"  x="25.96" y="-507.8" z="0" />
      <rotation name="rotFS58" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper59" unit="cm"  x="31.9499999999999" y="-507.8" z="0" />
+     <position name="posFieldShaper59" unit="cm"  x="31.96" y="-507.8" z="0" />
      <rotation name="rotFS59" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper60" unit="cm"  x="37.9499999999999" y="-507.8" z="0" />
+     <position name="posFieldShaper60" unit="cm"  x="37.96" y="-507.8" z="0" />
      <rotation name="rotFS60" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper61" unit="cm"  x="43.9499999999999" y="-507.8" z="0" />
+     <position name="posFieldShaper61" unit="cm"  x="43.96" y="-507.8" z="0" />
      <rotation name="rotFS61" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper62" unit="cm"  x="49.9499999999999" y="-507.8" z="0" />
+     <position name="posFieldShaper62" unit="cm"  x="49.96" y="-507.8" z="0" />
      <rotation name="rotFS62" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper63" unit="cm"  x="55.9499999999999" y="-507.8" z="0" />
+     <position name="posFieldShaper63" unit="cm"  x="55.96" y="-507.8" z="0" />
      <rotation name="rotFS63" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper64" unit="cm"  x="61.9499999999999" y="-507.8" z="0" />
+     <position name="posFieldShaper64" unit="cm"  x="61.96" y="-507.8" z="0" />
      <rotation name="rotFS64" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper65" unit="cm"  x="67.9499999999999" y="-507.8" z="0" />
+     <position name="posFieldShaper65" unit="cm"  x="67.96" y="-507.8" z="0" />
      <rotation name="rotFS65" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper66" unit="cm"  x="73.9499999999999" y="-507.8" z="0" />
+     <position name="posFieldShaper66" unit="cm"  x="73.96" y="-507.8" z="0" />
      <rotation name="rotFS66" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper67" unit="cm"  x="79.9499999999999" y="-507.8" z="0" />
+     <position name="posFieldShaper67" unit="cm"  x="79.96" y="-507.8" z="0" />
      <rotation name="rotFS67" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper68" unit="cm"  x="85.9499999999999" y="-507.8" z="0" />
+     <position name="posFieldShaper68" unit="cm"  x="85.96" y="-507.8" z="0" />
      <rotation name="rotFS68" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper69" unit="cm"  x="91.9499999999999" y="-507.8" z="0" />
+     <position name="posFieldShaper69" unit="cm"  x="91.96" y="-507.8" z="0" />
      <rotation name="rotFS69" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper70" unit="cm"  x="97.9499999999999" y="-507.8" z="0" />
+     <position name="posFieldShaper70" unit="cm"  x="97.96" y="-507.8" z="0" />
      <rotation name="rotFS70" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper71" unit="cm"  x="103.95" y="-507.8" z="0" />
+     <position name="posFieldShaper71" unit="cm"  x="103.96" y="-507.8" z="0" />
      <rotation name="rotFS71" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper72" unit="cm"  x="109.95" y="-507.8" z="0" />
+     <position name="posFieldShaper72" unit="cm"  x="109.96" y="-507.8" z="0" />
      <rotation name="rotFS72" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper73" unit="cm"  x="115.95" y="-507.8" z="0" />
+     <position name="posFieldShaper73" unit="cm"  x="115.96" y="-507.8" z="0" />
      <rotation name="rotFS73" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper74" unit="cm"  x="121.95" y="-507.8" z="0" />
+     <position name="posFieldShaper74" unit="cm"  x="121.96" y="-507.8" z="0" />
      <rotation name="rotFS74" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper75" unit="cm"  x="127.95" y="-507.8" z="0" />
+     <position name="posFieldShaper75" unit="cm"  x="127.96" y="-507.8" z="0" />
      <rotation name="rotFS75" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper76" unit="cm"  x="133.95" y="-507.8" z="0" />
+     <position name="posFieldShaper76" unit="cm"  x="133.96" y="-507.8" z="0" />
      <rotation name="rotFS76" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper77" unit="cm"  x="139.95" y="-507.8" z="0" />
+     <position name="posFieldShaper77" unit="cm"  x="139.96" y="-507.8" z="0" />
      <rotation name="rotFS77" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper78" unit="cm"  x="145.95" y="-507.8" z="0" />
+     <position name="posFieldShaper78" unit="cm"  x="145.96" y="-507.8" z="0" />
      <rotation name="rotFS78" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper79" unit="cm"  x="151.95" y="-507.8" z="0" />
+     <position name="posFieldShaper79" unit="cm"  x="151.96" y="-507.8" z="0" />
      <rotation name="rotFS79" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper80" unit="cm"  x="157.95" y="-507.8" z="0" />
+     <position name="posFieldShaper80" unit="cm"  x="157.96" y="-507.8" z="0" />
      <rotation name="rotFS80" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper81" unit="cm"  x="163.95" y="-507.8" z="0" />
+     <position name="posFieldShaper81" unit="cm"  x="163.96" y="-507.8" z="0" />
      <rotation name="rotFS81" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper82" unit="cm"  x="169.95" y="-507.8" z="0" />
+     <position name="posFieldShaper82" unit="cm"  x="169.96" y="-507.8" z="0" />
      <rotation name="rotFS82" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper83" unit="cm"  x="175.95" y="-507.8" z="0" />
+     <position name="posFieldShaper83" unit="cm"  x="175.96" y="-507.8" z="0" />
      <rotation name="rotFS83" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper84" unit="cm"  x="181.95" y="-507.8" z="0" />
+     <position name="posFieldShaper84" unit="cm"  x="181.96" y="-507.8" z="0" />
      <rotation name="rotFS84" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper85" unit="cm"  x="187.95" y="-507.8" z="0" />
+     <position name="posFieldShaper85" unit="cm"  x="187.96" y="-507.8" z="0" />
      <rotation name="rotFS85" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper86" unit="cm"  x="193.95" y="-507.8" z="0" />
+     <position name="posFieldShaper86" unit="cm"  x="193.96" y="-507.8" z="0" />
      <rotation name="rotFS86" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper87" unit="cm"  x="199.95" y="-507.8" z="0" />
+     <position name="posFieldShaper87" unit="cm"  x="199.96" y="-507.8" z="0" />
      <rotation name="rotFS87" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper88" unit="cm"  x="205.95" y="-507.8" z="0" />
+     <position name="posFieldShaper88" unit="cm"  x="205.96" y="-507.8" z="0" />
      <rotation name="rotFS88" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper89" unit="cm"  x="211.95" y="-507.8" z="0" />
+     <position name="posFieldShaper89" unit="cm"  x="211.96" y="-507.8" z="0" />
      <rotation name="rotFS89" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper90" unit="cm"  x="217.95" y="-507.8" z="0" />
+     <position name="posFieldShaper90" unit="cm"  x="217.96" y="-507.8" z="0" />
      <rotation name="rotFS90" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper91" unit="cm"  x="223.95" y="-507.8" z="0" />
+     <position name="posFieldShaper91" unit="cm"  x="223.96" y="-507.8" z="0" />
      <rotation name="rotFS91" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper92" unit="cm"  x="229.95" y="-507.8" z="0" />
+     <position name="posFieldShaper92" unit="cm"  x="229.96" y="-507.8" z="0" />
      <rotation name="rotFS92" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper93" unit="cm"  x="235.95" y="-507.8" z="0" />
+     <position name="posFieldShaper93" unit="cm"  x="235.96" y="-507.8" z="0" />
      <rotation name="rotFS93" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper94" unit="cm"  x="241.95" y="-507.8" z="0" />
+     <position name="posFieldShaper94" unit="cm"  x="241.96" y="-507.8" z="0" />
      <rotation name="rotFS94" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper95" unit="cm"  x="247.95" y="-507.8" z="0" />
+     <position name="posFieldShaper95" unit="cm"  x="247.96" y="-507.8" z="0" />
      <rotation name="rotFS95" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper96" unit="cm"  x="253.95" y="-507.8" z="0" />
+     <position name="posFieldShaper96" unit="cm"  x="253.96" y="-507.8" z="0" />
      <rotation name="rotFS96" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper97" unit="cm"  x="259.95" y="-507.8" z="0" />
+     <position name="posFieldShaper97" unit="cm"  x="259.96" y="-507.8" z="0" />
      <rotation name="rotFS97" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper98" unit="cm"  x="265.95" y="-507.8" z="0" />
+     <position name="posFieldShaper98" unit="cm"  x="265.96" y="-507.8" z="0" />
      <rotation name="rotFS98" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper99" unit="cm"  x="271.95" y="-507.8" z="0" />
+     <position name="posFieldShaper99" unit="cm"  x="271.96" y="-507.8" z="0" />
      <rotation name="rotFS99" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper100" unit="cm"  x="277.95" y="-507.8" z="0" />
+     <position name="posFieldShaper100" unit="cm"  x="277.96" y="-507.8" z="0" />
      <rotation name="rotFS100" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper101" unit="cm"  x="283.95" y="-507.8" z="0" />
+     <position name="posFieldShaper101" unit="cm"  x="283.96" y="-507.8" z="0" />
      <rotation name="rotFS101" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper102" unit="cm"  x="289.95" y="-507.8" z="0" />
+     <position name="posFieldShaper102" unit="cm"  x="289.96" y="-507.8" z="0" />
      <rotation name="rotFS102" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper103" unit="cm"  x="295.95" y="-507.8" z="0" />
+     <position name="posFieldShaper103" unit="cm"  x="295.96" y="-507.8" z="0" />
      <rotation name="rotFS103" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper104" unit="cm"  x="301.95" y="-507.8" z="0" />
+     <position name="posFieldShaper104" unit="cm"  x="301.96" y="-507.8" z="0" />
      <rotation name="rotFS104" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper105" unit="cm"  x="307.95" y="-507.8" z="0" />
+     <position name="posFieldShaper105" unit="cm"  x="307.96" y="-507.8" z="0" />
      <rotation name="rotFS105" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper106" unit="cm"  x="313.95" y="-507.8" z="0" />
+     <position name="posFieldShaper106" unit="cm"  x="313.96" y="-507.8" z="0" />
      <rotation name="rotFS106" unit="deg" x="0" y="0" z="90" />
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper107" unit="cm"  x="319.95" y="-507.8" z="0" />
+     <position name="posFieldShaper107" unit="cm"  x="319.96" y="-507.8" z="0" />
      <rotation name="rotFS107" unit="deg" x="0" y="0" z="90" />
   </physvol>
       <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-0" unit="cm" x="-328.04" y="-337.5" z="-299.3018"/>
       </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-0" unit="cm" 
+         x="325.045" y="-337.5" z="-299.3018"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
       <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-1" unit="cm" x="-328.04" y="-1.5" z="-299.3018"/>
       </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-1" unit="cm" 
+         x="325.045" y="-1.5" z="-299.3018"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
       <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-2" unit="cm" x="-328.04" y="334.5" z="-299.3018"/>
       </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-2" unit="cm" 
+         x="325.045" y="334.5" z="-299.3018"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
       <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-3" unit="cm" x="-328.04" y="-337.5" z="-1.50000000000006"/>
       </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-3" unit="cm" 
+         x="325.045" y="-337.5" z="-1.50000000000006"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
       <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-4" unit="cm" x="-328.04" y="-1.5" z="-1.50000000000006"/>
       </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-4" unit="cm" 
+         x="325.045" y="-1.5" z="-1.50000000000006"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
       <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-5" unit="cm" x="-328.04" y="334.5" z="-1.50000000000006"/>
       </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-5" unit="cm" 
+         x="325.045" y="334.5" z="-1.50000000000006"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
       <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-6" unit="cm" x="-328.04" y="-337.5" z="296.3018"/>
       </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-6" unit="cm" 
+         x="325.045" y="-337.5" z="296.3018"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
       <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-7" unit="cm" x="-328.04" y="-1.5" z="296.3018"/>
       </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-7" unit="cm" 
+         x="325.045" y="-1.5" z="296.3018"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
       <physvol>
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid-8" unit="cm" x="-328.04" y="334.5" z="296.3018"/>
       </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-8" unit="cm" 
+         x="325.045" y="334.5" z="296.3018"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
      <physvol>
        <volumeref ref="volArapucaDouble_0-0-0"/>
        <position name="posArapucaDouble0-Frame-0-0" unit="cm" 
@@ -2450,7 +2498,7 @@
 
       <physvol>
         <volumeref ref="volDetEnclosure"/>
-	<position name="posDetEnclosure" unit="cm" x="50.0500000000001" y="0" z="448.2027"/>
+	<position name="posDetEnclosure" unit="cm" x="50.04" y="0" z="448.2027"/>
       </physvol>
 
     </volume>

--- a/dunecore/Geometry/gdml/generate_dunevd10kt_3view_30deg_v3_refactored.pl
+++ b/dunecore/Geometry/gdml/generate_dunevd10kt_3view_30deg_v3_refactored.pl
@@ -31,15 +31,9 @@
 #                       Induction pitch = 7.65 mm (7.335 mm in v2) 
 #                       Reference for changes: https://indico.fnal.gov/event/53111/timetable/
 #           May 2022: Inclusion of anode plate on top of the 3 wire planes as requested by the background TF.
-#           In order to avoid overlaps, the TPC drift size was increased by 1*$padWidth = 0.02 cm. Also, 
-#           a small displacement downwards (upwards) in the TPC (cathode) was included to keep cathode and 
-#           wireplanes in their original positions (world origin remains vertically centered on active TPC). 
-#           This change uses parameters: $nplate=1 and $tpc_x_disp, that should both be set to zero (or 
-#           deleted) if the anode plate is no longer needed. Other impacts are (all in drift direction): 
-#           Argon volume from 850.08 to 850.1 cm, Detector enclosure from 1310.32 to 1310.34 cm, TPC 
-#           origin from 50.04 to 50.05 cm, and TPC dimension from 650.08 to 650.1 cm. Currently the 
-#           material of this plate is set to vm2000 so that no additional
-#           geometry (ReflAnode) is needed to obtain optical fast simulation.
+#           This is included together with the cathode switch on. In order to avoid overlaps, the gaseous argon
+#           was decreased by $padWidth = 0.02 cm. Currently the material of this plate is set to 
+#           vm2000 so that no additional geometry (ReflAnode) is needed to obtain optical fast simulation.
 #           TO DO: include perforated PCB in the gdml (see LEMs in dual phase gdml) 
 #
 #################################################################################
@@ -203,10 +197,8 @@ $lengthTPCActive = $nCRM_z * $lengthCRM + $nCRM_z * $borderCRP; # around 6000 fo
 $driftTPCActive  = 650.0;
 
 # model anode strips as wires of some diameter
-$nplate            = 1; #use 0 if the anode plate is no longer needed
 $padWidth          = 0.02;
-$tpc_x_disp        = $padWidth/2.; #displacement to maintain cathode and wire planes in their original positions when including the anode plate --> Change to 0 if no longer needed
-$ReadoutPlane      = ($nplate+$nViews) * $padWidth; # 3 readout planes (no space b/w) + space for anode plate!
+$ReadoutPlane      = $nViews * $padWidth; # 3 readout planes (no space b/w)!
 
 ##################################################################
 ############## Parameters for TPC and inner volume ###############
@@ -700,11 +692,6 @@ print TPC <<EOF;
       y="$TPCActive_y"
       z="$TPCActive_z"
       lunit="cm"/>
-   <box name="AnodePlate" 
-      x="$padWidth/2."
-      y="$TPCActive_y"
-      z="$TPCActive_z"
-      lunit="cm"/>
    <box name="CRMActive" 
       x="$TPCActive_x"
       y="$TPCActive_y"
@@ -884,35 +871,19 @@ EOF
 }
 print TPC <<EOF;
   </volume>
-     
-   <volume name="volAnodePlate">
-     <materialref ref="vm2000"/>
-     <solidref ref="AnodePlate"/>
-EOF
-print TPC <<EOF;
-  </volume>
 EOF
 
-#$posUplane[0] = 0.5*$TPC_x - 2.5*$padWidth; #the original positions without the anode plate are commented
-$posUplane[0] = 0.5*$TPC_x - 3.5*$padWidth + $tpc_x_disp;
+$posUplane[0] = 0.5*$TPC_x - 2.5*$padWidth; 
 $posUplane[1] = 0;
 $posUplane[2] = 0;
 
-#$posVplane[0] = 0.5*$TPC_x - 1.5*$padWidth;
-$posVplane[0] = 0.5*$TPC_x - 2.5*$padWidth + $tpc_x_disp;
+$posVplane[0] = 0.5*$TPC_x - 1.5*$padWidth;
 $posVplane[1] = 0;
 $posVplane[2] = 0;
 
-#$posZplane[0] = 0.5*$TPC_x - 0.5*$padWidth;
-$posZplane[0] = 0.5*$TPC_x - 1.5*$padWidth + $tpc_x_disp;
+$posZplane[0] = 0.5*$TPC_x - 0.5*$padWidth;
 $posZplane[1] = 0; 
 $posZplane[2] = 0;
-
-#to simulate backgrounds from anode
-$posAnodePlate[0] = 0.5*$TPC_x - 0.5*$padWidth + $tpc_x_disp/2.;
-$posAnodePlate[1] = 0; 
-$posAnodePlate[2] = 0;
-#print "anode= $posAnodePlate[0], Zplane= $posZplane[0], Vplane= $posVplane[0], Uplane=$posUplane[0]\n";
 
 $posTPCActive[0] = -$ReadoutPlane/2;
 $posTPCActive[1] = 0;
@@ -942,12 +913,6 @@ print TPC <<EOF;
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volAnodePlate"/>
-       <position name="posAnodePlate" unit="cm" 
-         x="$posAnodePlate[0]" y="$posAnodePlate[1]" z="$posAnodePlate[2]"/>
-       <rotationref ref="rIdentity"/>
-     </physvol>
-     <physvol>
        <volumeref ref="volTPCActive"/>
        <position name="posActive" unit="cm" 
         x="$posTPCActive[0]" y="$posTPCAtive[1]" z="$posTPCActive[2]"/>
@@ -955,7 +920,6 @@ print TPC <<EOF;
      </physvol>
    </volume>
 EOF
-
 print TPC <<EOF;
  </structure>
  </gdml>
@@ -1154,7 +1118,7 @@ print CRYO <<EOF;
       z="$Argon_z"/>
 
     <box name="GaseousArgon" lunit="cm" 
-      x="$HeightGaseousAr"
+      x="$HeightGaseousAr - $padWidth"
       y="$Argon_y"
       z="$Argon_z"/>
 
@@ -1241,6 +1205,10 @@ print CRYO <<EOF;
     <volume name="volGroundGrid">
       <materialref ref="STEEL_STAINLESS_Fe7Cr2Ni" />
       <solidref ref="CathodeGrid" />
+    </volume>
+    <volume name="volAnodePlate">
+     <materialref ref="vm2000"/>
+     <solidref ref="AnodePlate"/>
     </volume>
     <volume name="volGaseousArgon">
       <materialref ref="ArGas"/>
@@ -1415,6 +1383,7 @@ EOF
 $CathodePosX =-$OriginXSet+50+(-1-$NFieldShapers*0.5)*$FieldShaperSeparation + $tpc_x_disp;
 $CathodePosY = -0.5*$Argon_y + $yLArBuffer + 0.5*$widthCathode;
 $CathodePosZ = -0.5*$Argon_z + $zLArBuffer + 0.5*$lengthCathode;
+$posAnodePlate = 0.5*($driftTPCActive + $nViews*$padWidth) + $padWidth/4;#right above TPC vol
 
 $idx = 0;
   if ( $Cathode_switch eq "on" )
@@ -1428,6 +1397,11 @@ $idx = 0;
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid\-$idx" unit="cm" x="$CathodePosX" y="@{[$CathodePosY]}" z="@{[$CathodePosZ]}"/>
       </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate\-$idx" unit="cm" x="$posAnodePlate" y="@{[$CathodePosY]}" z="@{[$CathodePosZ]}"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
 EOF
        $idx++;
        $CathodePosY += $widthCathode;
@@ -1763,6 +1737,12 @@ print ENCL <<EOF;
       <second ref="CathodeVoid"/>
       <position name="posCathodeSub16" x="0" y="@{[1.5*$widthCathodeVoid+2.0*$CathodeBorder]}" z="@{[1.5*$lengthCathodeVoid+2.0*$CathodeBorder]}" unit="cm"/>
     </subtraction>
+
+   <box name="AnodePlate" 
+      x="$padWidth/2."
+      y="$widthCathode"
+      z="$lengthCathode"
+      lunit="cm"/>
 
     <box name="FoamPadBlock" lunit="cm"
       x="@{[$Cryostat_x + 2*$FoamPadding]}"

--- a/dunecore/Geometry/gdml/generate_dunevd10kt_3view_v3_refactored.pl
+++ b/dunecore/Geometry/gdml/generate_dunevd10kt_3view_v3_refactored.pl
@@ -26,15 +26,9 @@
 #	      Mar 2022: Cathode included
 #
 #    V3     May 2022: Inclusion of anode plate on top of the 3 wire planes as requested by the background TF.
-#           In order to avoid overlaps, the TPC drift size was increased by 1*$padWidth = 0.02 cm. Also, 
-#           a small displacement downwards (upwards) in the TPC (cathode) was included to keep cathode and 
-#           wireplanes in their original positions (world origin remains vertically centered on active TPC). 
-#           This change uses parameters: $nplate=1 and $tpc_x_disp, that should both be set to zero (or 
-#           deleted) if the anode plate is no longer needed. Other impacts are (all in drift direction): 
-#           Argon volume from 850.08 to 850.1 cm, Detector enclosure from 1310.32 to 1310.34 cm, TPC 
-#           origin from 50.04 to 50.05 cm, and TPC dimension from 650.08 to 650.1 cm. Currently the 
-#           material of this plate is set to vm2000 so that no additional
-#           geometry (ReflAnode) is needed to obtain optical fast simulation.
+#           This is included together with the cathode switch on. In order to avoid overlaps, the gaseous argon
+#           was decreased by $padWidth = 0.02 cm. Currently the material of this plate is set to 
+#           vm2000 so that no additional geometry (ReflAnode) is needed to obtain optical fast simulation.
 #           TO DO: include perforated PCB in the gdml (see LEMs in dual phase gdml) 
 #
 #################################################################################
@@ -195,10 +189,8 @@ $lengthTPCActive = $nCRM_z * $lengthCRM + $nCRM_z * $borderCRP; # around 6000 fo
 $driftTPCActive  = 650.0;
 
 # model anode strips as wires of some diameter
-$nplate            = 1; #use 0 if the anode plate is no longer needed
 $padWidth          = 0.02;
-$tpc_x_disp        = $padWidth/2.; #displacement to maintain cathode and wire planes in their original positions when including the anode plate --> Change to 0 if no longer needed
-$ReadoutPlane      = ($nplate+$nViews) * $padWidth; # 3 readout planes (no space b/w) + space for anode plate!
+$ReadoutPlane      = $nViews * $padWidth; # 3 readout planes (no space b/w)!
 
 ##################################################################
 ############## Parameters for TPC and inner volume ###############
@@ -686,11 +678,6 @@ print TPC <<EOF;
       y="$TPCActive_y"
       z="$TPCActive_z"
       lunit="cm"/>
-   <box name="AnodePlate" 
-      x="$padWidth/2."
-      y="$TPCActive_y"
-      z="$TPCActive_z"
-      lunit="cm"/>
    <box name="CRMActive" 
       x="$TPCActive_x"
       y="$TPCActive_y"
@@ -853,35 +840,19 @@ EOF
 }
 print TPC <<EOF;
   </volume>
-     
-   <volume name="volAnodePlate">
-     <materialref ref="vm2000"/>
-     <solidref ref="AnodePlate"/>
-EOF
-
-print TPC <<EOF;
-  </volume>
 EOF
        
-#$posUplane[0] = 0.5*$TPC_x - 2.5*$padWidth; #the original positions without the anode plate are commented
-$posUplane[0] = 0.5*$TPC_x - 3.5*$padWidth + $tpc_x_disp;
+$posUplane[0] = 0.5*$TPC_x - 2.5*$padWidth;
 $posUplane[1] = 0;
 $posUplane[2] = 0;
 
-#$posYplane[0] = 0.5*$TPC_x - 1.5*$padWidth;
-$posYplane[0] = 0.5*$TPC_x - 2.5*$padWidth + $tpc_x_disp;
+$posYplane[0] = 0.5*$TPC_x - 1.5*$padWidth;
 $posYplane[1] = 0;
 $posYplane[2] = 0;
 
-#$posZplane[0] = 0.5*$TPC_x - 0.5*$padWidth;
-$posZplane[0] = 0.5*$TPC_x - 1.5*$padWidth + $tpc_x_disp;
+$posZplane[0] = 0.5*$TPC_x - 0.5*$padWidth;
 $posZplane[1] = 0; 
 $posZplane[2] = 0;
-
-#to simulate backgrounds from anode
-$posAnodePlate[0] = 0.5*$TPC_x - 0.5*$padWidth + $tpc_x_disp/2;
-$posAnodePlate[1] = 0; 
-$posAnodePlate[2] = 0;
 
 $posTPCActive[0] = -$ReadoutPlane/2;
 $posTPCActive[1] = 0;
@@ -911,12 +882,6 @@ print TPC <<EOF;
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volAnodePlate"/>
-       <position name="posAnodePlate" unit="cm" 
-         x="$posAnodePlate[0]" y="$posAnodePlate[1]" z="$posAnodePlate[2]"/>
-       <rotationref ref="rIdentity"/>
-     </physvol>    
-     <physvol>
        <volumeref ref="volTPCActive"/>
        <position name="posActive" unit="cm" 
         x="$posTPCActive[0]" y="$posTPCAtive[1]" z="$posTPCActive[2]"/>
@@ -924,8 +889,6 @@ print TPC <<EOF;
      </physvol>
    </volume>
 EOF
-## x="@{[$posTPCActive[0]+$padWidth]}" y="$posTPCActive[1]" z="$posTPCActive[2]"/>
-
 print TPC <<EOF;
  </structure>
  </gdml>
@@ -1124,7 +1087,7 @@ print CRYO <<EOF;
       z="$Argon_z"/>
 
     <box name="GaseousArgon" lunit="cm" 
-      x="$HeightGaseousAr"
+      x="$HeightGaseousAr - $padWidth"
       y="$Argon_y"
       z="$Argon_z"/>
 
@@ -1212,6 +1175,10 @@ print CRYO <<EOF;
       <materialref ref="STEEL_STAINLESS_Fe7Cr2Ni" />
       <solidref ref="CathodeGrid" />
     </volume>    
+    <volume name="volAnodePlate">
+     <materialref ref="vm2000"/>
+     <solidref ref="AnodePlate"/>
+    </volume>
     <volume name="volGaseousArgon">
       <materialref ref="ArGas"/>
       <solidref ref="GaseousArgon"/>
@@ -1309,7 +1276,7 @@ EOF
       </physvol>
 EOF
 
-if ($tpc_on==1) # place TPC inside croysotat offsetting each pair of CRMs by borderCRP
+if ($tpc_on==1) # place TPC inside cryostat offsetting each pair of CRMs by borderCRP
 {
   $posX =  $Argon_x/2 - $HeightGaseousAr - 0.5*($driftTPCActive + $ReadoutPlane); 
   $idx = 0;
@@ -1382,9 +1349,10 @@ EOF
   }
 
 
-$CathodePosX =-$OriginXSet+50+(-1-$NFieldShapers*0.5)*$FieldShaperSeparation + $tpc_x_disp;
+$CathodePosX =-$OriginXSet+50+(-1-$NFieldShapers*0.5)*$FieldShaperSeparation;
 $CathodePosY = -0.5*$Argon_y + $yLArBuffer + 0.5*$widthCathode;
 $CathodePosZ = -0.5*$Argon_z + $zLArBuffer + 0.5*$lengthCathode;
+$posAnodePlate = 0.5*($driftTPCActive + $nViews*$padWidth) + $padWidth/4;#right above TPC vol
 
 $idx = 0;
   if ( $Cathode_switch eq "on" )
@@ -1398,6 +1366,12 @@ $idx = 0;
    <volumeref ref="volGroundGrid"/>
    <position name="posGroundGrid\-$idx" unit="cm" x="$CathodePosX" y="@{[$CathodePosY]}" z="@{[$CathodePosZ]}"/>
       </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate\-$idx" unit="cm" 
+         x="$posAnodePlate" y="@{[$CathodePosY]}" z="@{[$CathodePosZ]}"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
 EOF
        $idx++;
        $CathodePosY += $widthCathode;
@@ -1733,6 +1707,12 @@ print ENCL <<EOF;
       <second ref="CathodeVoid"/>
       <position name="posCathodeSub16" x="0" y="@{[1.5*$widthCathodeVoid+2.0*$CathodeBorder]}" z="@{[1.5*$lengthCathodeVoid+2.0*$CathodeBorder]}" unit="cm"/>
     </subtraction>
+
+   <box name="AnodePlate" 
+      x="$padWidth/2."
+      y="$widthCathode"
+      z="$lengthCathode"
+      lunit="cm"/>
 
     <box name="FoamPadBlock" lunit="cm"
       x="@{[$Cryostat_x + 2*$FoamPadding]}"


### PR DESCRIPTION
Since the old PR was merged before review and Thiago had some issues in getting the background working, here comes a new PR with a new solution. This time, nothing inside the TPC was changed, so all TPC positions and dimensions are the same as v2. Also, no change in the detector enclosure size was made. The only change was the inclusion of a plate right on top of the TPC and the decrease of 0.02 cm of the gaseous argon gas. Thiago, will this solution satisfy the needs of the bkg TF? Slavic, does it look reasonable to you? Haiwang and Dom, would this also be ok from the tpc group point of view?