### PR TITLE
Feature/lp vdgeobkg2

### DIFF
--- a/dunecore/Geometry/gdml/dunevd10kt_3view_30deg_v2_refactored_1x8x6ref.gdml
+++ b/dunecore/Geometry/gdml/dunevd10kt_3view_30deg_v2_refactored_1x8x6ref.gdml
@@ -3580,97 +3580,6 @@
 
 
 
-    <box name="CathodeBlock" lunit="cm"
-      x="4"
-      y="335.4012"
-      z="297.312" />
-
-    <box name="CathodeVoid" lunit="cm"
-      x="5"
-      y="76.35"
-      z="67" />
-
-    <subtraction name="Cathode1">
-      <first ref="CathodeBlock"/>
-      <second ref="CathodeVoid"/>
-      <position name="posCathodeSub1" x="0" y="-122.525" z="-108.5" unit="cm"/>
-    </subtraction>
-    <subtraction name="Cathode2">
-      <first ref="Cathode1"/>
-      <second ref="CathodeVoid"/>
-      <position name="posCathodeSub2" x="0" y="-122.525" z="-37.5" unit="cm"/>
-    </subtraction>
-    <subtraction name="Cathode3">
-      <first ref="Cathode2"/>
-      <second ref="CathodeVoid"/>
-      <position name="posCathodeSub3" x="0" y="-122.525" z="37.5" unit="cm"/>
-    </subtraction>
-    <subtraction name="Cathode4">
-      <first ref="Cathode3"/>
-      <second ref="CathodeVoid"/>
-      <position name="posCathodeSub4" x="0" y="-122.525" z="108.5" unit="cm"/>
-    </subtraction>
-    <subtraction name="Cathode5">
-      <first ref="Cathode4"/>
-      <second ref="CathodeVoid"/>
-      <position name="posCathodeSub5" x="0" y="-42.175" z="-108.5" unit="cm"/>
-    </subtraction>
-    <subtraction name="Cathode6">
-      <first ref="Cathode5"/>
-      <second ref="CathodeVoid"/>
-      <position name="posCathodeSub6" x="0" y="-42.175" z="-37.5" unit="cm"/>
-    </subtraction>
-    <subtraction name="Cathode7">
-      <first ref="Cathode6"/>
-      <second ref="CathodeVoid"/>
-      <position name="posCathodeSub7" x="0" y="-42.175" z="37.5" unit="cm"/>
-    </subtraction>
-    <subtraction name="Cathode8">
-      <first ref="Cathode7"/>
-      <second ref="CathodeVoid"/>
-      <position name="posCathodeSub8" x="0" y="-42.175" z="108.5" unit="cm"/>
-    </subtraction>
-    <subtraction name="Cathode9">
-      <first ref="Cathode8"/>
-      <second ref="CathodeVoid"/>
-      <position name="posCathodeSub9" x="0" y="42.175" z="-108.5" unit="cm"/>
-    </subtraction>
-    <subtraction name="Cathode10">
-      <first ref="Cathode9"/>
-      <second ref="CathodeVoid"/>
-      <position name="posCathodeSub10" x="0" y="42.175" z="-37.5" unit="cm"/>
-    </subtraction>
-    <subtraction name="Cathode11">
-      <first ref="Cathode10"/>
-      <second ref="CathodeVoid"/>
-      <position name="posCathodeSub11" x="0" y="42.175" z="37.5" unit="cm"/>
-    </subtraction>
-    <subtraction name="Cathode12">
-      <first ref="Cathode11"/>
-      <second ref="CathodeVoid"/>
-      <position name="posCathodeSub12" x="0" y="42.175" z="108.5" unit="cm"/>
-    </subtraction>
-    <subtraction name="Cathode13">
-      <first ref="Cathode12"/>
-      <second ref="CathodeVoid"/>
-      <position name="posCathodeSub13" x="0" y="122.525" z="-108.5" unit="cm"/>
-    </subtraction>
-    <subtraction name="Cathode14">
-      <first ref="Cathode13"/>
-      <second ref="CathodeVoid"/>
-      <position name="posCathodeSub14" x="0" y="122.525" z="-37.5" unit="cm"/>
-    </subtraction>
-    <subtraction name="Cathode15">
-      <first ref="Cathode14"/>
-      <second ref="CathodeVoid"/>
-      <position name="posCathodeSub15" x="0" y="122.525" z="37.5" unit="cm"/>
-    </subtraction>
-    <subtraction name="CathodeGrid">
-      <first ref="Cathode15"/>
-      <second ref="CathodeVoid"/>
-      <position name="posCathodeSub16" x="0" y="122.525" z="108.5" unit="cm"/>
-    </subtraction>
-
     <box name="FoamPadBlock" lunit="cm"
       x="1010.32"
       y="1705.8448"
@@ -10656,10 +10565,6 @@
       <materialref ref="STEEL_STAINLESS_Fe7Cr2Ni" />
       <solidref ref="SteelShell" />
     </volume>
-    <volume name="volGroundGrid">
-      <materialref ref="STEEL_STAINLESS_Fe7Cr2Ni" />
-      <solidref ref="CathodeGrid" />
-    </volume>
     <volume name="volGaseousArgon">
       <materialref ref="ArGas"/>
       <solidref ref="GaseousArgon"/>
@@ -12044,773 +11949,725 @@
      <position name="posFieldShaper107" unit="cm"  x="319.96" y="-675.1024" z="0" />
      <rotation name="rotFS107" unit="deg" x="0" y="0" z="90" />
   </physvol>
-      <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-0" unit="cm" x="-328.04" y="-505.1018" z="-298.812"/>
-      </physvol>
-      <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-1" unit="cm" x="-328.04" y="-169.7006" z="-298.812"/>
-      </physvol>
-      <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-2" unit="cm" x="-328.04" y="165.7006" z="-298.812"/>
-      </physvol>
-      <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-3" unit="cm" x="-328.04" y="501.1018" z="-298.812"/>
-      </physvol>
-      <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-4" unit="cm" x="-328.04" y="-505.1018" z="-1.5"/>
-      </physvol>
-      <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-5" unit="cm" x="-328.04" y="-169.7006" z="-1.5"/>
-      </physvol>
-      <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-6" unit="cm" x="-328.04" y="165.7006" z="-1.5"/>
-      </physvol>
-      <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-7" unit="cm" x="-328.04" y="501.1018" z="-1.5"/>
-      </physvol>
-      <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-8" unit="cm" x="-328.04" y="-505.1018" z="295.812"/>
-      </physvol>
-      <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-9" unit="cm" x="-328.04" y="-169.7006" z="295.812"/>
-      </physvol>
-      <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-10" unit="cm" x="-328.04" y="165.7006" z="295.812"/>
-      </physvol>
-      <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-11" unit="cm" x="-328.04" y="501.1018" z="295.812"/>
-      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-0-0"/>
        <position name="posArapucaDouble0-Frame-0-0" unit="cm" 
-         x="-328.04"
-	 y="-632.8018" 
-	 z="-261.312"/>
+         x="-327.04"
+	 y="-626.3524" 
+	 z="-262.773"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-0"/>
        <position name="posOpArapucaDouble0-Frame-0-0" unit="cm" 
-         x="-327.3"
-	 y="-632.8018" 
-	 z="-261.312"/>
+         x="-326.3"
+	 y="-626.3524" 
+	 z="-262.773"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-0-1"/>
        <position name="posArapucaDouble1-Frame-0-0" unit="cm" 
-         x="-328.04"
-	 y="-542.1018" 
-	 z="-407.312"/>
+         x="-327.04"
+	 y="-536.1018" 
+	 z="-400.179"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-1"/>
        <position name="posOpArapucaDouble1-Frame-0-0" unit="cm" 
-         x="-327.3"
-	 y="-542.1018" 
-	 z="-407.312"/>
+         x="-326.3"
+	 y="-536.1018" 
+	 z="-400.179"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-0-2"/>
        <position name="posArapucaDouble2-Frame-0-0" unit="cm" 
-         x="-328.04"
-	 y="-468.1018" 
-	 z="-190.312"/>
+         x="-327.04"
+	 y="-470.1018" 
+	 z="-194.445"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-2"/>
        <position name="posOpArapucaDouble2-Frame-0-0" unit="cm" 
-         x="-327.3"
-	 y="-468.1018" 
-	 z="-190.312"/>
+         x="-326.3"
+	 y="-470.1018" 
+	 z="-194.445"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-0-3"/>
        <position name="posArapucaDouble3-Frame-0-0" unit="cm" 
-         x="-328.04"
-	 y="-377.4018" 
-	 z="-336.312"/>
+         x="-327.04"
+	 y="-379.8512" 
+	 z="-331.851"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-3"/>
        <position name="posOpArapucaDouble3-Frame-0-0" unit="cm" 
-         x="-327.3"
-	 y="-377.4018" 
-	 z="-336.312"/>
+         x="-326.3"
+	 y="-379.8512" 
+	 z="-331.851"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-1-0"/>
        <position name="posArapucaDouble0-Frame-0-1" unit="cm" 
-         x="-328.04"
-	 y="-632.8018" 
-	 z="36"/>
+         x="-327.04"
+	 y="-626.3524" 
+	 z="34.5390000000001"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-0"/>
        <position name="posOpArapucaDouble0-Frame-0-1" unit="cm" 
-         x="-327.3"
-	 y="-632.8018" 
-	 z="36"/>
+         x="-326.3"
+	 y="-626.3524" 
+	 z="34.5390000000001"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-1-1"/>
        <position name="posArapucaDouble1-Frame-0-1" unit="cm" 
-         x="-328.04"
-	 y="-542.1018" 
-	 z="-110"/>
+         x="-327.04"
+	 y="-536.1018" 
+	 z="-102.867"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-1"/>
        <position name="posOpArapucaDouble1-Frame-0-1" unit="cm" 
-         x="-327.3"
-	 y="-542.1018" 
-	 z="-110"/>
+         x="-326.3"
+	 y="-536.1018" 
+	 z="-102.867"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-1-2"/>
        <position name="posArapucaDouble2-Frame-0-1" unit="cm" 
-         x="-328.04"
-	 y="-468.1018" 
-	 z="107"/>
+         x="-327.04"
+	 y="-470.1018" 
+	 z="102.867"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-2"/>
        <position name="posOpArapucaDouble2-Frame-0-1" unit="cm" 
-         x="-327.3"
-	 y="-468.1018" 
-	 z="107"/>
+         x="-326.3"
+	 y="-470.1018" 
+	 z="102.867"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-1-3"/>
        <position name="posArapucaDouble3-Frame-0-1" unit="cm" 
-         x="-328.04"
-	 y="-377.4018" 
-	 z="-39"/>
+         x="-327.04"
+	 y="-379.8512" 
+	 z="-34.5389999999999"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-3"/>
        <position name="posOpArapucaDouble3-Frame-0-1" unit="cm" 
-         x="-327.3"
-	 y="-377.4018" 
-	 z="-39"/>
+         x="-326.3"
+	 y="-379.8512" 
+	 z="-34.5389999999999"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-2-0"/>
        <position name="posArapucaDouble0-Frame-0-2" unit="cm" 
-         x="-328.04"
-	 y="-632.8018" 
-	 z="333.312"/>
+         x="-327.04"
+	 y="-626.3524" 
+	 z="331.851"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-0"/>
        <position name="posOpArapucaDouble0-Frame-0-2" unit="cm" 
-         x="-327.3"
-	 y="-632.8018" 
-	 z="333.312"/>
+         x="-326.3"
+	 y="-626.3524" 
+	 z="331.851"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-2-1"/>
        <position name="posArapucaDouble1-Frame-0-2" unit="cm" 
-         x="-328.04"
-	 y="-542.1018" 
-	 z="187.312"/>
+         x="-327.04"
+	 y="-536.1018" 
+	 z="194.445"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-1"/>
        <position name="posOpArapucaDouble1-Frame-0-2" unit="cm" 
-         x="-327.3"
-	 y="-542.1018" 
-	 z="187.312"/>
+         x="-326.3"
+	 y="-536.1018" 
+	 z="194.445"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-2-2"/>
        <position name="posArapucaDouble2-Frame-0-2" unit="cm" 
-         x="-328.04"
-	 y="-468.1018" 
-	 z="404.312"/>
+         x="-327.04"
+	 y="-470.1018" 
+	 z="400.179"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-2"/>
        <position name="posOpArapucaDouble2-Frame-0-2" unit="cm" 
-         x="-327.3"
-	 y="-468.1018" 
-	 z="404.312"/>
+         x="-326.3"
+	 y="-470.1018" 
+	 z="400.179"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-2-3"/>
        <position name="posArapucaDouble3-Frame-0-2" unit="cm" 
-         x="-328.04"
-	 y="-377.4018" 
-	 z="258.312"/>
+         x="-327.04"
+	 y="-379.8512" 
+	 z="262.773"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-3"/>
        <position name="posOpArapucaDouble3-Frame-0-2" unit="cm" 
-         x="-327.3"
-	 y="-377.4018" 
-	 z="258.312"/>
+         x="-326.3"
+	 y="-379.8512" 
+	 z="262.773"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-0-0"/>
        <position name="posArapucaDouble0-Frame-1-0" unit="cm" 
-         x="-328.04"
-	 y="-297.4006" 
-	 z="-261.312"/>
+         x="-327.04"
+	 y="-290.9512" 
+	 z="-262.773"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-0"/>
        <position name="posOpArapucaDouble0-Frame-1-0" unit="cm" 
-         x="-327.3"
-	 y="-297.4006" 
-	 z="-261.312"/>
+         x="-326.3"
+	 y="-290.9512" 
+	 z="-262.773"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-0-1"/>
        <position name="posArapucaDouble1-Frame-1-0" unit="cm" 
-         x="-328.04"
-	 y="-206.7006" 
-	 z="-407.312"/>
+         x="-327.04"
+	 y="-200.7006" 
+	 z="-400.179"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-1"/>
        <position name="posOpArapucaDouble1-Frame-1-0" unit="cm" 
-         x="-327.3"
-	 y="-206.7006" 
-	 z="-407.312"/>
+         x="-326.3"
+	 y="-200.7006" 
+	 z="-400.179"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-0-2"/>
        <position name="posArapucaDouble2-Frame-1-0" unit="cm" 
-         x="-328.04"
-	 y="-132.7006" 
-	 z="-190.312"/>
+         x="-327.04"
+	 y="-134.7006" 
+	 z="-194.445"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-2"/>
        <position name="posOpArapucaDouble2-Frame-1-0" unit="cm" 
-         x="-327.3"
-	 y="-132.7006" 
-	 z="-190.312"/>
+         x="-326.3"
+	 y="-134.7006" 
+	 z="-194.445"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-0-3"/>
        <position name="posArapucaDouble3-Frame-1-0" unit="cm" 
-         x="-328.04"
-	 y="-42.0006" 
-	 z="-336.312"/>
+         x="-327.04"
+	 y="-44.45" 
+	 z="-331.851"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-3"/>
        <position name="posOpArapucaDouble3-Frame-1-0" unit="cm" 
-         x="-327.3"
-	 y="-42.0006" 
-	 z="-336.312"/>
+         x="-326.3"
+	 y="-44.45" 
+	 z="-331.851"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-1-0"/>
        <position name="posArapucaDouble0-Frame-1-1" unit="cm" 
-         x="-328.04"
-	 y="-297.4006" 
-	 z="36"/>
+         x="-327.04"
+	 y="-290.9512" 
+	 z="34.5390000000001"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-0"/>
        <position name="posOpArapucaDouble0-Frame-1-1" unit="cm" 
-         x="-327.3"
-	 y="-297.4006" 
-	 z="36"/>
+         x="-326.3"
+	 y="-290.9512" 
+	 z="34.5390000000001"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-1-1"/>
        <position name="posArapucaDouble1-Frame-1-1" unit="cm" 
-         x="-328.04"
-	 y="-206.7006" 
-	 z="-110"/>
+         x="-327.04"
+	 y="-200.7006" 
+	 z="-102.867"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-1"/>
        <position name="posOpArapucaDouble1-Frame-1-1" unit="cm" 
-         x="-327.3"
-	 y="-206.7006" 
-	 z="-110"/>
+         x="-326.3"
+	 y="-200.7006" 
+	 z="-102.867"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-1-2"/>
        <position name="posArapucaDouble2-Frame-1-1" unit="cm" 
-         x="-328.04"
-	 y="-132.7006" 
-	 z="107"/>
+         x="-327.04"
+	 y="-134.7006" 
+	 z="102.867"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-2"/>
        <position name="posOpArapucaDouble2-Frame-1-1" unit="cm" 
-         x="-327.3"
-	 y="-132.7006" 
-	 z="107"/>
+         x="-326.3"
+	 y="-134.7006" 
+	 z="102.867"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-1-3"/>
        <position name="posArapucaDouble3-Frame-1-1" unit="cm" 
-         x="-328.04"
-	 y="-42.0006" 
-	 z="-39"/>
+         x="-327.04"
+	 y="-44.45" 
+	 z="-34.5389999999999"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-3"/>
        <position name="posOpArapucaDouble3-Frame-1-1" unit="cm" 
-         x="-327.3"
-	 y="-42.0006" 
-	 z="-39"/>
+         x="-326.3"
+	 y="-44.45" 
+	 z="-34.5389999999999"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-2-0"/>
        <position name="posArapucaDouble0-Frame-1-2" unit="cm" 
-         x="-328.04"
-	 y="-297.4006" 
-	 z="333.312"/>
+         x="-327.04"
+	 y="-290.9512" 
+	 z="331.851"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-0"/>
        <position name="posOpArapucaDouble0-Frame-1-2" unit="cm" 
-         x="-327.3"
-	 y="-297.4006" 
-	 z="333.312"/>
+         x="-326.3"
+	 y="-290.9512" 
+	 z="331.851"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-2-1"/>
        <position name="posArapucaDouble1-Frame-1-2" unit="cm" 
-         x="-328.04"
-	 y="-206.7006" 
-	 z="187.312"/>
+         x="-327.04"
+	 y="-200.7006" 
+	 z="194.445"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-1"/>
        <position name="posOpArapucaDouble1-Frame-1-2" unit="cm" 
-         x="-327.3"
-	 y="-206.7006" 
-	 z="187.312"/>
+         x="-326.3"
+	 y="-200.7006" 
+	 z="194.445"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-2-2"/>
        <position name="posArapucaDouble2-Frame-1-2" unit="cm" 
-         x="-328.04"
-	 y="-132.7006" 
-	 z="404.312"/>
+         x="-327.04"
+	 y="-134.7006" 
+	 z="400.179"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-2"/>
        <position name="posOpArapucaDouble2-Frame-1-2" unit="cm" 
-         x="-327.3"
-	 y="-132.7006" 
-	 z="404.312"/>
+         x="-326.3"
+	 y="-134.7006" 
+	 z="400.179"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-2-3"/>
        <position name="posArapucaDouble3-Frame-1-2" unit="cm" 
-         x="-328.04"
-	 y="-42.0006" 
-	 z="258.312"/>
+         x="-327.04"
+	 y="-44.45" 
+	 z="262.773"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-3"/>
        <position name="posOpArapucaDouble3-Frame-1-2" unit="cm" 
-         x="-327.3"
-	 y="-42.0006" 
-	 z="258.312"/>
+         x="-326.3"
+	 y="-44.45" 
+	 z="262.773"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-0-0"/>
        <position name="posArapucaDouble0-Frame-2-0" unit="cm" 
-         x="-328.04"
-	 y="38.0006" 
-	 z="-261.312"/>
+         x="-327.04"
+	 y="44.45" 
+	 z="-262.773"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-0"/>
        <position name="posOpArapucaDouble0-Frame-2-0" unit="cm" 
-         x="-327.3"
-	 y="38.0006" 
-	 z="-261.312"/>
+         x="-326.3"
+	 y="44.45" 
+	 z="-262.773"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-0-1"/>
        <position name="posArapucaDouble1-Frame-2-0" unit="cm" 
-         x="-328.04"
-	 y="128.7006" 
-	 z="-407.312"/>
+         x="-327.04"
+	 y="134.7006" 
+	 z="-400.179"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-1"/>
        <position name="posOpArapucaDouble1-Frame-2-0" unit="cm" 
-         x="-327.3"
-	 y="128.7006" 
-	 z="-407.312"/>
+         x="-326.3"
+	 y="134.7006" 
+	 z="-400.179"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-0-2"/>
        <position name="posArapucaDouble2-Frame-2-0" unit="cm" 
-         x="-328.04"
-	 y="202.7006" 
-	 z="-190.312"/>
+         x="-327.04"
+	 y="200.7006" 
+	 z="-194.445"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-2"/>
        <position name="posOpArapucaDouble2-Frame-2-0" unit="cm" 
-         x="-327.3"
-	 y="202.7006" 
-	 z="-190.312"/>
+         x="-326.3"
+	 y="200.7006" 
+	 z="-194.445"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-0-3"/>
        <position name="posArapucaDouble3-Frame-2-0" unit="cm" 
-         x="-328.04"
-	 y="293.4006" 
-	 z="-336.312"/>
+         x="-327.04"
+	 y="290.9512" 
+	 z="-331.851"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-3"/>
        <position name="posOpArapucaDouble3-Frame-2-0" unit="cm" 
-         x="-327.3"
-	 y="293.4006" 
-	 z="-336.312"/>
+         x="-326.3"
+	 y="290.9512" 
+	 z="-331.851"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-1-0"/>
        <position name="posArapucaDouble0-Frame-2-1" unit="cm" 
-         x="-328.04"
-	 y="38.0006" 
-	 z="36"/>
+         x="-327.04"
+	 y="44.45" 
+	 z="34.5390000000001"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-0"/>
        <position name="posOpArapucaDouble0-Frame-2-1" unit="cm" 
-         x="-327.3"
-	 y="38.0006" 
-	 z="36"/>
+         x="-326.3"
+	 y="44.45" 
+	 z="34.5390000000001"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-1-1"/>
        <position name="posArapucaDouble1-Frame-2-1" unit="cm" 
-         x="-328.04"
-	 y="128.7006" 
-	 z="-110"/>
+         x="-327.04"
+	 y="134.7006" 
+	 z="-102.867"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-1"/>
        <position name="posOpArapucaDouble1-Frame-2-1" unit="cm" 
-         x="-327.3"
-	 y="128.7006" 
-	 z="-110"/>
+         x="-326.3"
+	 y="134.7006" 
+	 z="-102.867"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-1-2"/>
        <position name="posArapucaDouble2-Frame-2-1" unit="cm" 
-         x="-328.04"
-	 y="202.7006" 
-	 z="107"/>
+         x="-327.04"
+	 y="200.7006" 
+	 z="102.867"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-2"/>
        <position name="posOpArapucaDouble2-Frame-2-1" unit="cm" 
-         x="-327.3"
-	 y="202.7006" 
-	 z="107"/>
+         x="-326.3"
+	 y="200.7006" 
+	 z="102.867"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-1-3"/>
        <position name="posArapucaDouble3-Frame-2-1" unit="cm" 
-         x="-328.04"
-	 y="293.4006" 
-	 z="-39"/>
+         x="-327.04"
+	 y="290.9512" 
+	 z="-34.5389999999999"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-3"/>
        <position name="posOpArapucaDouble3-Frame-2-1" unit="cm" 
-         x="-327.3"
-	 y="293.4006" 
-	 z="-39"/>
+         x="-326.3"
+	 y="290.9512" 
+	 z="-34.5389999999999"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-2-0"/>
        <position name="posArapucaDouble0-Frame-2-2" unit="cm" 
-         x="-328.04"
-	 y="38.0006" 
-	 z="333.312"/>
+         x="-327.04"
+	 y="44.45" 
+	 z="331.851"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-0"/>
        <position name="posOpArapucaDouble0-Frame-2-2" unit="cm" 
-         x="-327.3"
-	 y="38.0006" 
-	 z="333.312"/>
+         x="-326.3"
+	 y="44.45" 
+	 z="331.851"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-2-1"/>
        <position name="posArapucaDouble1-Frame-2-2" unit="cm" 
-         x="-328.04"
-	 y="128.7006" 
-	 z="187.312"/>
+         x="-327.04"
+	 y="134.7006" 
+	 z="194.445"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-1"/>
        <position name="posOpArapucaDouble1-Frame-2-2" unit="cm" 
-         x="-327.3"
-	 y="128.7006" 
-	 z="187.312"/>
+         x="-326.3"
+	 y="134.7006" 
+	 z="194.445"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-2-2"/>
        <position name="posArapucaDouble2-Frame-2-2" unit="cm" 
-         x="-328.04"
-	 y="202.7006" 
-	 z="404.312"/>
+         x="-327.04"
+	 y="200.7006" 
+	 z="400.179"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-2"/>
        <position name="posOpArapucaDouble2-Frame-2-2" unit="cm" 
-         x="-327.3"
-	 y="202.7006" 
-	 z="404.312"/>
+         x="-326.3"
+	 y="200.7006" 
+	 z="400.179"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-2-3"/>
        <position name="posArapucaDouble3-Frame-2-2" unit="cm" 
-         x="-328.04"
-	 y="293.4006" 
-	 z="258.312"/>
+         x="-327.04"
+	 y="290.9512" 
+	 z="262.773"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-3"/>
        <position name="posOpArapucaDouble3-Frame-2-2" unit="cm" 
-         x="-327.3"
-	 y="293.4006" 
-	 z="258.312"/>
+         x="-326.3"
+	 y="290.9512" 
+	 z="262.773"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-0-0"/>
        <position name="posArapucaDouble0-Frame-3-0" unit="cm" 
-         x="-328.04"
-	 y="373.4018" 
-	 z="-261.312"/>
+         x="-327.04"
+	 y="379.8512" 
+	 z="-262.773"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-0"/>
        <position name="posOpArapucaDouble0-Frame-3-0" unit="cm" 
-         x="-327.3"
-	 y="373.4018" 
-	 z="-261.312"/>
+         x="-326.3"
+	 y="379.8512" 
+	 z="-262.773"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-0-1"/>
        <position name="posArapucaDouble1-Frame-3-0" unit="cm" 
-         x="-328.04"
-	 y="464.1018" 
-	 z="-407.312"/>
+         x="-327.04"
+	 y="470.1018" 
+	 z="-400.179"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-1"/>
        <position name="posOpArapucaDouble1-Frame-3-0" unit="cm" 
-         x="-327.3"
-	 y="464.1018" 
-	 z="-407.312"/>
+         x="-326.3"
+	 y="470.1018" 
+	 z="-400.179"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-0-2"/>
        <position name="posArapucaDouble2-Frame-3-0" unit="cm" 
-         x="-328.04"
-	 y="538.1018" 
-	 z="-190.312"/>
+         x="-327.04"
+	 y="536.1018" 
+	 z="-194.445"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-2"/>
        <position name="posOpArapucaDouble2-Frame-3-0" unit="cm" 
-         x="-327.3"
-	 y="538.1018" 
-	 z="-190.312"/>
+         x="-326.3"
+	 y="536.1018" 
+	 z="-194.445"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-0-3"/>
        <position name="posArapucaDouble3-Frame-3-0" unit="cm" 
-         x="-328.04"
-	 y="628.8018" 
-	 z="-336.312"/>
+         x="-327.04"
+	 y="626.3524" 
+	 z="-331.851"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-3"/>
        <position name="posOpArapucaDouble3-Frame-3-0" unit="cm" 
-         x="-327.3"
-	 y="628.8018" 
-	 z="-336.312"/>
+         x="-326.3"
+	 y="626.3524" 
+	 z="-331.851"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-1-0"/>
        <position name="posArapucaDouble0-Frame-3-1" unit="cm" 
-         x="-328.04"
-	 y="373.4018" 
-	 z="36"/>
+         x="-327.04"
+	 y="379.8512" 
+	 z="34.5390000000001"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-0"/>
        <position name="posOpArapucaDouble0-Frame-3-1" unit="cm" 
-         x="-327.3"
-	 y="373.4018" 
-	 z="36"/>
+         x="-326.3"
+	 y="379.8512" 
+	 z="34.5390000000001"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-1-1"/>
        <position name="posArapucaDouble1-Frame-3-1" unit="cm" 
-         x="-328.04"
-	 y="464.1018" 
-	 z="-110"/>
+         x="-327.04"
+	 y="470.1018" 
+	 z="-102.867"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-1"/>
        <position name="posOpArapucaDouble1-Frame-3-1" unit="cm" 
-         x="-327.3"
-	 y="464.1018" 
-	 z="-110"/>
+         x="-326.3"
+	 y="470.1018" 
+	 z="-102.867"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-1-2"/>
        <position name="posArapucaDouble2-Frame-3-1" unit="cm" 
-         x="-328.04"
-	 y="538.1018" 
-	 z="107"/>
+         x="-327.04"
+	 y="536.1018" 
+	 z="102.867"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-2"/>
        <position name="posOpArapucaDouble2-Frame-3-1" unit="cm" 
-         x="-327.3"
-	 y="538.1018" 
-	 z="107"/>
+         x="-326.3"
+	 y="536.1018" 
+	 z="102.867"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-1-3"/>
        <position name="posArapucaDouble3-Frame-3-1" unit="cm" 
-         x="-328.04"
-	 y="628.8018" 
-	 z="-39"/>
+         x="-327.04"
+	 y="626.3524" 
+	 z="-34.5389999999999"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-3"/>
        <position name="posOpArapucaDouble3-Frame-3-1" unit="cm" 
-         x="-327.3"
-	 y="628.8018" 
-	 z="-39"/>
+         x="-326.3"
+	 y="626.3524" 
+	 z="-34.5389999999999"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-2-0"/>
        <position name="posArapucaDouble0-Frame-3-2" unit="cm" 
-         x="-328.04"
-	 y="373.4018" 
-	 z="333.312"/>
+         x="-327.04"
+	 y="379.8512" 
+	 z="331.851"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-0"/>
        <position name="posOpArapucaDouble0-Frame-3-2" unit="cm" 
-         x="-327.3"
-	 y="373.4018" 
-	 z="333.312"/>
+         x="-326.3"
+	 y="379.8512" 
+	 z="331.851"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-2-1"/>
        <position name="posArapucaDouble1-Frame-3-2" unit="cm" 
-         x="-328.04"
-	 y="464.1018" 
-	 z="187.312"/>
+         x="-327.04"
+	 y="470.1018" 
+	 z="194.445"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-1"/>
        <position name="posOpArapucaDouble1-Frame-3-2" unit="cm" 
-         x="-327.3"
-	 y="464.1018" 
-	 z="187.312"/>
+         x="-326.3"
+	 y="470.1018" 
+	 z="194.445"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-2-2"/>
        <position name="posArapucaDouble2-Frame-3-2" unit="cm" 
-         x="-328.04"
-	 y="538.1018" 
-	 z="404.312"/>
+         x="-327.04"
+	 y="536.1018" 
+	 z="400.179"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-2"/>
        <position name="posOpArapucaDouble2-Frame-3-2" unit="cm" 
-         x="-327.3"
-	 y="538.1018" 
-	 z="404.312"/>
+         x="-326.3"
+	 y="536.1018" 
+	 z="400.179"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-2-3"/>
        <position name="posArapucaDouble3-Frame-3-2" unit="cm" 
-         x="-328.04"
-	 y="628.8018" 
-	 z="258.312"/>
+         x="-327.04"
+	 y="626.3524" 
+	 z="262.773"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-3"/>
        <position name="posOpArapucaDouble3-Frame-3-2" unit="cm" 
-         x="-327.3"
-	 y="628.8018" 
-	 z="258.312"/>
+         x="-326.3"
+	 y="626.3524" 
+	 z="262.773"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-0"/>

--- a/dunecore/Geometry/gdml/dunevd10kt_3view_30deg_v2_refactored_1x8x6ref_nowires.gdml
+++ b/dunecore/Geometry/gdml/dunevd10kt_3view_30deg_v2_refactored_1x8x6ref_nowires.gdml
@@ -595,97 +595,6 @@
 
 
 
-    <box name="CathodeBlock" lunit="cm"
-      x="4"
-      y="335.4012"
-      z="297.312" />
-
-    <box name="CathodeVoid" lunit="cm"
-      x="5"
-      y="76.35"
-      z="67" />
-
-    <subtraction name="Cathode1">
-      <first ref="CathodeBlock"/>
-      <second ref="CathodeVoid"/>
-      <position name="posCathodeSub1" x="0" y="-122.525" z="-108.5" unit="cm"/>
-    </subtraction>
-    <subtraction name="Cathode2">
-      <first ref="Cathode1"/>
-      <second ref="CathodeVoid"/>
-      <position name="posCathodeSub2" x="0" y="-122.525" z="-37.5" unit="cm"/>
-    </subtraction>
-    <subtraction name="Cathode3">
-      <first ref="Cathode2"/>
-      <second ref="CathodeVoid"/>
-      <position name="posCathodeSub3" x="0" y="-122.525" z="37.5" unit="cm"/>
-    </subtraction>
-    <subtraction name="Cathode4">
-      <first ref="Cathode3"/>
-      <second ref="CathodeVoid"/>
-      <position name="posCathodeSub4" x="0" y="-122.525" z="108.5" unit="cm"/>
-    </subtraction>
-    <subtraction name="Cathode5">
-      <first ref="Cathode4"/>
-      <second ref="CathodeVoid"/>
-      <position name="posCathodeSub5" x="0" y="-42.175" z="-108.5" unit="cm"/>
-    </subtraction>
-    <subtraction name="Cathode6">
-      <first ref="Cathode5"/>
-      <second ref="CathodeVoid"/>
-      <position name="posCathodeSub6" x="0" y="-42.175" z="-37.5" unit="cm"/>
-    </subtraction>
-    <subtraction name="Cathode7">
-      <first ref="Cathode6"/>
-      <second ref="CathodeVoid"/>
-      <position name="posCathodeSub7" x="0" y="-42.175" z="37.5" unit="cm"/>
-    </subtraction>
-    <subtraction name="Cathode8">
-      <first ref="Cathode7"/>
-      <second ref="CathodeVoid"/>
-      <position name="posCathodeSub8" x="0" y="-42.175" z="108.5" unit="cm"/>
-    </subtraction>
-    <subtraction name="Cathode9">
-      <first ref="Cathode8"/>
-      <second ref="CathodeVoid"/>
-      <position name="posCathodeSub9" x="0" y="42.175" z="-108.5" unit="cm"/>
-    </subtraction>
-    <subtraction name="Cathode10">
-      <first ref="Cathode9"/>
-      <second ref="CathodeVoid"/>
-      <position name="posCathodeSub10" x="0" y="42.175" z="-37.5" unit="cm"/>
-    </subtraction>
-    <subtraction name="Cathode11">
-      <first ref="Cathode10"/>
-      <second ref="CathodeVoid"/>
-      <position name="posCathodeSub11" x="0" y="42.175" z="37.5" unit="cm"/>
-    </subtraction>
-    <subtraction name="Cathode12">
-      <first ref="Cathode11"/>
-      <second ref="CathodeVoid"/>
-      <position name="posCathodeSub12" x="0" y="42.175" z="108.5" unit="cm"/>
-    </subtraction>
-    <subtraction name="Cathode13">
-      <first ref="Cathode12"/>
-      <second ref="CathodeVoid"/>
-      <position name="posCathodeSub13" x="0" y="122.525" z="-108.5" unit="cm"/>
-    </subtraction>
-    <subtraction name="Cathode14">
-      <first ref="Cathode13"/>
-      <second ref="CathodeVoid"/>
-      <position name="posCathodeSub14" x="0" y="122.525" z="-37.5" unit="cm"/>
-    </subtraction>
-    <subtraction name="Cathode15">
-      <first ref="Cathode14"/>
-      <second ref="CathodeVoid"/>
-      <position name="posCathodeSub15" x="0" y="122.525" z="37.5" unit="cm"/>
-    </subtraction>
-    <subtraction name="CathodeGrid">
-      <first ref="Cathode15"/>
-      <second ref="CathodeVoid"/>
-      <position name="posCathodeSub16" x="0" y="122.525" z="108.5" unit="cm"/>
-    </subtraction>
-
     <box name="FoamPadBlock" lunit="cm"
       x="1010.32"
       y="1705.8448"
@@ -782,10 +691,6 @@
     <volume name="volSteelShell">
       <materialref ref="STEEL_STAINLESS_Fe7Cr2Ni" />
       <solidref ref="SteelShell" />
-    </volume>
-    <volume name="volGroundGrid">
-      <materialref ref="STEEL_STAINLESS_Fe7Cr2Ni" />
-      <solidref ref="CathodeGrid" />
     </volume>
     <volume name="volGaseousArgon">
       <materialref ref="ArGas"/>
@@ -2171,773 +2076,725 @@
      <position name="posFieldShaper107" unit="cm"  x="319.96" y="-675.1024" z="0" />
      <rotation name="rotFS107" unit="deg" x="0" y="0" z="90" />
   </physvol>
-      <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-0" unit="cm" x="-328.04" y="-505.1018" z="-298.812"/>
-      </physvol>
-      <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-1" unit="cm" x="-328.04" y="-169.7006" z="-298.812"/>
-      </physvol>
-      <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-2" unit="cm" x="-328.04" y="165.7006" z="-298.812"/>
-      </physvol>
-      <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-3" unit="cm" x="-328.04" y="501.1018" z="-298.812"/>
-      </physvol>
-      <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-4" unit="cm" x="-328.04" y="-505.1018" z="-1.5"/>
-      </physvol>
-      <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-5" unit="cm" x="-328.04" y="-169.7006" z="-1.5"/>
-      </physvol>
-      <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-6" unit="cm" x="-328.04" y="165.7006" z="-1.5"/>
-      </physvol>
-      <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-7" unit="cm" x="-328.04" y="501.1018" z="-1.5"/>
-      </physvol>
-      <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-8" unit="cm" x="-328.04" y="-505.1018" z="295.812"/>
-      </physvol>
-      <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-9" unit="cm" x="-328.04" y="-169.7006" z="295.812"/>
-      </physvol>
-      <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-10" unit="cm" x="-328.04" y="165.7006" z="295.812"/>
-      </physvol>
-      <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-11" unit="cm" x="-328.04" y="501.1018" z="295.812"/>
-      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-0-0"/>
        <position name="posArapucaDouble0-Frame-0-0" unit="cm" 
-         x="-328.04"
-	 y="-632.8018" 
-	 z="-261.312"/>
+         x="-327.04"
+	 y="-626.3524" 
+	 z="-262.773"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-0"/>
        <position name="posOpArapucaDouble0-Frame-0-0" unit="cm" 
-         x="-327.3"
-	 y="-632.8018" 
-	 z="-261.312"/>
+         x="-326.3"
+	 y="-626.3524" 
+	 z="-262.773"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-0-1"/>
        <position name="posArapucaDouble1-Frame-0-0" unit="cm" 
-         x="-328.04"
-	 y="-542.1018" 
-	 z="-407.312"/>
+         x="-327.04"
+	 y="-536.1018" 
+	 z="-400.179"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-1"/>
        <position name="posOpArapucaDouble1-Frame-0-0" unit="cm" 
-         x="-327.3"
-	 y="-542.1018" 
-	 z="-407.312"/>
+         x="-326.3"
+	 y="-536.1018" 
+	 z="-400.179"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-0-2"/>
        <position name="posArapucaDouble2-Frame-0-0" unit="cm" 
-         x="-328.04"
-	 y="-468.1018" 
-	 z="-190.312"/>
+         x="-327.04"
+	 y="-470.1018" 
+	 z="-194.445"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-2"/>
        <position name="posOpArapucaDouble2-Frame-0-0" unit="cm" 
-         x="-327.3"
-	 y="-468.1018" 
-	 z="-190.312"/>
+         x="-326.3"
+	 y="-470.1018" 
+	 z="-194.445"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-0-3"/>
        <position name="posArapucaDouble3-Frame-0-0" unit="cm" 
-         x="-328.04"
-	 y="-377.4018" 
-	 z="-336.312"/>
+         x="-327.04"
+	 y="-379.8512" 
+	 z="-331.851"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-3"/>
        <position name="posOpArapucaDouble3-Frame-0-0" unit="cm" 
-         x="-327.3"
-	 y="-377.4018" 
-	 z="-336.312"/>
+         x="-326.3"
+	 y="-379.8512" 
+	 z="-331.851"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-1-0"/>
        <position name="posArapucaDouble0-Frame-0-1" unit="cm" 
-         x="-328.04"
-	 y="-632.8018" 
-	 z="36"/>
+         x="-327.04"
+	 y="-626.3524" 
+	 z="34.5390000000001"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-0"/>
        <position name="posOpArapucaDouble0-Frame-0-1" unit="cm" 
-         x="-327.3"
-	 y="-632.8018" 
-	 z="36"/>
+         x="-326.3"
+	 y="-626.3524" 
+	 z="34.5390000000001"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-1-1"/>
        <position name="posArapucaDouble1-Frame-0-1" unit="cm" 
-         x="-328.04"
-	 y="-542.1018" 
-	 z="-110"/>
+         x="-327.04"
+	 y="-536.1018" 
+	 z="-102.867"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-1"/>
        <position name="posOpArapucaDouble1-Frame-0-1" unit="cm" 
-         x="-327.3"
-	 y="-542.1018" 
-	 z="-110"/>
+         x="-326.3"
+	 y="-536.1018" 
+	 z="-102.867"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-1-2"/>
        <position name="posArapucaDouble2-Frame-0-1" unit="cm" 
-         x="-328.04"
-	 y="-468.1018" 
-	 z="107"/>
+         x="-327.04"
+	 y="-470.1018" 
+	 z="102.867"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-2"/>
        <position name="posOpArapucaDouble2-Frame-0-1" unit="cm" 
-         x="-327.3"
-	 y="-468.1018" 
-	 z="107"/>
+         x="-326.3"
+	 y="-470.1018" 
+	 z="102.867"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-1-3"/>
        <position name="posArapucaDouble3-Frame-0-1" unit="cm" 
-         x="-328.04"
-	 y="-377.4018" 
-	 z="-39"/>
+         x="-327.04"
+	 y="-379.8512" 
+	 z="-34.5389999999999"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-3"/>
        <position name="posOpArapucaDouble3-Frame-0-1" unit="cm" 
-         x="-327.3"
-	 y="-377.4018" 
-	 z="-39"/>
+         x="-326.3"
+	 y="-379.8512" 
+	 z="-34.5389999999999"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-2-0"/>
        <position name="posArapucaDouble0-Frame-0-2" unit="cm" 
-         x="-328.04"
-	 y="-632.8018" 
-	 z="333.312"/>
+         x="-327.04"
+	 y="-626.3524" 
+	 z="331.851"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-0"/>
        <position name="posOpArapucaDouble0-Frame-0-2" unit="cm" 
-         x="-327.3"
-	 y="-632.8018" 
-	 z="333.312"/>
+         x="-326.3"
+	 y="-626.3524" 
+	 z="331.851"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-2-1"/>
        <position name="posArapucaDouble1-Frame-0-2" unit="cm" 
-         x="-328.04"
-	 y="-542.1018" 
-	 z="187.312"/>
+         x="-327.04"
+	 y="-536.1018" 
+	 z="194.445"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-1"/>
        <position name="posOpArapucaDouble1-Frame-0-2" unit="cm" 
-         x="-327.3"
-	 y="-542.1018" 
-	 z="187.312"/>
+         x="-326.3"
+	 y="-536.1018" 
+	 z="194.445"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-2-2"/>
        <position name="posArapucaDouble2-Frame-0-2" unit="cm" 
-         x="-328.04"
-	 y="-468.1018" 
-	 z="404.312"/>
+         x="-327.04"
+	 y="-470.1018" 
+	 z="400.179"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-2"/>
        <position name="posOpArapucaDouble2-Frame-0-2" unit="cm" 
-         x="-327.3"
-	 y="-468.1018" 
-	 z="404.312"/>
+         x="-326.3"
+	 y="-470.1018" 
+	 z="400.179"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-2-3"/>
        <position name="posArapucaDouble3-Frame-0-2" unit="cm" 
-         x="-328.04"
-	 y="-377.4018" 
-	 z="258.312"/>
+         x="-327.04"
+	 y="-379.8512" 
+	 z="262.773"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-3"/>
        <position name="posOpArapucaDouble3-Frame-0-2" unit="cm" 
-         x="-327.3"
-	 y="-377.4018" 
-	 z="258.312"/>
+         x="-326.3"
+	 y="-379.8512" 
+	 z="262.773"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-0-0"/>
        <position name="posArapucaDouble0-Frame-1-0" unit="cm" 
-         x="-328.04"
-	 y="-297.4006" 
-	 z="-261.312"/>
+         x="-327.04"
+	 y="-290.9512" 
+	 z="-262.773"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-0"/>
        <position name="posOpArapucaDouble0-Frame-1-0" unit="cm" 
-         x="-327.3"
-	 y="-297.4006" 
-	 z="-261.312"/>
+         x="-326.3"
+	 y="-290.9512" 
+	 z="-262.773"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-0-1"/>
        <position name="posArapucaDouble1-Frame-1-0" unit="cm" 
-         x="-328.04"
-	 y="-206.7006" 
-	 z="-407.312"/>
+         x="-327.04"
+	 y="-200.7006" 
+	 z="-400.179"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-1"/>
        <position name="posOpArapucaDouble1-Frame-1-0" unit="cm" 
-         x="-327.3"
-	 y="-206.7006" 
-	 z="-407.312"/>
+         x="-326.3"
+	 y="-200.7006" 
+	 z="-400.179"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-0-2"/>
        <position name="posArapucaDouble2-Frame-1-0" unit="cm" 
-         x="-328.04"
-	 y="-132.7006" 
-	 z="-190.312"/>
+         x="-327.04"
+	 y="-134.7006" 
+	 z="-194.445"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-2"/>
        <position name="posOpArapucaDouble2-Frame-1-0" unit="cm" 
-         x="-327.3"
-	 y="-132.7006" 
-	 z="-190.312"/>
+         x="-326.3"
+	 y="-134.7006" 
+	 z="-194.445"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-0-3"/>
        <position name="posArapucaDouble3-Frame-1-0" unit="cm" 
-         x="-328.04"
-	 y="-42.0006" 
-	 z="-336.312"/>
+         x="-327.04"
+	 y="-44.45" 
+	 z="-331.851"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-3"/>
        <position name="posOpArapucaDouble3-Frame-1-0" unit="cm" 
-         x="-327.3"
-	 y="-42.0006" 
-	 z="-336.312"/>
+         x="-326.3"
+	 y="-44.45" 
+	 z="-331.851"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-1-0"/>
        <position name="posArapucaDouble0-Frame-1-1" unit="cm" 
-         x="-328.04"
-	 y="-297.4006" 
-	 z="36"/>
+         x="-327.04"
+	 y="-290.9512" 
+	 z="34.5390000000001"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-0"/>
        <position name="posOpArapucaDouble0-Frame-1-1" unit="cm" 
-         x="-327.3"
-	 y="-297.4006" 
-	 z="36"/>
+         x="-326.3"
+	 y="-290.9512" 
+	 z="34.5390000000001"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-1-1"/>
        <position name="posArapucaDouble1-Frame-1-1" unit="cm" 
-         x="-328.04"
-	 y="-206.7006" 
-	 z="-110"/>
+         x="-327.04"
+	 y="-200.7006" 
+	 z="-102.867"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-1"/>
        <position name="posOpArapucaDouble1-Frame-1-1" unit="cm" 
-         x="-327.3"
-	 y="-206.7006" 
-	 z="-110"/>
+         x="-326.3"
+	 y="-200.7006" 
+	 z="-102.867"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-1-2"/>
        <position name="posArapucaDouble2-Frame-1-1" unit="cm" 
-         x="-328.04"
-	 y="-132.7006" 
-	 z="107"/>
+         x="-327.04"
+	 y="-134.7006" 
+	 z="102.867"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-2"/>
        <position name="posOpArapucaDouble2-Frame-1-1" unit="cm" 
-         x="-327.3"
-	 y="-132.7006" 
-	 z="107"/>
+         x="-326.3"
+	 y="-134.7006" 
+	 z="102.867"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-1-3"/>
        <position name="posArapucaDouble3-Frame-1-1" unit="cm" 
-         x="-328.04"
-	 y="-42.0006" 
-	 z="-39"/>
+         x="-327.04"
+	 y="-44.45" 
+	 z="-34.5389999999999"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-3"/>
        <position name="posOpArapucaDouble3-Frame-1-1" unit="cm" 
-         x="-327.3"
-	 y="-42.0006" 
-	 z="-39"/>
+         x="-326.3"
+	 y="-44.45" 
+	 z="-34.5389999999999"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-2-0"/>
        <position name="posArapucaDouble0-Frame-1-2" unit="cm" 
-         x="-328.04"
-	 y="-297.4006" 
-	 z="333.312"/>
+         x="-327.04"
+	 y="-290.9512" 
+	 z="331.851"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-0"/>
        <position name="posOpArapucaDouble0-Frame-1-2" unit="cm" 
-         x="-327.3"
-	 y="-297.4006" 
-	 z="333.312"/>
+         x="-326.3"
+	 y="-290.9512" 
+	 z="331.851"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-2-1"/>
        <position name="posArapucaDouble1-Frame-1-2" unit="cm" 
-         x="-328.04"
-	 y="-206.7006" 
-	 z="187.312"/>
+         x="-327.04"
+	 y="-200.7006" 
+	 z="194.445"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-1"/>
        <position name="posOpArapucaDouble1-Frame-1-2" unit="cm" 
-         x="-327.3"
-	 y="-206.7006" 
-	 z="187.312"/>
+         x="-326.3"
+	 y="-200.7006" 
+	 z="194.445"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-2-2"/>
        <position name="posArapucaDouble2-Frame-1-2" unit="cm" 
-         x="-328.04"
-	 y="-132.7006" 
-	 z="404.312"/>
+         x="-327.04"
+	 y="-134.7006" 
+	 z="400.179"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-2"/>
        <position name="posOpArapucaDouble2-Frame-1-2" unit="cm" 
-         x="-327.3"
-	 y="-132.7006" 
-	 z="404.312"/>
+         x="-326.3"
+	 y="-134.7006" 
+	 z="400.179"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-2-3"/>
        <position name="posArapucaDouble3-Frame-1-2" unit="cm" 
-         x="-328.04"
-	 y="-42.0006" 
-	 z="258.312"/>
+         x="-327.04"
+	 y="-44.45" 
+	 z="262.773"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-3"/>
        <position name="posOpArapucaDouble3-Frame-1-2" unit="cm" 
-         x="-327.3"
-	 y="-42.0006" 
-	 z="258.312"/>
+         x="-326.3"
+	 y="-44.45" 
+	 z="262.773"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-0-0"/>
        <position name="posArapucaDouble0-Frame-2-0" unit="cm" 
-         x="-328.04"
-	 y="38.0006" 
-	 z="-261.312"/>
+         x="-327.04"
+	 y="44.45" 
+	 z="-262.773"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-0"/>
        <position name="posOpArapucaDouble0-Frame-2-0" unit="cm" 
-         x="-327.3"
-	 y="38.0006" 
-	 z="-261.312"/>
+         x="-326.3"
+	 y="44.45" 
+	 z="-262.773"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-0-1"/>
        <position name="posArapucaDouble1-Frame-2-0" unit="cm" 
-         x="-328.04"
-	 y="128.7006" 
-	 z="-407.312"/>
+         x="-327.04"
+	 y="134.7006" 
+	 z="-400.179"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-1"/>
        <position name="posOpArapucaDouble1-Frame-2-0" unit="cm" 
-         x="-327.3"
-	 y="128.7006" 
-	 z="-407.312"/>
+         x="-326.3"
+	 y="134.7006" 
+	 z="-400.179"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-0-2"/>
        <position name="posArapucaDouble2-Frame-2-0" unit="cm" 
-         x="-328.04"
-	 y="202.7006" 
-	 z="-190.312"/>
+         x="-327.04"
+	 y="200.7006" 
+	 z="-194.445"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-2"/>
        <position name="posOpArapucaDouble2-Frame-2-0" unit="cm" 
-         x="-327.3"
-	 y="202.7006" 
-	 z="-190.312"/>
+         x="-326.3"
+	 y="200.7006" 
+	 z="-194.445"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-0-3"/>
        <position name="posArapucaDouble3-Frame-2-0" unit="cm" 
-         x="-328.04"
-	 y="293.4006" 
-	 z="-336.312"/>
+         x="-327.04"
+	 y="290.9512" 
+	 z="-331.851"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-3"/>
        <position name="posOpArapucaDouble3-Frame-2-0" unit="cm" 
-         x="-327.3"
-	 y="293.4006" 
-	 z="-336.312"/>
+         x="-326.3"
+	 y="290.9512" 
+	 z="-331.851"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-1-0"/>
        <position name="posArapucaDouble0-Frame-2-1" unit="cm" 
-         x="-328.04"
-	 y="38.0006" 
-	 z="36"/>
+         x="-327.04"
+	 y="44.45" 
+	 z="34.5390000000001"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-0"/>
        <position name="posOpArapucaDouble0-Frame-2-1" unit="cm" 
-         x="-327.3"
-	 y="38.0006" 
-	 z="36"/>
+         x="-326.3"
+	 y="44.45" 
+	 z="34.5390000000001"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-1-1"/>
        <position name="posArapucaDouble1-Frame-2-1" unit="cm" 
-         x="-328.04"
-	 y="128.7006" 
-	 z="-110"/>
+         x="-327.04"
+	 y="134.7006" 
+	 z="-102.867"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-1"/>
        <position name="posOpArapucaDouble1-Frame-2-1" unit="cm" 
-         x="-327.3"
-	 y="128.7006" 
-	 z="-110"/>
+         x="-326.3"
+	 y="134.7006" 
+	 z="-102.867"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-1-2"/>
        <position name="posArapucaDouble2-Frame-2-1" unit="cm" 
-         x="-328.04"
-	 y="202.7006" 
-	 z="107"/>
+         x="-327.04"
+	 y="200.7006" 
+	 z="102.867"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-2"/>
        <position name="posOpArapucaDouble2-Frame-2-1" unit="cm" 
-         x="-327.3"
-	 y="202.7006" 
-	 z="107"/>
+         x="-326.3"
+	 y="200.7006" 
+	 z="102.867"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-1-3"/>
        <position name="posArapucaDouble3-Frame-2-1" unit="cm" 
-         x="-328.04"
-	 y="293.4006" 
-	 z="-39"/>
+         x="-327.04"
+	 y="290.9512" 
+	 z="-34.5389999999999"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-3"/>
        <position name="posOpArapucaDouble3-Frame-2-1" unit="cm" 
-         x="-327.3"
-	 y="293.4006" 
-	 z="-39"/>
+         x="-326.3"
+	 y="290.9512" 
+	 z="-34.5389999999999"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-2-0"/>
        <position name="posArapucaDouble0-Frame-2-2" unit="cm" 
-         x="-328.04"
-	 y="38.0006" 
-	 z="333.312"/>
+         x="-327.04"
+	 y="44.45" 
+	 z="331.851"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-0"/>
        <position name="posOpArapucaDouble0-Frame-2-2" unit="cm" 
-         x="-327.3"
-	 y="38.0006" 
-	 z="333.312"/>
+         x="-326.3"
+	 y="44.45" 
+	 z="331.851"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-2-1"/>
        <position name="posArapucaDouble1-Frame-2-2" unit="cm" 
-         x="-328.04"
-	 y="128.7006" 
-	 z="187.312"/>
+         x="-327.04"
+	 y="134.7006" 
+	 z="194.445"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-1"/>
        <position name="posOpArapucaDouble1-Frame-2-2" unit="cm" 
-         x="-327.3"
-	 y="128.7006" 
-	 z="187.312"/>
+         x="-326.3"
+	 y="134.7006" 
+	 z="194.445"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-2-2"/>
        <position name="posArapucaDouble2-Frame-2-2" unit="cm" 
-         x="-328.04"
-	 y="202.7006" 
-	 z="404.312"/>
+         x="-327.04"
+	 y="200.7006" 
+	 z="400.179"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-2"/>
        <position name="posOpArapucaDouble2-Frame-2-2" unit="cm" 
-         x="-327.3"
-	 y="202.7006" 
-	 z="404.312"/>
+         x="-326.3"
+	 y="200.7006" 
+	 z="400.179"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-2-3"/>
        <position name="posArapucaDouble3-Frame-2-2" unit="cm" 
-         x="-328.04"
-	 y="293.4006" 
-	 z="258.312"/>
+         x="-327.04"
+	 y="290.9512" 
+	 z="262.773"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-3"/>
        <position name="posOpArapucaDouble3-Frame-2-2" unit="cm" 
-         x="-327.3"
-	 y="293.4006" 
-	 z="258.312"/>
+         x="-326.3"
+	 y="290.9512" 
+	 z="262.773"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-0-0"/>
        <position name="posArapucaDouble0-Frame-3-0" unit="cm" 
-         x="-328.04"
-	 y="373.4018" 
-	 z="-261.312"/>
+         x="-327.04"
+	 y="379.8512" 
+	 z="-262.773"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-0"/>
        <position name="posOpArapucaDouble0-Frame-3-0" unit="cm" 
-         x="-327.3"
-	 y="373.4018" 
-	 z="-261.312"/>
+         x="-326.3"
+	 y="379.8512" 
+	 z="-262.773"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-0-1"/>
        <position name="posArapucaDouble1-Frame-3-0" unit="cm" 
-         x="-328.04"
-	 y="464.1018" 
-	 z="-407.312"/>
+         x="-327.04"
+	 y="470.1018" 
+	 z="-400.179"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-1"/>
        <position name="posOpArapucaDouble1-Frame-3-0" unit="cm" 
-         x="-327.3"
-	 y="464.1018" 
-	 z="-407.312"/>
+         x="-326.3"
+	 y="470.1018" 
+	 z="-400.179"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-0-2"/>
        <position name="posArapucaDouble2-Frame-3-0" unit="cm" 
-         x="-328.04"
-	 y="538.1018" 
-	 z="-190.312"/>
+         x="-327.04"
+	 y="536.1018" 
+	 z="-194.445"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-2"/>
        <position name="posOpArapucaDouble2-Frame-3-0" unit="cm" 
-         x="-327.3"
-	 y="538.1018" 
-	 z="-190.312"/>
+         x="-326.3"
+	 y="536.1018" 
+	 z="-194.445"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-0-3"/>
        <position name="posArapucaDouble3-Frame-3-0" unit="cm" 
-         x="-328.04"
-	 y="628.8018" 
-	 z="-336.312"/>
+         x="-327.04"
+	 y="626.3524" 
+	 z="-331.851"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-3"/>
        <position name="posOpArapucaDouble3-Frame-3-0" unit="cm" 
-         x="-327.3"
-	 y="628.8018" 
-	 z="-336.312"/>
+         x="-326.3"
+	 y="626.3524" 
+	 z="-331.851"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-1-0"/>
        <position name="posArapucaDouble0-Frame-3-1" unit="cm" 
-         x="-328.04"
-	 y="373.4018" 
-	 z="36"/>
+         x="-327.04"
+	 y="379.8512" 
+	 z="34.5390000000001"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-0"/>
        <position name="posOpArapucaDouble0-Frame-3-1" unit="cm" 
-         x="-327.3"
-	 y="373.4018" 
-	 z="36"/>
+         x="-326.3"
+	 y="379.8512" 
+	 z="34.5390000000001"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-1-1"/>
        <position name="posArapucaDouble1-Frame-3-1" unit="cm" 
-         x="-328.04"
-	 y="464.1018" 
-	 z="-110"/>
+         x="-327.04"
+	 y="470.1018" 
+	 z="-102.867"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-1"/>
        <position name="posOpArapucaDouble1-Frame-3-1" unit="cm" 
-         x="-327.3"
-	 y="464.1018" 
-	 z="-110"/>
+         x="-326.3"
+	 y="470.1018" 
+	 z="-102.867"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-1-2"/>
        <position name="posArapucaDouble2-Frame-3-1" unit="cm" 
-         x="-328.04"
-	 y="538.1018" 
-	 z="107"/>
+         x="-327.04"
+	 y="536.1018" 
+	 z="102.867"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-2"/>
        <position name="posOpArapucaDouble2-Frame-3-1" unit="cm" 
-         x="-327.3"
-	 y="538.1018" 
-	 z="107"/>
+         x="-326.3"
+	 y="536.1018" 
+	 z="102.867"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-1-3"/>
        <position name="posArapucaDouble3-Frame-3-1" unit="cm" 
-         x="-328.04"
-	 y="628.8018" 
-	 z="-39"/>
+         x="-327.04"
+	 y="626.3524" 
+	 z="-34.5389999999999"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-3"/>
        <position name="posOpArapucaDouble3-Frame-3-1" unit="cm" 
-         x="-327.3"
-	 y="628.8018" 
-	 z="-39"/>
+         x="-326.3"
+	 y="626.3524" 
+	 z="-34.5389999999999"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-2-0"/>
        <position name="posArapucaDouble0-Frame-3-2" unit="cm" 
-         x="-328.04"
-	 y="373.4018" 
-	 z="333.312"/>
+         x="-327.04"
+	 y="379.8512" 
+	 z="331.851"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-0"/>
        <position name="posOpArapucaDouble0-Frame-3-2" unit="cm" 
-         x="-327.3"
-	 y="373.4018" 
-	 z="333.312"/>
+         x="-326.3"
+	 y="379.8512" 
+	 z="331.851"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-2-1"/>
        <position name="posArapucaDouble1-Frame-3-2" unit="cm" 
-         x="-328.04"
-	 y="464.1018" 
-	 z="187.312"/>
+         x="-327.04"
+	 y="470.1018" 
+	 z="194.445"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-1"/>
        <position name="posOpArapucaDouble1-Frame-3-2" unit="cm" 
-         x="-327.3"
-	 y="464.1018" 
-	 z="187.312"/>
+         x="-326.3"
+	 y="470.1018" 
+	 z="194.445"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-2-2"/>
        <position name="posArapucaDouble2-Frame-3-2" unit="cm" 
-         x="-328.04"
-	 y="538.1018" 
-	 z="404.312"/>
+         x="-327.04"
+	 y="536.1018" 
+	 z="400.179"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-2"/>
        <position name="posOpArapucaDouble2-Frame-3-2" unit="cm" 
-         x="-327.3"
-	 y="538.1018" 
-	 z="404.312"/>
+         x="-326.3"
+	 y="536.1018" 
+	 z="400.179"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-2-3"/>
        <position name="posArapucaDouble3-Frame-3-2" unit="cm" 
-         x="-328.04"
-	 y="628.8018" 
-	 z="258.312"/>
+         x="-327.04"
+	 y="626.3524" 
+	 z="262.773"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-3"/>
        <position name="posOpArapucaDouble3-Frame-3-2" unit="cm" 
-         x="-327.3"
-	 y="628.8018" 
-	 z="258.312"/>
+         x="-326.3"
+	 y="626.3524" 
+	 z="262.773"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-0"/>

--- a/dunecore/Geometry/gdml/dunevd10kt_3view_30deg_v4_refactored_1x8x14ref.gdml
+++ b/dunecore/Geometry/gdml/dunevd10kt_3view_30deg_v4_refactored_1x8x14ref.gdml
@@ -1,0 +1,15565 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<gdml_simple_extension xmlns:gdml_simple_extension="http://www.example.org"
+                       xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"          
+                       xs:noNamespaceSchemaLocation="RefactoredGDMLSchema/SimpleExtension.xsd"> 
+<extension>
+   <color name="magenta"     R="0.0"  G="1.0"  B="0.0"  A="1.0" />
+   <color name="green"       R="0.0"  G="1.0"  B="0.0"  A="1.0" />
+   <color name="red"         R="1.0"  G="0.0"  B="0.0"  A="1.0" />
+   <color name="blue"        R="0.0"  G="0.0"  B="1.0"  A="1.0" />
+   <color name="yellow"      R="1.0"  G="1.0"  B="0.0"  A="1.0" />    
+</extension>
+<define>
+
+<!--
+
+
+
+-->
+
+   <position name="posCryoInDetEnc"     unit="cm" x="-50.0000000000001" y="0" z="0"/>
+   <position name="posCenter"           unit="cm" x="0" y="0" z="0"/>
+   <rotation name="rUWireAboutX"        unit="deg" x="150" y="0" z="0"/>
+   <rotation name="rVWireAboutX"        unit="deg" x="30" y="0" z="0"/>
+   <rotation name="rPlus90AboutX"       unit="deg" x="90" y="0" z="0"/>
+   <rotation name="rPlus90AboutY"       unit="deg" x="0" y="90" z="0"/>
+   <rotation name="rPlus90AboutXPlus90AboutY" unit="deg" x="90" y="90" z="0"/>
+   <rotation name="rMinus90AboutX"      unit="deg" x="270" y="0" z="0"/>
+   <rotation name="rMinus90AboutY"      unit="deg" x="0" y="270" z="0"/>
+   <rotation name="rMinus90AboutYMinus90AboutX"       unit="deg" x="270" y="270" z="0"/>
+   <rotation name="rPlus180AboutX"	unit="deg" x="180" y="0"   z="0"/>
+   <rotation name="rPlus180AboutY"	unit="deg" x="0" y="180"   z="0"/>
+   <rotation name="rPlus180AboutXPlus180AboutY"	unit="deg" x="180" y="180"   z="0"/>
+   <rotation name="rIdentity"		unit="deg" x="0" y="0"   z="0"/>
+</define>
+<materials>
+  <element name="videRef" formula="VACUUM" Z="1">  <atom value="1"/> </element>
+  <element name="copper" formula="Cu" Z="29">  <atom value="63.546"/>  </element>
+  <element name="beryllium" formula="Be" Z="4">  <atom value="9.0121831"/>  </element>
+  <element name="bromine" formula="Br" Z="35"> <atom value="79.904"/> </element>
+  <element name="hydrogen" formula="H" Z="1">  <atom value="1.0079"/> </element>
+  <element name="nitrogen" formula="N" Z="7">  <atom value="14.0067"/> </element>
+  <element name="oxygen" formula="O" Z="8">  <atom value="15.999"/> </element>
+  <element name="aluminum" formula="Al" Z="13"> <atom value="26.9815"/>  </element>
+  <element name="silicon" formula="Si" Z="14"> <atom value="28.0855"/>  </element>
+  <element name="carbon" formula="C" Z="6">  <atom value="12.0107"/>  </element>
+  <element name="potassium" formula="K" Z="19"> <atom value="39.0983"/>  </element>
+  <element name="chromium" formula="Cr" Z="24"> <atom value="51.9961"/>  </element>
+  <element name="iron" formula="Fe" Z="26"> <atom value="55.8450"/>  </element>
+  <element name="nickel" formula="Ni" Z="28"> <atom value="58.6934"/>  </element>
+  <element name="calcium" formula="Ca" Z="20"> <atom value="40.078"/>   </element>
+  <element name="magnesium" formula="Mg" Z="12"> <atom value="24.305"/>   </element>
+  <element name="sodium" formula="Na" Z="11"> <atom value="22.99"/>    </element>
+  <element name="titanium" formula="Ti" Z="22"> <atom value="47.867"/>   </element>
+  <element name="argon" formula="Ar" Z="18"> <atom value="39.9480"/>  </element>
+  <element name="sulphur" formula="S" Z="16"> <atom value="32.065"/>  </element>
+  <element name="phosphorus" formula="P" Z="15"> <atom value="30.973"/>  </element>
+
+  <material name="Vacuum" formula="Vacuum">
+   <D value="1.e-25" unit="g/cm3"/>
+   <fraction n="1.0" ref="videRef"/>
+  </material>
+
+  <material name="ALUMINUM_Al" formula="ALUMINUM_Al">
+   <D value="2.6990" unit="g/cm3"/>
+   <fraction n="1.0000" ref="aluminum"/>
+  </material>
+
+  <material name="SILICON_Si" formula="SILICON_Si">
+   <D value="2.3300" unit="g/cm3"/>
+   <fraction n="1.0000" ref="silicon"/>
+  </material>
+
+  <material name="epoxy_resin" formula="C38H40O6Br4">
+   <D value="1.1250" unit="g/cm3"/>
+   <composite n="38" ref="carbon"/>
+   <composite n="40" ref="hydrogen"/>
+   <composite n="6" ref="oxygen"/>
+   <composite n="4" ref="bromine"/>
+  </material>
+
+  <material name="SiO2" formula="SiO2">
+   <D value="2.2" unit="g/cm3"/>
+   <composite n="1" ref="silicon"/>
+   <composite n="2" ref="oxygen"/>
+  </material>
+
+  <material name="Al2O3" formula="Al2O3">
+   <D value="3.97" unit="g/cm3"/>
+   <composite n="2" ref="aluminum"/>
+   <composite n="3" ref="oxygen"/>
+  </material>
+
+  <material name="Fe2O3" formula="Fe2O3">
+   <D value="5.24" unit="g/cm3"/>
+   <composite n="2" ref="iron"/>
+   <composite n="3" ref="oxygen"/>
+  </material>
+
+  <material name="CaO" formula="CaO">
+   <D value="3.35" unit="g/cm3"/>
+   <composite n="1" ref="calcium"/>
+   <composite n="1" ref="oxygen"/>
+  </material>
+
+  <material name="Delrin" formula="CH2O">
+    <D value="1.41" unit="g/cm3"/>
+    <composite n="1" ref="carbon"/>
+    <composite n="2" ref="hydrogen"/>
+    <composite n="1" ref="oxygen"/>
+  </material>
+
+  <material name="MgO" formula="MgO">
+   <D value="3.58" unit="g/cm3"/>
+   <composite n="1" ref="magnesium"/>
+   <composite n="1" ref="oxygen"/>
+  </material>
+
+  <material name="Na2O" formula="Na2O">
+   <D value="2.27" unit="g/cm3"/>
+   <composite n="2" ref="sodium"/>
+   <composite n="1" ref="oxygen"/>
+  </material>
+
+  <material name="TiO2" formula="TiO2">
+   <D value="4.23" unit="g/cm3"/>
+   <composite n="1" ref="titanium"/>
+   <composite n="2" ref="oxygen"/>
+  </material>
+
+  <material name="FeO" formula="FeO">
+   <D value="5.745" unit="g/cm3"/>
+   <composite n="1" ref="iron"/>
+   <composite n="1" ref="oxygen"/>
+  </material>
+
+  <material name="CO2" formula="CO2">
+   <D value="1.562" unit="g/cm3"/>
+   <composite n="1" ref="iron"/>
+   <composite n="2" ref="oxygen"/>
+  </material>
+
+  <material name="P2O5" formula="P2O5">
+   <D value="1.562" unit="g/cm3"/>
+   <composite n="2" ref="phosphorus"/>
+   <composite n="5" ref="oxygen"/>
+  </material>
+
+  <material formula=" " name="DUSEL_Rock">
+    <D value="2.82" unit="g/cm3"/>
+    <fraction n="0.5267" ref="SiO2"/>
+    <fraction n="0.1174" ref="FeO"/>
+    <fraction n="0.1025" ref="Al2O3"/>
+    <fraction n="0.0473" ref="MgO"/>
+    <fraction n="0.0422" ref="CO2"/>
+    <fraction n="0.0382" ref="CaO"/>
+    <fraction n="0.0240" ref="carbon"/>
+    <fraction n="0.0186" ref="sulphur"/>
+    <fraction n="0.0053" ref="Na2O"/>
+    <fraction n="0.00070" ref="P2O5"/>
+    <fraction n="0.0771" ref="oxygen"/>
+  </material> 
+
+  <material formula="Air" name="Air">
+   <D value="0.001205" unit="g/cm3"/>
+   <fraction n="0.781154" ref="nitrogen"/>
+   <fraction n="0.209476" ref="oxygen"/>
+   <fraction n="0.00934" ref="argon"/>
+  </material>
+
+  <material name="fibrous_glass">
+   <D value="2.74351" unit="g/cm3"/>
+   <fraction n="0.600" ref="SiO2"/>
+   <fraction n="0.118" ref="Al2O3"/>
+   <fraction n="0.001" ref="Fe2O3"/>
+   <fraction n="0.224" ref="CaO"/>
+   <fraction n="0.034" ref="MgO"/>
+   <fraction n="0.010" ref="Na2O"/>
+   <fraction n="0.013" ref="TiO2"/>
+  </material>
+
+  <!-- density referenced from EHN1-Cold Cryostats Technical Requirements:
+       https://edms.cern.ch/document/1543254 -->
+  <material name="FD_foam">
+   <D value="0.09" unit="g/cm3"/>
+   <fraction n="0.95" ref="Air"/>
+   <fraction n="0.05" ref="fibrous_glass"/>
+  </material>
+
+  <!-- Foam density is 70 kg / m^3 for the 3x1x1 -->
+  <material name="foam_3x1x1dp">
+   <D value="0.07" unit="g/cm3"/>
+   <fraction n="0.95" ref="Air"/>
+   <fraction n="0.05" ref="fibrous_glass"/>
+  </material>
+
+  <!-- Copied from protodune_v4.gdml -->
+  <material name="foam_protoDUNEdp">
+   <D value="0.135" unit="g/cm3"/>
+   <composite n="17" ref="carbon"/>
+   <composite n="16" ref="hydrogen"/>
+   <composite n="2" ref="nitrogen"/>
+   <composite n="4" ref="oxygen"/>
+  </material>
+
+  <material name="FR4">
+   <D value="1.98281" unit="g/cm3"/>
+   <fraction n="0.47" ref="epoxy_resin"/>
+   <fraction n="0.53" ref="fibrous_glass"/>
+  </material>
+
+  <material name="STEEL_STAINLESS_Fe7Cr2Ni" formula="STEEL_STAINLESS_Fe7Cr2Ni">
+   <D value="7.9300" unit="g/cm3"/>
+   <fraction n="0.0010" ref="carbon"/>
+   <fraction n="0.1792" ref="chromium"/>
+   <fraction n="0.7298" ref="iron"/>
+   <fraction n="0.0900" ref="nickel"/>
+  </material>
+
+  <material name="Copper_Beryllium_alloy25" formula="Copper_Beryllium_alloy25">
+   <D value="8.26" unit="g/cm3"/>
+   <fraction n="0.981" ref="copper"/>
+   <fraction n="0.019" ref="beryllium"/>
+  </material>
+
+  <material name="LAr" formula="LAr">
+   <D value="1.40" unit="g/cm3"/>
+   <fraction n="1.0000" ref="argon"/>
+  </material>
+
+  <material name="ArGas" formula="ArGas">
+   <D value="0.00166" unit="g/cm3"/>
+   <fraction n="1.0" ref="argon"/>
+  </material>
+
+  <material formula=" " name="G10">
+   <D value="1.7" unit="g/cm3"/>
+   <fraction n="0.2805" ref="silicon"/>
+   <fraction n="0.3954" ref="oxygen"/>
+   <fraction n="0.2990" ref="carbon"/>
+   <fraction n="0.0251" ref="hydrogen"/>
+  </material>
+
+  <material formula=" " name="Granite">
+   <D value="2.7" unit="g/cm3"/>
+   <fraction n="0.438" ref="oxygen"/>
+   <fraction n="0.257" ref="silicon"/>
+   <fraction n="0.222" ref="sodium"/>
+   <fraction n="0.049" ref="aluminum"/>
+   <fraction n="0.019" ref="iron"/>
+   <fraction n="0.015" ref="potassium"/>
+  </material>
+
+  <material formula=" " name="ShotRock">
+   <D value="1.62" unit="g/cm3"/>
+   <fraction n="0.438" ref="oxygen"/>
+   <fraction n="0.257" ref="silicon"/>
+   <fraction n="0.222" ref="sodium"/>
+   <fraction n="0.049" ref="aluminum"/>
+   <fraction n="0.019" ref="iron"/>
+   <fraction n="0.015" ref="potassium"/>
+  </material>
+
+  <material formula=" " name="Dirt">
+   <D value="1.7" unit="g/cm3"/>
+   <fraction n="0.438" ref="oxygen"/>
+   <fraction n="0.257" ref="silicon"/>
+   <fraction n="0.222" ref="sodium"/>
+   <fraction n="0.049" ref="aluminum"/>
+   <fraction n="0.019" ref="iron"/>
+   <fraction n="0.015" ref="potassium"/>
+  </material>
+
+  <material formula=" " name="Concrete">
+   <D value="2.3" unit="g/cm3"/>
+   <fraction n="0.530" ref="oxygen"/>
+   <fraction n="0.335" ref="silicon"/>
+   <fraction n="0.060" ref="calcium"/>
+   <fraction n="0.015" ref="sodium"/>
+   <fraction n="0.020" ref="iron"/>
+   <fraction n="0.040" ref="aluminum"/>
+  </material>
+
+  <material formula="H2O" name="Water">
+   <D value="1.0" unit="g/cm3"/>
+   <fraction n="0.1119" ref="hydrogen"/>
+   <fraction n="0.8881" ref="oxygen"/>
+  </material>
+
+  <material formula="Ti" name="Titanium">
+   <D value="4.506" unit="g/cm3"/>
+   <fraction n="1." ref="titanium"/>
+  </material>
+
+  <material name="TPB" formula="TPB">
+   <D value="1.40" unit="g/cm3"/>
+   <fraction n="1.0000" ref="argon"/>
+  </material>
+
+  <material name="Glass">
+   <D value="2.74351" unit="g/cm3"/>
+   <fraction n="0.600" ref="SiO2"/>
+   <fraction n="0.118" ref="Al2O3"/>
+   <fraction n="0.001" ref="Fe2O3"/>
+   <fraction n="0.224" ref="CaO"/>
+   <fraction n="0.034" ref="MgO"/>
+   <fraction n="0.010" ref="Na2O"/>
+   <fraction n="0.013" ref="TiO2"/>
+  </material>
+
+  <material name="Acrylic">
+   <D value="1.19" unit="g/cm3"/>
+   <fraction n="0.600" ref="carbon"/>
+   <fraction n="0.320" ref="oxygen"/>
+   <fraction n="0.080" ref="hydrogen"/>
+  </material>
+
+  <material name="NiGas1atm80K">
+   <D value="0.0039" unit="g/cm3"/>
+   <fraction n="1.000" ref="nitrogen"/>
+  </material>
+
+  <material name="NiGas">
+   <D value="0.001165" unit="g/cm3"/>
+   <fraction n="1.000" ref="nitrogen"/>
+  </material>
+
+  <material name="PolyurethaneFoam">
+   <D value="0.088" unit="g/cm3"/>
+   <composite n="17" ref="carbon"/>
+   <composite n="16" ref="hydrogen"/>
+   <composite n="2" ref="nitrogen"/>
+   <composite n="4" ref="oxygen"/>
+  </material>
+
+  <material name="ProtoDUNEFoam">
+   <D value="0.135" unit="g/cm3"/>
+   <composite n="17" ref="carbon"/>
+   <composite n="16" ref="hydrogen"/>
+   <composite n="2" ref="nitrogen"/>
+   <composite n="4" ref="oxygen"/>
+  </material>
+
+  <material name="LightPolyurethaneFoam">
+   <D value="0.009" unit="g/cm3"/>
+   <composite n="17" ref="carbon"/>
+   <composite n="16" ref="hydrogen"/>
+   <composite n="2" ref="nitrogen"/>
+   <composite n="4" ref="oxygen"/>
+  </material>
+
+  <material name="ProtoDUNEBWFoam">
+   <D value="0.021" unit="g/cm3"/>
+   <composite n="17" ref="carbon"/>
+   <composite n="16" ref="hydrogen"/>
+   <composite n="2" ref="nitrogen"/>
+   <composite n="4" ref="oxygen"/>
+  </material>
+
+  <material name="GlassWool">
+   <D value="0.035" unit="g/cm3"/>
+   <fraction n="0.65" ref="SiO2"/>
+   <fraction n="0.09" ref="Al2O3"/>
+   <fraction n="0.07" ref="CaO"/>
+   <fraction n="0.03" ref="MgO"/>
+   <fraction n="0.16" ref="Na2O"/>
+  </material>
+
+  <material name="Polystyrene">
+   <D value="1.06" unit="g/cm3"/>
+   <composite n="8" ref="carbon"/>
+   <composite n="8" ref="hydrogen"/>
+  </material>
+
+
+
+  <!-- preliminary values -->
+  <material name="AirSteelMixture" formula="AirSteelMixture">
+   <D value=" 0.001205*(1-0.5) + 7.9300*0.5 " unit="g/cm3"/>
+   <fraction n="0.5" ref="STEEL_STAINLESS_Fe7Cr2Ni"/>
+   <fraction n="0.5"   ref="Air"/>
+  </material>
+  <material name="vm2000" formula="vm2000">
+    <D value="1.2" unit="g/cm3"/>
+    <composite n="2" ref="carbon"/>
+    <composite n="4" ref="hydrogen"/>
+  </material>
+
+</materials>
+<solids>
+     <torus name="FieldShaperCorner" rmin="0.5" rmax="2.285" rtor="2.3" deltaphi="90" startphi="0" aunit="deg" lunit="cm"/>
+     <tube name="FieldShaperLongtube" rmin="0.5" rmax="2.285" z="2091.88" deltaphi="360" startphi="0" aunit="deg" lunit="cm"/>
+     <tube name="FieldShaperLongtubeSlim" rmin="0.5" rmax="0.75" z="2091.88" deltaphi="360" startphi="0" aunit="deg" lunit="cm"/>
+     <tube name="FieldShaperShorttube" rmin="0.5" rmax="2.285" z="1345.6048" deltaphi="360" startphi="0" aunit="deg" lunit="cm"/>
+
+    <union name="FSunion1">
+      <first ref="FieldShaperLongtube"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos1" unit="cm" x="-2.3" y="0" z="1045.94"/>
+		<rotation name="rot1" unit="deg" x="90" y="0" z="0" />
+    </union>
+
+    <union name="FSunion2">
+      <first ref="FSunion1"/>
+      <second ref="FieldShaperShorttube"/>
+   		<position name="esquinapos2" unit="cm" x="-675.1024" y="0" z="1048.24"/>
+   		<rotation name="rot2" unit="deg" x="0" y="90" z="0" />
+    </union>
+
+    <union name="FSunion3">
+      <first ref="FSunion2"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos3" unit="cm" x="-1347.9048" y="0" z="1045.94"/>
+		<rotation name="rot3" unit="deg" x="90" y="270" z="0" />
+    </union>
+
+    <union name="FSunion4">
+      <first ref="FSunion3"/>
+      <second ref="FieldShaperLongtube"/>
+   		<position name="esquinapos4" unit="cm" x="-1350.2048" y="0" z="0"/>
+    </union>
+
+    <union name="FSunion5">
+      <first ref="FSunion4"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos5" unit="cm" x="-1347.9048" y="0" z="-1045.94"/>
+		<rotation name="rot5" unit="deg" x="90" y="180" z="0" />
+    </union>
+
+    <union name="FSunion6">
+      <first ref="FSunion5"/>
+      <second ref="FieldShaperShorttube"/>
+   		<position name="esquinapos6" unit="cm" x="-675.1024" y="0" z="-1048.24"/>
+		<rotation name="rot6" unit="deg" x="0" y="90" z="0" />
+    </union>
+
+    <union name="FieldShaperSolid">
+      <first ref="FSunion6"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos7" unit="cm" x="-2.3" y="0" z="-1045.94"/>
+		<rotation name="rot7" unit="deg" x="90" y="90" z="0" />
+    </union>
+    
+    <union name="FSunionSlim1">
+      <first ref="FieldShaperLongtubeSlim"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos1" unit="cm" x="-2.3" y="0" z="1045.94"/>
+		<rotation name="rot1" unit="deg" x="90" y="0" z="0" />
+    </union>
+
+    <union name="FSunionSlim2">
+      <first ref="FSunionSlim1"/>
+      <second ref="FieldShaperShorttube"/>
+   		<position name="esquinapos2" unit="cm" x="-675.1024" y="0" z="1048.24"/>
+   		<rotation name="rot2" unit="deg" x="0" y="90" z="0" />
+    </union>
+
+    <union name="FSunionSlim3">
+      <first ref="FSunionSlim2"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos3" unit="cm" x="-1347.9048" y="0" z="1045.94"/>
+		<rotation name="rot3" unit="deg" x="90" y="270" z="0" />
+    </union>
+
+    <union name="FSunionSlim4">
+      <first ref="FSunionSlim3"/>
+      <second ref="FieldShaperLongtubeSlim"/>
+   		<position name="esquinapos4" unit="cm" x="-1350.2048" y="0" z="0"/>
+    </union>
+
+    <union name="FSunionSlim5">
+      <first ref="FSunionSlim4"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos5" unit="cm" x="-1347.9048" y="0" z="-1045.94"/>
+		<rotation name="rot5" unit="deg" x="90" y="180" z="0" />
+    </union>
+
+    <union name="FSunionSlim6">
+      <first ref="FSunionSlim5"/>
+      <second ref="FieldShaperShorttube"/>
+   		<position name="esquinapos6" unit="cm" x="-675.1024" y="0" z="-1048.24"/>
+		<rotation name="rot6" unit="deg" x="0" y="90" z="0" />
+    </union>
+
+    <union name="FieldShaperSolidSlim">
+      <first ref="FSunionSlim6"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos7" unit="cm" x="-2.3" y="0" z="-1045.94"/>
+		<rotation name="rot7" unit="deg" x="90" y="90" z="0" />
+    </union>
+    
+
+   <box name="CRM"
+      x="650.08" 
+      y="167.7006" 
+      z="148.92"
+      lunit="cm"/>
+   <box name="CRMUPlane" 
+      x="0.02" 
+      y="167.7006" 
+      z="148.92"
+      lunit="cm"/>
+   <box name="CRMVPlane" 
+      x="0.02" 
+      y="167.7006" 
+      z="148.92"
+      lunit="cm"/>
+   <box name="CRMZPlane" 
+      x="0.02"
+      y="167.7006"
+      z="148.92"
+      lunit="cm"/>
+   <box name="CRMActive" 
+      x="650"
+      y="167.7006"
+      z="148.92"
+      lunit="cm"/>
+   <tube name="CRMWireU0"
+      rmax="0.5*0.02"
+      z="0.883345911860126"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU1"
+      rmax="0.5*0.02"
+      z="2.65003773558038"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU2"
+      rmax="0.5*0.02"
+      z="4.41672955930064"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU3"
+      rmax="0.5*0.02"
+      z="6.18342138302089"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU4"
+      rmax="0.5*0.02"
+      z="7.95011320674115"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU5"
+      rmax="0.5*0.02"
+      z="9.7168050304614"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU6"
+      rmax="0.5*0.02"
+      z="11.4834968541817"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU7"
+      rmax="0.5*0.02"
+      z="13.2501886779019"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU8"
+      rmax="0.5*0.02"
+      z="15.0168805016222"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU9"
+      rmax="0.5*0.02"
+      z="16.7835723253424"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU10"
+      rmax="0.5*0.02"
+      z="18.5502641490627"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU11"
+      rmax="0.5*0.02"
+      z="20.3169559727829"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU12"
+      rmax="0.5*0.02"
+      z="22.0836477965032"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU13"
+      rmax="0.5*0.02"
+      z="23.8503396202234"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU14"
+      rmax="0.5*0.02"
+      z="25.6170314439437"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU15"
+      rmax="0.5*0.02"
+      z="27.383723267664"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU16"
+      rmax="0.5*0.02"
+      z="29.1504150913842"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU17"
+      rmax="0.5*0.02"
+      z="30.9171069151045"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU18"
+      rmax="0.5*0.02"
+      z="32.6837987388247"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU19"
+      rmax="0.5*0.02"
+      z="34.450490562545"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU20"
+      rmax="0.5*0.02"
+      z="36.2171823862652"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU21"
+      rmax="0.5*0.02"
+      z="37.9838742099855"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU22"
+      rmax="0.5*0.02"
+      z="39.7505660337058"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU23"
+      rmax="0.5*0.02"
+      z="41.517257857426"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU24"
+      rmax="0.5*0.02"
+      z="43.2839496811463"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU25"
+      rmax="0.5*0.02"
+      z="45.0506415048665"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU26"
+      rmax="0.5*0.02"
+      z="46.8173333285868"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU27"
+      rmax="0.5*0.02"
+      z="48.584025152307"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU28"
+      rmax="0.5*0.02"
+      z="50.3507169760273"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU29"
+      rmax="0.5*0.02"
+      z="52.1174087997475"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU30"
+      rmax="0.5*0.02"
+      z="53.8841006234678"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU31"
+      rmax="0.5*0.02"
+      z="55.6507924471881"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU32"
+      rmax="0.5*0.02"
+      z="57.4174842709083"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU33"
+      rmax="0.5*0.02"
+      z="59.1841760946286"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU34"
+      rmax="0.5*0.02"
+      z="60.9508679183488"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU35"
+      rmax="0.5*0.02"
+      z="62.7175597420691"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU36"
+      rmax="0.5*0.02"
+      z="64.4842515657894"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU37"
+      rmax="0.5*0.02"
+      z="66.2509433895096"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU38"
+      rmax="0.5*0.02"
+      z="68.0176352132299"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU39"
+      rmax="0.5*0.02"
+      z="69.7843270369501"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU40"
+      rmax="0.5*0.02"
+      z="71.5510188606704"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU41"
+      rmax="0.5*0.02"
+      z="73.3177106843906"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU42"
+      rmax="0.5*0.02"
+      z="75.0844025081109"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU43"
+      rmax="0.5*0.02"
+      z="76.8510943318311"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU44"
+      rmax="0.5*0.02"
+      z="78.6177861555514"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU45"
+      rmax="0.5*0.02"
+      z="80.3844779792717"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU46"
+      rmax="0.5*0.02"
+      z="82.1511698029919"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU47"
+      rmax="0.5*0.02"
+      z="83.9178616267122"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU48"
+      rmax="0.5*0.02"
+      z="85.6845534504324"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU49"
+      rmax="0.5*0.02"
+      z="87.4512452741527"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU50"
+      rmax="0.5*0.02"
+      z="89.2179370978729"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU51"
+      rmax="0.5*0.02"
+      z="90.9846289215932"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU52"
+      rmax="0.5*0.02"
+      z="92.7513207453134"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU53"
+      rmax="0.5*0.02"
+      z="94.5180125690337"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU54"
+      rmax="0.5*0.02"
+      z="96.284704392754"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU55"
+      rmax="0.5*0.02"
+      z="98.0513962164742"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU56"
+      rmax="0.5*0.02"
+      z="99.8180880401945"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU57"
+      rmax="0.5*0.02"
+      z="101.584779863915"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU58"
+      rmax="0.5*0.02"
+      z="103.351471687635"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU59"
+      rmax="0.5*0.02"
+      z="105.118163511355"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU60"
+      rmax="0.5*0.02"
+      z="106.884855335075"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU61"
+      rmax="0.5*0.02"
+      z="108.651547158796"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU62"
+      rmax="0.5*0.02"
+      z="110.418238982516"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU63"
+      rmax="0.5*0.02"
+      z="112.184930806236"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU64"
+      rmax="0.5*0.02"
+      z="113.951622629957"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU65"
+      rmax="0.5*0.02"
+      z="115.718314453677"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU66"
+      rmax="0.5*0.02"
+      z="117.485006277397"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU67"
+      rmax="0.5*0.02"
+      z="119.251698101117"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU68"
+      rmax="0.5*0.02"
+      z="121.018389924838"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU69"
+      rmax="0.5*0.02"
+      z="122.785081748558"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU70"
+      rmax="0.5*0.02"
+      z="124.551773572278"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU71"
+      rmax="0.5*0.02"
+      z="126.318465395998"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU72"
+      rmax="0.5*0.02"
+      z="128.085157219719"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU73"
+      rmax="0.5*0.02"
+      z="129.851849043439"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU74"
+      rmax="0.5*0.02"
+      z="131.618540867159"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU75"
+      rmax="0.5*0.02"
+      z="133.385232690879"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU76"
+      rmax="0.5*0.02"
+      z="135.1519245146"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU77"
+      rmax="0.5*0.02"
+      z="136.91861633832"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU78"
+      rmax="0.5*0.02"
+      z="138.68530816204"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU79"
+      rmax="0.5*0.02"
+      z="140.45199998576"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU80"
+      rmax="0.5*0.02"
+      z="142.218691809481"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU81"
+      rmax="0.5*0.02"
+      z="143.985383633201"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU82"
+      rmax="0.5*0.02"
+      z="145.752075456921"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU83"
+      rmax="0.5*0.02"
+      z="147.518767280641"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU84"
+      rmax="0.5*0.02"
+      z="149.285459104362"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU85"
+      rmax="0.5*0.02"
+      z="151.052150928082"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU86"
+      rmax="0.5*0.02"
+      z="152.818842751802"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU87"
+      rmax="0.5*0.02"
+      z="154.585534575522"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU88"
+      rmax="0.5*0.02"
+      z="156.352226399243"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU89"
+      rmax="0.5*0.02"
+      z="158.118918222963"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU90"
+      rmax="0.5*0.02"
+      z="159.885610046683"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU91"
+      rmax="0.5*0.02"
+      z="161.652301870403"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU92"
+      rmax="0.5*0.02"
+      z="163.418993694124"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU93"
+      rmax="0.5*0.02"
+      z="165.185685517844"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU94"
+      rmax="0.5*0.02"
+      z="166.952377341564"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU95"
+      rmax="0.5*0.02"
+      z="168.719069165284"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU96"
+      rmax="0.5*0.02"
+      z="170.485760989005"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU97"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU98"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU99"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU100"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU101"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU102"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU103"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU104"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU105"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU106"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU107"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU108"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU109"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU110"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU111"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU112"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU113"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU114"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU115"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU116"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU117"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU118"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU119"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU120"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU121"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU122"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU123"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU124"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU125"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU126"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU127"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU128"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU129"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU130"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU131"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU132"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU133"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU134"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU135"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU136"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU137"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU138"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU139"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU140"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU141"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU142"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU143"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU144"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU145"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU146"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU147"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU148"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU149"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU150"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU151"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU152"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU153"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU154"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU155"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU156"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU157"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU158"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU159"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU160"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU161"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU162"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU163"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU164"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU165"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU166"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU167"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU168"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU169"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU170"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU171"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU172"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU173"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU174"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU175"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU176"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU177"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU178"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU179"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU180"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU181"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU182"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU183"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU184"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU185"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU186"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU187"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU188"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU189"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU190"
+      rmax="0.5*0.02"
+      z="171.074658263579"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU191"
+      rmax="0.5*0.02"
+      z="169.307966439858"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU192"
+      rmax="0.5*0.02"
+      z="167.541274616138"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU193"
+      rmax="0.5*0.02"
+      z="165.774582792418"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU194"
+      rmax="0.5*0.02"
+      z="164.007890968698"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU195"
+      rmax="0.5*0.02"
+      z="162.241199144977"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU196"
+      rmax="0.5*0.02"
+      z="160.474507321257"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU197"
+      rmax="0.5*0.02"
+      z="158.707815497537"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU198"
+      rmax="0.5*0.02"
+      z="156.941123673817"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU199"
+      rmax="0.5*0.02"
+      z="155.174431850097"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU200"
+      rmax="0.5*0.02"
+      z="153.407740026376"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU201"
+      rmax="0.5*0.02"
+      z="151.641048202656"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU202"
+      rmax="0.5*0.02"
+      z="149.874356378936"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU203"
+      rmax="0.5*0.02"
+      z="148.107664555216"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU204"
+      rmax="0.5*0.02"
+      z="146.340972731495"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU205"
+      rmax="0.5*0.02"
+      z="144.574280907775"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU206"
+      rmax="0.5*0.02"
+      z="142.807589084055"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU207"
+      rmax="0.5*0.02"
+      z="141.040897260335"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU208"
+      rmax="0.5*0.02"
+      z="139.274205436614"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU209"
+      rmax="0.5*0.02"
+      z="137.507513612894"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU210"
+      rmax="0.5*0.02"
+      z="135.740821789174"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU211"
+      rmax="0.5*0.02"
+      z="133.974129965454"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU212"
+      rmax="0.5*0.02"
+      z="132.207438141734"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU213"
+      rmax="0.5*0.02"
+      z="130.440746318013"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU214"
+      rmax="0.5*0.02"
+      z="128.674054494293"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU215"
+      rmax="0.5*0.02"
+      z="126.907362670573"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU216"
+      rmax="0.5*0.02"
+      z="125.140670846853"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU217"
+      rmax="0.5*0.02"
+      z="123.373979023133"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU218"
+      rmax="0.5*0.02"
+      z="121.607287199412"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU219"
+      rmax="0.5*0.02"
+      z="119.840595375692"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU220"
+      rmax="0.5*0.02"
+      z="118.073903551972"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU221"
+      rmax="0.5*0.02"
+      z="116.307211728252"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU222"
+      rmax="0.5*0.02"
+      z="114.540519904531"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU223"
+      rmax="0.5*0.02"
+      z="112.773828080811"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU224"
+      rmax="0.5*0.02"
+      z="111.007136257091"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU225"
+      rmax="0.5*0.02"
+      z="109.240444433371"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU226"
+      rmax="0.5*0.02"
+      z="107.47375260965"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU227"
+      rmax="0.5*0.02"
+      z="105.70706078593"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU228"
+      rmax="0.5*0.02"
+      z="103.94036896221"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU229"
+      rmax="0.5*0.02"
+      z="102.17367713849"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU230"
+      rmax="0.5*0.02"
+      z="100.40698531477"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU231"
+      rmax="0.5*0.02"
+      z="98.6402934910494"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU232"
+      rmax="0.5*0.02"
+      z="96.8736016673292"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU233"
+      rmax="0.5*0.02"
+      z="95.106909843609"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU234"
+      rmax="0.5*0.02"
+      z="93.3402180198887"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU235"
+      rmax="0.5*0.02"
+      z="91.5735261961685"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU236"
+      rmax="0.5*0.02"
+      z="89.8068343724483"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU237"
+      rmax="0.5*0.02"
+      z="88.040142548728"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU238"
+      rmax="0.5*0.02"
+      z="86.2734507250078"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU239"
+      rmax="0.5*0.02"
+      z="84.5067589012876"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU240"
+      rmax="0.5*0.02"
+      z="82.7400670775674"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU241"
+      rmax="0.5*0.02"
+      z="80.9733752538472"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU242"
+      rmax="0.5*0.02"
+      z="79.2066834301269"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU243"
+      rmax="0.5*0.02"
+      z="77.4399916064067"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU244"
+      rmax="0.5*0.02"
+      z="75.6732997826865"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU245"
+      rmax="0.5*0.02"
+      z="73.9066079589663"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU246"
+      rmax="0.5*0.02"
+      z="72.1399161352461"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU247"
+      rmax="0.5*0.02"
+      z="70.3732243115258"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU248"
+      rmax="0.5*0.02"
+      z="68.6065324878056"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU249"
+      rmax="0.5*0.02"
+      z="66.8398406640853"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU250"
+      rmax="0.5*0.02"
+      z="65.0731488403651"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU251"
+      rmax="0.5*0.02"
+      z="63.3064570166449"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU252"
+      rmax="0.5*0.02"
+      z="61.5397651929247"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU253"
+      rmax="0.5*0.02"
+      z="59.7730733692045"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU254"
+      rmax="0.5*0.02"
+      z="58.0063815454843"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU255"
+      rmax="0.5*0.02"
+      z="56.239689721764"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU256"
+      rmax="0.5*0.02"
+      z="54.4729978980438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU257"
+      rmax="0.5*0.02"
+      z="52.7063060743236"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU258"
+      rmax="0.5*0.02"
+      z="50.9396142506034"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU259"
+      rmax="0.5*0.02"
+      z="49.1729224268832"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU260"
+      rmax="0.5*0.02"
+      z="47.406230603163"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU261"
+      rmax="0.5*0.02"
+      z="45.6395387794427"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU262"
+      rmax="0.5*0.02"
+      z="43.8728469557225"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU263"
+      rmax="0.5*0.02"
+      z="42.1061551320022"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU264"
+      rmax="0.5*0.02"
+      z="40.339463308282"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU265"
+      rmax="0.5*0.02"
+      z="38.5727714845618"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU266"
+      rmax="0.5*0.02"
+      z="36.8060796608416"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU267"
+      rmax="0.5*0.02"
+      z="35.0393878371214"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU268"
+      rmax="0.5*0.02"
+      z="33.2726960134011"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU269"
+      rmax="0.5*0.02"
+      z="31.5060041896809"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU270"
+      rmax="0.5*0.02"
+      z="29.7393123659607"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU271"
+      rmax="0.5*0.02"
+      z="27.9726205422405"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU272"
+      rmax="0.5*0.02"
+      z="26.2059287185202"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU273"
+      rmax="0.5*0.02"
+      z="24.4392368948"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU274"
+      rmax="0.5*0.02"
+      z="22.6725450710797"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU275"
+      rmax="0.5*0.02"
+      z="20.9058532473595"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU276"
+      rmax="0.5*0.02"
+      z="19.1391614236393"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU277"
+      rmax="0.5*0.02"
+      z="17.3724695999191"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU278"
+      rmax="0.5*0.02"
+      z="15.6057777761989"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU279"
+      rmax="0.5*0.02"
+      z="13.8390859524787"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU280"
+      rmax="0.5*0.02"
+      z="12.0723941287584"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU281"
+      rmax="0.5*0.02"
+      z="10.3057023050382"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU282"
+      rmax="0.5*0.02"
+      z="8.53901048131801"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU283"
+      rmax="0.5*0.02"
+      z="6.7723186575978"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU284"
+      rmax="0.5*0.02"
+      z="5.00562683387757"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU285"
+      rmax="0.5*0.02"
+      z="3.23893501015734"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV0"
+      rmax="0.5*0.02"
+      z="0.883345911860106"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV1"
+      rmax="0.5*0.02"
+      z="2.6500377355804"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV2"
+      rmax="0.5*0.02"
+      z="4.41672955930062"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV3"
+      rmax="0.5*0.02"
+      z="6.18342138302091"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV4"
+      rmax="0.5*0.02"
+      z="7.95011320674114"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV5"
+      rmax="0.5*0.02"
+      z="9.71680503046143"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV6"
+      rmax="0.5*0.02"
+      z="11.4834968541816"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV7"
+      rmax="0.5*0.02"
+      z="13.2501886779019"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV8"
+      rmax="0.5*0.02"
+      z="15.0168805016222"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV9"
+      rmax="0.5*0.02"
+      z="16.7835723253424"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV10"
+      rmax="0.5*0.02"
+      z="18.5502641490627"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV11"
+      rmax="0.5*0.02"
+      z="20.3169559727829"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV12"
+      rmax="0.5*0.02"
+      z="22.0836477965032"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV13"
+      rmax="0.5*0.02"
+      z="23.8503396202235"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV14"
+      rmax="0.5*0.02"
+      z="25.6170314439437"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV15"
+      rmax="0.5*0.02"
+      z="27.383723267664"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV16"
+      rmax="0.5*0.02"
+      z="29.1504150913842"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV17"
+      rmax="0.5*0.02"
+      z="30.9171069151045"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV18"
+      rmax="0.5*0.02"
+      z="32.6837987388247"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV19"
+      rmax="0.5*0.02"
+      z="34.450490562545"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV20"
+      rmax="0.5*0.02"
+      z="36.2171823862652"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV21"
+      rmax="0.5*0.02"
+      z="37.9838742099855"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV22"
+      rmax="0.5*0.02"
+      z="39.7505660337057"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV23"
+      rmax="0.5*0.02"
+      z="41.517257857426"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV24"
+      rmax="0.5*0.02"
+      z="43.2839496811462"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV25"
+      rmax="0.5*0.02"
+      z="45.0506415048665"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV26"
+      rmax="0.5*0.02"
+      z="46.8173333285868"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV27"
+      rmax="0.5*0.02"
+      z="48.584025152307"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV28"
+      rmax="0.5*0.02"
+      z="50.3507169760273"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV29"
+      rmax="0.5*0.02"
+      z="52.1174087997476"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV30"
+      rmax="0.5*0.02"
+      z="53.8841006234678"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV31"
+      rmax="0.5*0.02"
+      z="55.6507924471881"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV32"
+      rmax="0.5*0.02"
+      z="57.4174842709083"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV33"
+      rmax="0.5*0.02"
+      z="59.1841760946286"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV34"
+      rmax="0.5*0.02"
+      z="60.9508679183488"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV35"
+      rmax="0.5*0.02"
+      z="62.7175597420691"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV36"
+      rmax="0.5*0.02"
+      z="64.4842515657893"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV37"
+      rmax="0.5*0.02"
+      z="66.2509433895096"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV38"
+      rmax="0.5*0.02"
+      z="68.0176352132298"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV39"
+      rmax="0.5*0.02"
+      z="69.7843270369501"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV40"
+      rmax="0.5*0.02"
+      z="71.5510188606703"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV41"
+      rmax="0.5*0.02"
+      z="73.3177106843906"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV42"
+      rmax="0.5*0.02"
+      z="75.0844025081108"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV43"
+      rmax="0.5*0.02"
+      z="76.8510943318311"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV44"
+      rmax="0.5*0.02"
+      z="78.6177861555514"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV45"
+      rmax="0.5*0.02"
+      z="80.3844779792717"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV46"
+      rmax="0.5*0.02"
+      z="82.1511698029919"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV47"
+      rmax="0.5*0.02"
+      z="83.9178616267122"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV48"
+      rmax="0.5*0.02"
+      z="85.6845534504325"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV49"
+      rmax="0.5*0.02"
+      z="87.4512452741527"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV50"
+      rmax="0.5*0.02"
+      z="89.2179370978729"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV51"
+      rmax="0.5*0.02"
+      z="90.9846289215932"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV52"
+      rmax="0.5*0.02"
+      z="92.7513207453135"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV53"
+      rmax="0.5*0.02"
+      z="94.5180125690337"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV54"
+      rmax="0.5*0.02"
+      z="96.2847043927539"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV55"
+      rmax="0.5*0.02"
+      z="98.0513962164742"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV56"
+      rmax="0.5*0.02"
+      z="99.8180880401945"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV57"
+      rmax="0.5*0.02"
+      z="101.584779863915"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV58"
+      rmax="0.5*0.02"
+      z="103.351471687635"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV59"
+      rmax="0.5*0.02"
+      z="105.118163511355"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV60"
+      rmax="0.5*0.02"
+      z="106.884855335075"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV61"
+      rmax="0.5*0.02"
+      z="108.651547158796"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV62"
+      rmax="0.5*0.02"
+      z="110.418238982516"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV63"
+      rmax="0.5*0.02"
+      z="112.184930806236"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV64"
+      rmax="0.5*0.02"
+      z="113.951622629957"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV65"
+      rmax="0.5*0.02"
+      z="115.718314453677"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV66"
+      rmax="0.5*0.02"
+      z="117.485006277397"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV67"
+      rmax="0.5*0.02"
+      z="119.251698101117"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV68"
+      rmax="0.5*0.02"
+      z="121.018389924838"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV69"
+      rmax="0.5*0.02"
+      z="122.785081748558"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV70"
+      rmax="0.5*0.02"
+      z="124.551773572278"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV71"
+      rmax="0.5*0.02"
+      z="126.318465395998"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV72"
+      rmax="0.5*0.02"
+      z="128.085157219719"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV73"
+      rmax="0.5*0.02"
+      z="129.851849043439"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV74"
+      rmax="0.5*0.02"
+      z="131.618540867159"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV75"
+      rmax="0.5*0.02"
+      z="133.385232690879"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV76"
+      rmax="0.5*0.02"
+      z="135.1519245146"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV77"
+      rmax="0.5*0.02"
+      z="136.91861633832"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV78"
+      rmax="0.5*0.02"
+      z="138.68530816204"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV79"
+      rmax="0.5*0.02"
+      z="140.45199998576"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV80"
+      rmax="0.5*0.02"
+      z="142.218691809481"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV81"
+      rmax="0.5*0.02"
+      z="143.985383633201"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV82"
+      rmax="0.5*0.02"
+      z="145.752075456921"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV83"
+      rmax="0.5*0.02"
+      z="147.518767280641"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV84"
+      rmax="0.5*0.02"
+      z="149.285459104362"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV85"
+      rmax="0.5*0.02"
+      z="151.052150928082"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV86"
+      rmax="0.5*0.02"
+      z="152.818842751802"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV87"
+      rmax="0.5*0.02"
+      z="154.585534575522"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV88"
+      rmax="0.5*0.02"
+      z="156.352226399243"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV89"
+      rmax="0.5*0.02"
+      z="158.118918222963"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV90"
+      rmax="0.5*0.02"
+      z="159.885610046683"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV91"
+      rmax="0.5*0.02"
+      z="161.652301870403"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV92"
+      rmax="0.5*0.02"
+      z="163.418993694124"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV93"
+      rmax="0.5*0.02"
+      z="165.185685517844"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV94"
+      rmax="0.5*0.02"
+      z="166.952377341564"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV95"
+      rmax="0.5*0.02"
+      z="168.719069165284"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV96"
+      rmax="0.5*0.02"
+      z="170.485760989005"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV97"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV98"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV99"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV100"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV101"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV102"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV103"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV104"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV105"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV106"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV107"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV108"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV109"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV110"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV111"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV112"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV113"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV114"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV115"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV116"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV117"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV118"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV119"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV120"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV121"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV122"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV123"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV124"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV125"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV126"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV127"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV128"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV129"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV130"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV131"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV132"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV133"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV134"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV135"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV136"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV137"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV138"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV139"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV140"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV141"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV142"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV143"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV144"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV145"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV146"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV147"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV148"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV149"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV150"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV151"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV152"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV153"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV154"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV155"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV156"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV157"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV158"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV159"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV160"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV161"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV162"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV163"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV164"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV165"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV166"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV167"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV168"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV169"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV170"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV171"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV172"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV173"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV174"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV175"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV176"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV177"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV178"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV179"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV180"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV181"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV182"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV183"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV184"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV185"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV186"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV187"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV188"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV189"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV190"
+      rmax="0.5*0.02"
+      z="171.074658263579"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV191"
+      rmax="0.5*0.02"
+      z="169.307966439858"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV192"
+      rmax="0.5*0.02"
+      z="167.541274616138"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV193"
+      rmax="0.5*0.02"
+      z="165.774582792418"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV194"
+      rmax="0.5*0.02"
+      z="164.007890968698"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV195"
+      rmax="0.5*0.02"
+      z="162.241199144977"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV196"
+      rmax="0.5*0.02"
+      z="160.474507321257"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV197"
+      rmax="0.5*0.02"
+      z="158.707815497537"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV198"
+      rmax="0.5*0.02"
+      z="156.941123673817"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV199"
+      rmax="0.5*0.02"
+      z="155.174431850097"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV200"
+      rmax="0.5*0.02"
+      z="153.407740026376"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV201"
+      rmax="0.5*0.02"
+      z="151.641048202656"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV202"
+      rmax="0.5*0.02"
+      z="149.874356378936"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV203"
+      rmax="0.5*0.02"
+      z="148.107664555216"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV204"
+      rmax="0.5*0.02"
+      z="146.340972731495"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV205"
+      rmax="0.5*0.02"
+      z="144.574280907775"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV206"
+      rmax="0.5*0.02"
+      z="142.807589084055"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV207"
+      rmax="0.5*0.02"
+      z="141.040897260335"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV208"
+      rmax="0.5*0.02"
+      z="139.274205436614"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV209"
+      rmax="0.5*0.02"
+      z="137.507513612894"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV210"
+      rmax="0.5*0.02"
+      z="135.740821789174"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV211"
+      rmax="0.5*0.02"
+      z="133.974129965454"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV212"
+      rmax="0.5*0.02"
+      z="132.207438141734"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV213"
+      rmax="0.5*0.02"
+      z="130.440746318013"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV214"
+      rmax="0.5*0.02"
+      z="128.674054494293"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV215"
+      rmax="0.5*0.02"
+      z="126.907362670573"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV216"
+      rmax="0.5*0.02"
+      z="125.140670846853"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV217"
+      rmax="0.5*0.02"
+      z="123.373979023133"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV218"
+      rmax="0.5*0.02"
+      z="121.607287199412"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV219"
+      rmax="0.5*0.02"
+      z="119.840595375692"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV220"
+      rmax="0.5*0.02"
+      z="118.073903551972"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV221"
+      rmax="0.5*0.02"
+      z="116.307211728252"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV222"
+      rmax="0.5*0.02"
+      z="114.540519904531"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV223"
+      rmax="0.5*0.02"
+      z="112.773828080811"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV224"
+      rmax="0.5*0.02"
+      z="111.007136257091"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV225"
+      rmax="0.5*0.02"
+      z="109.240444433371"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV226"
+      rmax="0.5*0.02"
+      z="107.47375260965"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV227"
+      rmax="0.5*0.02"
+      z="105.70706078593"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV228"
+      rmax="0.5*0.02"
+      z="103.94036896221"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV229"
+      rmax="0.5*0.02"
+      z="102.17367713849"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV230"
+      rmax="0.5*0.02"
+      z="100.40698531477"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV231"
+      rmax="0.5*0.02"
+      z="98.6402934910494"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV232"
+      rmax="0.5*0.02"
+      z="96.8736016673292"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV233"
+      rmax="0.5*0.02"
+      z="95.106909843609"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV234"
+      rmax="0.5*0.02"
+      z="93.3402180198887"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV235"
+      rmax="0.5*0.02"
+      z="91.5735261961685"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV236"
+      rmax="0.5*0.02"
+      z="89.8068343724483"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV237"
+      rmax="0.5*0.02"
+      z="88.040142548728"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV238"
+      rmax="0.5*0.02"
+      z="86.2734507250078"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV239"
+      rmax="0.5*0.02"
+      z="84.5067589012876"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV240"
+      rmax="0.5*0.02"
+      z="82.7400670775674"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV241"
+      rmax="0.5*0.02"
+      z="80.9733752538472"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV242"
+      rmax="0.5*0.02"
+      z="79.2066834301269"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV243"
+      rmax="0.5*0.02"
+      z="77.4399916064067"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV244"
+      rmax="0.5*0.02"
+      z="75.6732997826865"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV245"
+      rmax="0.5*0.02"
+      z="73.9066079589663"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV246"
+      rmax="0.5*0.02"
+      z="72.1399161352461"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV247"
+      rmax="0.5*0.02"
+      z="70.3732243115258"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV248"
+      rmax="0.5*0.02"
+      z="68.6065324878056"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV249"
+      rmax="0.5*0.02"
+      z="66.8398406640853"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV250"
+      rmax="0.5*0.02"
+      z="65.0731488403651"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV251"
+      rmax="0.5*0.02"
+      z="63.3064570166449"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV252"
+      rmax="0.5*0.02"
+      z="61.5397651929247"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV253"
+      rmax="0.5*0.02"
+      z="59.7730733692045"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV254"
+      rmax="0.5*0.02"
+      z="58.0063815454843"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV255"
+      rmax="0.5*0.02"
+      z="56.239689721764"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV256"
+      rmax="0.5*0.02"
+      z="54.4729978980438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV257"
+      rmax="0.5*0.02"
+      z="52.7063060743236"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV258"
+      rmax="0.5*0.02"
+      z="50.9396142506034"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV259"
+      rmax="0.5*0.02"
+      z="49.1729224268832"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV260"
+      rmax="0.5*0.02"
+      z="47.4062306031629"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV261"
+      rmax="0.5*0.02"
+      z="45.6395387794427"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV262"
+      rmax="0.5*0.02"
+      z="43.8728469557225"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV263"
+      rmax="0.5*0.02"
+      z="42.1061551320022"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV264"
+      rmax="0.5*0.02"
+      z="40.339463308282"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV265"
+      rmax="0.5*0.02"
+      z="38.5727714845618"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV266"
+      rmax="0.5*0.02"
+      z="36.8060796608416"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV267"
+      rmax="0.5*0.02"
+      z="35.0393878371214"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV268"
+      rmax="0.5*0.02"
+      z="33.2726960134011"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV269"
+      rmax="0.5*0.02"
+      z="31.5060041896809"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV270"
+      rmax="0.5*0.02"
+      z="29.7393123659607"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV271"
+      rmax="0.5*0.02"
+      z="27.9726205422405"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV272"
+      rmax="0.5*0.02"
+      z="26.2059287185203"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV273"
+      rmax="0.5*0.02"
+      z="24.4392368948"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV274"
+      rmax="0.5*0.02"
+      z="22.6725450710797"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV275"
+      rmax="0.5*0.02"
+      z="20.9058532473596"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV276"
+      rmax="0.5*0.02"
+      z="19.1391614236393"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV277"
+      rmax="0.5*0.02"
+      z="17.3724695999191"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV278"
+      rmax="0.5*0.02"
+      z="15.6057777761989"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV279"
+      rmax="0.5*0.02"
+      z="13.8390859524787"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV280"
+      rmax="0.5*0.02"
+      z="12.0723941287584"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV281"
+      rmax="0.5*0.02"
+      z="10.3057023050382"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV282"
+      rmax="0.5*0.02"
+      z="8.53901048131802"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV283"
+      rmax="0.5*0.02"
+      z="6.7723186575978"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV284"
+      rmax="0.5*0.02"
+      z="5.00562683387757"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV285"
+      rmax="0.5*0.02"
+      z="3.23893501015735"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireZ"
+      rmax="0.5*0.02"
+      z="167.7006"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+
+    <box name="ArapucaOut" lunit="cm"
+      x="65"
+      y="2.5"
+      z="65"/>
+
+    <box name="ArapucaIn" lunit="cm"
+      x="60"
+      y="2.5"
+      z="60"/>
+
+     <subtraction name="ArapucaWalls">
+      <first  ref="ArapucaOut"/>
+      <second ref="ArapucaIn"/>
+      <position name="posArapucaSub" x="0" y="1.25" z="0." unit="cm"/>
+      </subtraction>
+
+    <box name="ArapucaAcceptanceWindow" lunit="cm"
+      x="60"
+      y="1"
+      z="60"/>
+
+    <box name="ArapucaDoubleIn" lunit="cm"
+      x="60"
+      y="3.5"
+      z="60"/>
+
+     <subtraction name="ArapucaDoubleWalls">
+      <first  ref="ArapucaOut"/>
+      <second ref="ArapucaDoubleIn"/>
+      <position name="posArapucaDoubleSub" x="0" y="0" z="0" unit="cm"/>
+      </subtraction>
+
+    <box name="ArapucaDoubleAcceptanceWindow" lunit="cm"
+      x="2.48"
+      y="60"
+      z="60"/>
+
+    <box name="ArapucaCathodeAcceptanceWindow" lunit="cm"
+      x="1"
+      y="60"
+      z="60"/>
+
+
+    <box name="Cryostat" lunit="cm" 
+      x="850.32" 
+      y="1545.8448" 
+      z="2292.12"/>
+
+    <box name="ArgonInterior" lunit="cm" 
+      x="850.08"
+      y="1545.6048"
+      z="2291.88"/>
+
+    <box name="GaseousArgon" lunit="cm" 
+      x="100 - 0.01"
+      y="1545.6048"
+      z="2291.88"/>
+
+    <box name="ExternalAuxOut" lunit="cm" 
+      x="850.08 - 100"
+      y="1545.6048 - 2*2.5 - 2*40"
+      z="2291.88"/>
+
+    <box name="ExternalAuxIn" lunit="cm" 
+      x="850.08"
+      y="1356.7748"
+      z="2291.88 + 1"/>
+
+   <subtraction name="ExternalActive">
+      <first ref="ExternalAuxOut"/>
+      <second ref="ExternalAuxIn"/>
+    </subtraction>
+
+    <subtraction name="SteelShell">
+      <first ref="Cryostat"/>
+      <second ref="ArgonInterior"/>
+    </subtraction>
+
+
+
+    <box name="CathodeBlock" lunit="cm"
+      x="4"
+      y="335.4012"
+      z="297.84" />
+
+    <box name="CathodeVoid" lunit="cm"
+      x="5"
+      y="76.35"
+      z="67" />
+
+    <subtraction name="Cathode1">
+      <first ref="CathodeBlock"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub1" x="0" y="-122.525" z="-108.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode2">
+      <first ref="Cathode1"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub2" x="0" y="-122.525" z="-37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode3">
+      <first ref="Cathode2"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub3" x="0" y="-122.525" z="37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode4">
+      <first ref="Cathode3"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub4" x="0" y="-122.525" z="108.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode5">
+      <first ref="Cathode4"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub5" x="0" y="-42.175" z="-108.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode6">
+      <first ref="Cathode5"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub6" x="0" y="-42.175" z="-37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode7">
+      <first ref="Cathode6"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub7" x="0" y="-42.175" z="37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode8">
+      <first ref="Cathode7"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub8" x="0" y="-42.175" z="108.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode9">
+      <first ref="Cathode8"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub9" x="0" y="42.175" z="-108.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode10">
+      <first ref="Cathode9"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub10" x="0" y="42.175" z="-37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode11">
+      <first ref="Cathode10"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub11" x="0" y="42.175" z="37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode12">
+      <first ref="Cathode11"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub12" x="0" y="42.175" z="108.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode13">
+      <first ref="Cathode12"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub13" x="0" y="122.525" z="-108.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode14">
+      <first ref="Cathode13"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub14" x="0" y="122.525" z="-37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode15">
+      <first ref="Cathode14"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub15" x="0" y="122.525" z="37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="CathodeGrid">
+      <first ref="Cathode15"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub16" x="0" y="122.525" z="108.5" unit="cm"/>
+    </subtraction>
+
+   <box name="AnodePlate" 
+      x="0.01"
+      y="335.4012"
+      z="297.84"
+      lunit="cm"/>
+
+    <box name="FoamPadBlock" lunit="cm"
+      x="1010.32"
+      y="1705.8448"
+      z="2452.12" />
+
+    <subtraction name="FoamPadding">
+      <first ref="FoamPadBlock"/>
+      <second ref="Cryostat"/>
+      <positionref ref="posCenter"/>
+    </subtraction>
+
+    <box name="SteelSupportBlock" lunit="cm"
+      x="1210.32"
+      y="1905.8448"
+      z="2652.12" />
+
+    <subtraction name="SteelSupport">
+      <first ref="SteelSupportBlock"/>
+      <second ref="FoamPadBlock"/>
+      <positionref ref="posCenter"/>
+    </subtraction>
+
+    <box name="DetEnclosure" lunit="cm" 
+      x="1310.32"
+      y="2105.8448"
+      z="2852.12"/>
+
+
+    <box name="World" lunit="cm" 
+      x="9310.32" 
+      y="10105.8448" 
+      z="10852.12"/>
+</solids>
+<structure>
+<volume name="volFieldShaper">
+  <materialref ref="Al2O3"/>
+  <solidref ref="FieldShaperSolid"/>
+</volume>
+<volume name="volFieldShaperSlim">
+  <materialref ref="Al2O3"/>
+  <solidref ref="FieldShaperSolidSlim"/>
+</volume>
+
+
+    <volume name="volTPCActive">
+      <materialref ref="LAr"/>
+      <solidref ref="CRMActive"/>
+      <auxiliary auxtype="SensDet" auxvalue="SimEnergyDeposit"/>
+      <auxiliary auxtype="StepLimit" auxunit="cm" auxvalue="0.5208*cm"/>
+      <auxiliary auxtype="Efield" auxunit="V/cm" auxvalue="500*V/cm"/>
+      <colorref ref="blue"/>
+    </volume>
+    <volume name="volTPCWireU0">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU0"/>
+    </volume>
+    <volume name="volTPCWireU1">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU1"/>
+    </volume>
+    <volume name="volTPCWireU2">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU2"/>
+    </volume>
+    <volume name="volTPCWireU3">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU3"/>
+    </volume>
+    <volume name="volTPCWireU4">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU4"/>
+    </volume>
+    <volume name="volTPCWireU5">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU5"/>
+    </volume>
+    <volume name="volTPCWireU6">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU6"/>
+    </volume>
+    <volume name="volTPCWireU7">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU7"/>
+    </volume>
+    <volume name="volTPCWireU8">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU8"/>
+    </volume>
+    <volume name="volTPCWireU9">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU9"/>
+    </volume>
+    <volume name="volTPCWireU10">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU10"/>
+    </volume>
+    <volume name="volTPCWireU11">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU11"/>
+    </volume>
+    <volume name="volTPCWireU12">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU12"/>
+    </volume>
+    <volume name="volTPCWireU13">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU13"/>
+    </volume>
+    <volume name="volTPCWireU14">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU14"/>
+    </volume>
+    <volume name="volTPCWireU15">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU15"/>
+    </volume>
+    <volume name="volTPCWireU16">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU16"/>
+    </volume>
+    <volume name="volTPCWireU17">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU17"/>
+    </volume>
+    <volume name="volTPCWireU18">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU18"/>
+    </volume>
+    <volume name="volTPCWireU19">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU19"/>
+    </volume>
+    <volume name="volTPCWireU20">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU20"/>
+    </volume>
+    <volume name="volTPCWireU21">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU21"/>
+    </volume>
+    <volume name="volTPCWireU22">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU22"/>
+    </volume>
+    <volume name="volTPCWireU23">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU23"/>
+    </volume>
+    <volume name="volTPCWireU24">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU24"/>
+    </volume>
+    <volume name="volTPCWireU25">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU25"/>
+    </volume>
+    <volume name="volTPCWireU26">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU26"/>
+    </volume>
+    <volume name="volTPCWireU27">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU27"/>
+    </volume>
+    <volume name="volTPCWireU28">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU28"/>
+    </volume>
+    <volume name="volTPCWireU29">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU29"/>
+    </volume>
+    <volume name="volTPCWireU30">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU30"/>
+    </volume>
+    <volume name="volTPCWireU31">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU31"/>
+    </volume>
+    <volume name="volTPCWireU32">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU32"/>
+    </volume>
+    <volume name="volTPCWireU33">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU33"/>
+    </volume>
+    <volume name="volTPCWireU34">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU34"/>
+    </volume>
+    <volume name="volTPCWireU35">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU35"/>
+    </volume>
+    <volume name="volTPCWireU36">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU36"/>
+    </volume>
+    <volume name="volTPCWireU37">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU37"/>
+    </volume>
+    <volume name="volTPCWireU38">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU38"/>
+    </volume>
+    <volume name="volTPCWireU39">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU39"/>
+    </volume>
+    <volume name="volTPCWireU40">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU40"/>
+    </volume>
+    <volume name="volTPCWireU41">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU41"/>
+    </volume>
+    <volume name="volTPCWireU42">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU42"/>
+    </volume>
+    <volume name="volTPCWireU43">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU43"/>
+    </volume>
+    <volume name="volTPCWireU44">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU44"/>
+    </volume>
+    <volume name="volTPCWireU45">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU45"/>
+    </volume>
+    <volume name="volTPCWireU46">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU46"/>
+    </volume>
+    <volume name="volTPCWireU47">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU47"/>
+    </volume>
+    <volume name="volTPCWireU48">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU48"/>
+    </volume>
+    <volume name="volTPCWireU49">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU49"/>
+    </volume>
+    <volume name="volTPCWireU50">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU50"/>
+    </volume>
+    <volume name="volTPCWireU51">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU51"/>
+    </volume>
+    <volume name="volTPCWireU52">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU52"/>
+    </volume>
+    <volume name="volTPCWireU53">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU53"/>
+    </volume>
+    <volume name="volTPCWireU54">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU54"/>
+    </volume>
+    <volume name="volTPCWireU55">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU55"/>
+    </volume>
+    <volume name="volTPCWireU56">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU56"/>
+    </volume>
+    <volume name="volTPCWireU57">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU57"/>
+    </volume>
+    <volume name="volTPCWireU58">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU58"/>
+    </volume>
+    <volume name="volTPCWireU59">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU59"/>
+    </volume>
+    <volume name="volTPCWireU60">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU60"/>
+    </volume>
+    <volume name="volTPCWireU61">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU61"/>
+    </volume>
+    <volume name="volTPCWireU62">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU62"/>
+    </volume>
+    <volume name="volTPCWireU63">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU63"/>
+    </volume>
+    <volume name="volTPCWireU64">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU64"/>
+    </volume>
+    <volume name="volTPCWireU65">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU65"/>
+    </volume>
+    <volume name="volTPCWireU66">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU66"/>
+    </volume>
+    <volume name="volTPCWireU67">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU67"/>
+    </volume>
+    <volume name="volTPCWireU68">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU68"/>
+    </volume>
+    <volume name="volTPCWireU69">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU69"/>
+    </volume>
+    <volume name="volTPCWireU70">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU70"/>
+    </volume>
+    <volume name="volTPCWireU71">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU71"/>
+    </volume>
+    <volume name="volTPCWireU72">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU72"/>
+    </volume>
+    <volume name="volTPCWireU73">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU73"/>
+    </volume>
+    <volume name="volTPCWireU74">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU74"/>
+    </volume>
+    <volume name="volTPCWireU75">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU75"/>
+    </volume>
+    <volume name="volTPCWireU76">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU76"/>
+    </volume>
+    <volume name="volTPCWireU77">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU77"/>
+    </volume>
+    <volume name="volTPCWireU78">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU78"/>
+    </volume>
+    <volume name="volTPCWireU79">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU79"/>
+    </volume>
+    <volume name="volTPCWireU80">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU80"/>
+    </volume>
+    <volume name="volTPCWireU81">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU81"/>
+    </volume>
+    <volume name="volTPCWireU82">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU82"/>
+    </volume>
+    <volume name="volTPCWireU83">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU83"/>
+    </volume>
+    <volume name="volTPCWireU84">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU84"/>
+    </volume>
+    <volume name="volTPCWireU85">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU85"/>
+    </volume>
+    <volume name="volTPCWireU86">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU86"/>
+    </volume>
+    <volume name="volTPCWireU87">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU87"/>
+    </volume>
+    <volume name="volTPCWireU88">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU88"/>
+    </volume>
+    <volume name="volTPCWireU89">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU89"/>
+    </volume>
+    <volume name="volTPCWireU90">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU90"/>
+    </volume>
+    <volume name="volTPCWireU91">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU91"/>
+    </volume>
+    <volume name="volTPCWireU92">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU92"/>
+    </volume>
+    <volume name="volTPCWireU93">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU93"/>
+    </volume>
+    <volume name="volTPCWireU94">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU94"/>
+    </volume>
+    <volume name="volTPCWireU95">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU95"/>
+    </volume>
+    <volume name="volTPCWireU96">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU96"/>
+    </volume>
+    <volume name="volTPCWireU97">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU97"/>
+    </volume>
+    <volume name="volTPCWireU98">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU98"/>
+    </volume>
+    <volume name="volTPCWireU99">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU99"/>
+    </volume>
+    <volume name="volTPCWireU100">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU100"/>
+    </volume>
+    <volume name="volTPCWireU101">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU101"/>
+    </volume>
+    <volume name="volTPCWireU102">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU102"/>
+    </volume>
+    <volume name="volTPCWireU103">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU103"/>
+    </volume>
+    <volume name="volTPCWireU104">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU104"/>
+    </volume>
+    <volume name="volTPCWireU105">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU105"/>
+    </volume>
+    <volume name="volTPCWireU106">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU106"/>
+    </volume>
+    <volume name="volTPCWireU107">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU107"/>
+    </volume>
+    <volume name="volTPCWireU108">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU108"/>
+    </volume>
+    <volume name="volTPCWireU109">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU109"/>
+    </volume>
+    <volume name="volTPCWireU110">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU110"/>
+    </volume>
+    <volume name="volTPCWireU111">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU111"/>
+    </volume>
+    <volume name="volTPCWireU112">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU112"/>
+    </volume>
+    <volume name="volTPCWireU113">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU113"/>
+    </volume>
+    <volume name="volTPCWireU114">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU114"/>
+    </volume>
+    <volume name="volTPCWireU115">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU115"/>
+    </volume>
+    <volume name="volTPCWireU116">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU116"/>
+    </volume>
+    <volume name="volTPCWireU117">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU117"/>
+    </volume>
+    <volume name="volTPCWireU118">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU118"/>
+    </volume>
+    <volume name="volTPCWireU119">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU119"/>
+    </volume>
+    <volume name="volTPCWireU120">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU120"/>
+    </volume>
+    <volume name="volTPCWireU121">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU121"/>
+    </volume>
+    <volume name="volTPCWireU122">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU122"/>
+    </volume>
+    <volume name="volTPCWireU123">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU123"/>
+    </volume>
+    <volume name="volTPCWireU124">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU124"/>
+    </volume>
+    <volume name="volTPCWireU125">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU125"/>
+    </volume>
+    <volume name="volTPCWireU126">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU126"/>
+    </volume>
+    <volume name="volTPCWireU127">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU127"/>
+    </volume>
+    <volume name="volTPCWireU128">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU128"/>
+    </volume>
+    <volume name="volTPCWireU129">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU129"/>
+    </volume>
+    <volume name="volTPCWireU130">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU130"/>
+    </volume>
+    <volume name="volTPCWireU131">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU131"/>
+    </volume>
+    <volume name="volTPCWireU132">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU132"/>
+    </volume>
+    <volume name="volTPCWireU133">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU133"/>
+    </volume>
+    <volume name="volTPCWireU134">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU134"/>
+    </volume>
+    <volume name="volTPCWireU135">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU135"/>
+    </volume>
+    <volume name="volTPCWireU136">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU136"/>
+    </volume>
+    <volume name="volTPCWireU137">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU137"/>
+    </volume>
+    <volume name="volTPCWireU138">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU138"/>
+    </volume>
+    <volume name="volTPCWireU139">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU139"/>
+    </volume>
+    <volume name="volTPCWireU140">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU140"/>
+    </volume>
+    <volume name="volTPCWireU141">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU141"/>
+    </volume>
+    <volume name="volTPCWireU142">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU142"/>
+    </volume>
+    <volume name="volTPCWireU143">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU143"/>
+    </volume>
+    <volume name="volTPCWireU144">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU144"/>
+    </volume>
+    <volume name="volTPCWireU145">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU145"/>
+    </volume>
+    <volume name="volTPCWireU146">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU146"/>
+    </volume>
+    <volume name="volTPCWireU147">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU147"/>
+    </volume>
+    <volume name="volTPCWireU148">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU148"/>
+    </volume>
+    <volume name="volTPCWireU149">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU149"/>
+    </volume>
+    <volume name="volTPCWireU150">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU150"/>
+    </volume>
+    <volume name="volTPCWireU151">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU151"/>
+    </volume>
+    <volume name="volTPCWireU152">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU152"/>
+    </volume>
+    <volume name="volTPCWireU153">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU153"/>
+    </volume>
+    <volume name="volTPCWireU154">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU154"/>
+    </volume>
+    <volume name="volTPCWireU155">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU155"/>
+    </volume>
+    <volume name="volTPCWireU156">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU156"/>
+    </volume>
+    <volume name="volTPCWireU157">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU157"/>
+    </volume>
+    <volume name="volTPCWireU158">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU158"/>
+    </volume>
+    <volume name="volTPCWireU159">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU159"/>
+    </volume>
+    <volume name="volTPCWireU160">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU160"/>
+    </volume>
+    <volume name="volTPCWireU161">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU161"/>
+    </volume>
+    <volume name="volTPCWireU162">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU162"/>
+    </volume>
+    <volume name="volTPCWireU163">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU163"/>
+    </volume>
+    <volume name="volTPCWireU164">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU164"/>
+    </volume>
+    <volume name="volTPCWireU165">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU165"/>
+    </volume>
+    <volume name="volTPCWireU166">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU166"/>
+    </volume>
+    <volume name="volTPCWireU167">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU167"/>
+    </volume>
+    <volume name="volTPCWireU168">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU168"/>
+    </volume>
+    <volume name="volTPCWireU169">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU169"/>
+    </volume>
+    <volume name="volTPCWireU170">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU170"/>
+    </volume>
+    <volume name="volTPCWireU171">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU171"/>
+    </volume>
+    <volume name="volTPCWireU172">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU172"/>
+    </volume>
+    <volume name="volTPCWireU173">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU173"/>
+    </volume>
+    <volume name="volTPCWireU174">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU174"/>
+    </volume>
+    <volume name="volTPCWireU175">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU175"/>
+    </volume>
+    <volume name="volTPCWireU176">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU176"/>
+    </volume>
+    <volume name="volTPCWireU177">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU177"/>
+    </volume>
+    <volume name="volTPCWireU178">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU178"/>
+    </volume>
+    <volume name="volTPCWireU179">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU179"/>
+    </volume>
+    <volume name="volTPCWireU180">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU180"/>
+    </volume>
+    <volume name="volTPCWireU181">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU181"/>
+    </volume>
+    <volume name="volTPCWireU182">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU182"/>
+    </volume>
+    <volume name="volTPCWireU183">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU183"/>
+    </volume>
+    <volume name="volTPCWireU184">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU184"/>
+    </volume>
+    <volume name="volTPCWireU185">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU185"/>
+    </volume>
+    <volume name="volTPCWireU186">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU186"/>
+    </volume>
+    <volume name="volTPCWireU187">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU187"/>
+    </volume>
+    <volume name="volTPCWireU188">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU188"/>
+    </volume>
+    <volume name="volTPCWireU189">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU189"/>
+    </volume>
+    <volume name="volTPCWireU190">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU190"/>
+    </volume>
+    <volume name="volTPCWireU191">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU191"/>
+    </volume>
+    <volume name="volTPCWireU192">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU192"/>
+    </volume>
+    <volume name="volTPCWireU193">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU193"/>
+    </volume>
+    <volume name="volTPCWireU194">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU194"/>
+    </volume>
+    <volume name="volTPCWireU195">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU195"/>
+    </volume>
+    <volume name="volTPCWireU196">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU196"/>
+    </volume>
+    <volume name="volTPCWireU197">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU197"/>
+    </volume>
+    <volume name="volTPCWireU198">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU198"/>
+    </volume>
+    <volume name="volTPCWireU199">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU199"/>
+    </volume>
+    <volume name="volTPCWireU200">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU200"/>
+    </volume>
+    <volume name="volTPCWireU201">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU201"/>
+    </volume>
+    <volume name="volTPCWireU202">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU202"/>
+    </volume>
+    <volume name="volTPCWireU203">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU203"/>
+    </volume>
+    <volume name="volTPCWireU204">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU204"/>
+    </volume>
+    <volume name="volTPCWireU205">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU205"/>
+    </volume>
+    <volume name="volTPCWireU206">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU206"/>
+    </volume>
+    <volume name="volTPCWireU207">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU207"/>
+    </volume>
+    <volume name="volTPCWireU208">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU208"/>
+    </volume>
+    <volume name="volTPCWireU209">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU209"/>
+    </volume>
+    <volume name="volTPCWireU210">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU210"/>
+    </volume>
+    <volume name="volTPCWireU211">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU211"/>
+    </volume>
+    <volume name="volTPCWireU212">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU212"/>
+    </volume>
+    <volume name="volTPCWireU213">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU213"/>
+    </volume>
+    <volume name="volTPCWireU214">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU214"/>
+    </volume>
+    <volume name="volTPCWireU215">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU215"/>
+    </volume>
+    <volume name="volTPCWireU216">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU216"/>
+    </volume>
+    <volume name="volTPCWireU217">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU217"/>
+    </volume>
+    <volume name="volTPCWireU218">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU218"/>
+    </volume>
+    <volume name="volTPCWireU219">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU219"/>
+    </volume>
+    <volume name="volTPCWireU220">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU220"/>
+    </volume>
+    <volume name="volTPCWireU221">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU221"/>
+    </volume>
+    <volume name="volTPCWireU222">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU222"/>
+    </volume>
+    <volume name="volTPCWireU223">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU223"/>
+    </volume>
+    <volume name="volTPCWireU224">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU224"/>
+    </volume>
+    <volume name="volTPCWireU225">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU225"/>
+    </volume>
+    <volume name="volTPCWireU226">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU226"/>
+    </volume>
+    <volume name="volTPCWireU227">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU227"/>
+    </volume>
+    <volume name="volTPCWireU228">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU228"/>
+    </volume>
+    <volume name="volTPCWireU229">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU229"/>
+    </volume>
+    <volume name="volTPCWireU230">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU230"/>
+    </volume>
+    <volume name="volTPCWireU231">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU231"/>
+    </volume>
+    <volume name="volTPCWireU232">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU232"/>
+    </volume>
+    <volume name="volTPCWireU233">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU233"/>
+    </volume>
+    <volume name="volTPCWireU234">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU234"/>
+    </volume>
+    <volume name="volTPCWireU235">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU235"/>
+    </volume>
+    <volume name="volTPCWireU236">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU236"/>
+    </volume>
+    <volume name="volTPCWireU237">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU237"/>
+    </volume>
+    <volume name="volTPCWireU238">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU238"/>
+    </volume>
+    <volume name="volTPCWireU239">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU239"/>
+    </volume>
+    <volume name="volTPCWireU240">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU240"/>
+    </volume>
+    <volume name="volTPCWireU241">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU241"/>
+    </volume>
+    <volume name="volTPCWireU242">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU242"/>
+    </volume>
+    <volume name="volTPCWireU243">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU243"/>
+    </volume>
+    <volume name="volTPCWireU244">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU244"/>
+    </volume>
+    <volume name="volTPCWireU245">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU245"/>
+    </volume>
+    <volume name="volTPCWireU246">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU246"/>
+    </volume>
+    <volume name="volTPCWireU247">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU247"/>
+    </volume>
+    <volume name="volTPCWireU248">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU248"/>
+    </volume>
+    <volume name="volTPCWireU249">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU249"/>
+    </volume>
+    <volume name="volTPCWireU250">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU250"/>
+    </volume>
+    <volume name="volTPCWireU251">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU251"/>
+    </volume>
+    <volume name="volTPCWireU252">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU252"/>
+    </volume>
+    <volume name="volTPCWireU253">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU253"/>
+    </volume>
+    <volume name="volTPCWireU254">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU254"/>
+    </volume>
+    <volume name="volTPCWireU255">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU255"/>
+    </volume>
+    <volume name="volTPCWireU256">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU256"/>
+    </volume>
+    <volume name="volTPCWireU257">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU257"/>
+    </volume>
+    <volume name="volTPCWireU258">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU258"/>
+    </volume>
+    <volume name="volTPCWireU259">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU259"/>
+    </volume>
+    <volume name="volTPCWireU260">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU260"/>
+    </volume>
+    <volume name="volTPCWireU261">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU261"/>
+    </volume>
+    <volume name="volTPCWireU262">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU262"/>
+    </volume>
+    <volume name="volTPCWireU263">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU263"/>
+    </volume>
+    <volume name="volTPCWireU264">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU264"/>
+    </volume>
+    <volume name="volTPCWireU265">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU265"/>
+    </volume>
+    <volume name="volTPCWireU266">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU266"/>
+    </volume>
+    <volume name="volTPCWireU267">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU267"/>
+    </volume>
+    <volume name="volTPCWireU268">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU268"/>
+    </volume>
+    <volume name="volTPCWireU269">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU269"/>
+    </volume>
+    <volume name="volTPCWireU270">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU270"/>
+    </volume>
+    <volume name="volTPCWireU271">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU271"/>
+    </volume>
+    <volume name="volTPCWireU272">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU272"/>
+    </volume>
+    <volume name="volTPCWireU273">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU273"/>
+    </volume>
+    <volume name="volTPCWireU274">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU274"/>
+    </volume>
+    <volume name="volTPCWireU275">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU275"/>
+    </volume>
+    <volume name="volTPCWireU276">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU276"/>
+    </volume>
+    <volume name="volTPCWireU277">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU277"/>
+    </volume>
+    <volume name="volTPCWireU278">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU278"/>
+    </volume>
+    <volume name="volTPCWireU279">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU279"/>
+    </volume>
+    <volume name="volTPCWireU280">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU280"/>
+    </volume>
+    <volume name="volTPCWireU281">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU281"/>
+    </volume>
+    <volume name="volTPCWireU282">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU282"/>
+    </volume>
+    <volume name="volTPCWireU283">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU283"/>
+    </volume>
+    <volume name="volTPCWireU284">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU284"/>
+    </volume>
+    <volume name="volTPCWireU285">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU285"/>
+    </volume>
+    <volume name="volTPCWireV0">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV0"/>
+    </volume>
+    <volume name="volTPCWireV1">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV1"/>
+    </volume>
+    <volume name="volTPCWireV2">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV2"/>
+    </volume>
+    <volume name="volTPCWireV3">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV3"/>
+    </volume>
+    <volume name="volTPCWireV4">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV4"/>
+    </volume>
+    <volume name="volTPCWireV5">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV5"/>
+    </volume>
+    <volume name="volTPCWireV6">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV6"/>
+    </volume>
+    <volume name="volTPCWireV7">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV7"/>
+    </volume>
+    <volume name="volTPCWireV8">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV8"/>
+    </volume>
+    <volume name="volTPCWireV9">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV9"/>
+    </volume>
+    <volume name="volTPCWireV10">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV10"/>
+    </volume>
+    <volume name="volTPCWireV11">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV11"/>
+    </volume>
+    <volume name="volTPCWireV12">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV12"/>
+    </volume>
+    <volume name="volTPCWireV13">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV13"/>
+    </volume>
+    <volume name="volTPCWireV14">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV14"/>
+    </volume>
+    <volume name="volTPCWireV15">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV15"/>
+    </volume>
+    <volume name="volTPCWireV16">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV16"/>
+    </volume>
+    <volume name="volTPCWireV17">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV17"/>
+    </volume>
+    <volume name="volTPCWireV18">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV18"/>
+    </volume>
+    <volume name="volTPCWireV19">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV19"/>
+    </volume>
+    <volume name="volTPCWireV20">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV20"/>
+    </volume>
+    <volume name="volTPCWireV21">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV21"/>
+    </volume>
+    <volume name="volTPCWireV22">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV22"/>
+    </volume>
+    <volume name="volTPCWireV23">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV23"/>
+    </volume>
+    <volume name="volTPCWireV24">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV24"/>
+    </volume>
+    <volume name="volTPCWireV25">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV25"/>
+    </volume>
+    <volume name="volTPCWireV26">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV26"/>
+    </volume>
+    <volume name="volTPCWireV27">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV27"/>
+    </volume>
+    <volume name="volTPCWireV28">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV28"/>
+    </volume>
+    <volume name="volTPCWireV29">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV29"/>
+    </volume>
+    <volume name="volTPCWireV30">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV30"/>
+    </volume>
+    <volume name="volTPCWireV31">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV31"/>
+    </volume>
+    <volume name="volTPCWireV32">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV32"/>
+    </volume>
+    <volume name="volTPCWireV33">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV33"/>
+    </volume>
+    <volume name="volTPCWireV34">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV34"/>
+    </volume>
+    <volume name="volTPCWireV35">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV35"/>
+    </volume>
+    <volume name="volTPCWireV36">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV36"/>
+    </volume>
+    <volume name="volTPCWireV37">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV37"/>
+    </volume>
+    <volume name="volTPCWireV38">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV38"/>
+    </volume>
+    <volume name="volTPCWireV39">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV39"/>
+    </volume>
+    <volume name="volTPCWireV40">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV40"/>
+    </volume>
+    <volume name="volTPCWireV41">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV41"/>
+    </volume>
+    <volume name="volTPCWireV42">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV42"/>
+    </volume>
+    <volume name="volTPCWireV43">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV43"/>
+    </volume>
+    <volume name="volTPCWireV44">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV44"/>
+    </volume>
+    <volume name="volTPCWireV45">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV45"/>
+    </volume>
+    <volume name="volTPCWireV46">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV46"/>
+    </volume>
+    <volume name="volTPCWireV47">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV47"/>
+    </volume>
+    <volume name="volTPCWireV48">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV48"/>
+    </volume>
+    <volume name="volTPCWireV49">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV49"/>
+    </volume>
+    <volume name="volTPCWireV50">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV50"/>
+    </volume>
+    <volume name="volTPCWireV51">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV51"/>
+    </volume>
+    <volume name="volTPCWireV52">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV52"/>
+    </volume>
+    <volume name="volTPCWireV53">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV53"/>
+    </volume>
+    <volume name="volTPCWireV54">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV54"/>
+    </volume>
+    <volume name="volTPCWireV55">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV55"/>
+    </volume>
+    <volume name="volTPCWireV56">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV56"/>
+    </volume>
+    <volume name="volTPCWireV57">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV57"/>
+    </volume>
+    <volume name="volTPCWireV58">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV58"/>
+    </volume>
+    <volume name="volTPCWireV59">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV59"/>
+    </volume>
+    <volume name="volTPCWireV60">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV60"/>
+    </volume>
+    <volume name="volTPCWireV61">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV61"/>
+    </volume>
+    <volume name="volTPCWireV62">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV62"/>
+    </volume>
+    <volume name="volTPCWireV63">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV63"/>
+    </volume>
+    <volume name="volTPCWireV64">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV64"/>
+    </volume>
+    <volume name="volTPCWireV65">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV65"/>
+    </volume>
+    <volume name="volTPCWireV66">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV66"/>
+    </volume>
+    <volume name="volTPCWireV67">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV67"/>
+    </volume>
+    <volume name="volTPCWireV68">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV68"/>
+    </volume>
+    <volume name="volTPCWireV69">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV69"/>
+    </volume>
+    <volume name="volTPCWireV70">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV70"/>
+    </volume>
+    <volume name="volTPCWireV71">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV71"/>
+    </volume>
+    <volume name="volTPCWireV72">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV72"/>
+    </volume>
+    <volume name="volTPCWireV73">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV73"/>
+    </volume>
+    <volume name="volTPCWireV74">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV74"/>
+    </volume>
+    <volume name="volTPCWireV75">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV75"/>
+    </volume>
+    <volume name="volTPCWireV76">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV76"/>
+    </volume>
+    <volume name="volTPCWireV77">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV77"/>
+    </volume>
+    <volume name="volTPCWireV78">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV78"/>
+    </volume>
+    <volume name="volTPCWireV79">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV79"/>
+    </volume>
+    <volume name="volTPCWireV80">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV80"/>
+    </volume>
+    <volume name="volTPCWireV81">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV81"/>
+    </volume>
+    <volume name="volTPCWireV82">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV82"/>
+    </volume>
+    <volume name="volTPCWireV83">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV83"/>
+    </volume>
+    <volume name="volTPCWireV84">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV84"/>
+    </volume>
+    <volume name="volTPCWireV85">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV85"/>
+    </volume>
+    <volume name="volTPCWireV86">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV86"/>
+    </volume>
+    <volume name="volTPCWireV87">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV87"/>
+    </volume>
+    <volume name="volTPCWireV88">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV88"/>
+    </volume>
+    <volume name="volTPCWireV89">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV89"/>
+    </volume>
+    <volume name="volTPCWireV90">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV90"/>
+    </volume>
+    <volume name="volTPCWireV91">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV91"/>
+    </volume>
+    <volume name="volTPCWireV92">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV92"/>
+    </volume>
+    <volume name="volTPCWireV93">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV93"/>
+    </volume>
+    <volume name="volTPCWireV94">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV94"/>
+    </volume>
+    <volume name="volTPCWireV95">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV95"/>
+    </volume>
+    <volume name="volTPCWireV96">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV96"/>
+    </volume>
+    <volume name="volTPCWireV97">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV97"/>
+    </volume>
+    <volume name="volTPCWireV98">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV98"/>
+    </volume>
+    <volume name="volTPCWireV99">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV99"/>
+    </volume>
+    <volume name="volTPCWireV100">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV100"/>
+    </volume>
+    <volume name="volTPCWireV101">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV101"/>
+    </volume>
+    <volume name="volTPCWireV102">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV102"/>
+    </volume>
+    <volume name="volTPCWireV103">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV103"/>
+    </volume>
+    <volume name="volTPCWireV104">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV104"/>
+    </volume>
+    <volume name="volTPCWireV105">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV105"/>
+    </volume>
+    <volume name="volTPCWireV106">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV106"/>
+    </volume>
+    <volume name="volTPCWireV107">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV107"/>
+    </volume>
+    <volume name="volTPCWireV108">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV108"/>
+    </volume>
+    <volume name="volTPCWireV109">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV109"/>
+    </volume>
+    <volume name="volTPCWireV110">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV110"/>
+    </volume>
+    <volume name="volTPCWireV111">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV111"/>
+    </volume>
+    <volume name="volTPCWireV112">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV112"/>
+    </volume>
+    <volume name="volTPCWireV113">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV113"/>
+    </volume>
+    <volume name="volTPCWireV114">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV114"/>
+    </volume>
+    <volume name="volTPCWireV115">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV115"/>
+    </volume>
+    <volume name="volTPCWireV116">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV116"/>
+    </volume>
+    <volume name="volTPCWireV117">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV117"/>
+    </volume>
+    <volume name="volTPCWireV118">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV118"/>
+    </volume>
+    <volume name="volTPCWireV119">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV119"/>
+    </volume>
+    <volume name="volTPCWireV120">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV120"/>
+    </volume>
+    <volume name="volTPCWireV121">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV121"/>
+    </volume>
+    <volume name="volTPCWireV122">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV122"/>
+    </volume>
+    <volume name="volTPCWireV123">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV123"/>
+    </volume>
+    <volume name="volTPCWireV124">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV124"/>
+    </volume>
+    <volume name="volTPCWireV125">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV125"/>
+    </volume>
+    <volume name="volTPCWireV126">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV126"/>
+    </volume>
+    <volume name="volTPCWireV127">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV127"/>
+    </volume>
+    <volume name="volTPCWireV128">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV128"/>
+    </volume>
+    <volume name="volTPCWireV129">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV129"/>
+    </volume>
+    <volume name="volTPCWireV130">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV130"/>
+    </volume>
+    <volume name="volTPCWireV131">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV131"/>
+    </volume>
+    <volume name="volTPCWireV132">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV132"/>
+    </volume>
+    <volume name="volTPCWireV133">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV133"/>
+    </volume>
+    <volume name="volTPCWireV134">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV134"/>
+    </volume>
+    <volume name="volTPCWireV135">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV135"/>
+    </volume>
+    <volume name="volTPCWireV136">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV136"/>
+    </volume>
+    <volume name="volTPCWireV137">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV137"/>
+    </volume>
+    <volume name="volTPCWireV138">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV138"/>
+    </volume>
+    <volume name="volTPCWireV139">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV139"/>
+    </volume>
+    <volume name="volTPCWireV140">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV140"/>
+    </volume>
+    <volume name="volTPCWireV141">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV141"/>
+    </volume>
+    <volume name="volTPCWireV142">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV142"/>
+    </volume>
+    <volume name="volTPCWireV143">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV143"/>
+    </volume>
+    <volume name="volTPCWireV144">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV144"/>
+    </volume>
+    <volume name="volTPCWireV145">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV145"/>
+    </volume>
+    <volume name="volTPCWireV146">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV146"/>
+    </volume>
+    <volume name="volTPCWireV147">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV147"/>
+    </volume>
+    <volume name="volTPCWireV148">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV148"/>
+    </volume>
+    <volume name="volTPCWireV149">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV149"/>
+    </volume>
+    <volume name="volTPCWireV150">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV150"/>
+    </volume>
+    <volume name="volTPCWireV151">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV151"/>
+    </volume>
+    <volume name="volTPCWireV152">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV152"/>
+    </volume>
+    <volume name="volTPCWireV153">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV153"/>
+    </volume>
+    <volume name="volTPCWireV154">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV154"/>
+    </volume>
+    <volume name="volTPCWireV155">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV155"/>
+    </volume>
+    <volume name="volTPCWireV156">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV156"/>
+    </volume>
+    <volume name="volTPCWireV157">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV157"/>
+    </volume>
+    <volume name="volTPCWireV158">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV158"/>
+    </volume>
+    <volume name="volTPCWireV159">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV159"/>
+    </volume>
+    <volume name="volTPCWireV160">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV160"/>
+    </volume>
+    <volume name="volTPCWireV161">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV161"/>
+    </volume>
+    <volume name="volTPCWireV162">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV162"/>
+    </volume>
+    <volume name="volTPCWireV163">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV163"/>
+    </volume>
+    <volume name="volTPCWireV164">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV164"/>
+    </volume>
+    <volume name="volTPCWireV165">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV165"/>
+    </volume>
+    <volume name="volTPCWireV166">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV166"/>
+    </volume>
+    <volume name="volTPCWireV167">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV167"/>
+    </volume>
+    <volume name="volTPCWireV168">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV168"/>
+    </volume>
+    <volume name="volTPCWireV169">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV169"/>
+    </volume>
+    <volume name="volTPCWireV170">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV170"/>
+    </volume>
+    <volume name="volTPCWireV171">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV171"/>
+    </volume>
+    <volume name="volTPCWireV172">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV172"/>
+    </volume>
+    <volume name="volTPCWireV173">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV173"/>
+    </volume>
+    <volume name="volTPCWireV174">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV174"/>
+    </volume>
+    <volume name="volTPCWireV175">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV175"/>
+    </volume>
+    <volume name="volTPCWireV176">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV176"/>
+    </volume>
+    <volume name="volTPCWireV177">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV177"/>
+    </volume>
+    <volume name="volTPCWireV178">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV178"/>
+    </volume>
+    <volume name="volTPCWireV179">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV179"/>
+    </volume>
+    <volume name="volTPCWireV180">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV180"/>
+    </volume>
+    <volume name="volTPCWireV181">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV181"/>
+    </volume>
+    <volume name="volTPCWireV182">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV182"/>
+    </volume>
+    <volume name="volTPCWireV183">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV183"/>
+    </volume>
+    <volume name="volTPCWireV184">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV184"/>
+    </volume>
+    <volume name="volTPCWireV185">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV185"/>
+    </volume>
+    <volume name="volTPCWireV186">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV186"/>
+    </volume>
+    <volume name="volTPCWireV187">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV187"/>
+    </volume>
+    <volume name="volTPCWireV188">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV188"/>
+    </volume>
+    <volume name="volTPCWireV189">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV189"/>
+    </volume>
+    <volume name="volTPCWireV190">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV190"/>
+    </volume>
+    <volume name="volTPCWireV191">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV191"/>
+    </volume>
+    <volume name="volTPCWireV192">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV192"/>
+    </volume>
+    <volume name="volTPCWireV193">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV193"/>
+    </volume>
+    <volume name="volTPCWireV194">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV194"/>
+    </volume>
+    <volume name="volTPCWireV195">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV195"/>
+    </volume>
+    <volume name="volTPCWireV196">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV196"/>
+    </volume>
+    <volume name="volTPCWireV197">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV197"/>
+    </volume>
+    <volume name="volTPCWireV198">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV198"/>
+    </volume>
+    <volume name="volTPCWireV199">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV199"/>
+    </volume>
+    <volume name="volTPCWireV200">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV200"/>
+    </volume>
+    <volume name="volTPCWireV201">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV201"/>
+    </volume>
+    <volume name="volTPCWireV202">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV202"/>
+    </volume>
+    <volume name="volTPCWireV203">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV203"/>
+    </volume>
+    <volume name="volTPCWireV204">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV204"/>
+    </volume>
+    <volume name="volTPCWireV205">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV205"/>
+    </volume>
+    <volume name="volTPCWireV206">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV206"/>
+    </volume>
+    <volume name="volTPCWireV207">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV207"/>
+    </volume>
+    <volume name="volTPCWireV208">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV208"/>
+    </volume>
+    <volume name="volTPCWireV209">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV209"/>
+    </volume>
+    <volume name="volTPCWireV210">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV210"/>
+    </volume>
+    <volume name="volTPCWireV211">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV211"/>
+    </volume>
+    <volume name="volTPCWireV212">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV212"/>
+    </volume>
+    <volume name="volTPCWireV213">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV213"/>
+    </volume>
+    <volume name="volTPCWireV214">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV214"/>
+    </volume>
+    <volume name="volTPCWireV215">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV215"/>
+    </volume>
+    <volume name="volTPCWireV216">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV216"/>
+    </volume>
+    <volume name="volTPCWireV217">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV217"/>
+    </volume>
+    <volume name="volTPCWireV218">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV218"/>
+    </volume>
+    <volume name="volTPCWireV219">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV219"/>
+    </volume>
+    <volume name="volTPCWireV220">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV220"/>
+    </volume>
+    <volume name="volTPCWireV221">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV221"/>
+    </volume>
+    <volume name="volTPCWireV222">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV222"/>
+    </volume>
+    <volume name="volTPCWireV223">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV223"/>
+    </volume>
+    <volume name="volTPCWireV224">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV224"/>
+    </volume>
+    <volume name="volTPCWireV225">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV225"/>
+    </volume>
+    <volume name="volTPCWireV226">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV226"/>
+    </volume>
+    <volume name="volTPCWireV227">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV227"/>
+    </volume>
+    <volume name="volTPCWireV228">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV228"/>
+    </volume>
+    <volume name="volTPCWireV229">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV229"/>
+    </volume>
+    <volume name="volTPCWireV230">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV230"/>
+    </volume>
+    <volume name="volTPCWireV231">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV231"/>
+    </volume>
+    <volume name="volTPCWireV232">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV232"/>
+    </volume>
+    <volume name="volTPCWireV233">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV233"/>
+    </volume>
+    <volume name="volTPCWireV234">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV234"/>
+    </volume>
+    <volume name="volTPCWireV235">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV235"/>
+    </volume>
+    <volume name="volTPCWireV236">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV236"/>
+    </volume>
+    <volume name="volTPCWireV237">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV237"/>
+    </volume>
+    <volume name="volTPCWireV238">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV238"/>
+    </volume>
+    <volume name="volTPCWireV239">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV239"/>
+    </volume>
+    <volume name="volTPCWireV240">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV240"/>
+    </volume>
+    <volume name="volTPCWireV241">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV241"/>
+    </volume>
+    <volume name="volTPCWireV242">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV242"/>
+    </volume>
+    <volume name="volTPCWireV243">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV243"/>
+    </volume>
+    <volume name="volTPCWireV244">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV244"/>
+    </volume>
+    <volume name="volTPCWireV245">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV245"/>
+    </volume>
+    <volume name="volTPCWireV246">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV246"/>
+    </volume>
+    <volume name="volTPCWireV247">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV247"/>
+    </volume>
+    <volume name="volTPCWireV248">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV248"/>
+    </volume>
+    <volume name="volTPCWireV249">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV249"/>
+    </volume>
+    <volume name="volTPCWireV250">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV250"/>
+    </volume>
+    <volume name="volTPCWireV251">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV251"/>
+    </volume>
+    <volume name="volTPCWireV252">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV252"/>
+    </volume>
+    <volume name="volTPCWireV253">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV253"/>
+    </volume>
+    <volume name="volTPCWireV254">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV254"/>
+    </volume>
+    <volume name="volTPCWireV255">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV255"/>
+    </volume>
+    <volume name="volTPCWireV256">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV256"/>
+    </volume>
+    <volume name="volTPCWireV257">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV257"/>
+    </volume>
+    <volume name="volTPCWireV258">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV258"/>
+    </volume>
+    <volume name="volTPCWireV259">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV259"/>
+    </volume>
+    <volume name="volTPCWireV260">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV260"/>
+    </volume>
+    <volume name="volTPCWireV261">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV261"/>
+    </volume>
+    <volume name="volTPCWireV262">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV262"/>
+    </volume>
+    <volume name="volTPCWireV263">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV263"/>
+    </volume>
+    <volume name="volTPCWireV264">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV264"/>
+    </volume>
+    <volume name="volTPCWireV265">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV265"/>
+    </volume>
+    <volume name="volTPCWireV266">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV266"/>
+    </volume>
+    <volume name="volTPCWireV267">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV267"/>
+    </volume>
+    <volume name="volTPCWireV268">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV268"/>
+    </volume>
+    <volume name="volTPCWireV269">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV269"/>
+    </volume>
+    <volume name="volTPCWireV270">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV270"/>
+    </volume>
+    <volume name="volTPCWireV271">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV271"/>
+    </volume>
+    <volume name="volTPCWireV272">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV272"/>
+    </volume>
+    <volume name="volTPCWireV273">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV273"/>
+    </volume>
+    <volume name="volTPCWireV274">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV274"/>
+    </volume>
+    <volume name="volTPCWireV275">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV275"/>
+    </volume>
+    <volume name="volTPCWireV276">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV276"/>
+    </volume>
+    <volume name="volTPCWireV277">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV277"/>
+    </volume>
+    <volume name="volTPCWireV278">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV278"/>
+    </volume>
+    <volume name="volTPCWireV279">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV279"/>
+    </volume>
+    <volume name="volTPCWireV280">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV280"/>
+    </volume>
+    <volume name="volTPCWireV281">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV281"/>
+    </volume>
+    <volume name="volTPCWireV282">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV282"/>
+    </volume>
+    <volume name="volTPCWireV283">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV283"/>
+    </volume>
+    <volume name="volTPCWireV284">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV284"/>
+    </volume>
+    <volume name="volTPCWireV285">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV285"/>
+    </volume>
+    <volume name="volTPCWireZ">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireZ"/>
+    </volume>
+   <volume name="volTPCPlaneU">
+     <materialref ref="LAr"/>
+     <solidref ref="CRMUPlane"/>
+     <physvol>
+       <volumeref ref="volTPCWireU0"/> 
+       <position name="posWireU0" unit="cm" x="0" y="-83.6970251487471" z="-74.0775"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU1"/> 
+       <position name="posWireU1" unit="cm" x="0" y="-83.255352192817" z="-73.3125"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU2"/> 
+       <position name="posWireU2" unit="cm" x="0" y="-82.8136792368869" z="-72.5475"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU3"/> 
+       <position name="posWireU3" unit="cm" x="0" y="-82.3720062809569" z="-71.7825"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU4"/> 
+       <position name="posWireU4" unit="cm" x="0" y="-81.9303333250268" z="-71.0175"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU5"/> 
+       <position name="posWireU5" unit="cm" x="0" y="-81.4886603690967" z="-70.2525"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU6"/> 
+       <position name="posWireU6" unit="cm" x="0" y="-81.0469874131667" z="-69.4875"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU7"/> 
+       <position name="posWireU7" unit="cm" x="0" y="-80.6053144572366" z="-68.7225"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU8"/> 
+       <position name="posWireU8" unit="cm" x="0" y="-80.1636415013066" z="-67.9575"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU9"/> 
+       <position name="posWireU9" unit="cm" x="0" y="-79.7219685453765" z="-67.1925"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU10"/> 
+       <position name="posWireU10" unit="cm" x="0" y="-79.2802955894464" z="-66.4275"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU11"/> 
+       <position name="posWireU11" unit="cm" x="0" y="-78.8386226335164" z="-65.6625"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU12"/> 
+       <position name="posWireU12" unit="cm" x="0" y="-78.3969496775863" z="-64.8975"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU13"/> 
+       <position name="posWireU13" unit="cm" x="0" y="-77.9552767216562" z="-64.1325"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU14"/> 
+       <position name="posWireU14" unit="cm" x="0" y="-77.5136037657262" z="-63.3675"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU15"/> 
+       <position name="posWireU15" unit="cm" x="0" y="-77.0719308097961" z="-62.6025"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU16"/> 
+       <position name="posWireU16" unit="cm" x="0" y="-76.630257853866" z="-61.8375"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU17"/> 
+       <position name="posWireU17" unit="cm" x="0" y="-76.188584897936" z="-61.0725"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU18"/> 
+       <position name="posWireU18" unit="cm" x="0" y="-75.7469119420059" z="-60.3075"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU19"/> 
+       <position name="posWireU19" unit="cm" x="0" y="-75.3052389860758" z="-59.5425"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU20"/> 
+       <position name="posWireU20" unit="cm" x="0" y="-74.8635660301458" z="-58.7775"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU21"/> 
+       <position name="posWireU21" unit="cm" x="0" y="-74.4218930742157" z="-58.0125"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU22"/> 
+       <position name="posWireU22" unit="cm" x="0" y="-73.9802201182857" z="-57.2475"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU23"/> 
+       <position name="posWireU23" unit="cm" x="0" y="-73.5385471623556" z="-56.4825"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU24"/> 
+       <position name="posWireU24" unit="cm" x="0" y="-73.0968742064255" z="-55.7175"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU25"/> 
+       <position name="posWireU25" unit="cm" x="0" y="-72.6552012504955" z="-54.9525"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU26"/> 
+       <position name="posWireU26" unit="cm" x="0" y="-72.2135282945654" z="-54.1875"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU27"/> 
+       <position name="posWireU27" unit="cm" x="0" y="-71.7718553386353" z="-53.4225"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU28"/> 
+       <position name="posWireU28" unit="cm" x="0" y="-71.3301823827053" z="-52.6575"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU29"/> 
+       <position name="posWireU29" unit="cm" x="0" y="-70.8885094267752" z="-51.8925"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU30"/> 
+       <position name="posWireU30" unit="cm" x="0" y="-70.4468364708451" z="-51.1275"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU31"/> 
+       <position name="posWireU31" unit="cm" x="0" y="-70.0051635149151" z="-50.3625"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU32"/> 
+       <position name="posWireU32" unit="cm" x="0" y="-69.563490558985" z="-49.5975"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU33"/> 
+       <position name="posWireU33" unit="cm" x="0" y="-69.121817603055" z="-48.8325"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU34"/> 
+       <position name="posWireU34" unit="cm" x="0" y="-68.6801446471249" z="-48.0675"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU35"/> 
+       <position name="posWireU35" unit="cm" x="0" y="-68.2384716911948" z="-47.3025"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU36"/> 
+       <position name="posWireU36" unit="cm" x="0" y="-67.7967987352648" z="-46.5375"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU37"/> 
+       <position name="posWireU37" unit="cm" x="0" y="-67.3551257793347" z="-45.7725"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU38"/> 
+       <position name="posWireU38" unit="cm" x="0" y="-66.9134528234046" z="-45.0075"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU39"/> 
+       <position name="posWireU39" unit="cm" x="0" y="-66.4717798674746" z="-44.2425"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU40"/> 
+       <position name="posWireU40" unit="cm" x="0" y="-66.0301069115445" z="-43.4775"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU41"/> 
+       <position name="posWireU41" unit="cm" x="0" y="-65.5884339556144" z="-42.7125"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU42"/> 
+       <position name="posWireU42" unit="cm" x="0" y="-65.1467609996844" z="-41.9475"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU43"/> 
+       <position name="posWireU43" unit="cm" x="0" y="-64.7050880437543" z="-41.1825"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU44"/> 
+       <position name="posWireU44" unit="cm" x="0" y="-64.2634150878243" z="-40.4175"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU45"/> 
+       <position name="posWireU45" unit="cm" x="0" y="-63.8217421318942" z="-39.6525"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU46"/> 
+       <position name="posWireU46" unit="cm" x="0" y="-63.3800691759641" z="-38.8875"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU47"/> 
+       <position name="posWireU47" unit="cm" x="0" y="-62.9383962200341" z="-38.1225"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU48"/> 
+       <position name="posWireU48" unit="cm" x="0" y="-62.496723264104" z="-37.3575"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU49"/> 
+       <position name="posWireU49" unit="cm" x="0" y="-62.0550503081739" z="-36.5925"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU50"/> 
+       <position name="posWireU50" unit="cm" x="0" y="-61.6133773522439" z="-35.8275"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU51"/> 
+       <position name="posWireU51" unit="cm" x="0" y="-61.1717043963138" z="-35.0625"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU52"/> 
+       <position name="posWireU52" unit="cm" x="0" y="-60.7300314403837" z="-34.2975"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU53"/> 
+       <position name="posWireU53" unit="cm" x="0" y="-60.2883584844537" z="-33.5325"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU54"/> 
+       <position name="posWireU54" unit="cm" x="0" y="-59.8466855285236" z="-32.7675"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU55"/> 
+       <position name="posWireU55" unit="cm" x="0" y="-59.4050125725935" z="-32.0025"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU56"/> 
+       <position name="posWireU56" unit="cm" x="0" y="-58.9633396166635" z="-31.2375"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU57"/> 
+       <position name="posWireU57" unit="cm" x="0" y="-58.5216666607334" z="-30.4725"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU58"/> 
+       <position name="posWireU58" unit="cm" x="0" y="-58.0799937048034" z="-29.7075"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU59"/> 
+       <position name="posWireU59" unit="cm" x="0" y="-57.6383207488733" z="-28.9425"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU60"/> 
+       <position name="posWireU60" unit="cm" x="0" y="-57.1966477929432" z="-28.1775"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU61"/> 
+       <position name="posWireU61" unit="cm" x="0" y="-56.7549748370132" z="-27.4125"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU62"/> 
+       <position name="posWireU62" unit="cm" x="0" y="-56.3133018810831" z="-26.6475"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU63"/> 
+       <position name="posWireU63" unit="cm" x="0" y="-55.871628925153" z="-25.8825"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU64"/> 
+       <position name="posWireU64" unit="cm" x="0" y="-55.429955969223" z="-25.1175"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU65"/> 
+       <position name="posWireU65" unit="cm" x="0" y="-54.9882830132929" z="-24.3525"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU66"/> 
+       <position name="posWireU66" unit="cm" x="0" y="-54.5466100573628" z="-23.5875"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU67"/> 
+       <position name="posWireU67" unit="cm" x="0" y="-54.1049371014328" z="-22.8225"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU68"/> 
+       <position name="posWireU68" unit="cm" x="0" y="-53.6632641455027" z="-22.0575"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU69"/> 
+       <position name="posWireU69" unit="cm" x="0" y="-53.2215911895726" z="-21.2925"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU70"/> 
+       <position name="posWireU70" unit="cm" x="0" y="-52.7799182336426" z="-20.5275"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU71"/> 
+       <position name="posWireU71" unit="cm" x="0" y="-52.3382452777125" z="-19.7625"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU72"/> 
+       <position name="posWireU72" unit="cm" x="0" y="-51.8965723217825" z="-18.9975"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU73"/> 
+       <position name="posWireU73" unit="cm" x="0" y="-51.4548993658524" z="-18.2325"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU74"/> 
+       <position name="posWireU74" unit="cm" x="0" y="-51.0132264099223" z="-17.4675"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU75"/> 
+       <position name="posWireU75" unit="cm" x="0" y="-50.5715534539923" z="-16.7025"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU76"/> 
+       <position name="posWireU76" unit="cm" x="0" y="-50.1298804980622" z="-15.9375"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU77"/> 
+       <position name="posWireU77" unit="cm" x="0" y="-49.6882075421321" z="-15.1725"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU78"/> 
+       <position name="posWireU78" unit="cm" x="0" y="-49.2465345862021" z="-14.4075"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU79"/> 
+       <position name="posWireU79" unit="cm" x="0" y="-48.804861630272" z="-13.6425"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU80"/> 
+       <position name="posWireU80" unit="cm" x="0" y="-48.3631886743419" z="-12.8775"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU81"/> 
+       <position name="posWireU81" unit="cm" x="0" y="-47.9215157184119" z="-12.1125"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU82"/> 
+       <position name="posWireU82" unit="cm" x="0" y="-47.4798427624818" z="-11.3475"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU83"/> 
+       <position name="posWireU83" unit="cm" x="0" y="-47.0381698065518" z="-10.5825"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU84"/> 
+       <position name="posWireU84" unit="cm" x="0" y="-46.5964968506217" z="-9.81749999999995"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU85"/> 
+       <position name="posWireU85" unit="cm" x="0" y="-46.1548238946916" z="-9.05249999999995"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU86"/> 
+       <position name="posWireU86" unit="cm" x="0" y="-45.7131509387616" z="-8.28749999999995"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU87"/> 
+       <position name="posWireU87" unit="cm" x="0" y="-45.2714779828315" z="-7.52249999999995"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU88"/> 
+       <position name="posWireU88" unit="cm" x="0" y="-44.8298050269014" z="-6.75749999999995"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU89"/> 
+       <position name="posWireU89" unit="cm" x="0" y="-44.3881320709714" z="-5.99249999999995"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU90"/> 
+       <position name="posWireU90" unit="cm" x="0" y="-43.9464591150413" z="-5.22749999999995"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU91"/> 
+       <position name="posWireU91" unit="cm" x="0" y="-43.5047861591112" z="-4.46249999999995"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU92"/> 
+       <position name="posWireU92" unit="cm" x="0" y="-43.0631132031812" z="-3.69749999999995"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU93"/> 
+       <position name="posWireU93" unit="cm" x="0" y="-42.6214402472511" z="-2.93249999999995"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU94"/> 
+       <position name="posWireU94" unit="cm" x="0" y="-42.1797672913211" z="-2.16749999999995"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU95"/> 
+       <position name="posWireU95" unit="cm" x="0" y="-41.738094335391" z="-1.40249999999995"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU96"/> 
+       <position name="posWireU96" unit="cm" x="0" y="-41.2964213794609" z="-0.637499999999946"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU97"/> 
+       <position name="posWireU97" unit="cm" x="0" y="-40.7811362642091" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU98"/> 
+       <position name="posWireU98" unit="cm" x="0" y="-39.897790352349" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU99"/> 
+       <position name="posWireU99" unit="cm" x="0" y="-39.0144444404889" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU100"/> 
+       <position name="posWireU100" unit="cm" x="0" y="-38.1310985286288" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU101"/> 
+       <position name="posWireU101" unit="cm" x="0" y="-37.2477526167686" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU102"/> 
+       <position name="posWireU102" unit="cm" x="0" y="-36.3644067049085" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU103"/> 
+       <position name="posWireU103" unit="cm" x="0" y="-35.4810607930484" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU104"/> 
+       <position name="posWireU104" unit="cm" x="0" y="-34.5977148811883" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU105"/> 
+       <position name="posWireU105" unit="cm" x="0" y="-33.7143689693281" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU106"/> 
+       <position name="posWireU106" unit="cm" x="0" y="-32.831023057468" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU107"/> 
+       <position name="posWireU107" unit="cm" x="0" y="-31.9476771456079" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU108"/> 
+       <position name="posWireU108" unit="cm" x="0" y="-31.0643312337477" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU109"/> 
+       <position name="posWireU109" unit="cm" x="0" y="-30.1809853218876" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU110"/> 
+       <position name="posWireU110" unit="cm" x="0" y="-29.2976394100275" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU111"/> 
+       <position name="posWireU111" unit="cm" x="0" y="-28.4142934981674" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU112"/> 
+       <position name="posWireU112" unit="cm" x="0" y="-27.5309475863072" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU113"/> 
+       <position name="posWireU113" unit="cm" x="0" y="-26.6476016744471" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU114"/> 
+       <position name="posWireU114" unit="cm" x="0" y="-25.764255762587" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU115"/> 
+       <position name="posWireU115" unit="cm" x="0" y="-24.8809098507268" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU116"/> 
+       <position name="posWireU116" unit="cm" x="0" y="-23.9975639388667" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU117"/> 
+       <position name="posWireU117" unit="cm" x="0" y="-23.1142180270066" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU118"/> 
+       <position name="posWireU118" unit="cm" x="0" y="-22.2308721151465" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU119"/> 
+       <position name="posWireU119" unit="cm" x="0" y="-21.3475262032863" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU120"/> 
+       <position name="posWireU120" unit="cm" x="0" y="-20.4641802914262" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU121"/> 
+       <position name="posWireU121" unit="cm" x="0" y="-19.5808343795661" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU122"/> 
+       <position name="posWireU122" unit="cm" x="0" y="-18.697488467706" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU123"/> 
+       <position name="posWireU123" unit="cm" x="0" y="-17.8141425558458" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU124"/> 
+       <position name="posWireU124" unit="cm" x="0" y="-16.9307966439857" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU125"/> 
+       <position name="posWireU125" unit="cm" x="0" y="-16.0474507321256" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU126"/> 
+       <position name="posWireU126" unit="cm" x="0" y="-15.1641048202654" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU127"/> 
+       <position name="posWireU127" unit="cm" x="0" y="-14.2807589084053" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU128"/> 
+       <position name="posWireU128" unit="cm" x="0" y="-13.3974129965452" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU129"/> 
+       <position name="posWireU129" unit="cm" x="0" y="-12.5140670846851" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU130"/> 
+       <position name="posWireU130" unit="cm" x="0" y="-11.6307211728249" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU131"/> 
+       <position name="posWireU131" unit="cm" x="0" y="-10.7473752609648" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU132"/> 
+       <position name="posWireU132" unit="cm" x="0" y="-9.86402934910468" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU133"/> 
+       <position name="posWireU133" unit="cm" x="0" y="-8.98068343724455" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU134"/> 
+       <position name="posWireU134" unit="cm" x="0" y="-8.09733752538442" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU135"/> 
+       <position name="posWireU135" unit="cm" x="0" y="-7.2139916135243" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU136"/> 
+       <position name="posWireU136" unit="cm" x="0" y="-6.33064570166416" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU137"/> 
+       <position name="posWireU137" unit="cm" x="0" y="-5.44729978980403" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU138"/> 
+       <position name="posWireU138" unit="cm" x="0" y="-4.56395387794391" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU139"/> 
+       <position name="posWireU139" unit="cm" x="0" y="-3.68060796608378" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU140"/> 
+       <position name="posWireU140" unit="cm" x="0" y="-2.79726205422365" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU141"/> 
+       <position name="posWireU141" unit="cm" x="0" y="-1.91391614236353" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU142"/> 
+       <position name="posWireU142" unit="cm" x="0" y="-1.0305702305034" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU143"/> 
+       <position name="posWireU143" unit="cm" x="0" y="-0.147224318643268" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU144"/> 
+       <position name="posWireU144" unit="cm" x="0" y="0.736121593216858" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU145"/> 
+       <position name="posWireU145" unit="cm" x="0" y="1.619467505077" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU146"/> 
+       <position name="posWireU146" unit="cm" x="0" y="2.50281341693712" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU147"/> 
+       <position name="posWireU147" unit="cm" x="0" y="3.38615932879726" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU148"/> 
+       <position name="posWireU148" unit="cm" x="0" y="4.26950524065738" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU149"/> 
+       <position name="posWireU149" unit="cm" x="0" y="5.15285115251751" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU150"/> 
+       <position name="posWireU150" unit="cm" x="0" y="6.03619706437765" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU151"/> 
+       <position name="posWireU151" unit="cm" x="0" y="6.91954297623776" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU152"/> 
+       <position name="posWireU152" unit="cm" x="0" y="7.80288888809789" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU153"/> 
+       <position name="posWireU153" unit="cm" x="0" y="8.68623479995803" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU154"/> 
+       <position name="posWireU154" unit="cm" x="0" y="9.56958071181815" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU155"/> 
+       <position name="posWireU155" unit="cm" x="0" y="10.4529266236783" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU156"/> 
+       <position name="posWireU156" unit="cm" x="0" y="11.3362725355384" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU157"/> 
+       <position name="posWireU157" unit="cm" x="0" y="12.2196184473985" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU158"/> 
+       <position name="posWireU158" unit="cm" x="0" y="13.1029643592587" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU159"/> 
+       <position name="posWireU159" unit="cm" x="0" y="13.9863102711188" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU160"/> 
+       <position name="posWireU160" unit="cm" x="0" y="14.8696561829789" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU161"/> 
+       <position name="posWireU161" unit="cm" x="0" y="15.753002094839" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU162"/> 
+       <position name="posWireU162" unit="cm" x="0" y="16.6363480066992" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU163"/> 
+       <position name="posWireU163" unit="cm" x="0" y="17.5196939185593" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU164"/> 
+       <position name="posWireU164" unit="cm" x="0" y="18.4030398304194" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU165"/> 
+       <position name="posWireU165" unit="cm" x="0" y="19.2863857422796" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU166"/> 
+       <position name="posWireU166" unit="cm" x="0" y="20.1697316541397" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU167"/> 
+       <position name="posWireU167" unit="cm" x="0" y="21.0530775659998" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU168"/> 
+       <position name="posWireU168" unit="cm" x="0" y="21.9364234778599" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU169"/> 
+       <position name="posWireU169" unit="cm" x="0" y="22.81976938972" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU170"/> 
+       <position name="posWireU170" unit="cm" x="0" y="23.7031153015801" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU171"/> 
+       <position name="posWireU171" unit="cm" x="0" y="24.5864612134402" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU172"/> 
+       <position name="posWireU172" unit="cm" x="0" y="25.4698071253003" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU173"/> 
+       <position name="posWireU173" unit="cm" x="0" y="26.3531530371605" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU174"/> 
+       <position name="posWireU174" unit="cm" x="0" y="27.2364989490206" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU175"/> 
+       <position name="posWireU175" unit="cm" x="0" y="28.1198448608807" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU176"/> 
+       <position name="posWireU176" unit="cm" x="0" y="29.0031907727408" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU177"/> 
+       <position name="posWireU177" unit="cm" x="0" y="29.8865366846009" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU178"/> 
+       <position name="posWireU178" unit="cm" x="0" y="30.769882596461" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU179"/> 
+       <position name="posWireU179" unit="cm" x="0" y="31.6532285083211" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU180"/> 
+       <position name="posWireU180" unit="cm" x="0" y="32.5365744201812" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU181"/> 
+       <position name="posWireU181" unit="cm" x="0" y="33.4199203320414" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU182"/> 
+       <position name="posWireU182" unit="cm" x="0" y="34.3032662439015" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU183"/> 
+       <position name="posWireU183" unit="cm" x="0" y="35.1866121557616" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU184"/> 
+       <position name="posWireU184" unit="cm" x="0" y="36.0699580676217" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU185"/> 
+       <position name="posWireU185" unit="cm" x="0" y="36.9533039794818" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU186"/> 
+       <position name="posWireU186" unit="cm" x="0" y="37.8366498913419" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU187"/> 
+       <position name="posWireU187" unit="cm" x="0" y="38.719995803202" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU188"/> 
+       <position name="posWireU188" unit="cm" x="0" y="39.6033417150621" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU189"/> 
+       <position name="posWireU189" unit="cm" x="0" y="40.4866876269222" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU190"/> 
+       <position name="posWireU190" unit="cm" x="0" y="41.1491970608175" z="0.382499999999759"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU191"/> 
+       <position name="posWireU191" unit="cm" x="0" y="41.5908700167475" z="1.14749999999976"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU192"/> 
+       <position name="posWireU192" unit="cm" x="0" y="42.0325429726776" z="1.91249999999975"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU193"/> 
+       <position name="posWireU193" unit="cm" x="0" y="42.4742159286076" z="2.67749999999972"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU194"/> 
+       <position name="posWireU194" unit="cm" x="0" y="42.9158888845377" z="3.44249999999973"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU195"/> 
+       <position name="posWireU195" unit="cm" x="0" y="43.3575618404678" z="4.20749999999971"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU196"/> 
+       <position name="posWireU196" unit="cm" x="0" y="43.7992347963978" z="4.97249999999969"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU197"/> 
+       <position name="posWireU197" unit="cm" x="0" y="44.2409077523279" z="5.73749999999968"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU198"/> 
+       <position name="posWireU198" unit="cm" x="0" y="44.6825807082579" z="6.50249999999967"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU199"/> 
+       <position name="posWireU199" unit="cm" x="0" y="45.124253664188" z="7.26749999999965"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU200"/> 
+       <position name="posWireU200" unit="cm" x="0" y="45.565926620118" z="8.03249999999964"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU201"/> 
+       <position name="posWireU201" unit="cm" x="0" y="46.0075995760481" z="8.79749999999962"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU202"/> 
+       <position name="posWireU202" unit="cm" x="0" y="46.4492725319781" z="9.56249999999961"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU203"/> 
+       <position name="posWireU203" unit="cm" x="0" y="46.8909454879082" z="10.3274999999996"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU204"/> 
+       <position name="posWireU204" unit="cm" x="0" y="47.3326184438382" z="11.0924999999996"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU205"/> 
+       <position name="posWireU205" unit="cm" x="0" y="47.7742913997683" z="11.8574999999996"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU206"/> 
+       <position name="posWireU206" unit="cm" x="0" y="48.2159643556984" z="12.6224999999995"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU207"/> 
+       <position name="posWireU207" unit="cm" x="0" y="48.6576373116284" z="13.3874999999996"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU208"/> 
+       <position name="posWireU208" unit="cm" x="0" y="49.0993102675585" z="14.1524999999995"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU209"/> 
+       <position name="posWireU209" unit="cm" x="0" y="49.5409832234885" z="14.9174999999995"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU210"/> 
+       <position name="posWireU210" unit="cm" x="0" y="49.9826561794186" z="15.6824999999995"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU211"/> 
+       <position name="posWireU211" unit="cm" x="0" y="50.4243291353486" z="16.4474999999995"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU212"/> 
+       <position name="posWireU212" unit="cm" x="0" y="50.8660020912787" z="17.2124999999995"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU213"/> 
+       <position name="posWireU213" unit="cm" x="0" y="51.3076750472087" z="17.9774999999995"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU214"/> 
+       <position name="posWireU214" unit="cm" x="0" y="51.7493480031388" z="18.7424999999994"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU215"/> 
+       <position name="posWireU215" unit="cm" x="0" y="52.1910209590689" z="19.5074999999994"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU216"/> 
+       <position name="posWireU216" unit="cm" x="0" y="52.6326939149989" z="20.2724999999994"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU217"/> 
+       <position name="posWireU217" unit="cm" x="0" y="53.074366870929" z="21.0374999999994"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU218"/> 
+       <position name="posWireU218" unit="cm" x="0" y="53.516039826859" z="21.8024999999994"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU219"/> 
+       <position name="posWireU219" unit="cm" x="0" y="53.9577127827891" z="22.5674999999994"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU220"/> 
+       <position name="posWireU220" unit="cm" x="0" y="54.3993857387191" z="23.3324999999994"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU221"/> 
+       <position name="posWireU221" unit="cm" x="0" y="54.8410586946492" z="24.0974999999994"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU222"/> 
+       <position name="posWireU222" unit="cm" x="0" y="55.2827316505793" z="24.8624999999993"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU223"/> 
+       <position name="posWireU223" unit="cm" x="0" y="55.7244046065093" z="25.6274999999993"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU224"/> 
+       <position name="posWireU224" unit="cm" x="0" y="56.1660775624394" z="26.3924999999993"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU225"/> 
+       <position name="posWireU225" unit="cm" x="0" y="56.6077505183694" z="27.1574999999993"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU226"/> 
+       <position name="posWireU226" unit="cm" x="0" y="57.0494234742995" z="27.9224999999993"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU227"/> 
+       <position name="posWireU227" unit="cm" x="0" y="57.4910964302295" z="28.6874999999993"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU228"/> 
+       <position name="posWireU228" unit="cm" x="0" y="57.9327693861596" z="29.4524999999993"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU229"/> 
+       <position name="posWireU229" unit="cm" x="0" y="58.3744423420896" z="30.2174999999992"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU230"/> 
+       <position name="posWireU230" unit="cm" x="0" y="58.8161152980197" z="30.9824999999992"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU231"/> 
+       <position name="posWireU231" unit="cm" x="0" y="59.2577882539497" z="31.7474999999992"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU232"/> 
+       <position name="posWireU232" unit="cm" x="0" y="59.6994612098798" z="32.5124999999992"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU233"/> 
+       <position name="posWireU233" unit="cm" x="0" y="60.1411341658099" z="33.2774999999992"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU234"/> 
+       <position name="posWireU234" unit="cm" x="0" y="60.5828071217399" z="34.0424999999992"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU235"/> 
+       <position name="posWireU235" unit="cm" x="0" y="61.02448007767" z="34.8074999999992"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU236"/> 
+       <position name="posWireU236" unit="cm" x="0" y="61.4661530336" z="35.5724999999992"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU237"/> 
+       <position name="posWireU237" unit="cm" x="0" y="61.9078259895301" z="36.3374999999991"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU238"/> 
+       <position name="posWireU238" unit="cm" x="0" y="62.3494989454601" z="37.1024999999991"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU239"/> 
+       <position name="posWireU239" unit="cm" x="0" y="62.7911719013902" z="37.8674999999991"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU240"/> 
+       <position name="posWireU240" unit="cm" x="0" y="63.2328448573203" z="38.6324999999991"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU241"/> 
+       <position name="posWireU241" unit="cm" x="0" y="63.6745178132503" z="39.3974999999991"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU242"/> 
+       <position name="posWireU242" unit="cm" x="0" y="64.1161907691804" z="40.1624999999991"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU243"/> 
+       <position name="posWireU243" unit="cm" x="0" y="64.5578637251104" z="40.927499999999"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU244"/> 
+       <position name="posWireU244" unit="cm" x="0" y="64.9995366810405" z="41.692499999999"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU245"/> 
+       <position name="posWireU245" unit="cm" x="0" y="65.4412096369705" z="42.457499999999"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU246"/> 
+       <position name="posWireU246" unit="cm" x="0" y="65.8828825929006" z="43.222499999999"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU247"/> 
+       <position name="posWireU247" unit="cm" x="0" y="66.3245555488307" z="43.987499999999"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU248"/> 
+       <position name="posWireU248" unit="cm" x="0" y="66.7662285047607" z="44.752499999999"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU249"/> 
+       <position name="posWireU249" unit="cm" x="0" y="67.2079014606908" z="45.517499999999"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU250"/> 
+       <position name="posWireU250" unit="cm" x="0" y="67.6495744166208" z="46.282499999999"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU251"/> 
+       <position name="posWireU251" unit="cm" x="0" y="68.0912473725509" z="47.0474999999989"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU252"/> 
+       <position name="posWireU252" unit="cm" x="0" y="68.5329203284809" z="47.8124999999989"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU253"/> 
+       <position name="posWireU253" unit="cm" x="0" y="68.974593284411" z="48.5774999999989"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU254"/> 
+       <position name="posWireU254" unit="cm" x="0" y="69.416266240341" z="49.3424999999989"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU255"/> 
+       <position name="posWireU255" unit="cm" x="0" y="69.8579391962711" z="50.1074999999989"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU256"/> 
+       <position name="posWireU256" unit="cm" x="0" y="70.2996121522011" z="50.8724999999989"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU257"/> 
+       <position name="posWireU257" unit="cm" x="0" y="70.7412851081312" z="51.6374999999989"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU258"/> 
+       <position name="posWireU258" unit="cm" x="0" y="71.1829580640613" z="52.4024999999988"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU259"/> 
+       <position name="posWireU259" unit="cm" x="0" y="71.6246310199913" z="53.1674999999988"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU260"/> 
+       <position name="posWireU260" unit="cm" x="0" y="72.0663039759214" z="53.9324999999988"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU261"/> 
+       <position name="posWireU261" unit="cm" x="0" y="72.5079769318514" z="54.6974999999988"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU262"/> 
+       <position name="posWireU262" unit="cm" x="0" y="72.9496498877815" z="55.4624999999988"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU263"/> 
+       <position name="posWireU263" unit="cm" x="0" y="73.3913228437115" z="56.2274999999988"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU264"/> 
+       <position name="posWireU264" unit="cm" x="0" y="73.8329957996416" z="56.9924999999988"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU265"/> 
+       <position name="posWireU265" unit="cm" x="0" y="74.2746687555717" z="57.7574999999988"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU266"/> 
+       <position name="posWireU266" unit="cm" x="0" y="74.7163417115017" z="58.5224999999987"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU267"/> 
+       <position name="posWireU267" unit="cm" x="0" y="75.1580146674318" z="59.2874999999987"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU268"/> 
+       <position name="posWireU268" unit="cm" x="0" y="75.5996876233618" z="60.0524999999987"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU269"/> 
+       <position name="posWireU269" unit="cm" x="0" y="76.0413605792919" z="60.8174999999987"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU270"/> 
+       <position name="posWireU270" unit="cm" x="0" y="76.4830335352219" z="61.5824999999987"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU271"/> 
+       <position name="posWireU271" unit="cm" x="0" y="76.924706491152" z="62.3474999999987"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU272"/> 
+       <position name="posWireU272" unit="cm" x="0" y="77.366379447082" z="63.1124999999986"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU273"/> 
+       <position name="posWireU273" unit="cm" x="0" y="77.8080524030121" z="63.8774999999986"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU274"/> 
+       <position name="posWireU274" unit="cm" x="0" y="78.2497253589422" z="64.6424999999986"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU275"/> 
+       <position name="posWireU275" unit="cm" x="0" y="78.6913983148722" z="65.4074999999986"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU276"/> 
+       <position name="posWireU276" unit="cm" x="0" y="79.1330712708023" z="66.1724999999986"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU277"/> 
+       <position name="posWireU277" unit="cm" x="0" y="79.5747442267323" z="66.9374999999986"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU278"/> 
+       <position name="posWireU278" unit="cm" x="0" y="80.0164171826624" z="67.7024999999986"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU279"/> 
+       <position name="posWireU279" unit="cm" x="0" y="80.4580901385924" z="68.4674999999986"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU280"/> 
+       <position name="posWireU280" unit="cm" x="0" y="80.8997630945225" z="69.2324999999986"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU281"/> 
+       <position name="posWireU281" unit="cm" x="0" y="81.3414360504525" z="69.9974999999985"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU282"/> 
+       <position name="posWireU282" unit="cm" x="0" y="81.7831090063826" z="70.7624999999985"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU283"/> 
+       <position name="posWireU283" unit="cm" x="0" y="82.2247819623126" z="71.5274999999985"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU284"/> 
+       <position name="posWireU284" unit="cm" x="0" y="82.6664549182427" z="72.2924999999985"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU285"/> 
+       <position name="posWireU285" unit="cm" x="0" y="83.1081278741728" z="73.0574999999985"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+   </volume>
+  <volume name="volTPCPlaneV">
+    <materialref ref="LAr"/>
+    <solidref ref="CRMVPlane"/>
+     <physvol>
+       <volumeref ref="volTPCWireV0"/> 
+       <position name="posWireV0" unit="cm" x="0" y="83.6970251487471" z="-74.0775"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV1"/> 
+       <position name="posWireV1" unit="cm" x="0" y="83.255352192817" z="-73.3125"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV2"/> 
+       <position name="posWireV2" unit="cm" x="0" y="82.8136792368869" z="-72.5475"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV3"/> 
+       <position name="posWireV3" unit="cm" x="0" y="82.3720062809569" z="-71.7825"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV4"/> 
+       <position name="posWireV4" unit="cm" x="0" y="81.9303333250268" z="-71.0175"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV5"/> 
+       <position name="posWireV5" unit="cm" x="0" y="81.4886603690967" z="-70.2525"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV6"/> 
+       <position name="posWireV6" unit="cm" x="0" y="81.0469874131667" z="-69.4875"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV7"/> 
+       <position name="posWireV7" unit="cm" x="0" y="80.6053144572366" z="-68.7225"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV8"/> 
+       <position name="posWireV8" unit="cm" x="0" y="80.1636415013066" z="-67.9575"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV9"/> 
+       <position name="posWireV9" unit="cm" x="0" y="79.7219685453765" z="-67.1925"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV10"/> 
+       <position name="posWireV10" unit="cm" x="0" y="79.2802955894464" z="-66.4275"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV11"/> 
+       <position name="posWireV11" unit="cm" x="0" y="78.8386226335164" z="-65.6625"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV12"/> 
+       <position name="posWireV12" unit="cm" x="0" y="78.3969496775863" z="-64.8975"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV13"/> 
+       <position name="posWireV13" unit="cm" x="0" y="77.9552767216562" z="-64.1325"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV14"/> 
+       <position name="posWireV14" unit="cm" x="0" y="77.5136037657262" z="-63.3675"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV15"/> 
+       <position name="posWireV15" unit="cm" x="0" y="77.0719308097961" z="-62.6025"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV16"/> 
+       <position name="posWireV16" unit="cm" x="0" y="76.630257853866" z="-61.8375"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV17"/> 
+       <position name="posWireV17" unit="cm" x="0" y="76.188584897936" z="-61.0725"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV18"/> 
+       <position name="posWireV18" unit="cm" x="0" y="75.7469119420059" z="-60.3075"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV19"/> 
+       <position name="posWireV19" unit="cm" x="0" y="75.3052389860758" z="-59.5425"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV20"/> 
+       <position name="posWireV20" unit="cm" x="0" y="74.8635660301458" z="-58.7775"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV21"/> 
+       <position name="posWireV21" unit="cm" x="0" y="74.4218930742157" z="-58.0125"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV22"/> 
+       <position name="posWireV22" unit="cm" x="0" y="73.9802201182857" z="-57.2475"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV23"/> 
+       <position name="posWireV23" unit="cm" x="0" y="73.5385471623556" z="-56.4825"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV24"/> 
+       <position name="posWireV24" unit="cm" x="0" y="73.0968742064255" z="-55.7175"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV25"/> 
+       <position name="posWireV25" unit="cm" x="0" y="72.6552012504955" z="-54.9525"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV26"/> 
+       <position name="posWireV26" unit="cm" x="0" y="72.2135282945654" z="-54.1875"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV27"/> 
+       <position name="posWireV27" unit="cm" x="0" y="71.7718553386353" z="-53.4225"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV28"/> 
+       <position name="posWireV28" unit="cm" x="0" y="71.3301823827053" z="-52.6575"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV29"/> 
+       <position name="posWireV29" unit="cm" x="0" y="70.8885094267752" z="-51.8925"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV30"/> 
+       <position name="posWireV30" unit="cm" x="0" y="70.4468364708452" z="-51.1275"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV31"/> 
+       <position name="posWireV31" unit="cm" x="0" y="70.0051635149151" z="-50.3625"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV32"/> 
+       <position name="posWireV32" unit="cm" x="0" y="69.563490558985" z="-49.5975"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV33"/> 
+       <position name="posWireV33" unit="cm" x="0" y="69.121817603055" z="-48.8325"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV34"/> 
+       <position name="posWireV34" unit="cm" x="0" y="68.6801446471249" z="-48.0675"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV35"/> 
+       <position name="posWireV35" unit="cm" x="0" y="68.2384716911948" z="-47.3025"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV36"/> 
+       <position name="posWireV36" unit="cm" x="0" y="67.7967987352648" z="-46.5375"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV37"/> 
+       <position name="posWireV37" unit="cm" x="0" y="67.3551257793347" z="-45.7725"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV38"/> 
+       <position name="posWireV38" unit="cm" x="0" y="66.9134528234046" z="-45.0075"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV39"/> 
+       <position name="posWireV39" unit="cm" x="0" y="66.4717798674746" z="-44.2425"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV40"/> 
+       <position name="posWireV40" unit="cm" x="0" y="66.0301069115445" z="-43.4775"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV41"/> 
+       <position name="posWireV41" unit="cm" x="0" y="65.5884339556144" z="-42.7125"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV42"/> 
+       <position name="posWireV42" unit="cm" x="0" y="65.1467609996844" z="-41.9475"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV43"/> 
+       <position name="posWireV43" unit="cm" x="0" y="64.7050880437543" z="-41.1825"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV44"/> 
+       <position name="posWireV44" unit="cm" x="0" y="64.2634150878243" z="-40.4175"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV45"/> 
+       <position name="posWireV45" unit="cm" x="0" y="63.8217421318942" z="-39.6525"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV46"/> 
+       <position name="posWireV46" unit="cm" x="0" y="63.3800691759641" z="-38.8875"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV47"/> 
+       <position name="posWireV47" unit="cm" x="0" y="62.9383962200341" z="-38.1225"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV48"/> 
+       <position name="posWireV48" unit="cm" x="0" y="62.496723264104" z="-37.3575"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV49"/> 
+       <position name="posWireV49" unit="cm" x="0" y="62.0550503081739" z="-36.5925"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV50"/> 
+       <position name="posWireV50" unit="cm" x="0" y="61.6133773522439" z="-35.8275"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV51"/> 
+       <position name="posWireV51" unit="cm" x="0" y="61.1717043963138" z="-35.0625"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV52"/> 
+       <position name="posWireV52" unit="cm" x="0" y="60.7300314403837" z="-34.2975"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV53"/> 
+       <position name="posWireV53" unit="cm" x="0" y="60.2883584844537" z="-33.5325"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV54"/> 
+       <position name="posWireV54" unit="cm" x="0" y="59.8466855285236" z="-32.7675"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV55"/> 
+       <position name="posWireV55" unit="cm" x="0" y="59.4050125725935" z="-32.0025"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV56"/> 
+       <position name="posWireV56" unit="cm" x="0" y="58.9633396166635" z="-31.2375"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV57"/> 
+       <position name="posWireV57" unit="cm" x="0" y="58.5216666607334" z="-30.4725"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV58"/> 
+       <position name="posWireV58" unit="cm" x="0" y="58.0799937048034" z="-29.7075"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV59"/> 
+       <position name="posWireV59" unit="cm" x="0" y="57.6383207488733" z="-28.9425"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV60"/> 
+       <position name="posWireV60" unit="cm" x="0" y="57.1966477929432" z="-28.1775"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV61"/> 
+       <position name="posWireV61" unit="cm" x="0" y="56.7549748370132" z="-27.4125"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV62"/> 
+       <position name="posWireV62" unit="cm" x="0" y="56.3133018810831" z="-26.6475"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV63"/> 
+       <position name="posWireV63" unit="cm" x="0" y="55.871628925153" z="-25.8825"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV64"/> 
+       <position name="posWireV64" unit="cm" x="0" y="55.429955969223" z="-25.1175"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV65"/> 
+       <position name="posWireV65" unit="cm" x="0" y="54.9882830132929" z="-24.3525"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV66"/> 
+       <position name="posWireV66" unit="cm" x="0" y="54.5466100573628" z="-23.5875"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV67"/> 
+       <position name="posWireV67" unit="cm" x="0" y="54.1049371014328" z="-22.8225"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV68"/> 
+       <position name="posWireV68" unit="cm" x="0" y="53.6632641455027" z="-22.0575"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV69"/> 
+       <position name="posWireV69" unit="cm" x="0" y="53.2215911895726" z="-21.2925"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV70"/> 
+       <position name="posWireV70" unit="cm" x="0" y="52.7799182336426" z="-20.5275"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV71"/> 
+       <position name="posWireV71" unit="cm" x="0" y="52.3382452777125" z="-19.7625"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV72"/> 
+       <position name="posWireV72" unit="cm" x="0" y="51.8965723217825" z="-18.9975"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV73"/> 
+       <position name="posWireV73" unit="cm" x="0" y="51.4548993658524" z="-18.2325"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV74"/> 
+       <position name="posWireV74" unit="cm" x="0" y="51.0132264099223" z="-17.4675"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV75"/> 
+       <position name="posWireV75" unit="cm" x="0" y="50.5715534539923" z="-16.7025"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV76"/> 
+       <position name="posWireV76" unit="cm" x="0" y="50.1298804980622" z="-15.9375"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV77"/> 
+       <position name="posWireV77" unit="cm" x="0" y="49.6882075421321" z="-15.1725"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV78"/> 
+       <position name="posWireV78" unit="cm" x="0" y="49.2465345862021" z="-14.4075"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV79"/> 
+       <position name="posWireV79" unit="cm" x="0" y="48.804861630272" z="-13.6425"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV80"/> 
+       <position name="posWireV80" unit="cm" x="0" y="48.3631886743419" z="-12.8775"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV81"/> 
+       <position name="posWireV81" unit="cm" x="0" y="47.9215157184119" z="-12.1125"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV82"/> 
+       <position name="posWireV82" unit="cm" x="0" y="47.4798427624818" z="-11.3475"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV83"/> 
+       <position name="posWireV83" unit="cm" x="0" y="47.0381698065518" z="-10.5825"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV84"/> 
+       <position name="posWireV84" unit="cm" x="0" y="46.5964968506217" z="-9.81749999999995"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV85"/> 
+       <position name="posWireV85" unit="cm" x="0" y="46.1548238946916" z="-9.05249999999995"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV86"/> 
+       <position name="posWireV86" unit="cm" x="0" y="45.7131509387616" z="-8.28749999999995"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV87"/> 
+       <position name="posWireV87" unit="cm" x="0" y="45.2714779828315" z="-7.52249999999995"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV88"/> 
+       <position name="posWireV88" unit="cm" x="0" y="44.8298050269014" z="-6.75749999999995"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV89"/> 
+       <position name="posWireV89" unit="cm" x="0" y="44.3881320709714" z="-5.99249999999995"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV90"/> 
+       <position name="posWireV90" unit="cm" x="0" y="43.9464591150413" z="-5.22749999999995"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV91"/> 
+       <position name="posWireV91" unit="cm" x="0" y="43.5047861591112" z="-4.46249999999995"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV92"/> 
+       <position name="posWireV92" unit="cm" x="0" y="43.0631132031812" z="-3.69749999999995"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV93"/> 
+       <position name="posWireV93" unit="cm" x="0" y="42.6214402472511" z="-2.93249999999996"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV94"/> 
+       <position name="posWireV94" unit="cm" x="0" y="42.179767291321" z="-2.16749999999995"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV95"/> 
+       <position name="posWireV95" unit="cm" x="0" y="41.738094335391" z="-1.40249999999996"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV96"/> 
+       <position name="posWireV96" unit="cm" x="0" y="41.2964213794609" z="-0.637499999999946"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV97"/> 
+       <position name="posWireV97" unit="cm" x="0" y="40.7811362642091" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV98"/> 
+       <position name="posWireV98" unit="cm" x="0" y="39.897790352349" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV99"/> 
+       <position name="posWireV99" unit="cm" x="0" y="39.0144444404889" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV100"/> 
+       <position name="posWireV100" unit="cm" x="0" y="38.1310985286288" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV101"/> 
+       <position name="posWireV101" unit="cm" x="0" y="37.2477526167686" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV102"/> 
+       <position name="posWireV102" unit="cm" x="0" y="36.3644067049085" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV103"/> 
+       <position name="posWireV103" unit="cm" x="0" y="35.4810607930484" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV104"/> 
+       <position name="posWireV104" unit="cm" x="0" y="34.5977148811883" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV105"/> 
+       <position name="posWireV105" unit="cm" x="0" y="33.7143689693281" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV106"/> 
+       <position name="posWireV106" unit="cm" x="0" y="32.831023057468" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV107"/> 
+       <position name="posWireV107" unit="cm" x="0" y="31.9476771456079" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV108"/> 
+       <position name="posWireV108" unit="cm" x="0" y="31.0643312337477" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV109"/> 
+       <position name="posWireV109" unit="cm" x="0" y="30.1809853218876" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV110"/> 
+       <position name="posWireV110" unit="cm" x="0" y="29.2976394100275" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV111"/> 
+       <position name="posWireV111" unit="cm" x="0" y="28.4142934981674" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV112"/> 
+       <position name="posWireV112" unit="cm" x="0" y="27.5309475863072" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV113"/> 
+       <position name="posWireV113" unit="cm" x="0" y="26.6476016744471" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV114"/> 
+       <position name="posWireV114" unit="cm" x="0" y="25.764255762587" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV115"/> 
+       <position name="posWireV115" unit="cm" x="0" y="24.8809098507268" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV116"/> 
+       <position name="posWireV116" unit="cm" x="0" y="23.9975639388667" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV117"/> 
+       <position name="posWireV117" unit="cm" x="0" y="23.1142180270066" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV118"/> 
+       <position name="posWireV118" unit="cm" x="0" y="22.2308721151465" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV119"/> 
+       <position name="posWireV119" unit="cm" x="0" y="21.3475262032863" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV120"/> 
+       <position name="posWireV120" unit="cm" x="0" y="20.4641802914262" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV121"/> 
+       <position name="posWireV121" unit="cm" x="0" y="19.5808343795661" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV122"/> 
+       <position name="posWireV122" unit="cm" x="0" y="18.697488467706" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV123"/> 
+       <position name="posWireV123" unit="cm" x="0" y="17.8141425558458" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV124"/> 
+       <position name="posWireV124" unit="cm" x="0" y="16.9307966439857" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV125"/> 
+       <position name="posWireV125" unit="cm" x="0" y="16.0474507321256" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV126"/> 
+       <position name="posWireV126" unit="cm" x="0" y="15.1641048202654" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV127"/> 
+       <position name="posWireV127" unit="cm" x="0" y="14.2807589084053" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV128"/> 
+       <position name="posWireV128" unit="cm" x="0" y="13.3974129965452" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV129"/> 
+       <position name="posWireV129" unit="cm" x="0" y="12.5140670846851" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV130"/> 
+       <position name="posWireV130" unit="cm" x="0" y="11.6307211728249" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV131"/> 
+       <position name="posWireV131" unit="cm" x="0" y="10.7473752609648" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV132"/> 
+       <position name="posWireV132" unit="cm" x="0" y="9.86402934910467" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV133"/> 
+       <position name="posWireV133" unit="cm" x="0" y="8.98068343724454" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV134"/> 
+       <position name="posWireV134" unit="cm" x="0" y="8.09733752538442" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV135"/> 
+       <position name="posWireV135" unit="cm" x="0" y="7.2139916135243" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV136"/> 
+       <position name="posWireV136" unit="cm" x="0" y="6.33064570166416" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV137"/> 
+       <position name="posWireV137" unit="cm" x="0" y="5.44729978980404" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV138"/> 
+       <position name="posWireV138" unit="cm" x="0" y="4.5639538779439" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV139"/> 
+       <position name="posWireV139" unit="cm" x="0" y="3.68060796608379" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV140"/> 
+       <position name="posWireV140" unit="cm" x="0" y="2.79726205422365" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV141"/> 
+       <position name="posWireV141" unit="cm" x="0" y="1.91391614236352" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV142"/> 
+       <position name="posWireV142" unit="cm" x="0" y="1.03057023050339" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV143"/> 
+       <position name="posWireV143" unit="cm" x="0" y="0.147224318643268" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV144"/> 
+       <position name="posWireV144" unit="cm" x="0" y="-0.736121593216858" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV145"/> 
+       <position name="posWireV145" unit="cm" x="0" y="-1.61946750507699" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV146"/> 
+       <position name="posWireV146" unit="cm" x="0" y="-2.50281341693713" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV147"/> 
+       <position name="posWireV147" unit="cm" x="0" y="-3.38615932879726" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV148"/> 
+       <position name="posWireV148" unit="cm" x="0" y="-4.26950524065738" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV149"/> 
+       <position name="posWireV149" unit="cm" x="0" y="-5.15285115251752" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV150"/> 
+       <position name="posWireV150" unit="cm" x="0" y="-6.03619706437764" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV151"/> 
+       <position name="posWireV151" unit="cm" x="0" y="-6.91954297623776" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV152"/> 
+       <position name="posWireV152" unit="cm" x="0" y="-7.80288888809789" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV153"/> 
+       <position name="posWireV153" unit="cm" x="0" y="-8.68623479995803" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV154"/> 
+       <position name="posWireV154" unit="cm" x="0" y="-9.56958071181815" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV155"/> 
+       <position name="posWireV155" unit="cm" x="0" y="-10.4529266236783" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV156"/> 
+       <position name="posWireV156" unit="cm" x="0" y="-11.3362725355384" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV157"/> 
+       <position name="posWireV157" unit="cm" x="0" y="-12.2196184473985" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV158"/> 
+       <position name="posWireV158" unit="cm" x="0" y="-13.1029643592587" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV159"/> 
+       <position name="posWireV159" unit="cm" x="0" y="-13.9863102711188" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV160"/> 
+       <position name="posWireV160" unit="cm" x="0" y="-14.8696561829789" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV161"/> 
+       <position name="posWireV161" unit="cm" x="0" y="-15.7530020948391" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV162"/> 
+       <position name="posWireV162" unit="cm" x="0" y="-16.6363480066992" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV163"/> 
+       <position name="posWireV163" unit="cm" x="0" y="-17.5196939185593" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV164"/> 
+       <position name="posWireV164" unit="cm" x="0" y="-18.4030398304194" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV165"/> 
+       <position name="posWireV165" unit="cm" x="0" y="-19.2863857422796" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV166"/> 
+       <position name="posWireV166" unit="cm" x="0" y="-20.1697316541397" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV167"/> 
+       <position name="posWireV167" unit="cm" x="0" y="-21.0530775659998" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV168"/> 
+       <position name="posWireV168" unit="cm" x="0" y="-21.9364234778599" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV169"/> 
+       <position name="posWireV169" unit="cm" x="0" y="-22.81976938972" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV170"/> 
+       <position name="posWireV170" unit="cm" x="0" y="-23.7031153015801" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV171"/> 
+       <position name="posWireV171" unit="cm" x="0" y="-24.5864612134402" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV172"/> 
+       <position name="posWireV172" unit="cm" x="0" y="-25.4698071253004" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV173"/> 
+       <position name="posWireV173" unit="cm" x="0" y="-26.3531530371605" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV174"/> 
+       <position name="posWireV174" unit="cm" x="0" y="-27.2364989490206" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV175"/> 
+       <position name="posWireV175" unit="cm" x="0" y="-28.1198448608807" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV176"/> 
+       <position name="posWireV176" unit="cm" x="0" y="-29.0031907727408" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV177"/> 
+       <position name="posWireV177" unit="cm" x="0" y="-29.8865366846009" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV178"/> 
+       <position name="posWireV178" unit="cm" x="0" y="-30.769882596461" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV179"/> 
+       <position name="posWireV179" unit="cm" x="0" y="-31.6532285083211" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV180"/> 
+       <position name="posWireV180" unit="cm" x="0" y="-32.5365744201812" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV181"/> 
+       <position name="posWireV181" unit="cm" x="0" y="-33.4199203320414" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV182"/> 
+       <position name="posWireV182" unit="cm" x="0" y="-34.3032662439015" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV183"/> 
+       <position name="posWireV183" unit="cm" x="0" y="-35.1866121557616" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV184"/> 
+       <position name="posWireV184" unit="cm" x="0" y="-36.0699580676217" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV185"/> 
+       <position name="posWireV185" unit="cm" x="0" y="-36.9533039794818" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV186"/> 
+       <position name="posWireV186" unit="cm" x="0" y="-37.8366498913419" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV187"/> 
+       <position name="posWireV187" unit="cm" x="0" y="-38.719995803202" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV188"/> 
+       <position name="posWireV188" unit="cm" x="0" y="-39.6033417150621" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV189"/> 
+       <position name="posWireV189" unit="cm" x="0" y="-40.4866876269222" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV190"/> 
+       <position name="posWireV190" unit="cm" x="0" y="-41.1491970608175" z="0.382499999999759"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV191"/> 
+       <position name="posWireV191" unit="cm" x="0" y="-41.5908700167475" z="1.14749999999976"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV192"/> 
+       <position name="posWireV192" unit="cm" x="0" y="-42.0325429726776" z="1.91249999999975"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV193"/> 
+       <position name="posWireV193" unit="cm" x="0" y="-42.4742159286076" z="2.67749999999972"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV194"/> 
+       <position name="posWireV194" unit="cm" x="0" y="-42.9158888845377" z="3.44249999999973"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV195"/> 
+       <position name="posWireV195" unit="cm" x="0" y="-43.3575618404678" z="4.20749999999971"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV196"/> 
+       <position name="posWireV196" unit="cm" x="0" y="-43.7992347963978" z="4.97249999999969"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV197"/> 
+       <position name="posWireV197" unit="cm" x="0" y="-44.2409077523279" z="5.73749999999968"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV198"/> 
+       <position name="posWireV198" unit="cm" x="0" y="-44.6825807082579" z="6.50249999999967"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV199"/> 
+       <position name="posWireV199" unit="cm" x="0" y="-45.124253664188" z="7.26749999999965"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV200"/> 
+       <position name="posWireV200" unit="cm" x="0" y="-45.565926620118" z="8.03249999999964"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV201"/> 
+       <position name="posWireV201" unit="cm" x="0" y="-46.0075995760481" z="8.79749999999962"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV202"/> 
+       <position name="posWireV202" unit="cm" x="0" y="-46.4492725319781" z="9.56249999999961"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV203"/> 
+       <position name="posWireV203" unit="cm" x="0" y="-46.8909454879082" z="10.3274999999996"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV204"/> 
+       <position name="posWireV204" unit="cm" x="0" y="-47.3326184438382" z="11.0924999999996"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV205"/> 
+       <position name="posWireV205" unit="cm" x="0" y="-47.7742913997683" z="11.8574999999996"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV206"/> 
+       <position name="posWireV206" unit="cm" x="0" y="-48.2159643556984" z="12.6224999999995"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV207"/> 
+       <position name="posWireV207" unit="cm" x="0" y="-48.6576373116284" z="13.3874999999996"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV208"/> 
+       <position name="posWireV208" unit="cm" x="0" y="-49.0993102675585" z="14.1524999999995"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV209"/> 
+       <position name="posWireV209" unit="cm" x="0" y="-49.5409832234885" z="14.9174999999995"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV210"/> 
+       <position name="posWireV210" unit="cm" x="0" y="-49.9826561794186" z="15.6824999999995"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV211"/> 
+       <position name="posWireV211" unit="cm" x="0" y="-50.4243291353486" z="16.4474999999995"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV212"/> 
+       <position name="posWireV212" unit="cm" x="0" y="-50.8660020912787" z="17.2124999999995"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV213"/> 
+       <position name="posWireV213" unit="cm" x="0" y="-51.3076750472087" z="17.9774999999995"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV214"/> 
+       <position name="posWireV214" unit="cm" x="0" y="-51.7493480031388" z="18.7424999999994"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV215"/> 
+       <position name="posWireV215" unit="cm" x="0" y="-52.1910209590689" z="19.5074999999994"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV216"/> 
+       <position name="posWireV216" unit="cm" x="0" y="-52.6326939149989" z="20.2724999999994"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV217"/> 
+       <position name="posWireV217" unit="cm" x="0" y="-53.074366870929" z="21.0374999999994"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV218"/> 
+       <position name="posWireV218" unit="cm" x="0" y="-53.516039826859" z="21.8024999999994"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV219"/> 
+       <position name="posWireV219" unit="cm" x="0" y="-53.9577127827891" z="22.5674999999994"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV220"/> 
+       <position name="posWireV220" unit="cm" x="0" y="-54.3993857387191" z="23.3324999999994"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV221"/> 
+       <position name="posWireV221" unit="cm" x="0" y="-54.8410586946492" z="24.0974999999994"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV222"/> 
+       <position name="posWireV222" unit="cm" x="0" y="-55.2827316505793" z="24.8624999999993"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV223"/> 
+       <position name="posWireV223" unit="cm" x="0" y="-55.7244046065093" z="25.6274999999993"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV224"/> 
+       <position name="posWireV224" unit="cm" x="0" y="-56.1660775624394" z="26.3924999999993"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV225"/> 
+       <position name="posWireV225" unit="cm" x="0" y="-56.6077505183694" z="27.1574999999993"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV226"/> 
+       <position name="posWireV226" unit="cm" x="0" y="-57.0494234742995" z="27.9224999999993"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV227"/> 
+       <position name="posWireV227" unit="cm" x="0" y="-57.4910964302295" z="28.6874999999993"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV228"/> 
+       <position name="posWireV228" unit="cm" x="0" y="-57.9327693861596" z="29.4524999999993"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV229"/> 
+       <position name="posWireV229" unit="cm" x="0" y="-58.3744423420896" z="30.2174999999992"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV230"/> 
+       <position name="posWireV230" unit="cm" x="0" y="-58.8161152980197" z="30.9824999999992"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV231"/> 
+       <position name="posWireV231" unit="cm" x="0" y="-59.2577882539497" z="31.7474999999992"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV232"/> 
+       <position name="posWireV232" unit="cm" x="0" y="-59.6994612098798" z="32.5124999999992"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV233"/> 
+       <position name="posWireV233" unit="cm" x="0" y="-60.1411341658099" z="33.2774999999992"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV234"/> 
+       <position name="posWireV234" unit="cm" x="0" y="-60.5828071217399" z="34.0424999999992"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV235"/> 
+       <position name="posWireV235" unit="cm" x="0" y="-61.02448007767" z="34.8074999999992"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV236"/> 
+       <position name="posWireV236" unit="cm" x="0" y="-61.4661530336" z="35.5724999999992"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV237"/> 
+       <position name="posWireV237" unit="cm" x="0" y="-61.9078259895301" z="36.3374999999991"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV238"/> 
+       <position name="posWireV238" unit="cm" x="0" y="-62.3494989454601" z="37.1024999999991"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV239"/> 
+       <position name="posWireV239" unit="cm" x="0" y="-62.7911719013902" z="37.8674999999991"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV240"/> 
+       <position name="posWireV240" unit="cm" x="0" y="-63.2328448573203" z="38.6324999999991"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV241"/> 
+       <position name="posWireV241" unit="cm" x="0" y="-63.6745178132503" z="39.3974999999991"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV242"/> 
+       <position name="posWireV242" unit="cm" x="0" y="-64.1161907691804" z="40.1624999999991"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV243"/> 
+       <position name="posWireV243" unit="cm" x="0" y="-64.5578637251104" z="40.927499999999"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV244"/> 
+       <position name="posWireV244" unit="cm" x="0" y="-64.9995366810405" z="41.692499999999"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV245"/> 
+       <position name="posWireV245" unit="cm" x="0" y="-65.4412096369705" z="42.457499999999"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV246"/> 
+       <position name="posWireV246" unit="cm" x="0" y="-65.8828825929006" z="43.222499999999"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV247"/> 
+       <position name="posWireV247" unit="cm" x="0" y="-66.3245555488307" z="43.987499999999"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV248"/> 
+       <position name="posWireV248" unit="cm" x="0" y="-66.7662285047607" z="44.752499999999"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV249"/> 
+       <position name="posWireV249" unit="cm" x="0" y="-67.2079014606908" z="45.517499999999"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV250"/> 
+       <position name="posWireV250" unit="cm" x="0" y="-67.6495744166208" z="46.282499999999"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV251"/> 
+       <position name="posWireV251" unit="cm" x="0" y="-68.0912473725509" z="47.0474999999989"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV252"/> 
+       <position name="posWireV252" unit="cm" x="0" y="-68.5329203284809" z="47.8124999999989"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV253"/> 
+       <position name="posWireV253" unit="cm" x="0" y="-68.974593284411" z="48.5774999999989"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV254"/> 
+       <position name="posWireV254" unit="cm" x="0" y="-69.416266240341" z="49.3424999999989"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV255"/> 
+       <position name="posWireV255" unit="cm" x="0" y="-69.8579391962711" z="50.1074999999989"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV256"/> 
+       <position name="posWireV256" unit="cm" x="0" y="-70.2996121522011" z="50.8724999999989"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV257"/> 
+       <position name="posWireV257" unit="cm" x="0" y="-70.7412851081312" z="51.6374999999989"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV258"/> 
+       <position name="posWireV258" unit="cm" x="0" y="-71.1829580640613" z="52.4024999999988"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV259"/> 
+       <position name="posWireV259" unit="cm" x="0" y="-71.6246310199913" z="53.1674999999988"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV260"/> 
+       <position name="posWireV260" unit="cm" x="0" y="-72.0663039759214" z="53.9324999999988"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV261"/> 
+       <position name="posWireV261" unit="cm" x="0" y="-72.5079769318514" z="54.6974999999988"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV262"/> 
+       <position name="posWireV262" unit="cm" x="0" y="-72.9496498877815" z="55.4624999999988"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV263"/> 
+       <position name="posWireV263" unit="cm" x="0" y="-73.3913228437115" z="56.2274999999988"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV264"/> 
+       <position name="posWireV264" unit="cm" x="0" y="-73.8329957996416" z="56.9924999999988"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV265"/> 
+       <position name="posWireV265" unit="cm" x="0" y="-74.2746687555717" z="57.7574999999988"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV266"/> 
+       <position name="posWireV266" unit="cm" x="0" y="-74.7163417115017" z="58.5224999999987"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV267"/> 
+       <position name="posWireV267" unit="cm" x="0" y="-75.1580146674318" z="59.2874999999987"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV268"/> 
+       <position name="posWireV268" unit="cm" x="0" y="-75.5996876233618" z="60.0524999999987"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV269"/> 
+       <position name="posWireV269" unit="cm" x="0" y="-76.0413605792919" z="60.8174999999987"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV270"/> 
+       <position name="posWireV270" unit="cm" x="0" y="-76.4830335352219" z="61.5824999999987"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV271"/> 
+       <position name="posWireV271" unit="cm" x="0" y="-76.924706491152" z="62.3474999999987"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV272"/> 
+       <position name="posWireV272" unit="cm" x="0" y="-77.366379447082" z="63.1124999999986"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV273"/> 
+       <position name="posWireV273" unit="cm" x="0" y="-77.8080524030121" z="63.8774999999986"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV274"/> 
+       <position name="posWireV274" unit="cm" x="0" y="-78.2497253589422" z="64.6424999999986"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV275"/> 
+       <position name="posWireV275" unit="cm" x="0" y="-78.6913983148722" z="65.4074999999986"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV276"/> 
+       <position name="posWireV276" unit="cm" x="0" y="-79.1330712708023" z="66.1724999999986"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV277"/> 
+       <position name="posWireV277" unit="cm" x="0" y="-79.5747442267323" z="66.9374999999986"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV278"/> 
+       <position name="posWireV278" unit="cm" x="0" y="-80.0164171826624" z="67.7024999999986"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV279"/> 
+       <position name="posWireV279" unit="cm" x="0" y="-80.4580901385924" z="68.4674999999986"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV280"/> 
+       <position name="posWireV280" unit="cm" x="0" y="-80.8997630945225" z="69.2324999999986"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV281"/> 
+       <position name="posWireV281" unit="cm" x="0" y="-81.3414360504525" z="69.9974999999985"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV282"/> 
+       <position name="posWireV282" unit="cm" x="0" y="-81.7831090063826" z="70.7624999999985"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV283"/> 
+       <position name="posWireV283" unit="cm" x="0" y="-82.2247819623126" z="71.5274999999985"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV284"/> 
+       <position name="posWireV284" unit="cm" x="0" y="-82.6664549182427" z="72.2924999999985"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV285"/> 
+       <position name="posWireV285" unit="cm" x="0" y="-83.1081278741728" z="73.0574999999985"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+  </volume>
+  <volume name="volTPCPlaneZ">
+    <materialref ref="LAr"/>
+    <solidref ref="CRMZPlane"/>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ0" unit="cm" x="0" y="0" z="-74.205"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ1" unit="cm" x="0" y="0" z="-73.695"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ2" unit="cm" x="0" y="0" z="-73.185"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ3" unit="cm" x="0" y="0" z="-72.675"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ4" unit="cm" x="0" y="0" z="-72.165"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ5" unit="cm" x="0" y="0" z="-71.655"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ6" unit="cm" x="0" y="0" z="-71.145"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ7" unit="cm" x="0" y="0" z="-70.635"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ8" unit="cm" x="0" y="0" z="-70.125"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ9" unit="cm" x="0" y="0" z="-69.615"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ10" unit="cm" x="0" y="0" z="-69.105"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ11" unit="cm" x="0" y="0" z="-68.595"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ12" unit="cm" x="0" y="0" z="-68.085"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ13" unit="cm" x="0" y="0" z="-67.575"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ14" unit="cm" x="0" y="0" z="-67.065"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ15" unit="cm" x="0" y="0" z="-66.555"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ16" unit="cm" x="0" y="0" z="-66.045"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ17" unit="cm" x="0" y="0" z="-65.535"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ18" unit="cm" x="0" y="0" z="-65.025"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ19" unit="cm" x="0" y="0" z="-64.515"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ20" unit="cm" x="0" y="0" z="-64.005"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ21" unit="cm" x="0" y="0" z="-63.495"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ22" unit="cm" x="0" y="0" z="-62.985"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ23" unit="cm" x="0" y="0" z="-62.475"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ24" unit="cm" x="0" y="0" z="-61.965"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ25" unit="cm" x="0" y="0" z="-61.455"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ26" unit="cm" x="0" y="0" z="-60.945"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ27" unit="cm" x="0" y="0" z="-60.435"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ28" unit="cm" x="0" y="0" z="-59.925"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ29" unit="cm" x="0" y="0" z="-59.415"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ30" unit="cm" x="0" y="0" z="-58.905"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ31" unit="cm" x="0" y="0" z="-58.395"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ32" unit="cm" x="0" y="0" z="-57.885"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ33" unit="cm" x="0" y="0" z="-57.375"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ34" unit="cm" x="0" y="0" z="-56.865"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ35" unit="cm" x="0" y="0" z="-56.355"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ36" unit="cm" x="0" y="0" z="-55.845"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ37" unit="cm" x="0" y="0" z="-55.335"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ38" unit="cm" x="0" y="0" z="-54.825"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ39" unit="cm" x="0" y="0" z="-54.315"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ40" unit="cm" x="0" y="0" z="-53.805"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ41" unit="cm" x="0" y="0" z="-53.295"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ42" unit="cm" x="0" y="0" z="-52.785"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ43" unit="cm" x="0" y="0" z="-52.275"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ44" unit="cm" x="0" y="0" z="-51.765"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ45" unit="cm" x="0" y="0" z="-51.255"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ46" unit="cm" x="0" y="0" z="-50.745"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ47" unit="cm" x="0" y="0" z="-50.235"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ48" unit="cm" x="0" y="0" z="-49.725"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ49" unit="cm" x="0" y="0" z="-49.215"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ50" unit="cm" x="0" y="0" z="-48.705"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ51" unit="cm" x="0" y="0" z="-48.195"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ52" unit="cm" x="0" y="0" z="-47.685"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ53" unit="cm" x="0" y="0" z="-47.175"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ54" unit="cm" x="0" y="0" z="-46.665"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ55" unit="cm" x="0" y="0" z="-46.155"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ56" unit="cm" x="0" y="0" z="-45.645"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ57" unit="cm" x="0" y="0" z="-45.135"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ58" unit="cm" x="0" y="0" z="-44.625"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ59" unit="cm" x="0" y="0" z="-44.115"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ60" unit="cm" x="0" y="0" z="-43.605"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ61" unit="cm" x="0" y="0" z="-43.095"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ62" unit="cm" x="0" y="0" z="-42.585"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ63" unit="cm" x="0" y="0" z="-42.075"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ64" unit="cm" x="0" y="0" z="-41.565"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ65" unit="cm" x="0" y="0" z="-41.055"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ66" unit="cm" x="0" y="0" z="-40.545"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ67" unit="cm" x="0" y="0" z="-40.035"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ68" unit="cm" x="0" y="0" z="-39.525"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ69" unit="cm" x="0" y="0" z="-39.015"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ70" unit="cm" x="0" y="0" z="-38.505"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ71" unit="cm" x="0" y="0" z="-37.995"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ72" unit="cm" x="0" y="0" z="-37.485"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ73" unit="cm" x="0" y="0" z="-36.975"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ74" unit="cm" x="0" y="0" z="-36.465"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ75" unit="cm" x="0" y="0" z="-35.955"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ76" unit="cm" x="0" y="0" z="-35.445"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ77" unit="cm" x="0" y="0" z="-34.935"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ78" unit="cm" x="0" y="0" z="-34.425"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ79" unit="cm" x="0" y="0" z="-33.915"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ80" unit="cm" x="0" y="0" z="-33.405"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ81" unit="cm" x="0" y="0" z="-32.895"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ82" unit="cm" x="0" y="0" z="-32.385"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ83" unit="cm" x="0" y="0" z="-31.875"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ84" unit="cm" x="0" y="0" z="-31.365"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ85" unit="cm" x="0" y="0" z="-30.855"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ86" unit="cm" x="0" y="0" z="-30.345"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ87" unit="cm" x="0" y="0" z="-29.835"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ88" unit="cm" x="0" y="0" z="-29.325"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ89" unit="cm" x="0" y="0" z="-28.815"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ90" unit="cm" x="0" y="0" z="-28.305"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ91" unit="cm" x="0" y="0" z="-27.795"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ92" unit="cm" x="0" y="0" z="-27.285"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ93" unit="cm" x="0" y="0" z="-26.775"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ94" unit="cm" x="0" y="0" z="-26.265"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ95" unit="cm" x="0" y="0" z="-25.755"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ96" unit="cm" x="0" y="0" z="-25.245"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ97" unit="cm" x="0" y="0" z="-24.735"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ98" unit="cm" x="0" y="0" z="-24.225"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ99" unit="cm" x="0" y="0" z="-23.715"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ100" unit="cm" x="0" y="0" z="-23.205"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ101" unit="cm" x="0" y="0" z="-22.695"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ102" unit="cm" x="0" y="0" z="-22.185"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ103" unit="cm" x="0" y="0" z="-21.675"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ104" unit="cm" x="0" y="0" z="-21.165"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ105" unit="cm" x="0" y="0" z="-20.655"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ106" unit="cm" x="0" y="0" z="-20.145"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ107" unit="cm" x="0" y="0" z="-19.635"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ108" unit="cm" x="0" y="0" z="-19.125"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ109" unit="cm" x="0" y="0" z="-18.615"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ110" unit="cm" x="0" y="0" z="-18.105"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ111" unit="cm" x="0" y="0" z="-17.595"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ112" unit="cm" x="0" y="0" z="-17.085"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ113" unit="cm" x="0" y="0" z="-16.575"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ114" unit="cm" x="0" y="0" z="-16.065"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ115" unit="cm" x="0" y="0" z="-15.555"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ116" unit="cm" x="0" y="0" z="-15.045"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ117" unit="cm" x="0" y="0" z="-14.535"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ118" unit="cm" x="0" y="0" z="-14.025"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ119" unit="cm" x="0" y="0" z="-13.515"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ120" unit="cm" x="0" y="0" z="-13.005"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ121" unit="cm" x="0" y="0" z="-12.495"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ122" unit="cm" x="0" y="0" z="-11.985"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ123" unit="cm" x="0" y="0" z="-11.475"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ124" unit="cm" x="0" y="0" z="-10.965"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ125" unit="cm" x="0" y="0" z="-10.455"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ126" unit="cm" x="0" y="0" z="-9.945"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ127" unit="cm" x="0" y="0" z="-9.435"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ128" unit="cm" x="0" y="0" z="-8.925"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ129" unit="cm" x="0" y="0" z="-8.415"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ130" unit="cm" x="0" y="0" z="-7.905"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ131" unit="cm" x="0" y="0" z="-7.395"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ132" unit="cm" x="0" y="0" z="-6.885"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ133" unit="cm" x="0" y="0" z="-6.375"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ134" unit="cm" x="0" y="0" z="-5.865"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ135" unit="cm" x="0" y="0" z="-5.355"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ136" unit="cm" x="0" y="0" z="-4.845"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ137" unit="cm" x="0" y="0" z="-4.335"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ138" unit="cm" x="0" y="0" z="-3.825"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ139" unit="cm" x="0" y="0" z="-3.315"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ140" unit="cm" x="0" y="0" z="-2.805"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ141" unit="cm" x="0" y="0" z="-2.295"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ142" unit="cm" x="0" y="0" z="-1.785"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ143" unit="cm" x="0" y="0" z="-1.275"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ144" unit="cm" x="0" y="0" z="-0.765"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ145" unit="cm" x="0" y="0" z="-0.255"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ146" unit="cm" x="0" y="0" z="0.255"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ147" unit="cm" x="0" y="0" z="0.765"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ148" unit="cm" x="0" y="0" z="1.275"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ149" unit="cm" x="0" y="0" z="1.785"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ150" unit="cm" x="0" y="0" z="2.295"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ151" unit="cm" x="0" y="0" z="2.805"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ152" unit="cm" x="0" y="0" z="3.315"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ153" unit="cm" x="0" y="0" z="3.825"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ154" unit="cm" x="0" y="0" z="4.335"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ155" unit="cm" x="0" y="0" z="4.845"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ156" unit="cm" x="0" y="0" z="5.355"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ157" unit="cm" x="0" y="0" z="5.865"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ158" unit="cm" x="0" y="0" z="6.375"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ159" unit="cm" x="0" y="0" z="6.885"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ160" unit="cm" x="0" y="0" z="7.395"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ161" unit="cm" x="0" y="0" z="7.905"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ162" unit="cm" x="0" y="0" z="8.415"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ163" unit="cm" x="0" y="0" z="8.925"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ164" unit="cm" x="0" y="0" z="9.435"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ165" unit="cm" x="0" y="0" z="9.945"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ166" unit="cm" x="0" y="0" z="10.455"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ167" unit="cm" x="0" y="0" z="10.965"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ168" unit="cm" x="0" y="0" z="11.475"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ169" unit="cm" x="0" y="0" z="11.985"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ170" unit="cm" x="0" y="0" z="12.495"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ171" unit="cm" x="0" y="0" z="13.005"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ172" unit="cm" x="0" y="0" z="13.515"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ173" unit="cm" x="0" y="0" z="14.025"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ174" unit="cm" x="0" y="0" z="14.535"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ175" unit="cm" x="0" y="0" z="15.045"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ176" unit="cm" x="0" y="0" z="15.555"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ177" unit="cm" x="0" y="0" z="16.065"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ178" unit="cm" x="0" y="0" z="16.575"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ179" unit="cm" x="0" y="0" z="17.085"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ180" unit="cm" x="0" y="0" z="17.595"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ181" unit="cm" x="0" y="0" z="18.105"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ182" unit="cm" x="0" y="0" z="18.615"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ183" unit="cm" x="0" y="0" z="19.125"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ184" unit="cm" x="0" y="0" z="19.635"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ185" unit="cm" x="0" y="0" z="20.145"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ186" unit="cm" x="0" y="0" z="20.655"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ187" unit="cm" x="0" y="0" z="21.165"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ188" unit="cm" x="0" y="0" z="21.675"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ189" unit="cm" x="0" y="0" z="22.185"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ190" unit="cm" x="0" y="0" z="22.695"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ191" unit="cm" x="0" y="0" z="23.205"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ192" unit="cm" x="0" y="0" z="23.715"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ193" unit="cm" x="0" y="0" z="24.225"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ194" unit="cm" x="0" y="0" z="24.735"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ195" unit="cm" x="0" y="0" z="25.245"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ196" unit="cm" x="0" y="0" z="25.755"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ197" unit="cm" x="0" y="0" z="26.265"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ198" unit="cm" x="0" y="0" z="26.775"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ199" unit="cm" x="0" y="0" z="27.285"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ200" unit="cm" x="0" y="0" z="27.795"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ201" unit="cm" x="0" y="0" z="28.305"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ202" unit="cm" x="0" y="0" z="28.815"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ203" unit="cm" x="0" y="0" z="29.325"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ204" unit="cm" x="0" y="0" z="29.835"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ205" unit="cm" x="0" y="0" z="30.345"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ206" unit="cm" x="0" y="0" z="30.855"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ207" unit="cm" x="0" y="0" z="31.365"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ208" unit="cm" x="0" y="0" z="31.875"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ209" unit="cm" x="0" y="0" z="32.385"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ210" unit="cm" x="0" y="0" z="32.895"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ211" unit="cm" x="0" y="0" z="33.405"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ212" unit="cm" x="0" y="0" z="33.915"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ213" unit="cm" x="0" y="0" z="34.425"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ214" unit="cm" x="0" y="0" z="34.935"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ215" unit="cm" x="0" y="0" z="35.445"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ216" unit="cm" x="0" y="0" z="35.955"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ217" unit="cm" x="0" y="0" z="36.465"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ218" unit="cm" x="0" y="0" z="36.975"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ219" unit="cm" x="0" y="0" z="37.485"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ220" unit="cm" x="0" y="0" z="37.995"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ221" unit="cm" x="0" y="0" z="38.505"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ222" unit="cm" x="0" y="0" z="39.015"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ223" unit="cm" x="0" y="0" z="39.525"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ224" unit="cm" x="0" y="0" z="40.035"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ225" unit="cm" x="0" y="0" z="40.545"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ226" unit="cm" x="0" y="0" z="41.055"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ227" unit="cm" x="0" y="0" z="41.565"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ228" unit="cm" x="0" y="0" z="42.075"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ229" unit="cm" x="0" y="0" z="42.585"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ230" unit="cm" x="0" y="0" z="43.095"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ231" unit="cm" x="0" y="0" z="43.605"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ232" unit="cm" x="0" y="0" z="44.115"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ233" unit="cm" x="0" y="0" z="44.625"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ234" unit="cm" x="0" y="0" z="45.135"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ235" unit="cm" x="0" y="0" z="45.645"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ236" unit="cm" x="0" y="0" z="46.155"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ237" unit="cm" x="0" y="0" z="46.665"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ238" unit="cm" x="0" y="0" z="47.175"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ239" unit="cm" x="0" y="0" z="47.685"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ240" unit="cm" x="0" y="0" z="48.195"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ241" unit="cm" x="0" y="0" z="48.705"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ242" unit="cm" x="0" y="0" z="49.215"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ243" unit="cm" x="0" y="0" z="49.725"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ244" unit="cm" x="0" y="0" z="50.235"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ245" unit="cm" x="0" y="0" z="50.745"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ246" unit="cm" x="0" y="0" z="51.255"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ247" unit="cm" x="0" y="0" z="51.765"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ248" unit="cm" x="0" y="0" z="52.275"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ249" unit="cm" x="0" y="0" z="52.785"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ250" unit="cm" x="0" y="0" z="53.295"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ251" unit="cm" x="0" y="0" z="53.805"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ252" unit="cm" x="0" y="0" z="54.315"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ253" unit="cm" x="0" y="0" z="54.825"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ254" unit="cm" x="0" y="0" z="55.335"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ255" unit="cm" x="0" y="0" z="55.845"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ256" unit="cm" x="0" y="0" z="56.355"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ257" unit="cm" x="0" y="0" z="56.865"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ258" unit="cm" x="0" y="0" z="57.375"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ259" unit="cm" x="0" y="0" z="57.885"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ260" unit="cm" x="0" y="0" z="58.395"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ261" unit="cm" x="0" y="0" z="58.905"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ262" unit="cm" x="0" y="0" z="59.415"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ263" unit="cm" x="0" y="0" z="59.925"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ264" unit="cm" x="0" y="0" z="60.435"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ265" unit="cm" x="0" y="0" z="60.945"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ266" unit="cm" x="0" y="0" z="61.455"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ267" unit="cm" x="0" y="0" z="61.965"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ268" unit="cm" x="0" y="0" z="62.475"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ269" unit="cm" x="0" y="0" z="62.985"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ270" unit="cm" x="0" y="0" z="63.495"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ271" unit="cm" x="0" y="0" z="64.005"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ272" unit="cm" x="0" y="0" z="64.515"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ273" unit="cm" x="0" y="0" z="65.025"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ274" unit="cm" x="0" y="0" z="65.535"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ275" unit="cm" x="0" y="0" z="66.045"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ276" unit="cm" x="0" y="0" z="66.555"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ277" unit="cm" x="0" y="0" z="67.065"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ278" unit="cm" x="0" y="0" z="67.575"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ279" unit="cm" x="0" y="0" z="68.085"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ280" unit="cm" x="0" y="0" z="68.595"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ281" unit="cm" x="0" y="0" z="69.105"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ282" unit="cm" x="0" y="0" z="69.615"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ283" unit="cm" x="0" y="0" z="70.125"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ284" unit="cm" x="0" y="0" z="70.635"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ285" unit="cm" x="0" y="0" z="71.145"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ286" unit="cm" x="0" y="0" z="71.655"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ287" unit="cm" x="0" y="0" z="72.165"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ288" unit="cm" x="0" y="0" z="72.675"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ289" unit="cm" x="0" y="0" z="73.185"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ290" unit="cm" x="0" y="0" z="73.695"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ291" unit="cm" x="0" y="0" z="74.205"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+  </volume>
+   <volume name="volTPC">
+     <materialref ref="LAr"/>
+       <solidref ref="CRM"/>
+       <physvol>
+       <volumeref ref="volTPCPlaneU"/>
+       <position name="posPlaneU" unit="cm" 
+         x="324.99" y="0" z="0"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCPlaneV"/>
+       <position name="posPlaneY" unit="cm" 
+         x="325.01" y="0" z="0"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCPlaneZ"/>
+       <position name="posPlaneZ" unit="cm" 
+         x="325.03" y="0" z="0"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCActive"/>
+       <position name="posActive" unit="cm" 
+        x="-0.04" y="" z="0"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+   </volume>
+ 
+    <volume name="volSteelShell">
+      <materialref ref="STEEL_STAINLESS_Fe7Cr2Ni" />
+      <solidref ref="SteelShell" />
+    </volume>
+    <volume name="volGroundGrid">
+      <materialref ref="STEEL_STAINLESS_Fe7Cr2Ni" />
+      <solidref ref="CathodeGrid" />
+    </volume>
+    <volume name="volAnodePlate">
+     <materialref ref="vm2000"/>
+     <solidref ref="AnodePlate"/>
+    </volume>
+    <volume name="volGaseousArgon">
+      <materialref ref="ArGas"/>
+      <solidref ref="GaseousArgon"/>
+    </volume>
+    <volume name="volExternalActive">
+      <materialref ref="LAr"/>
+      <solidref ref="ExternalActive"/>
+      <auxiliary auxtype="SensDet" auxvalue="SimEnergyDeposit"/>
+      <auxiliary auxtype="StepLimit" auxunit="cm" auxvalue="0.5208*cm"/>
+      <auxiliary auxtype="Efield" auxunit="V/cm" auxvalue="0*V/cm"/>
+      <colorref ref="green"/>
+    </volume>
+    <volume name="volArapucaDouble_0-0-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-0-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-0-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-0-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-0-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-0-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-0-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-0-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-1-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-1-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-1-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-1-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-1-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-1-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-1-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-1-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-2-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-2-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-2-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-2-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-2-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-2-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-2-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-2-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-3-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-3-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-3-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-3-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-3-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-3-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-3-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-3-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-4-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-4-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-4-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-4-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-4-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-4-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-4-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-4-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-5-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-5-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-5-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-5-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-5-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-5-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-5-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-5-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-6-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-6-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-6-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-6-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-6-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-6-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-6-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-6-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-0-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-0-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-0-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-0-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-0-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-0-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-0-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-0-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-1-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-1-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-1-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-1-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-1-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-1-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-1-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-1-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-2-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-2-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-2-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-2-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-2-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-2-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-2-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-2-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-3-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-3-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-3-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-3-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-3-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-3-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-3-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-3-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-4-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-4-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-4-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-4-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-4-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-4-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-4-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-4-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-5-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-5-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-5-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-5-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-5-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-5-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-5-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-5-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-6-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-6-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-6-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-6-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-6-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-6-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-6-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-6-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-0-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-0-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-0-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-0-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-0-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-0-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-0-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-0-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-1-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-1-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-1-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-1-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-1-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-1-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-1-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-1-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-2-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-2-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-2-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-2-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-2-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-2-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-2-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-2-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-3-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-3-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-3-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-3-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-3-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-3-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-3-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-3-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-4-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-4-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-4-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-4-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-4-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-4-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-4-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-4-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-5-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-5-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-5-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-5-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-5-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-5-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-5-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-5-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-6-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-6-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-6-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-6-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-6-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-6-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-6-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-6-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-0-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-0-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-0-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-0-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-0-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-0-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-0-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-0-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-1-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-1-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-1-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-1-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-1-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-1-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-1-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-1-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-2-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-2-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-2-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-2-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-2-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-2-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-2-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-2-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-3-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-3-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-3-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-3-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-3-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-3-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-3-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-3-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-4-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-4-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-4-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-4-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-4-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-4-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-4-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-4-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-5-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-5-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-5-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-5-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-5-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-5-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-5-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-5-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-6-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-6-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-6-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-6-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-6-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-6-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-6-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-6-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_0-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_0-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_0-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_0-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_0-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_0-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_0-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_0-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_0-4">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_0-4">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_0-5">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_0-5">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_0-6">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_0-6">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_0-7">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_0-7">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_1-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_1-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_1-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_1-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_1-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_1-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_1-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_1-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_1-4">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_1-4">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_1-5">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_1-5">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_1-6">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_1-6">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_1-7">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_1-7">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_2-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_2-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_2-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_2-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_2-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_2-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_2-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_2-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_2-4">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_2-4">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_2-5">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_2-5">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_2-6">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_2-6">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_2-7">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_2-7">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_3-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_3-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_3-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_3-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_3-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_3-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_3-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_3-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_3-4">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_3-4">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_3-5">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_3-5">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_3-6">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_3-6">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_3-7">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_3-7">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_4-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_4-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_4-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_4-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_4-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_4-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_4-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_4-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_4-4">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_4-4">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_4-5">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_4-5">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_4-6">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_4-6">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_4-7">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_4-7">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_5-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_5-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_5-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_5-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_5-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_5-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_5-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_5-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_5-4">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_5-4">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_5-5">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_5-5">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_5-6">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_5-6">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_5-7">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_5-7">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_6-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_6-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_6-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_6-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_6-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_6-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_6-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_6-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_6-4">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_6-4">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_6-5">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_6-5">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_6-6">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_6-6">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_6-7">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_6-7">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+
+    <volume name="volCryostat">
+      <materialref ref="LAr" />
+      <solidref ref="Cryostat" />
+      <physvol>
+        <volumeref ref="volGaseousArgon"/>
+        <position name="posGaseousArgon" unit="cm" x="375.045" y="0" z="0"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volSteelShell"/>
+        <position name="posSteelShell" unit="cm" x="0" y="0" z="0"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volExternalActive"/>
+        <position name="posExternalActive" unit="cm" x="-100/2" y="0" z="0"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-0" unit="cm"
+           x="0" y="-588.4521" z="-970.98"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-1" unit="cm"
+           x="0" y="-420.7515" z="-970.98"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-2" unit="cm"
+           x="0" y="-252.0509" z="-970.98"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-3" unit="cm"
+           x="0" y="-84.3502999999999" z="-970.98"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-4" unit="cm"
+           x="0" y="84.3503000000001" z="-970.98"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-5" unit="cm"
+           x="0" y="252.0509" z="-970.98"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-6" unit="cm"
+           x="0" y="420.7515" z="-970.98"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-7" unit="cm"
+           x="0" y="588.4521" z="-970.98"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-8" unit="cm"
+           x="0" y="-588.4521" z="-822.06"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-9" unit="cm"
+           x="0" y="-420.7515" z="-822.06"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-10" unit="cm"
+           x="0" y="-252.0509" z="-822.06"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-11" unit="cm"
+           x="0" y="-84.3502999999999" z="-822.06"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-12" unit="cm"
+           x="0" y="84.3503000000001" z="-822.06"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-13" unit="cm"
+           x="0" y="252.0509" z="-822.06"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-14" unit="cm"
+           x="0" y="420.7515" z="-822.06"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-15" unit="cm"
+           x="0" y="588.4521" z="-822.06"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-16" unit="cm"
+           x="0" y="-588.4521" z="-672.14"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-17" unit="cm"
+           x="0" y="-420.7515" z="-672.14"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-18" unit="cm"
+           x="0" y="-252.0509" z="-672.14"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-19" unit="cm"
+           x="0" y="-84.3502999999999" z="-672.14"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-20" unit="cm"
+           x="0" y="84.3503000000001" z="-672.14"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-21" unit="cm"
+           x="0" y="252.0509" z="-672.14"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-22" unit="cm"
+           x="0" y="420.7515" z="-672.14"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-23" unit="cm"
+           x="0" y="588.4521" z="-672.14"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-24" unit="cm"
+           x="0" y="-588.4521" z="-523.22"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-25" unit="cm"
+           x="0" y="-420.7515" z="-523.22"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-26" unit="cm"
+           x="0" y="-252.0509" z="-523.22"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-27" unit="cm"
+           x="0" y="-84.3502999999999" z="-523.22"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-28" unit="cm"
+           x="0" y="84.3503000000001" z="-523.22"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-29" unit="cm"
+           x="0" y="252.0509" z="-523.22"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-30" unit="cm"
+           x="0" y="420.7515" z="-523.22"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-31" unit="cm"
+           x="0" y="588.4521" z="-523.22"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-32" unit="cm"
+           x="0" y="-588.4521" z="-373.3"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-33" unit="cm"
+           x="0" y="-420.7515" z="-373.3"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-34" unit="cm"
+           x="0" y="-252.0509" z="-373.3"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-35" unit="cm"
+           x="0" y="-84.3502999999999" z="-373.3"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-36" unit="cm"
+           x="0" y="84.3503000000001" z="-373.3"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-37" unit="cm"
+           x="0" y="252.0509" z="-373.3"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-38" unit="cm"
+           x="0" y="420.7515" z="-373.3"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-39" unit="cm"
+           x="0" y="588.4521" z="-373.3"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-40" unit="cm"
+           x="0" y="-588.4521" z="-224.38"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-41" unit="cm"
+           x="0" y="-420.7515" z="-224.38"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-42" unit="cm"
+           x="0" y="-252.0509" z="-224.38"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-43" unit="cm"
+           x="0" y="-84.3502999999999" z="-224.38"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-44" unit="cm"
+           x="0" y="84.3503000000001" z="-224.38"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-45" unit="cm"
+           x="0" y="252.0509" z="-224.38"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-46" unit="cm"
+           x="0" y="420.7515" z="-224.38"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-47" unit="cm"
+           x="0" y="588.4521" z="-224.38"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-48" unit="cm"
+           x="0" y="-588.4521" z="-74.4599999999998"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-49" unit="cm"
+           x="0" y="-420.7515" z="-74.4599999999998"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-50" unit="cm"
+           x="0" y="-252.0509" z="-74.4599999999998"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-51" unit="cm"
+           x="0" y="-84.3502999999999" z="-74.4599999999998"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-52" unit="cm"
+           x="0" y="84.3503000000001" z="-74.4599999999998"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-53" unit="cm"
+           x="0" y="252.0509" z="-74.4599999999998"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-54" unit="cm"
+           x="0" y="420.7515" z="-74.4599999999998"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-55" unit="cm"
+           x="0" y="588.4521" z="-74.4599999999998"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-56" unit="cm"
+           x="0" y="-588.4521" z="74.4600000000003"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-57" unit="cm"
+           x="0" y="-420.7515" z="74.4600000000003"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-58" unit="cm"
+           x="0" y="-252.0509" z="74.4600000000003"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-59" unit="cm"
+           x="0" y="-84.3502999999999" z="74.4600000000003"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-60" unit="cm"
+           x="0" y="84.3503000000001" z="74.4600000000003"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-61" unit="cm"
+           x="0" y="252.0509" z="74.4600000000003"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-62" unit="cm"
+           x="0" y="420.7515" z="74.4600000000003"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-63" unit="cm"
+           x="0" y="588.4521" z="74.4600000000003"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-64" unit="cm"
+           x="0" y="-588.4521" z="224.38"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-65" unit="cm"
+           x="0" y="-420.7515" z="224.38"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-66" unit="cm"
+           x="0" y="-252.0509" z="224.38"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-67" unit="cm"
+           x="0" y="-84.3502999999999" z="224.38"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-68" unit="cm"
+           x="0" y="84.3503000000001" z="224.38"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-69" unit="cm"
+           x="0" y="252.0509" z="224.38"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-70" unit="cm"
+           x="0" y="420.7515" z="224.38"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-71" unit="cm"
+           x="0" y="588.4521" z="224.38"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-72" unit="cm"
+           x="0" y="-588.4521" z="373.3"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-73" unit="cm"
+           x="0" y="-420.7515" z="373.3"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-74" unit="cm"
+           x="0" y="-252.0509" z="373.3"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-75" unit="cm"
+           x="0" y="-84.3502999999999" z="373.3"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-76" unit="cm"
+           x="0" y="84.3503000000001" z="373.3"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-77" unit="cm"
+           x="0" y="252.0509" z="373.3"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-78" unit="cm"
+           x="0" y="420.7515" z="373.3"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-79" unit="cm"
+           x="0" y="588.4521" z="373.3"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-80" unit="cm"
+           x="0" y="-588.4521" z="523.22"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-81" unit="cm"
+           x="0" y="-420.7515" z="523.22"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-82" unit="cm"
+           x="0" y="-252.0509" z="523.22"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-83" unit="cm"
+           x="0" y="-84.3502999999999" z="523.22"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-84" unit="cm"
+           x="0" y="84.3503000000001" z="523.22"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-85" unit="cm"
+           x="0" y="252.0509" z="523.22"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-86" unit="cm"
+           x="0" y="420.7515" z="523.22"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-87" unit="cm"
+           x="0" y="588.4521" z="523.22"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-88" unit="cm"
+           x="0" y="-588.4521" z="672.14"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-89" unit="cm"
+           x="0" y="-420.7515" z="672.14"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-90" unit="cm"
+           x="0" y="-252.0509" z="672.14"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-91" unit="cm"
+           x="0" y="-84.3502999999999" z="672.14"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-92" unit="cm"
+           x="0" y="84.3503000000001" z="672.14"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-93" unit="cm"
+           x="0" y="252.0509" z="672.14"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-94" unit="cm"
+           x="0" y="420.7515" z="672.14"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-95" unit="cm"
+           x="0" y="588.4521" z="672.14"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-96" unit="cm"
+           x="0" y="-588.4521" z="822.06"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-97" unit="cm"
+           x="0" y="-420.7515" z="822.06"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-98" unit="cm"
+           x="0" y="-252.0509" z="822.06"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-99" unit="cm"
+           x="0" y="-84.3502999999999" z="822.06"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-100" unit="cm"
+           x="0" y="84.3503000000001" z="822.06"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-101" unit="cm"
+           x="0" y="252.0509" z="822.06"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-102" unit="cm"
+           x="0" y="420.7515" z="822.06"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-103" unit="cm"
+           x="0" y="588.4521" z="822.06"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-104" unit="cm"
+           x="0" y="-588.4521" z="970.98"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-105" unit="cm"
+           x="0" y="-420.7515" z="970.98"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-106" unit="cm"
+           x="0" y="-252.0509" z="970.98"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-107" unit="cm"
+           x="0" y="-84.3502999999999" z="970.98"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-108" unit="cm"
+           x="0" y="84.3503000000001" z="970.98"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-109" unit="cm"
+           x="0" y="252.0509" z="970.98"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-110" unit="cm"
+           x="0" y="420.7515" z="970.98"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-111" unit="cm"
+           x="0" y="588.4521" z="970.98"/>
+      </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper0" unit="cm"  x="-322.04" y="-675.1024" z="0" />
+     <rotation name="rotFS0" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper1" unit="cm"  x="-316.04" y="-675.1024" z="0" />
+     <rotation name="rotFS1" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper2" unit="cm"  x="-310.04" y="-675.1024" z="0" />
+     <rotation name="rotFS2" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper3" unit="cm"  x="-304.04" y="-675.1024" z="0" />
+     <rotation name="rotFS3" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper4" unit="cm"  x="-298.04" y="-675.1024" z="0" />
+     <rotation name="rotFS4" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper5" unit="cm"  x="-292.04" y="-675.1024" z="0" />
+     <rotation name="rotFS5" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper6" unit="cm"  x="-286.04" y="-675.1024" z="0" />
+     <rotation name="rotFS6" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper7" unit="cm"  x="-280.04" y="-675.1024" z="0" />
+     <rotation name="rotFS7" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper8" unit="cm"  x="-274.04" y="-675.1024" z="0" />
+     <rotation name="rotFS8" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper9" unit="cm"  x="-268.04" y="-675.1024" z="0" />
+     <rotation name="rotFS9" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper10" unit="cm"  x="-262.04" y="-675.1024" z="0" />
+     <rotation name="rotFS10" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper11" unit="cm"  x="-256.04" y="-675.1024" z="0" />
+     <rotation name="rotFS11" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper12" unit="cm"  x="-250.04" y="-675.1024" z="0" />
+     <rotation name="rotFS12" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper13" unit="cm"  x="-244.04" y="-675.1024" z="0" />
+     <rotation name="rotFS13" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper14" unit="cm"  x="-238.04" y="-675.1024" z="0" />
+     <rotation name="rotFS14" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper15" unit="cm"  x="-232.04" y="-675.1024" z="0" />
+     <rotation name="rotFS15" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper16" unit="cm"  x="-226.04" y="-675.1024" z="0" />
+     <rotation name="rotFS16" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper17" unit="cm"  x="-220.04" y="-675.1024" z="0" />
+     <rotation name="rotFS17" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper18" unit="cm"  x="-214.04" y="-675.1024" z="0" />
+     <rotation name="rotFS18" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper19" unit="cm"  x="-208.04" y="-675.1024" z="0" />
+     <rotation name="rotFS19" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper20" unit="cm"  x="-202.04" y="-675.1024" z="0" />
+     <rotation name="rotFS20" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper21" unit="cm"  x="-196.04" y="-675.1024" z="0" />
+     <rotation name="rotFS21" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper22" unit="cm"  x="-190.04" y="-675.1024" z="0" />
+     <rotation name="rotFS22" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper23" unit="cm"  x="-184.04" y="-675.1024" z="0" />
+     <rotation name="rotFS23" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper24" unit="cm"  x="-178.04" y="-675.1024" z="0" />
+     <rotation name="rotFS24" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper25" unit="cm"  x="-172.04" y="-675.1024" z="0" />
+     <rotation name="rotFS25" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper26" unit="cm"  x="-166.04" y="-675.1024" z="0" />
+     <rotation name="rotFS26" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper27" unit="cm"  x="-160.04" y="-675.1024" z="0" />
+     <rotation name="rotFS27" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper28" unit="cm"  x="-154.04" y="-675.1024" z="0" />
+     <rotation name="rotFS28" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper29" unit="cm"  x="-148.04" y="-675.1024" z="0" />
+     <rotation name="rotFS29" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper30" unit="cm"  x="-142.04" y="-675.1024" z="0" />
+     <rotation name="rotFS30" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper31" unit="cm"  x="-136.04" y="-675.1024" z="0" />
+     <rotation name="rotFS31" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper32" unit="cm"  x="-130.04" y="-675.1024" z="0" />
+     <rotation name="rotFS32" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper33" unit="cm"  x="-124.04" y="-675.1024" z="0" />
+     <rotation name="rotFS33" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper34" unit="cm"  x="-118.04" y="-675.1024" z="0" />
+     <rotation name="rotFS34" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper35" unit="cm"  x="-112.04" y="-675.1024" z="0" />
+     <rotation name="rotFS35" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper36" unit="cm"  x="-106.04" y="-675.1024" z="0" />
+     <rotation name="rotFS36" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper37" unit="cm"  x="-100.04" y="-675.1024" z="0" />
+     <rotation name="rotFS37" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper38" unit="cm"  x="-94.04" y="-675.1024" z="0" />
+     <rotation name="rotFS38" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper39" unit="cm"  x="-88.04" y="-675.1024" z="0" />
+     <rotation name="rotFS39" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper40" unit="cm"  x="-82.04" y="-675.1024" z="0" />
+     <rotation name="rotFS40" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper41" unit="cm"  x="-76.04" y="-675.1024" z="0" />
+     <rotation name="rotFS41" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper42" unit="cm"  x="-70.04" y="-675.1024" z="0" />
+     <rotation name="rotFS42" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper43" unit="cm"  x="-64.04" y="-675.1024" z="0" />
+     <rotation name="rotFS43" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper44" unit="cm"  x="-58.04" y="-675.1024" z="0" />
+     <rotation name="rotFS44" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper45" unit="cm"  x="-52.04" y="-675.1024" z="0" />
+     <rotation name="rotFS45" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper46" unit="cm"  x="-46.04" y="-675.1024" z="0" />
+     <rotation name="rotFS46" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper47" unit="cm"  x="-40.04" y="-675.1024" z="0" />
+     <rotation name="rotFS47" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper48" unit="cm"  x="-34.04" y="-675.1024" z="0" />
+     <rotation name="rotFS48" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper49" unit="cm"  x="-28.04" y="-675.1024" z="0" />
+     <rotation name="rotFS49" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper50" unit="cm"  x="-22.04" y="-675.1024" z="0" />
+     <rotation name="rotFS50" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper51" unit="cm"  x="-16.04" y="-675.1024" z="0" />
+     <rotation name="rotFS51" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper52" unit="cm"  x="-10.04" y="-675.1024" z="0" />
+     <rotation name="rotFS52" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper53" unit="cm"  x="-4.04000000000001" y="-675.1024" z="0" />
+     <rotation name="rotFS53" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper54" unit="cm"  x="1.95999999999999" y="-675.1024" z="0" />
+     <rotation name="rotFS54" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper55" unit="cm"  x="7.95999999999999" y="-675.1024" z="0" />
+     <rotation name="rotFS55" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper56" unit="cm"  x="13.96" y="-675.1024" z="0" />
+     <rotation name="rotFS56" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper57" unit="cm"  x="19.96" y="-675.1024" z="0" />
+     <rotation name="rotFS57" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper58" unit="cm"  x="25.96" y="-675.1024" z="0" />
+     <rotation name="rotFS58" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper59" unit="cm"  x="31.96" y="-675.1024" z="0" />
+     <rotation name="rotFS59" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper60" unit="cm"  x="37.96" y="-675.1024" z="0" />
+     <rotation name="rotFS60" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper61" unit="cm"  x="43.96" y="-675.1024" z="0" />
+     <rotation name="rotFS61" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper62" unit="cm"  x="49.96" y="-675.1024" z="0" />
+     <rotation name="rotFS62" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper63" unit="cm"  x="55.96" y="-675.1024" z="0" />
+     <rotation name="rotFS63" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper64" unit="cm"  x="61.96" y="-675.1024" z="0" />
+     <rotation name="rotFS64" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper65" unit="cm"  x="67.96" y="-675.1024" z="0" />
+     <rotation name="rotFS65" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper66" unit="cm"  x="73.96" y="-675.1024" z="0" />
+     <rotation name="rotFS66" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper67" unit="cm"  x="79.96" y="-675.1024" z="0" />
+     <rotation name="rotFS67" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper68" unit="cm"  x="85.96" y="-675.1024" z="0" />
+     <rotation name="rotFS68" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper69" unit="cm"  x="91.96" y="-675.1024" z="0" />
+     <rotation name="rotFS69" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper70" unit="cm"  x="97.96" y="-675.1024" z="0" />
+     <rotation name="rotFS70" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper71" unit="cm"  x="103.96" y="-675.1024" z="0" />
+     <rotation name="rotFS71" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper72" unit="cm"  x="109.96" y="-675.1024" z="0" />
+     <rotation name="rotFS72" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper73" unit="cm"  x="115.96" y="-675.1024" z="0" />
+     <rotation name="rotFS73" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper74" unit="cm"  x="121.96" y="-675.1024" z="0" />
+     <rotation name="rotFS74" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper75" unit="cm"  x="127.96" y="-675.1024" z="0" />
+     <rotation name="rotFS75" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper76" unit="cm"  x="133.96" y="-675.1024" z="0" />
+     <rotation name="rotFS76" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper77" unit="cm"  x="139.96" y="-675.1024" z="0" />
+     <rotation name="rotFS77" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper78" unit="cm"  x="145.96" y="-675.1024" z="0" />
+     <rotation name="rotFS78" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper79" unit="cm"  x="151.96" y="-675.1024" z="0" />
+     <rotation name="rotFS79" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper80" unit="cm"  x="157.96" y="-675.1024" z="0" />
+     <rotation name="rotFS80" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper81" unit="cm"  x="163.96" y="-675.1024" z="0" />
+     <rotation name="rotFS81" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper82" unit="cm"  x="169.96" y="-675.1024" z="0" />
+     <rotation name="rotFS82" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper83" unit="cm"  x="175.96" y="-675.1024" z="0" />
+     <rotation name="rotFS83" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper84" unit="cm"  x="181.96" y="-675.1024" z="0" />
+     <rotation name="rotFS84" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper85" unit="cm"  x="187.96" y="-675.1024" z="0" />
+     <rotation name="rotFS85" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper86" unit="cm"  x="193.96" y="-675.1024" z="0" />
+     <rotation name="rotFS86" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper87" unit="cm"  x="199.96" y="-675.1024" z="0" />
+     <rotation name="rotFS87" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper88" unit="cm"  x="205.96" y="-675.1024" z="0" />
+     <rotation name="rotFS88" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper89" unit="cm"  x="211.96" y="-675.1024" z="0" />
+     <rotation name="rotFS89" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper90" unit="cm"  x="217.96" y="-675.1024" z="0" />
+     <rotation name="rotFS90" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper91" unit="cm"  x="223.96" y="-675.1024" z="0" />
+     <rotation name="rotFS91" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper92" unit="cm"  x="229.96" y="-675.1024" z="0" />
+     <rotation name="rotFS92" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper93" unit="cm"  x="235.96" y="-675.1024" z="0" />
+     <rotation name="rotFS93" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper94" unit="cm"  x="241.96" y="-675.1024" z="0" />
+     <rotation name="rotFS94" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper95" unit="cm"  x="247.96" y="-675.1024" z="0" />
+     <rotation name="rotFS95" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper96" unit="cm"  x="253.96" y="-675.1024" z="0" />
+     <rotation name="rotFS96" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper97" unit="cm"  x="259.96" y="-675.1024" z="0" />
+     <rotation name="rotFS97" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper98" unit="cm"  x="265.96" y="-675.1024" z="0" />
+     <rotation name="rotFS98" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper99" unit="cm"  x="271.96" y="-675.1024" z="0" />
+     <rotation name="rotFS99" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper100" unit="cm"  x="277.96" y="-675.1024" z="0" />
+     <rotation name="rotFS100" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper101" unit="cm"  x="283.96" y="-675.1024" z="0" />
+     <rotation name="rotFS101" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper102" unit="cm"  x="289.96" y="-675.1024" z="0" />
+     <rotation name="rotFS102" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper103" unit="cm"  x="295.96" y="-675.1024" z="0" />
+     <rotation name="rotFS103" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper104" unit="cm"  x="301.96" y="-675.1024" z="0" />
+     <rotation name="rotFS104" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper105" unit="cm"  x="307.96" y="-675.1024" z="0" />
+     <rotation name="rotFS105" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper106" unit="cm"  x="313.96" y="-675.1024" z="0" />
+     <rotation name="rotFS106" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper107" unit="cm"  x="319.96" y="-675.1024" z="0" />
+     <rotation name="rotFS107" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-0" unit="cm" x="-328.04" y="-505.1018" z="-897.02"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-0" unit="cm" x="325.045" y="-505.1018" z="-897.02"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-1" unit="cm" x="-328.04" y="-169.7006" z="-897.02"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-1" unit="cm" x="325.045" y="-169.7006" z="-897.02"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-2" unit="cm" x="-328.04" y="165.7006" z="-897.02"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-2" unit="cm" x="325.045" y="165.7006" z="-897.02"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-3" unit="cm" x="-328.04" y="501.1018" z="-897.02"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-3" unit="cm" x="325.045" y="501.1018" z="-897.02"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-4" unit="cm" x="-328.04" y="-505.1018" z="-599.18"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-4" unit="cm" x="325.045" y="-505.1018" z="-599.18"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-5" unit="cm" x="-328.04" y="-169.7006" z="-599.18"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-5" unit="cm" x="325.045" y="-169.7006" z="-599.18"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-6" unit="cm" x="-328.04" y="165.7006" z="-599.18"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-6" unit="cm" x="325.045" y="165.7006" z="-599.18"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-7" unit="cm" x="-328.04" y="501.1018" z="-599.18"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-7" unit="cm" x="325.045" y="501.1018" z="-599.18"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-8" unit="cm" x="-328.04" y="-505.1018" z="-301.34"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-8" unit="cm" x="325.045" y="-505.1018" z="-301.34"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-9" unit="cm" x="-328.04" y="-169.7006" z="-301.34"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-9" unit="cm" x="325.045" y="-169.7006" z="-301.34"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-10" unit="cm" x="-328.04" y="165.7006" z="-301.34"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-10" unit="cm" x="325.045" y="165.7006" z="-301.34"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-11" unit="cm" x="-328.04" y="501.1018" z="-301.34"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-11" unit="cm" x="325.045" y="501.1018" z="-301.34"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-12" unit="cm" x="-328.04" y="-505.1018" z="-3.49999999999989"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-12" unit="cm" x="325.045" y="-505.1018" z="-3.49999999999989"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-13" unit="cm" x="-328.04" y="-169.7006" z="-3.49999999999989"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-13" unit="cm" x="325.045" y="-169.7006" z="-3.49999999999989"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-14" unit="cm" x="-328.04" y="165.7006" z="-3.49999999999989"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-14" unit="cm" x="325.045" y="165.7006" z="-3.49999999999989"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-15" unit="cm" x="-328.04" y="501.1018" z="-3.49999999999989"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-15" unit="cm" x="325.045" y="501.1018" z="-3.49999999999989"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-16" unit="cm" x="-328.04" y="-505.1018" z="294.34"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-16" unit="cm" x="325.045" y="-505.1018" z="294.34"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-17" unit="cm" x="-328.04" y="-169.7006" z="294.34"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-17" unit="cm" x="325.045" y="-169.7006" z="294.34"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-18" unit="cm" x="-328.04" y="165.7006" z="294.34"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-18" unit="cm" x="325.045" y="165.7006" z="294.34"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-19" unit="cm" x="-328.04" y="501.1018" z="294.34"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-19" unit="cm" x="325.045" y="501.1018" z="294.34"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-20" unit="cm" x="-328.04" y="-505.1018" z="592.18"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-20" unit="cm" x="325.045" y="-505.1018" z="592.18"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-21" unit="cm" x="-328.04" y="-169.7006" z="592.18"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-21" unit="cm" x="325.045" y="-169.7006" z="592.18"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-22" unit="cm" x="-328.04" y="165.7006" z="592.18"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-22" unit="cm" x="325.045" y="165.7006" z="592.18"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-23" unit="cm" x="-328.04" y="501.1018" z="592.18"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-23" unit="cm" x="325.045" y="501.1018" z="592.18"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-24" unit="cm" x="-328.04" y="-505.1018" z="890.02"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-24" unit="cm" x="325.045" y="-505.1018" z="890.02"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-25" unit="cm" x="-328.04" y="-169.7006" z="890.02"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-25" unit="cm" x="325.045" y="-169.7006" z="890.02"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-26" unit="cm" x="-328.04" y="165.7006" z="890.02"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-26" unit="cm" x="325.045" y="165.7006" z="890.02"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-27" unit="cm" x="-328.04" y="501.1018" z="890.02"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-27" unit="cm" x="325.045" y="501.1018" z="890.02"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-0-0"/>
+       <position name="posArapucaDouble0-Frame-0-0" unit="cm" 
+         x="-328.04"
+	 y="-632.8018" 
+	 z="-859.52"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-0"/>
+       <position name="posOpArapucaDouble0-Frame-0-0" unit="cm" 
+         x="-327.3"
+	 y="-632.8018" 
+	 z="-859.52"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-0-1"/>
+       <position name="posArapucaDouble1-Frame-0-0" unit="cm" 
+         x="-328.04"
+	 y="-542.1018" 
+	 z="-1005.52"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-1"/>
+       <position name="posOpArapucaDouble1-Frame-0-0" unit="cm" 
+         x="-327.3"
+	 y="-542.1018" 
+	 z="-1005.52"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-0-2"/>
+       <position name="posArapucaDouble2-Frame-0-0" unit="cm" 
+         x="-328.04"
+	 y="-468.1018" 
+	 z="-788.52"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-2"/>
+       <position name="posOpArapucaDouble2-Frame-0-0" unit="cm" 
+         x="-327.3"
+	 y="-468.1018" 
+	 z="-788.52"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-0-3"/>
+       <position name="posArapucaDouble3-Frame-0-0" unit="cm" 
+         x="-328.04"
+	 y="-377.4018" 
+	 z="-934.52"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-3"/>
+       <position name="posOpArapucaDouble3-Frame-0-0" unit="cm" 
+         x="-327.3"
+	 y="-377.4018" 
+	 z="-934.52"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-1-0"/>
+       <position name="posArapucaDouble0-Frame-0-1" unit="cm" 
+         x="-328.04"
+	 y="-632.8018" 
+	 z="-561.68"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-0"/>
+       <position name="posOpArapucaDouble0-Frame-0-1" unit="cm" 
+         x="-327.3"
+	 y="-632.8018" 
+	 z="-561.68"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-1-1"/>
+       <position name="posArapucaDouble1-Frame-0-1" unit="cm" 
+         x="-328.04"
+	 y="-542.1018" 
+	 z="-707.68"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-1"/>
+       <position name="posOpArapucaDouble1-Frame-0-1" unit="cm" 
+         x="-327.3"
+	 y="-542.1018" 
+	 z="-707.68"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-1-2"/>
+       <position name="posArapucaDouble2-Frame-0-1" unit="cm" 
+         x="-328.04"
+	 y="-468.1018" 
+	 z="-490.68"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-2"/>
+       <position name="posOpArapucaDouble2-Frame-0-1" unit="cm" 
+         x="-327.3"
+	 y="-468.1018" 
+	 z="-490.68"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-1-3"/>
+       <position name="posArapucaDouble3-Frame-0-1" unit="cm" 
+         x="-328.04"
+	 y="-377.4018" 
+	 z="-636.68"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-3"/>
+       <position name="posOpArapucaDouble3-Frame-0-1" unit="cm" 
+         x="-327.3"
+	 y="-377.4018" 
+	 z="-636.68"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-2-0"/>
+       <position name="posArapucaDouble0-Frame-0-2" unit="cm" 
+         x="-328.04"
+	 y="-632.8018" 
+	 z="-263.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-0"/>
+       <position name="posOpArapucaDouble0-Frame-0-2" unit="cm" 
+         x="-327.3"
+	 y="-632.8018" 
+	 z="-263.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-2-1"/>
+       <position name="posArapucaDouble1-Frame-0-2" unit="cm" 
+         x="-328.04"
+	 y="-542.1018" 
+	 z="-409.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-1"/>
+       <position name="posOpArapucaDouble1-Frame-0-2" unit="cm" 
+         x="-327.3"
+	 y="-542.1018" 
+	 z="-409.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-2-2"/>
+       <position name="posArapucaDouble2-Frame-0-2" unit="cm" 
+         x="-328.04"
+	 y="-468.1018" 
+	 z="-192.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-2"/>
+       <position name="posOpArapucaDouble2-Frame-0-2" unit="cm" 
+         x="-327.3"
+	 y="-468.1018" 
+	 z="-192.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-2-3"/>
+       <position name="posArapucaDouble3-Frame-0-2" unit="cm" 
+         x="-328.04"
+	 y="-377.4018" 
+	 z="-338.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-3"/>
+       <position name="posOpArapucaDouble3-Frame-0-2" unit="cm" 
+         x="-327.3"
+	 y="-377.4018" 
+	 z="-338.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-3-0"/>
+       <position name="posArapucaDouble0-Frame-0-3" unit="cm" 
+         x="-328.04"
+	 y="-632.8018" 
+	 z="34.0000000000001"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-3-0"/>
+       <position name="posOpArapucaDouble0-Frame-0-3" unit="cm" 
+         x="-327.3"
+	 y="-632.8018" 
+	 z="34.0000000000001"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-3-1"/>
+       <position name="posArapucaDouble1-Frame-0-3" unit="cm" 
+         x="-328.04"
+	 y="-542.1018" 
+	 z="-112"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-3-1"/>
+       <position name="posOpArapucaDouble1-Frame-0-3" unit="cm" 
+         x="-327.3"
+	 y="-542.1018" 
+	 z="-112"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-3-2"/>
+       <position name="posArapucaDouble2-Frame-0-3" unit="cm" 
+         x="-328.04"
+	 y="-468.1018" 
+	 z="105"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-3-2"/>
+       <position name="posOpArapucaDouble2-Frame-0-3" unit="cm" 
+         x="-327.3"
+	 y="-468.1018" 
+	 z="105"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-3-3"/>
+       <position name="posArapucaDouble3-Frame-0-3" unit="cm" 
+         x="-328.04"
+	 y="-377.4018" 
+	 z="-40.9999999999999"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-3-3"/>
+       <position name="posOpArapucaDouble3-Frame-0-3" unit="cm" 
+         x="-327.3"
+	 y="-377.4018" 
+	 z="-40.9999999999999"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-4-0"/>
+       <position name="posArapucaDouble0-Frame-0-4" unit="cm" 
+         x="-328.04"
+	 y="-632.8018" 
+	 z="331.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-4-0"/>
+       <position name="posOpArapucaDouble0-Frame-0-4" unit="cm" 
+         x="-327.3"
+	 y="-632.8018" 
+	 z="331.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-4-1"/>
+       <position name="posArapucaDouble1-Frame-0-4" unit="cm" 
+         x="-328.04"
+	 y="-542.1018" 
+	 z="185.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-4-1"/>
+       <position name="posOpArapucaDouble1-Frame-0-4" unit="cm" 
+         x="-327.3"
+	 y="-542.1018" 
+	 z="185.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-4-2"/>
+       <position name="posArapucaDouble2-Frame-0-4" unit="cm" 
+         x="-328.04"
+	 y="-468.1018" 
+	 z="402.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-4-2"/>
+       <position name="posOpArapucaDouble2-Frame-0-4" unit="cm" 
+         x="-327.3"
+	 y="-468.1018" 
+	 z="402.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-4-3"/>
+       <position name="posArapucaDouble3-Frame-0-4" unit="cm" 
+         x="-328.04"
+	 y="-377.4018" 
+	 z="256.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-4-3"/>
+       <position name="posOpArapucaDouble3-Frame-0-4" unit="cm" 
+         x="-327.3"
+	 y="-377.4018" 
+	 z="256.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-5-0"/>
+       <position name="posArapucaDouble0-Frame-0-5" unit="cm" 
+         x="-328.04"
+	 y="-632.8018" 
+	 z="629.68"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-5-0"/>
+       <position name="posOpArapucaDouble0-Frame-0-5" unit="cm" 
+         x="-327.3"
+	 y="-632.8018" 
+	 z="629.68"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-5-1"/>
+       <position name="posArapucaDouble1-Frame-0-5" unit="cm" 
+         x="-328.04"
+	 y="-542.1018" 
+	 z="483.68"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-5-1"/>
+       <position name="posOpArapucaDouble1-Frame-0-5" unit="cm" 
+         x="-327.3"
+	 y="-542.1018" 
+	 z="483.68"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-5-2"/>
+       <position name="posArapucaDouble2-Frame-0-5" unit="cm" 
+         x="-328.04"
+	 y="-468.1018" 
+	 z="700.68"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-5-2"/>
+       <position name="posOpArapucaDouble2-Frame-0-5" unit="cm" 
+         x="-327.3"
+	 y="-468.1018" 
+	 z="700.68"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-5-3"/>
+       <position name="posArapucaDouble3-Frame-0-5" unit="cm" 
+         x="-328.04"
+	 y="-377.4018" 
+	 z="554.68"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-5-3"/>
+       <position name="posOpArapucaDouble3-Frame-0-5" unit="cm" 
+         x="-327.3"
+	 y="-377.4018" 
+	 z="554.68"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-6-0"/>
+       <position name="posArapucaDouble0-Frame-0-6" unit="cm" 
+         x="-328.04"
+	 y="-632.8018" 
+	 z="927.52"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-6-0"/>
+       <position name="posOpArapucaDouble0-Frame-0-6" unit="cm" 
+         x="-327.3"
+	 y="-632.8018" 
+	 z="927.52"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-6-1"/>
+       <position name="posArapucaDouble1-Frame-0-6" unit="cm" 
+         x="-328.04"
+	 y="-542.1018" 
+	 z="781.52"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-6-1"/>
+       <position name="posOpArapucaDouble1-Frame-0-6" unit="cm" 
+         x="-327.3"
+	 y="-542.1018" 
+	 z="781.52"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-6-2"/>
+       <position name="posArapucaDouble2-Frame-0-6" unit="cm" 
+         x="-328.04"
+	 y="-468.1018" 
+	 z="998.52"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-6-2"/>
+       <position name="posOpArapucaDouble2-Frame-0-6" unit="cm" 
+         x="-327.3"
+	 y="-468.1018" 
+	 z="998.52"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-6-3"/>
+       <position name="posArapucaDouble3-Frame-0-6" unit="cm" 
+         x="-328.04"
+	 y="-377.4018" 
+	 z="852.52"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-6-3"/>
+       <position name="posOpArapucaDouble3-Frame-0-6" unit="cm" 
+         x="-327.3"
+	 y="-377.4018" 
+	 z="852.52"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-0-0"/>
+       <position name="posArapucaDouble0-Frame-1-0" unit="cm" 
+         x="-328.04"
+	 y="-297.4006" 
+	 z="-859.52"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-0"/>
+       <position name="posOpArapucaDouble0-Frame-1-0" unit="cm" 
+         x="-327.3"
+	 y="-297.4006" 
+	 z="-859.52"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-0-1"/>
+       <position name="posArapucaDouble1-Frame-1-0" unit="cm" 
+         x="-328.04"
+	 y="-206.7006" 
+	 z="-1005.52"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-1"/>
+       <position name="posOpArapucaDouble1-Frame-1-0" unit="cm" 
+         x="-327.3"
+	 y="-206.7006" 
+	 z="-1005.52"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-0-2"/>
+       <position name="posArapucaDouble2-Frame-1-0" unit="cm" 
+         x="-328.04"
+	 y="-132.7006" 
+	 z="-788.52"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-2"/>
+       <position name="posOpArapucaDouble2-Frame-1-0" unit="cm" 
+         x="-327.3"
+	 y="-132.7006" 
+	 z="-788.52"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-0-3"/>
+       <position name="posArapucaDouble3-Frame-1-0" unit="cm" 
+         x="-328.04"
+	 y="-42.0006" 
+	 z="-934.52"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-3"/>
+       <position name="posOpArapucaDouble3-Frame-1-0" unit="cm" 
+         x="-327.3"
+	 y="-42.0006" 
+	 z="-934.52"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-1-0"/>
+       <position name="posArapucaDouble0-Frame-1-1" unit="cm" 
+         x="-328.04"
+	 y="-297.4006" 
+	 z="-561.68"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-0"/>
+       <position name="posOpArapucaDouble0-Frame-1-1" unit="cm" 
+         x="-327.3"
+	 y="-297.4006" 
+	 z="-561.68"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-1-1"/>
+       <position name="posArapucaDouble1-Frame-1-1" unit="cm" 
+         x="-328.04"
+	 y="-206.7006" 
+	 z="-707.68"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-1"/>
+       <position name="posOpArapucaDouble1-Frame-1-1" unit="cm" 
+         x="-327.3"
+	 y="-206.7006" 
+	 z="-707.68"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-1-2"/>
+       <position name="posArapucaDouble2-Frame-1-1" unit="cm" 
+         x="-328.04"
+	 y="-132.7006" 
+	 z="-490.68"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-2"/>
+       <position name="posOpArapucaDouble2-Frame-1-1" unit="cm" 
+         x="-327.3"
+	 y="-132.7006" 
+	 z="-490.68"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-1-3"/>
+       <position name="posArapucaDouble3-Frame-1-1" unit="cm" 
+         x="-328.04"
+	 y="-42.0006" 
+	 z="-636.68"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-3"/>
+       <position name="posOpArapucaDouble3-Frame-1-1" unit="cm" 
+         x="-327.3"
+	 y="-42.0006" 
+	 z="-636.68"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-2-0"/>
+       <position name="posArapucaDouble0-Frame-1-2" unit="cm" 
+         x="-328.04"
+	 y="-297.4006" 
+	 z="-263.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-0"/>
+       <position name="posOpArapucaDouble0-Frame-1-2" unit="cm" 
+         x="-327.3"
+	 y="-297.4006" 
+	 z="-263.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-2-1"/>
+       <position name="posArapucaDouble1-Frame-1-2" unit="cm" 
+         x="-328.04"
+	 y="-206.7006" 
+	 z="-409.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-1"/>
+       <position name="posOpArapucaDouble1-Frame-1-2" unit="cm" 
+         x="-327.3"
+	 y="-206.7006" 
+	 z="-409.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-2-2"/>
+       <position name="posArapucaDouble2-Frame-1-2" unit="cm" 
+         x="-328.04"
+	 y="-132.7006" 
+	 z="-192.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-2"/>
+       <position name="posOpArapucaDouble2-Frame-1-2" unit="cm" 
+         x="-327.3"
+	 y="-132.7006" 
+	 z="-192.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-2-3"/>
+       <position name="posArapucaDouble3-Frame-1-2" unit="cm" 
+         x="-328.04"
+	 y="-42.0006" 
+	 z="-338.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-3"/>
+       <position name="posOpArapucaDouble3-Frame-1-2" unit="cm" 
+         x="-327.3"
+	 y="-42.0006" 
+	 z="-338.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-3-0"/>
+       <position name="posArapucaDouble0-Frame-1-3" unit="cm" 
+         x="-328.04"
+	 y="-297.4006" 
+	 z="34.0000000000001"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-3-0"/>
+       <position name="posOpArapucaDouble0-Frame-1-3" unit="cm" 
+         x="-327.3"
+	 y="-297.4006" 
+	 z="34.0000000000001"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-3-1"/>
+       <position name="posArapucaDouble1-Frame-1-3" unit="cm" 
+         x="-328.04"
+	 y="-206.7006" 
+	 z="-112"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-3-1"/>
+       <position name="posOpArapucaDouble1-Frame-1-3" unit="cm" 
+         x="-327.3"
+	 y="-206.7006" 
+	 z="-112"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-3-2"/>
+       <position name="posArapucaDouble2-Frame-1-3" unit="cm" 
+         x="-328.04"
+	 y="-132.7006" 
+	 z="105"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-3-2"/>
+       <position name="posOpArapucaDouble2-Frame-1-3" unit="cm" 
+         x="-327.3"
+	 y="-132.7006" 
+	 z="105"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-3-3"/>
+       <position name="posArapucaDouble3-Frame-1-3" unit="cm" 
+         x="-328.04"
+	 y="-42.0006" 
+	 z="-40.9999999999999"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-3-3"/>
+       <position name="posOpArapucaDouble3-Frame-1-3" unit="cm" 
+         x="-327.3"
+	 y="-42.0006" 
+	 z="-40.9999999999999"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-4-0"/>
+       <position name="posArapucaDouble0-Frame-1-4" unit="cm" 
+         x="-328.04"
+	 y="-297.4006" 
+	 z="331.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-4-0"/>
+       <position name="posOpArapucaDouble0-Frame-1-4" unit="cm" 
+         x="-327.3"
+	 y="-297.4006" 
+	 z="331.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-4-1"/>
+       <position name="posArapucaDouble1-Frame-1-4" unit="cm" 
+         x="-328.04"
+	 y="-206.7006" 
+	 z="185.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-4-1"/>
+       <position name="posOpArapucaDouble1-Frame-1-4" unit="cm" 
+         x="-327.3"
+	 y="-206.7006" 
+	 z="185.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-4-2"/>
+       <position name="posArapucaDouble2-Frame-1-4" unit="cm" 
+         x="-328.04"
+	 y="-132.7006" 
+	 z="402.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-4-2"/>
+       <position name="posOpArapucaDouble2-Frame-1-4" unit="cm" 
+         x="-327.3"
+	 y="-132.7006" 
+	 z="402.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-4-3"/>
+       <position name="posArapucaDouble3-Frame-1-4" unit="cm" 
+         x="-328.04"
+	 y="-42.0006" 
+	 z="256.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-4-3"/>
+       <position name="posOpArapucaDouble3-Frame-1-4" unit="cm" 
+         x="-327.3"
+	 y="-42.0006" 
+	 z="256.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-5-0"/>
+       <position name="posArapucaDouble0-Frame-1-5" unit="cm" 
+         x="-328.04"
+	 y="-297.4006" 
+	 z="629.68"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-5-0"/>
+       <position name="posOpArapucaDouble0-Frame-1-5" unit="cm" 
+         x="-327.3"
+	 y="-297.4006" 
+	 z="629.68"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-5-1"/>
+       <position name="posArapucaDouble1-Frame-1-5" unit="cm" 
+         x="-328.04"
+	 y="-206.7006" 
+	 z="483.68"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-5-1"/>
+       <position name="posOpArapucaDouble1-Frame-1-5" unit="cm" 
+         x="-327.3"
+	 y="-206.7006" 
+	 z="483.68"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-5-2"/>
+       <position name="posArapucaDouble2-Frame-1-5" unit="cm" 
+         x="-328.04"
+	 y="-132.7006" 
+	 z="700.68"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-5-2"/>
+       <position name="posOpArapucaDouble2-Frame-1-5" unit="cm" 
+         x="-327.3"
+	 y="-132.7006" 
+	 z="700.68"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-5-3"/>
+       <position name="posArapucaDouble3-Frame-1-5" unit="cm" 
+         x="-328.04"
+	 y="-42.0006" 
+	 z="554.68"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-5-3"/>
+       <position name="posOpArapucaDouble3-Frame-1-5" unit="cm" 
+         x="-327.3"
+	 y="-42.0006" 
+	 z="554.68"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-6-0"/>
+       <position name="posArapucaDouble0-Frame-1-6" unit="cm" 
+         x="-328.04"
+	 y="-297.4006" 
+	 z="927.52"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-6-0"/>
+       <position name="posOpArapucaDouble0-Frame-1-6" unit="cm" 
+         x="-327.3"
+	 y="-297.4006" 
+	 z="927.52"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-6-1"/>
+       <position name="posArapucaDouble1-Frame-1-6" unit="cm" 
+         x="-328.04"
+	 y="-206.7006" 
+	 z="781.52"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-6-1"/>
+       <position name="posOpArapucaDouble1-Frame-1-6" unit="cm" 
+         x="-327.3"
+	 y="-206.7006" 
+	 z="781.52"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-6-2"/>
+       <position name="posArapucaDouble2-Frame-1-6" unit="cm" 
+         x="-328.04"
+	 y="-132.7006" 
+	 z="998.52"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-6-2"/>
+       <position name="posOpArapucaDouble2-Frame-1-6" unit="cm" 
+         x="-327.3"
+	 y="-132.7006" 
+	 z="998.52"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-6-3"/>
+       <position name="posArapucaDouble3-Frame-1-6" unit="cm" 
+         x="-328.04"
+	 y="-42.0006" 
+	 z="852.52"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-6-3"/>
+       <position name="posOpArapucaDouble3-Frame-1-6" unit="cm" 
+         x="-327.3"
+	 y="-42.0006" 
+	 z="852.52"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-0-0"/>
+       <position name="posArapucaDouble0-Frame-2-0" unit="cm" 
+         x="-328.04"
+	 y="38.0006" 
+	 z="-859.52"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-0"/>
+       <position name="posOpArapucaDouble0-Frame-2-0" unit="cm" 
+         x="-327.3"
+	 y="38.0006" 
+	 z="-859.52"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-0-1"/>
+       <position name="posArapucaDouble1-Frame-2-0" unit="cm" 
+         x="-328.04"
+	 y="128.7006" 
+	 z="-1005.52"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-1"/>
+       <position name="posOpArapucaDouble1-Frame-2-0" unit="cm" 
+         x="-327.3"
+	 y="128.7006" 
+	 z="-1005.52"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-0-2"/>
+       <position name="posArapucaDouble2-Frame-2-0" unit="cm" 
+         x="-328.04"
+	 y="202.7006" 
+	 z="-788.52"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-2"/>
+       <position name="posOpArapucaDouble2-Frame-2-0" unit="cm" 
+         x="-327.3"
+	 y="202.7006" 
+	 z="-788.52"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-0-3"/>
+       <position name="posArapucaDouble3-Frame-2-0" unit="cm" 
+         x="-328.04"
+	 y="293.4006" 
+	 z="-934.52"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-3"/>
+       <position name="posOpArapucaDouble3-Frame-2-0" unit="cm" 
+         x="-327.3"
+	 y="293.4006" 
+	 z="-934.52"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-1-0"/>
+       <position name="posArapucaDouble0-Frame-2-1" unit="cm" 
+         x="-328.04"
+	 y="38.0006" 
+	 z="-561.68"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-0"/>
+       <position name="posOpArapucaDouble0-Frame-2-1" unit="cm" 
+         x="-327.3"
+	 y="38.0006" 
+	 z="-561.68"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-1-1"/>
+       <position name="posArapucaDouble1-Frame-2-1" unit="cm" 
+         x="-328.04"
+	 y="128.7006" 
+	 z="-707.68"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-1"/>
+       <position name="posOpArapucaDouble1-Frame-2-1" unit="cm" 
+         x="-327.3"
+	 y="128.7006" 
+	 z="-707.68"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-1-2"/>
+       <position name="posArapucaDouble2-Frame-2-1" unit="cm" 
+         x="-328.04"
+	 y="202.7006" 
+	 z="-490.68"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-2"/>
+       <position name="posOpArapucaDouble2-Frame-2-1" unit="cm" 
+         x="-327.3"
+	 y="202.7006" 
+	 z="-490.68"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-1-3"/>
+       <position name="posArapucaDouble3-Frame-2-1" unit="cm" 
+         x="-328.04"
+	 y="293.4006" 
+	 z="-636.68"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-3"/>
+       <position name="posOpArapucaDouble3-Frame-2-1" unit="cm" 
+         x="-327.3"
+	 y="293.4006" 
+	 z="-636.68"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-2-0"/>
+       <position name="posArapucaDouble0-Frame-2-2" unit="cm" 
+         x="-328.04"
+	 y="38.0006" 
+	 z="-263.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-0"/>
+       <position name="posOpArapucaDouble0-Frame-2-2" unit="cm" 
+         x="-327.3"
+	 y="38.0006" 
+	 z="-263.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-2-1"/>
+       <position name="posArapucaDouble1-Frame-2-2" unit="cm" 
+         x="-328.04"
+	 y="128.7006" 
+	 z="-409.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-1"/>
+       <position name="posOpArapucaDouble1-Frame-2-2" unit="cm" 
+         x="-327.3"
+	 y="128.7006" 
+	 z="-409.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-2-2"/>
+       <position name="posArapucaDouble2-Frame-2-2" unit="cm" 
+         x="-328.04"
+	 y="202.7006" 
+	 z="-192.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-2"/>
+       <position name="posOpArapucaDouble2-Frame-2-2" unit="cm" 
+         x="-327.3"
+	 y="202.7006" 
+	 z="-192.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-2-3"/>
+       <position name="posArapucaDouble3-Frame-2-2" unit="cm" 
+         x="-328.04"
+	 y="293.4006" 
+	 z="-338.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-3"/>
+       <position name="posOpArapucaDouble3-Frame-2-2" unit="cm" 
+         x="-327.3"
+	 y="293.4006" 
+	 z="-338.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-3-0"/>
+       <position name="posArapucaDouble0-Frame-2-3" unit="cm" 
+         x="-328.04"
+	 y="38.0006" 
+	 z="34.0000000000001"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-3-0"/>
+       <position name="posOpArapucaDouble0-Frame-2-3" unit="cm" 
+         x="-327.3"
+	 y="38.0006" 
+	 z="34.0000000000001"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-3-1"/>
+       <position name="posArapucaDouble1-Frame-2-3" unit="cm" 
+         x="-328.04"
+	 y="128.7006" 
+	 z="-112"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-3-1"/>
+       <position name="posOpArapucaDouble1-Frame-2-3" unit="cm" 
+         x="-327.3"
+	 y="128.7006" 
+	 z="-112"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-3-2"/>
+       <position name="posArapucaDouble2-Frame-2-3" unit="cm" 
+         x="-328.04"
+	 y="202.7006" 
+	 z="105"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-3-2"/>
+       <position name="posOpArapucaDouble2-Frame-2-3" unit="cm" 
+         x="-327.3"
+	 y="202.7006" 
+	 z="105"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-3-3"/>
+       <position name="posArapucaDouble3-Frame-2-3" unit="cm" 
+         x="-328.04"
+	 y="293.4006" 
+	 z="-40.9999999999999"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-3-3"/>
+       <position name="posOpArapucaDouble3-Frame-2-3" unit="cm" 
+         x="-327.3"
+	 y="293.4006" 
+	 z="-40.9999999999999"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-4-0"/>
+       <position name="posArapucaDouble0-Frame-2-4" unit="cm" 
+         x="-328.04"
+	 y="38.0006" 
+	 z="331.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-4-0"/>
+       <position name="posOpArapucaDouble0-Frame-2-4" unit="cm" 
+         x="-327.3"
+	 y="38.0006" 
+	 z="331.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-4-1"/>
+       <position name="posArapucaDouble1-Frame-2-4" unit="cm" 
+         x="-328.04"
+	 y="128.7006" 
+	 z="185.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-4-1"/>
+       <position name="posOpArapucaDouble1-Frame-2-4" unit="cm" 
+         x="-327.3"
+	 y="128.7006" 
+	 z="185.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-4-2"/>
+       <position name="posArapucaDouble2-Frame-2-4" unit="cm" 
+         x="-328.04"
+	 y="202.7006" 
+	 z="402.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-4-2"/>
+       <position name="posOpArapucaDouble2-Frame-2-4" unit="cm" 
+         x="-327.3"
+	 y="202.7006" 
+	 z="402.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-4-3"/>
+       <position name="posArapucaDouble3-Frame-2-4" unit="cm" 
+         x="-328.04"
+	 y="293.4006" 
+	 z="256.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-4-3"/>
+       <position name="posOpArapucaDouble3-Frame-2-4" unit="cm" 
+         x="-327.3"
+	 y="293.4006" 
+	 z="256.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-5-0"/>
+       <position name="posArapucaDouble0-Frame-2-5" unit="cm" 
+         x="-328.04"
+	 y="38.0006" 
+	 z="629.68"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-5-0"/>
+       <position name="posOpArapucaDouble0-Frame-2-5" unit="cm" 
+         x="-327.3"
+	 y="38.0006" 
+	 z="629.68"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-5-1"/>
+       <position name="posArapucaDouble1-Frame-2-5" unit="cm" 
+         x="-328.04"
+	 y="128.7006" 
+	 z="483.68"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-5-1"/>
+       <position name="posOpArapucaDouble1-Frame-2-5" unit="cm" 
+         x="-327.3"
+	 y="128.7006" 
+	 z="483.68"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-5-2"/>
+       <position name="posArapucaDouble2-Frame-2-5" unit="cm" 
+         x="-328.04"
+	 y="202.7006" 
+	 z="700.68"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-5-2"/>
+       <position name="posOpArapucaDouble2-Frame-2-5" unit="cm" 
+         x="-327.3"
+	 y="202.7006" 
+	 z="700.68"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-5-3"/>
+       <position name="posArapucaDouble3-Frame-2-5" unit="cm" 
+         x="-328.04"
+	 y="293.4006" 
+	 z="554.68"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-5-3"/>
+       <position name="posOpArapucaDouble3-Frame-2-5" unit="cm" 
+         x="-327.3"
+	 y="293.4006" 
+	 z="554.68"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-6-0"/>
+       <position name="posArapucaDouble0-Frame-2-6" unit="cm" 
+         x="-328.04"
+	 y="38.0006" 
+	 z="927.52"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-6-0"/>
+       <position name="posOpArapucaDouble0-Frame-2-6" unit="cm" 
+         x="-327.3"
+	 y="38.0006" 
+	 z="927.52"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-6-1"/>
+       <position name="posArapucaDouble1-Frame-2-6" unit="cm" 
+         x="-328.04"
+	 y="128.7006" 
+	 z="781.52"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-6-1"/>
+       <position name="posOpArapucaDouble1-Frame-2-6" unit="cm" 
+         x="-327.3"
+	 y="128.7006" 
+	 z="781.52"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-6-2"/>
+       <position name="posArapucaDouble2-Frame-2-6" unit="cm" 
+         x="-328.04"
+	 y="202.7006" 
+	 z="998.52"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-6-2"/>
+       <position name="posOpArapucaDouble2-Frame-2-6" unit="cm" 
+         x="-327.3"
+	 y="202.7006" 
+	 z="998.52"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-6-3"/>
+       <position name="posArapucaDouble3-Frame-2-6" unit="cm" 
+         x="-328.04"
+	 y="293.4006" 
+	 z="852.52"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-6-3"/>
+       <position name="posOpArapucaDouble3-Frame-2-6" unit="cm" 
+         x="-327.3"
+	 y="293.4006" 
+	 z="852.52"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-0-0"/>
+       <position name="posArapucaDouble0-Frame-3-0" unit="cm" 
+         x="-328.04"
+	 y="373.4018" 
+	 z="-859.52"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-0"/>
+       <position name="posOpArapucaDouble0-Frame-3-0" unit="cm" 
+         x="-327.3"
+	 y="373.4018" 
+	 z="-859.52"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-0-1"/>
+       <position name="posArapucaDouble1-Frame-3-0" unit="cm" 
+         x="-328.04"
+	 y="464.1018" 
+	 z="-1005.52"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-1"/>
+       <position name="posOpArapucaDouble1-Frame-3-0" unit="cm" 
+         x="-327.3"
+	 y="464.1018" 
+	 z="-1005.52"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-0-2"/>
+       <position name="posArapucaDouble2-Frame-3-0" unit="cm" 
+         x="-328.04"
+	 y="538.1018" 
+	 z="-788.52"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-2"/>
+       <position name="posOpArapucaDouble2-Frame-3-0" unit="cm" 
+         x="-327.3"
+	 y="538.1018" 
+	 z="-788.52"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-0-3"/>
+       <position name="posArapucaDouble3-Frame-3-0" unit="cm" 
+         x="-328.04"
+	 y="628.8018" 
+	 z="-934.52"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-3"/>
+       <position name="posOpArapucaDouble3-Frame-3-0" unit="cm" 
+         x="-327.3"
+	 y="628.8018" 
+	 z="-934.52"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-1-0"/>
+       <position name="posArapucaDouble0-Frame-3-1" unit="cm" 
+         x="-328.04"
+	 y="373.4018" 
+	 z="-561.68"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-0"/>
+       <position name="posOpArapucaDouble0-Frame-3-1" unit="cm" 
+         x="-327.3"
+	 y="373.4018" 
+	 z="-561.68"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-1-1"/>
+       <position name="posArapucaDouble1-Frame-3-1" unit="cm" 
+         x="-328.04"
+	 y="464.1018" 
+	 z="-707.68"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-1"/>
+       <position name="posOpArapucaDouble1-Frame-3-1" unit="cm" 
+         x="-327.3"
+	 y="464.1018" 
+	 z="-707.68"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-1-2"/>
+       <position name="posArapucaDouble2-Frame-3-1" unit="cm" 
+         x="-328.04"
+	 y="538.1018" 
+	 z="-490.68"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-2"/>
+       <position name="posOpArapucaDouble2-Frame-3-1" unit="cm" 
+         x="-327.3"
+	 y="538.1018" 
+	 z="-490.68"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-1-3"/>
+       <position name="posArapucaDouble3-Frame-3-1" unit="cm" 
+         x="-328.04"
+	 y="628.8018" 
+	 z="-636.68"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-3"/>
+       <position name="posOpArapucaDouble3-Frame-3-1" unit="cm" 
+         x="-327.3"
+	 y="628.8018" 
+	 z="-636.68"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-2-0"/>
+       <position name="posArapucaDouble0-Frame-3-2" unit="cm" 
+         x="-328.04"
+	 y="373.4018" 
+	 z="-263.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-0"/>
+       <position name="posOpArapucaDouble0-Frame-3-2" unit="cm" 
+         x="-327.3"
+	 y="373.4018" 
+	 z="-263.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-2-1"/>
+       <position name="posArapucaDouble1-Frame-3-2" unit="cm" 
+         x="-328.04"
+	 y="464.1018" 
+	 z="-409.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-1"/>
+       <position name="posOpArapucaDouble1-Frame-3-2" unit="cm" 
+         x="-327.3"
+	 y="464.1018" 
+	 z="-409.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-2-2"/>
+       <position name="posArapucaDouble2-Frame-3-2" unit="cm" 
+         x="-328.04"
+	 y="538.1018" 
+	 z="-192.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-2"/>
+       <position name="posOpArapucaDouble2-Frame-3-2" unit="cm" 
+         x="-327.3"
+	 y="538.1018" 
+	 z="-192.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-2-3"/>
+       <position name="posArapucaDouble3-Frame-3-2" unit="cm" 
+         x="-328.04"
+	 y="628.8018" 
+	 z="-338.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-3"/>
+       <position name="posOpArapucaDouble3-Frame-3-2" unit="cm" 
+         x="-327.3"
+	 y="628.8018" 
+	 z="-338.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-3-0"/>
+       <position name="posArapucaDouble0-Frame-3-3" unit="cm" 
+         x="-328.04"
+	 y="373.4018" 
+	 z="34.0000000000001"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-3-0"/>
+       <position name="posOpArapucaDouble0-Frame-3-3" unit="cm" 
+         x="-327.3"
+	 y="373.4018" 
+	 z="34.0000000000001"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-3-1"/>
+       <position name="posArapucaDouble1-Frame-3-3" unit="cm" 
+         x="-328.04"
+	 y="464.1018" 
+	 z="-112"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-3-1"/>
+       <position name="posOpArapucaDouble1-Frame-3-3" unit="cm" 
+         x="-327.3"
+	 y="464.1018" 
+	 z="-112"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-3-2"/>
+       <position name="posArapucaDouble2-Frame-3-3" unit="cm" 
+         x="-328.04"
+	 y="538.1018" 
+	 z="105"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-3-2"/>
+       <position name="posOpArapucaDouble2-Frame-3-3" unit="cm" 
+         x="-327.3"
+	 y="538.1018" 
+	 z="105"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-3-3"/>
+       <position name="posArapucaDouble3-Frame-3-3" unit="cm" 
+         x="-328.04"
+	 y="628.8018" 
+	 z="-40.9999999999999"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-3-3"/>
+       <position name="posOpArapucaDouble3-Frame-3-3" unit="cm" 
+         x="-327.3"
+	 y="628.8018" 
+	 z="-40.9999999999999"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-4-0"/>
+       <position name="posArapucaDouble0-Frame-3-4" unit="cm" 
+         x="-328.04"
+	 y="373.4018" 
+	 z="331.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-4-0"/>
+       <position name="posOpArapucaDouble0-Frame-3-4" unit="cm" 
+         x="-327.3"
+	 y="373.4018" 
+	 z="331.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-4-1"/>
+       <position name="posArapucaDouble1-Frame-3-4" unit="cm" 
+         x="-328.04"
+	 y="464.1018" 
+	 z="185.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-4-1"/>
+       <position name="posOpArapucaDouble1-Frame-3-4" unit="cm" 
+         x="-327.3"
+	 y="464.1018" 
+	 z="185.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-4-2"/>
+       <position name="posArapucaDouble2-Frame-3-4" unit="cm" 
+         x="-328.04"
+	 y="538.1018" 
+	 z="402.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-4-2"/>
+       <position name="posOpArapucaDouble2-Frame-3-4" unit="cm" 
+         x="-327.3"
+	 y="538.1018" 
+	 z="402.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-4-3"/>
+       <position name="posArapucaDouble3-Frame-3-4" unit="cm" 
+         x="-328.04"
+	 y="628.8018" 
+	 z="256.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-4-3"/>
+       <position name="posOpArapucaDouble3-Frame-3-4" unit="cm" 
+         x="-327.3"
+	 y="628.8018" 
+	 z="256.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-5-0"/>
+       <position name="posArapucaDouble0-Frame-3-5" unit="cm" 
+         x="-328.04"
+	 y="373.4018" 
+	 z="629.68"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-5-0"/>
+       <position name="posOpArapucaDouble0-Frame-3-5" unit="cm" 
+         x="-327.3"
+	 y="373.4018" 
+	 z="629.68"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-5-1"/>
+       <position name="posArapucaDouble1-Frame-3-5" unit="cm" 
+         x="-328.04"
+	 y="464.1018" 
+	 z="483.68"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-5-1"/>
+       <position name="posOpArapucaDouble1-Frame-3-5" unit="cm" 
+         x="-327.3"
+	 y="464.1018" 
+	 z="483.68"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-5-2"/>
+       <position name="posArapucaDouble2-Frame-3-5" unit="cm" 
+         x="-328.04"
+	 y="538.1018" 
+	 z="700.68"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-5-2"/>
+       <position name="posOpArapucaDouble2-Frame-3-5" unit="cm" 
+         x="-327.3"
+	 y="538.1018" 
+	 z="700.68"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-5-3"/>
+       <position name="posArapucaDouble3-Frame-3-5" unit="cm" 
+         x="-328.04"
+	 y="628.8018" 
+	 z="554.68"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-5-3"/>
+       <position name="posOpArapucaDouble3-Frame-3-5" unit="cm" 
+         x="-327.3"
+	 y="628.8018" 
+	 z="554.68"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-6-0"/>
+       <position name="posArapucaDouble0-Frame-3-6" unit="cm" 
+         x="-328.04"
+	 y="373.4018" 
+	 z="927.52"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-6-0"/>
+       <position name="posOpArapucaDouble0-Frame-3-6" unit="cm" 
+         x="-327.3"
+	 y="373.4018" 
+	 z="927.52"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-6-1"/>
+       <position name="posArapucaDouble1-Frame-3-6" unit="cm" 
+         x="-328.04"
+	 y="464.1018" 
+	 z="781.52"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-6-1"/>
+       <position name="posOpArapucaDouble1-Frame-3-6" unit="cm" 
+         x="-327.3"
+	 y="464.1018" 
+	 z="781.52"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-6-2"/>
+       <position name="posArapucaDouble2-Frame-3-6" unit="cm" 
+         x="-328.04"
+	 y="538.1018" 
+	 z="998.52"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-6-2"/>
+       <position name="posOpArapucaDouble2-Frame-3-6" unit="cm" 
+         x="-327.3"
+	 y="538.1018" 
+	 z="998.52"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-6-3"/>
+       <position name="posArapucaDouble3-Frame-3-6" unit="cm" 
+         x="-328.04"
+	 y="628.8018" 
+	 z="852.52"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-6-3"/>
+       <position name="posOpArapucaDouble3-Frame-3-6" unit="cm" 
+         x="-327.3"
+	 y="628.8018" 
+	 z="852.52"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_0-0"/>
+       <position name="posArapuca0-Lat-0" unit="cm" 
+         x="285.03"
+	 y="-732.8024" 
+	 z="-893.52"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_0-0"/>
+       <position name="posOpArapuca0-Lat-0" unit="cm" 
+         x="285.03"
+	 y="-732.0624" 
+	 z="-893.52"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_0-1"/>
+       <position name="posArapuca1-Lat-0" unit="cm" 
+         x="210.03"
+	 y="-732.8024" 
+	 z="-893.52"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_0-1"/>
+       <position name="posOpArapuca1-Lat-0" unit="cm" 
+         x="210.03"
+	 y="-732.0624" 
+	 z="-893.52"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_0-2"/>
+       <position name="posArapuca2-Lat-0" unit="cm" 
+         x="135.03"
+	 y="-732.8024" 
+	 z="-893.52"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_0-2"/>
+       <position name="posOpArapuca2-Lat-0" unit="cm" 
+         x="135.03"
+	 y="-732.0624" 
+	 z="-893.52"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_0-3"/>
+       <position name="posArapuca3-Lat-0" unit="cm" 
+         x="60.03"
+	 y="-732.8024" 
+	 z="-893.52"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_0-3"/>
+       <position name="posOpArapuca3-Lat-0" unit="cm" 
+         x="60.03"
+	 y="-732.0624" 
+	 z="-893.52"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_0-4"/>
+       <position name="posArapuca4-Lat-0" unit="cm" 
+         x="285.03"
+	 y="732.8024" 
+	 z="-893.52"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_0-4"/>
+       <position name="posOpArapuca4-Lat-0" unit="cm" 
+         x="285.03"
+	 y="732.0624" 
+	 z="-893.52"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_0-5"/>
+       <position name="posArapuca5-Lat-0" unit="cm" 
+         x="210.03"
+	 y="732.8024" 
+	 z="-893.52"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_0-5"/>
+       <position name="posOpArapuca5-Lat-0" unit="cm" 
+         x="210.03"
+	 y="732.0624" 
+	 z="-893.52"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_0-6"/>
+       <position name="posArapuca6-Lat-0" unit="cm" 
+         x="135.03"
+	 y="732.8024" 
+	 z="-893.52"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_0-6"/>
+       <position name="posOpArapuca6-Lat-0" unit="cm" 
+         x="135.03"
+	 y="732.0624" 
+	 z="-893.52"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_0-7"/>
+       <position name="posArapuca7-Lat-0" unit="cm" 
+         x="60.03"
+	 y="732.8024" 
+	 z="-893.52"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_0-7"/>
+       <position name="posOpArapuca7-Lat-0" unit="cm" 
+         x="60.03"
+	 y="732.0624" 
+	 z="-893.52"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_1-0"/>
+       <position name="posArapuca0-Lat-1" unit="cm" 
+         x="285.03"
+	 y="-732.8024" 
+	 z="-595.68"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_1-0"/>
+       <position name="posOpArapuca0-Lat-1" unit="cm" 
+         x="285.03"
+	 y="-732.0624" 
+	 z="-595.68"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_1-1"/>
+       <position name="posArapuca1-Lat-1" unit="cm" 
+         x="210.03"
+	 y="-732.8024" 
+	 z="-595.68"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_1-1"/>
+       <position name="posOpArapuca1-Lat-1" unit="cm" 
+         x="210.03"
+	 y="-732.0624" 
+	 z="-595.68"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_1-2"/>
+       <position name="posArapuca2-Lat-1" unit="cm" 
+         x="135.03"
+	 y="-732.8024" 
+	 z="-595.68"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_1-2"/>
+       <position name="posOpArapuca2-Lat-1" unit="cm" 
+         x="135.03"
+	 y="-732.0624" 
+	 z="-595.68"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_1-3"/>
+       <position name="posArapuca3-Lat-1" unit="cm" 
+         x="60.03"
+	 y="-732.8024" 
+	 z="-595.68"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_1-3"/>
+       <position name="posOpArapuca3-Lat-1" unit="cm" 
+         x="60.03"
+	 y="-732.0624" 
+	 z="-595.68"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_1-4"/>
+       <position name="posArapuca4-Lat-1" unit="cm" 
+         x="285.03"
+	 y="732.8024" 
+	 z="-595.68"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_1-4"/>
+       <position name="posOpArapuca4-Lat-1" unit="cm" 
+         x="285.03"
+	 y="732.0624" 
+	 z="-595.68"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_1-5"/>
+       <position name="posArapuca5-Lat-1" unit="cm" 
+         x="210.03"
+	 y="732.8024" 
+	 z="-595.68"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_1-5"/>
+       <position name="posOpArapuca5-Lat-1" unit="cm" 
+         x="210.03"
+	 y="732.0624" 
+	 z="-595.68"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_1-6"/>
+       <position name="posArapuca6-Lat-1" unit="cm" 
+         x="135.03"
+	 y="732.8024" 
+	 z="-595.68"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_1-6"/>
+       <position name="posOpArapuca6-Lat-1" unit="cm" 
+         x="135.03"
+	 y="732.0624" 
+	 z="-595.68"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_1-7"/>
+       <position name="posArapuca7-Lat-1" unit="cm" 
+         x="60.03"
+	 y="732.8024" 
+	 z="-595.68"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_1-7"/>
+       <position name="posOpArapuca7-Lat-1" unit="cm" 
+         x="60.03"
+	 y="732.0624" 
+	 z="-595.68"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_2-0"/>
+       <position name="posArapuca0-Lat-2" unit="cm" 
+         x="285.03"
+	 y="-732.8024" 
+	 z="-297.84"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_2-0"/>
+       <position name="posOpArapuca0-Lat-2" unit="cm" 
+         x="285.03"
+	 y="-732.0624" 
+	 z="-297.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_2-1"/>
+       <position name="posArapuca1-Lat-2" unit="cm" 
+         x="210.03"
+	 y="-732.8024" 
+	 z="-297.84"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_2-1"/>
+       <position name="posOpArapuca1-Lat-2" unit="cm" 
+         x="210.03"
+	 y="-732.0624" 
+	 z="-297.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_2-2"/>
+       <position name="posArapuca2-Lat-2" unit="cm" 
+         x="135.03"
+	 y="-732.8024" 
+	 z="-297.84"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_2-2"/>
+       <position name="posOpArapuca2-Lat-2" unit="cm" 
+         x="135.03"
+	 y="-732.0624" 
+	 z="-297.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_2-3"/>
+       <position name="posArapuca3-Lat-2" unit="cm" 
+         x="60.03"
+	 y="-732.8024" 
+	 z="-297.84"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_2-3"/>
+       <position name="posOpArapuca3-Lat-2" unit="cm" 
+         x="60.03"
+	 y="-732.0624" 
+	 z="-297.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_2-4"/>
+       <position name="posArapuca4-Lat-2" unit="cm" 
+         x="285.03"
+	 y="732.8024" 
+	 z="-297.84"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_2-4"/>
+       <position name="posOpArapuca4-Lat-2" unit="cm" 
+         x="285.03"
+	 y="732.0624" 
+	 z="-297.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_2-5"/>
+       <position name="posArapuca5-Lat-2" unit="cm" 
+         x="210.03"
+	 y="732.8024" 
+	 z="-297.84"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_2-5"/>
+       <position name="posOpArapuca5-Lat-2" unit="cm" 
+         x="210.03"
+	 y="732.0624" 
+	 z="-297.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_2-6"/>
+       <position name="posArapuca6-Lat-2" unit="cm" 
+         x="135.03"
+	 y="732.8024" 
+	 z="-297.84"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_2-6"/>
+       <position name="posOpArapuca6-Lat-2" unit="cm" 
+         x="135.03"
+	 y="732.0624" 
+	 z="-297.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_2-7"/>
+       <position name="posArapuca7-Lat-2" unit="cm" 
+         x="60.03"
+	 y="732.8024" 
+	 z="-297.84"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_2-7"/>
+       <position name="posOpArapuca7-Lat-2" unit="cm" 
+         x="60.03"
+	 y="732.0624" 
+	 z="-297.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_3-0"/>
+       <position name="posArapuca0-Lat-3" unit="cm" 
+         x="285.03"
+	 y="-732.8024" 
+	 z="-1.13686837721616e-13"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_3-0"/>
+       <position name="posOpArapuca0-Lat-3" unit="cm" 
+         x="285.03"
+	 y="-732.0624" 
+	 z="-1.13686837721616e-13"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_3-1"/>
+       <position name="posArapuca1-Lat-3" unit="cm" 
+         x="210.03"
+	 y="-732.8024" 
+	 z="-1.13686837721616e-13"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_3-1"/>
+       <position name="posOpArapuca1-Lat-3" unit="cm" 
+         x="210.03"
+	 y="-732.0624" 
+	 z="-1.13686837721616e-13"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_3-2"/>
+       <position name="posArapuca2-Lat-3" unit="cm" 
+         x="135.03"
+	 y="-732.8024" 
+	 z="-1.13686837721616e-13"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_3-2"/>
+       <position name="posOpArapuca2-Lat-3" unit="cm" 
+         x="135.03"
+	 y="-732.0624" 
+	 z="-1.13686837721616e-13"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_3-3"/>
+       <position name="posArapuca3-Lat-3" unit="cm" 
+         x="60.03"
+	 y="-732.8024" 
+	 z="-1.13686837721616e-13"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_3-3"/>
+       <position name="posOpArapuca3-Lat-3" unit="cm" 
+         x="60.03"
+	 y="-732.0624" 
+	 z="-1.13686837721616e-13"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_3-4"/>
+       <position name="posArapuca4-Lat-3" unit="cm" 
+         x="285.03"
+	 y="732.8024" 
+	 z="-1.13686837721616e-13"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_3-4"/>
+       <position name="posOpArapuca4-Lat-3" unit="cm" 
+         x="285.03"
+	 y="732.0624" 
+	 z="-1.13686837721616e-13"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_3-5"/>
+       <position name="posArapuca5-Lat-3" unit="cm" 
+         x="210.03"
+	 y="732.8024" 
+	 z="-1.13686837721616e-13"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_3-5"/>
+       <position name="posOpArapuca5-Lat-3" unit="cm" 
+         x="210.03"
+	 y="732.0624" 
+	 z="-1.13686837721616e-13"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_3-6"/>
+       <position name="posArapuca6-Lat-3" unit="cm" 
+         x="135.03"
+	 y="732.8024" 
+	 z="-1.13686837721616e-13"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_3-6"/>
+       <position name="posOpArapuca6-Lat-3" unit="cm" 
+         x="135.03"
+	 y="732.0624" 
+	 z="-1.13686837721616e-13"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_3-7"/>
+       <position name="posArapuca7-Lat-3" unit="cm" 
+         x="60.03"
+	 y="732.8024" 
+	 z="-1.13686837721616e-13"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_3-7"/>
+       <position name="posOpArapuca7-Lat-3" unit="cm" 
+         x="60.03"
+	 y="732.0624" 
+	 z="-1.13686837721616e-13"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_4-0"/>
+       <position name="posArapuca0-Lat-4" unit="cm" 
+         x="285.03"
+	 y="-732.8024" 
+	 z="297.84"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_4-0"/>
+       <position name="posOpArapuca0-Lat-4" unit="cm" 
+         x="285.03"
+	 y="-732.0624" 
+	 z="297.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_4-1"/>
+       <position name="posArapuca1-Lat-4" unit="cm" 
+         x="210.03"
+	 y="-732.8024" 
+	 z="297.84"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_4-1"/>
+       <position name="posOpArapuca1-Lat-4" unit="cm" 
+         x="210.03"
+	 y="-732.0624" 
+	 z="297.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_4-2"/>
+       <position name="posArapuca2-Lat-4" unit="cm" 
+         x="135.03"
+	 y="-732.8024" 
+	 z="297.84"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_4-2"/>
+       <position name="posOpArapuca2-Lat-4" unit="cm" 
+         x="135.03"
+	 y="-732.0624" 
+	 z="297.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_4-3"/>
+       <position name="posArapuca3-Lat-4" unit="cm" 
+         x="60.03"
+	 y="-732.8024" 
+	 z="297.84"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_4-3"/>
+       <position name="posOpArapuca3-Lat-4" unit="cm" 
+         x="60.03"
+	 y="-732.0624" 
+	 z="297.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_4-4"/>
+       <position name="posArapuca4-Lat-4" unit="cm" 
+         x="285.03"
+	 y="732.8024" 
+	 z="297.84"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_4-4"/>
+       <position name="posOpArapuca4-Lat-4" unit="cm" 
+         x="285.03"
+	 y="732.0624" 
+	 z="297.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_4-5"/>
+       <position name="posArapuca5-Lat-4" unit="cm" 
+         x="210.03"
+	 y="732.8024" 
+	 z="297.84"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_4-5"/>
+       <position name="posOpArapuca5-Lat-4" unit="cm" 
+         x="210.03"
+	 y="732.0624" 
+	 z="297.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_4-6"/>
+       <position name="posArapuca6-Lat-4" unit="cm" 
+         x="135.03"
+	 y="732.8024" 
+	 z="297.84"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_4-6"/>
+       <position name="posOpArapuca6-Lat-4" unit="cm" 
+         x="135.03"
+	 y="732.0624" 
+	 z="297.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_4-7"/>
+       <position name="posArapuca7-Lat-4" unit="cm" 
+         x="60.03"
+	 y="732.8024" 
+	 z="297.84"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_4-7"/>
+       <position name="posOpArapuca7-Lat-4" unit="cm" 
+         x="60.03"
+	 y="732.0624" 
+	 z="297.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_5-0"/>
+       <position name="posArapuca0-Lat-5" unit="cm" 
+         x="285.03"
+	 y="-732.8024" 
+	 z="595.68"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_5-0"/>
+       <position name="posOpArapuca0-Lat-5" unit="cm" 
+         x="285.03"
+	 y="-732.0624" 
+	 z="595.68"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_5-1"/>
+       <position name="posArapuca1-Lat-5" unit="cm" 
+         x="210.03"
+	 y="-732.8024" 
+	 z="595.68"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_5-1"/>
+       <position name="posOpArapuca1-Lat-5" unit="cm" 
+         x="210.03"
+	 y="-732.0624" 
+	 z="595.68"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_5-2"/>
+       <position name="posArapuca2-Lat-5" unit="cm" 
+         x="135.03"
+	 y="-732.8024" 
+	 z="595.68"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_5-2"/>
+       <position name="posOpArapuca2-Lat-5" unit="cm" 
+         x="135.03"
+	 y="-732.0624" 
+	 z="595.68"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_5-3"/>
+       <position name="posArapuca3-Lat-5" unit="cm" 
+         x="60.03"
+	 y="-732.8024" 
+	 z="595.68"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_5-3"/>
+       <position name="posOpArapuca3-Lat-5" unit="cm" 
+         x="60.03"
+	 y="-732.0624" 
+	 z="595.68"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_5-4"/>
+       <position name="posArapuca4-Lat-5" unit="cm" 
+         x="285.03"
+	 y="732.8024" 
+	 z="595.68"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_5-4"/>
+       <position name="posOpArapuca4-Lat-5" unit="cm" 
+         x="285.03"
+	 y="732.0624" 
+	 z="595.68"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_5-5"/>
+       <position name="posArapuca5-Lat-5" unit="cm" 
+         x="210.03"
+	 y="732.8024" 
+	 z="595.68"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_5-5"/>
+       <position name="posOpArapuca5-Lat-5" unit="cm" 
+         x="210.03"
+	 y="732.0624" 
+	 z="595.68"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_5-6"/>
+       <position name="posArapuca6-Lat-5" unit="cm" 
+         x="135.03"
+	 y="732.8024" 
+	 z="595.68"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_5-6"/>
+       <position name="posOpArapuca6-Lat-5" unit="cm" 
+         x="135.03"
+	 y="732.0624" 
+	 z="595.68"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_5-7"/>
+       <position name="posArapuca7-Lat-5" unit="cm" 
+         x="60.03"
+	 y="732.8024" 
+	 z="595.68"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_5-7"/>
+       <position name="posOpArapuca7-Lat-5" unit="cm" 
+         x="60.03"
+	 y="732.0624" 
+	 z="595.68"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_6-0"/>
+       <position name="posArapuca0-Lat-6" unit="cm" 
+         x="285.03"
+	 y="-732.8024" 
+	 z="893.52"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_6-0"/>
+       <position name="posOpArapuca0-Lat-6" unit="cm" 
+         x="285.03"
+	 y="-732.0624" 
+	 z="893.52"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_6-1"/>
+       <position name="posArapuca1-Lat-6" unit="cm" 
+         x="210.03"
+	 y="-732.8024" 
+	 z="893.52"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_6-1"/>
+       <position name="posOpArapuca1-Lat-6" unit="cm" 
+         x="210.03"
+	 y="-732.0624" 
+	 z="893.52"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_6-2"/>
+       <position name="posArapuca2-Lat-6" unit="cm" 
+         x="135.03"
+	 y="-732.8024" 
+	 z="893.52"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_6-2"/>
+       <position name="posOpArapuca2-Lat-6" unit="cm" 
+         x="135.03"
+	 y="-732.0624" 
+	 z="893.52"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_6-3"/>
+       <position name="posArapuca3-Lat-6" unit="cm" 
+         x="60.03"
+	 y="-732.8024" 
+	 z="893.52"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_6-3"/>
+       <position name="posOpArapuca3-Lat-6" unit="cm" 
+         x="60.03"
+	 y="-732.0624" 
+	 z="893.52"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_6-4"/>
+       <position name="posArapuca4-Lat-6" unit="cm" 
+         x="285.03"
+	 y="732.8024" 
+	 z="893.52"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_6-4"/>
+       <position name="posOpArapuca4-Lat-6" unit="cm" 
+         x="285.03"
+	 y="732.0624" 
+	 z="893.52"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_6-5"/>
+       <position name="posArapuca5-Lat-6" unit="cm" 
+         x="210.03"
+	 y="732.8024" 
+	 z="893.52"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_6-5"/>
+       <position name="posOpArapuca5-Lat-6" unit="cm" 
+         x="210.03"
+	 y="732.0624" 
+	 z="893.52"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_6-6"/>
+       <position name="posArapuca6-Lat-6" unit="cm" 
+         x="135.03"
+	 y="732.8024" 
+	 z="893.52"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_6-6"/>
+       <position name="posOpArapuca6-Lat-6" unit="cm" 
+         x="135.03"
+	 y="732.0624" 
+	 z="893.52"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_6-7"/>
+       <position name="posArapuca7-Lat-6" unit="cm" 
+         x="60.03"
+	 y="732.8024" 
+	 z="893.52"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_6-7"/>
+       <position name="posOpArapuca7-Lat-6" unit="cm" 
+         x="60.03"
+	 y="732.0624" 
+	 z="893.52"/>
+     </physvol>
+    </volume>
+
+    <volume name="volFoamPadding">
+      <materialref ref="fibrous_glass"/>
+      <solidref ref="FoamPadding"/>
+    </volume>
+
+    <volume name="volSteelSupport">
+      <materialref ref="AirSteelMixture"/>
+      <solidref ref="SteelSupport"/>
+    </volume>
+
+    <volume name="volDetEnclosure">
+      <materialref ref="Air"/>
+      <solidref ref="DetEnclosure"/>
+
+       <physvol>
+           <volumeref ref="volFoamPadding"/>
+           <positionref ref="posCryoInDetEnc"/>
+       </physvol>
+       <physvol>
+           <volumeref ref="volSteelSupport"/>
+           <positionref ref="posCryoInDetEnc"/>
+       </physvol>
+       <physvol>
+           <volumeref ref="volCryostat"/>
+           <positionref ref="posCryoInDetEnc"/>
+       </physvol>
+    </volume>
+
+    <volume name="volWorld" >
+      <materialref ref="DUSEL_Rock"/>
+      <solidref ref="World"/>
+
+      <physvol>
+        <volumeref ref="volDetEnclosure"/>
+	<position name="posDetEnclosure" unit="cm" x="50.04" y="-1.13686837721616e-13" z="1045.94"/>
+      </physvol>
+
+    </volume>
+</structure>
+  <setup name="Default" version="1.0">
+    <world ref="volWorld"/>
+  </setup>
+</gdml_simple_extension>

--- a/dunecore/Geometry/gdml/dunevd10kt_3view_30deg_v4_refactored_1x8x14ref_nowires.gdml
+++ b/dunecore/Geometry/gdml/dunevd10kt_3view_30deg_v4_refactored_1x8x14ref_nowires.gdml
@@ -1,0 +1,6088 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<gdml_simple_extension xmlns:gdml_simple_extension="http://www.example.org"
+                       xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"          
+                       xs:noNamespaceSchemaLocation="RefactoredGDMLSchema/SimpleExtension.xsd"> 
+<extension>
+   <color name="magenta"     R="0.0"  G="1.0"  B="0.0"  A="1.0" />
+   <color name="green"       R="0.0"  G="1.0"  B="0.0"  A="1.0" />
+   <color name="red"         R="1.0"  G="0.0"  B="0.0"  A="1.0" />
+   <color name="blue"        R="0.0"  G="0.0"  B="1.0"  A="1.0" />
+   <color name="yellow"      R="1.0"  G="1.0"  B="0.0"  A="1.0" />    
+</extension>
+<define>
+
+<!--
+
+
+
+-->
+
+   <position name="posCryoInDetEnc"     unit="cm" x="-50.0000000000001" y="0" z="0"/>
+   <position name="posCenter"           unit="cm" x="0" y="0" z="0"/>
+   <rotation name="rUWireAboutX"        unit="deg" x="150" y="0" z="0"/>
+   <rotation name="rVWireAboutX"        unit="deg" x="30" y="0" z="0"/>
+   <rotation name="rPlus90AboutX"       unit="deg" x="90" y="0" z="0"/>
+   <rotation name="rPlus90AboutY"       unit="deg" x="0" y="90" z="0"/>
+   <rotation name="rPlus90AboutXPlus90AboutY" unit="deg" x="90" y="90" z="0"/>
+   <rotation name="rMinus90AboutX"      unit="deg" x="270" y="0" z="0"/>
+   <rotation name="rMinus90AboutY"      unit="deg" x="0" y="270" z="0"/>
+   <rotation name="rMinus90AboutYMinus90AboutX"       unit="deg" x="270" y="270" z="0"/>
+   <rotation name="rPlus180AboutX"	unit="deg" x="180" y="0"   z="0"/>
+   <rotation name="rPlus180AboutY"	unit="deg" x="0" y="180"   z="0"/>
+   <rotation name="rPlus180AboutXPlus180AboutY"	unit="deg" x="180" y="180"   z="0"/>
+   <rotation name="rIdentity"		unit="deg" x="0" y="0"   z="0"/>
+</define>
+<materials>
+  <element name="videRef" formula="VACUUM" Z="1">  <atom value="1"/> </element>
+  <element name="copper" formula="Cu" Z="29">  <atom value="63.546"/>  </element>
+  <element name="beryllium" formula="Be" Z="4">  <atom value="9.0121831"/>  </element>
+  <element name="bromine" formula="Br" Z="35"> <atom value="79.904"/> </element>
+  <element name="hydrogen" formula="H" Z="1">  <atom value="1.0079"/> </element>
+  <element name="nitrogen" formula="N" Z="7">  <atom value="14.0067"/> </element>
+  <element name="oxygen" formula="O" Z="8">  <atom value="15.999"/> </element>
+  <element name="aluminum" formula="Al" Z="13"> <atom value="26.9815"/>  </element>
+  <element name="silicon" formula="Si" Z="14"> <atom value="28.0855"/>  </element>
+  <element name="carbon" formula="C" Z="6">  <atom value="12.0107"/>  </element>
+  <element name="potassium" formula="K" Z="19"> <atom value="39.0983"/>  </element>
+  <element name="chromium" formula="Cr" Z="24"> <atom value="51.9961"/>  </element>
+  <element name="iron" formula="Fe" Z="26"> <atom value="55.8450"/>  </element>
+  <element name="nickel" formula="Ni" Z="28"> <atom value="58.6934"/>  </element>
+  <element name="calcium" formula="Ca" Z="20"> <atom value="40.078"/>   </element>
+  <element name="magnesium" formula="Mg" Z="12"> <atom value="24.305"/>   </element>
+  <element name="sodium" formula="Na" Z="11"> <atom value="22.99"/>    </element>
+  <element name="titanium" formula="Ti" Z="22"> <atom value="47.867"/>   </element>
+  <element name="argon" formula="Ar" Z="18"> <atom value="39.9480"/>  </element>
+  <element name="sulphur" formula="S" Z="16"> <atom value="32.065"/>  </element>
+  <element name="phosphorus" formula="P" Z="15"> <atom value="30.973"/>  </element>
+
+  <material name="Vacuum" formula="Vacuum">
+   <D value="1.e-25" unit="g/cm3"/>
+   <fraction n="1.0" ref="videRef"/>
+  </material>
+
+  <material name="ALUMINUM_Al" formula="ALUMINUM_Al">
+   <D value="2.6990" unit="g/cm3"/>
+   <fraction n="1.0000" ref="aluminum"/>
+  </material>
+
+  <material name="SILICON_Si" formula="SILICON_Si">
+   <D value="2.3300" unit="g/cm3"/>
+   <fraction n="1.0000" ref="silicon"/>
+  </material>
+
+  <material name="epoxy_resin" formula="C38H40O6Br4">
+   <D value="1.1250" unit="g/cm3"/>
+   <composite n="38" ref="carbon"/>
+   <composite n="40" ref="hydrogen"/>
+   <composite n="6" ref="oxygen"/>
+   <composite n="4" ref="bromine"/>
+  </material>
+
+  <material name="SiO2" formula="SiO2">
+   <D value="2.2" unit="g/cm3"/>
+   <composite n="1" ref="silicon"/>
+   <composite n="2" ref="oxygen"/>
+  </material>
+
+  <material name="Al2O3" formula="Al2O3">
+   <D value="3.97" unit="g/cm3"/>
+   <composite n="2" ref="aluminum"/>
+   <composite n="3" ref="oxygen"/>
+  </material>
+
+  <material name="Fe2O3" formula="Fe2O3">
+   <D value="5.24" unit="g/cm3"/>
+   <composite n="2" ref="iron"/>
+   <composite n="3" ref="oxygen"/>
+  </material>
+
+  <material name="CaO" formula="CaO">
+   <D value="3.35" unit="g/cm3"/>
+   <composite n="1" ref="calcium"/>
+   <composite n="1" ref="oxygen"/>
+  </material>
+
+  <material name="Delrin" formula="CH2O">
+    <D value="1.41" unit="g/cm3"/>
+    <composite n="1" ref="carbon"/>
+    <composite n="2" ref="hydrogen"/>
+    <composite n="1" ref="oxygen"/>
+  </material>
+
+  <material name="MgO" formula="MgO">
+   <D value="3.58" unit="g/cm3"/>
+   <composite n="1" ref="magnesium"/>
+   <composite n="1" ref="oxygen"/>
+  </material>
+
+  <material name="Na2O" formula="Na2O">
+   <D value="2.27" unit="g/cm3"/>
+   <composite n="2" ref="sodium"/>
+   <composite n="1" ref="oxygen"/>
+  </material>
+
+  <material name="TiO2" formula="TiO2">
+   <D value="4.23" unit="g/cm3"/>
+   <composite n="1" ref="titanium"/>
+   <composite n="2" ref="oxygen"/>
+  </material>
+
+  <material name="FeO" formula="FeO">
+   <D value="5.745" unit="g/cm3"/>
+   <composite n="1" ref="iron"/>
+   <composite n="1" ref="oxygen"/>
+  </material>
+
+  <material name="CO2" formula="CO2">
+   <D value="1.562" unit="g/cm3"/>
+   <composite n="1" ref="iron"/>
+   <composite n="2" ref="oxygen"/>
+  </material>
+
+  <material name="P2O5" formula="P2O5">
+   <D value="1.562" unit="g/cm3"/>
+   <composite n="2" ref="phosphorus"/>
+   <composite n="5" ref="oxygen"/>
+  </material>
+
+  <material formula=" " name="DUSEL_Rock">
+    <D value="2.82" unit="g/cm3"/>
+    <fraction n="0.5267" ref="SiO2"/>
+    <fraction n="0.1174" ref="FeO"/>
+    <fraction n="0.1025" ref="Al2O3"/>
+    <fraction n="0.0473" ref="MgO"/>
+    <fraction n="0.0422" ref="CO2"/>
+    <fraction n="0.0382" ref="CaO"/>
+    <fraction n="0.0240" ref="carbon"/>
+    <fraction n="0.0186" ref="sulphur"/>
+    <fraction n="0.0053" ref="Na2O"/>
+    <fraction n="0.00070" ref="P2O5"/>
+    <fraction n="0.0771" ref="oxygen"/>
+  </material> 
+
+  <material formula="Air" name="Air">
+   <D value="0.001205" unit="g/cm3"/>
+   <fraction n="0.781154" ref="nitrogen"/>
+   <fraction n="0.209476" ref="oxygen"/>
+   <fraction n="0.00934" ref="argon"/>
+  </material>
+
+  <material name="fibrous_glass">
+   <D value="2.74351" unit="g/cm3"/>
+   <fraction n="0.600" ref="SiO2"/>
+   <fraction n="0.118" ref="Al2O3"/>
+   <fraction n="0.001" ref="Fe2O3"/>
+   <fraction n="0.224" ref="CaO"/>
+   <fraction n="0.034" ref="MgO"/>
+   <fraction n="0.010" ref="Na2O"/>
+   <fraction n="0.013" ref="TiO2"/>
+  </material>
+
+  <!-- density referenced from EHN1-Cold Cryostats Technical Requirements:
+       https://edms.cern.ch/document/1543254 -->
+  <material name="FD_foam">
+   <D value="0.09" unit="g/cm3"/>
+   <fraction n="0.95" ref="Air"/>
+   <fraction n="0.05" ref="fibrous_glass"/>
+  </material>
+
+  <!-- Foam density is 70 kg / m^3 for the 3x1x1 -->
+  <material name="foam_3x1x1dp">
+   <D value="0.07" unit="g/cm3"/>
+   <fraction n="0.95" ref="Air"/>
+   <fraction n="0.05" ref="fibrous_glass"/>
+  </material>
+
+  <!-- Copied from protodune_v4.gdml -->
+  <material name="foam_protoDUNEdp">
+   <D value="0.135" unit="g/cm3"/>
+   <composite n="17" ref="carbon"/>
+   <composite n="16" ref="hydrogen"/>
+   <composite n="2" ref="nitrogen"/>
+   <composite n="4" ref="oxygen"/>
+  </material>
+
+  <material name="FR4">
+   <D value="1.98281" unit="g/cm3"/>
+   <fraction n="0.47" ref="epoxy_resin"/>
+   <fraction n="0.53" ref="fibrous_glass"/>
+  </material>
+
+  <material name="STEEL_STAINLESS_Fe7Cr2Ni" formula="STEEL_STAINLESS_Fe7Cr2Ni">
+   <D value="7.9300" unit="g/cm3"/>
+   <fraction n="0.0010" ref="carbon"/>
+   <fraction n="0.1792" ref="chromium"/>
+   <fraction n="0.7298" ref="iron"/>
+   <fraction n="0.0900" ref="nickel"/>
+  </material>
+
+  <material name="Copper_Beryllium_alloy25" formula="Copper_Beryllium_alloy25">
+   <D value="8.26" unit="g/cm3"/>
+   <fraction n="0.981" ref="copper"/>
+   <fraction n="0.019" ref="beryllium"/>
+  </material>
+
+  <material name="LAr" formula="LAr">
+   <D value="1.40" unit="g/cm3"/>
+   <fraction n="1.0000" ref="argon"/>
+  </material>
+
+  <material name="ArGas" formula="ArGas">
+   <D value="0.00166" unit="g/cm3"/>
+   <fraction n="1.0" ref="argon"/>
+  </material>
+
+  <material formula=" " name="G10">
+   <D value="1.7" unit="g/cm3"/>
+   <fraction n="0.2805" ref="silicon"/>
+   <fraction n="0.3954" ref="oxygen"/>
+   <fraction n="0.2990" ref="carbon"/>
+   <fraction n="0.0251" ref="hydrogen"/>
+  </material>
+
+  <material formula=" " name="Granite">
+   <D value="2.7" unit="g/cm3"/>
+   <fraction n="0.438" ref="oxygen"/>
+   <fraction n="0.257" ref="silicon"/>
+   <fraction n="0.222" ref="sodium"/>
+   <fraction n="0.049" ref="aluminum"/>
+   <fraction n="0.019" ref="iron"/>
+   <fraction n="0.015" ref="potassium"/>
+  </material>
+
+  <material formula=" " name="ShotRock">
+   <D value="1.62" unit="g/cm3"/>
+   <fraction n="0.438" ref="oxygen"/>
+   <fraction n="0.257" ref="silicon"/>
+   <fraction n="0.222" ref="sodium"/>
+   <fraction n="0.049" ref="aluminum"/>
+   <fraction n="0.019" ref="iron"/>
+   <fraction n="0.015" ref="potassium"/>
+  </material>
+
+  <material formula=" " name="Dirt">
+   <D value="1.7" unit="g/cm3"/>
+   <fraction n="0.438" ref="oxygen"/>
+   <fraction n="0.257" ref="silicon"/>
+   <fraction n="0.222" ref="sodium"/>
+   <fraction n="0.049" ref="aluminum"/>
+   <fraction n="0.019" ref="iron"/>
+   <fraction n="0.015" ref="potassium"/>
+  </material>
+
+  <material formula=" " name="Concrete">
+   <D value="2.3" unit="g/cm3"/>
+   <fraction n="0.530" ref="oxygen"/>
+   <fraction n="0.335" ref="silicon"/>
+   <fraction n="0.060" ref="calcium"/>
+   <fraction n="0.015" ref="sodium"/>
+   <fraction n="0.020" ref="iron"/>
+   <fraction n="0.040" ref="aluminum"/>
+  </material>
+
+  <material formula="H2O" name="Water">
+   <D value="1.0" unit="g/cm3"/>
+   <fraction n="0.1119" ref="hydrogen"/>
+   <fraction n="0.8881" ref="oxygen"/>
+  </material>
+
+  <material formula="Ti" name="Titanium">
+   <D value="4.506" unit="g/cm3"/>
+   <fraction n="1." ref="titanium"/>
+  </material>
+
+  <material name="TPB" formula="TPB">
+   <D value="1.40" unit="g/cm3"/>
+   <fraction n="1.0000" ref="argon"/>
+  </material>
+
+  <material name="Glass">
+   <D value="2.74351" unit="g/cm3"/>
+   <fraction n="0.600" ref="SiO2"/>
+   <fraction n="0.118" ref="Al2O3"/>
+   <fraction n="0.001" ref="Fe2O3"/>
+   <fraction n="0.224" ref="CaO"/>
+   <fraction n="0.034" ref="MgO"/>
+   <fraction n="0.010" ref="Na2O"/>
+   <fraction n="0.013" ref="TiO2"/>
+  </material>
+
+  <material name="Acrylic">
+   <D value="1.19" unit="g/cm3"/>
+   <fraction n="0.600" ref="carbon"/>
+   <fraction n="0.320" ref="oxygen"/>
+   <fraction n="0.080" ref="hydrogen"/>
+  </material>
+
+  <material name="NiGas1atm80K">
+   <D value="0.0039" unit="g/cm3"/>
+   <fraction n="1.000" ref="nitrogen"/>
+  </material>
+
+  <material name="NiGas">
+   <D value="0.001165" unit="g/cm3"/>
+   <fraction n="1.000" ref="nitrogen"/>
+  </material>
+
+  <material name="PolyurethaneFoam">
+   <D value="0.088" unit="g/cm3"/>
+   <composite n="17" ref="carbon"/>
+   <composite n="16" ref="hydrogen"/>
+   <composite n="2" ref="nitrogen"/>
+   <composite n="4" ref="oxygen"/>
+  </material>
+
+  <material name="ProtoDUNEFoam">
+   <D value="0.135" unit="g/cm3"/>
+   <composite n="17" ref="carbon"/>
+   <composite n="16" ref="hydrogen"/>
+   <composite n="2" ref="nitrogen"/>
+   <composite n="4" ref="oxygen"/>
+  </material>
+
+  <material name="LightPolyurethaneFoam">
+   <D value="0.009" unit="g/cm3"/>
+   <composite n="17" ref="carbon"/>
+   <composite n="16" ref="hydrogen"/>
+   <composite n="2" ref="nitrogen"/>
+   <composite n="4" ref="oxygen"/>
+  </material>
+
+  <material name="ProtoDUNEBWFoam">
+   <D value="0.021" unit="g/cm3"/>
+   <composite n="17" ref="carbon"/>
+   <composite n="16" ref="hydrogen"/>
+   <composite n="2" ref="nitrogen"/>
+   <composite n="4" ref="oxygen"/>
+  </material>
+
+  <material name="GlassWool">
+   <D value="0.035" unit="g/cm3"/>
+   <fraction n="0.65" ref="SiO2"/>
+   <fraction n="0.09" ref="Al2O3"/>
+   <fraction n="0.07" ref="CaO"/>
+   <fraction n="0.03" ref="MgO"/>
+   <fraction n="0.16" ref="Na2O"/>
+  </material>
+
+  <material name="Polystyrene">
+   <D value="1.06" unit="g/cm3"/>
+   <composite n="8" ref="carbon"/>
+   <composite n="8" ref="hydrogen"/>
+  </material>
+
+
+
+  <!-- preliminary values -->
+  <material name="AirSteelMixture" formula="AirSteelMixture">
+   <D value=" 0.001205*(1-0.5) + 7.9300*0.5 " unit="g/cm3"/>
+   <fraction n="0.5" ref="STEEL_STAINLESS_Fe7Cr2Ni"/>
+   <fraction n="0.5"   ref="Air"/>
+  </material>
+  <material name="vm2000" formula="vm2000">
+    <D value="1.2" unit="g/cm3"/>
+    <composite n="2" ref="carbon"/>
+    <composite n="4" ref="hydrogen"/>
+  </material>
+
+</materials>
+<solids>
+     <torus name="FieldShaperCorner" rmin="0.5" rmax="2.285" rtor="2.3" deltaphi="90" startphi="0" aunit="deg" lunit="cm"/>
+     <tube name="FieldShaperLongtube" rmin="0.5" rmax="2.285" z="2091.88" deltaphi="360" startphi="0" aunit="deg" lunit="cm"/>
+     <tube name="FieldShaperLongtubeSlim" rmin="0.5" rmax="0.75" z="2091.88" deltaphi="360" startphi="0" aunit="deg" lunit="cm"/>
+     <tube name="FieldShaperShorttube" rmin="0.5" rmax="2.285" z="1345.6048" deltaphi="360" startphi="0" aunit="deg" lunit="cm"/>
+
+    <union name="FSunion1">
+      <first ref="FieldShaperLongtube"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos1" unit="cm" x="-2.3" y="0" z="1045.94"/>
+		<rotation name="rot1" unit="deg" x="90" y="0" z="0" />
+    </union>
+
+    <union name="FSunion2">
+      <first ref="FSunion1"/>
+      <second ref="FieldShaperShorttube"/>
+   		<position name="esquinapos2" unit="cm" x="-675.1024" y="0" z="1048.24"/>
+   		<rotation name="rot2" unit="deg" x="0" y="90" z="0" />
+    </union>
+
+    <union name="FSunion3">
+      <first ref="FSunion2"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos3" unit="cm" x="-1347.9048" y="0" z="1045.94"/>
+		<rotation name="rot3" unit="deg" x="90" y="270" z="0" />
+    </union>
+
+    <union name="FSunion4">
+      <first ref="FSunion3"/>
+      <second ref="FieldShaperLongtube"/>
+   		<position name="esquinapos4" unit="cm" x="-1350.2048" y="0" z="0"/>
+    </union>
+
+    <union name="FSunion5">
+      <first ref="FSunion4"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos5" unit="cm" x="-1347.9048" y="0" z="-1045.94"/>
+		<rotation name="rot5" unit="deg" x="90" y="180" z="0" />
+    </union>
+
+    <union name="FSunion6">
+      <first ref="FSunion5"/>
+      <second ref="FieldShaperShorttube"/>
+   		<position name="esquinapos6" unit="cm" x="-675.1024" y="0" z="-1048.24"/>
+		<rotation name="rot6" unit="deg" x="0" y="90" z="0" />
+    </union>
+
+    <union name="FieldShaperSolid">
+      <first ref="FSunion6"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos7" unit="cm" x="-2.3" y="0" z="-1045.94"/>
+		<rotation name="rot7" unit="deg" x="90" y="90" z="0" />
+    </union>
+    
+    <union name="FSunionSlim1">
+      <first ref="FieldShaperLongtubeSlim"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos1" unit="cm" x="-2.3" y="0" z="1045.94"/>
+		<rotation name="rot1" unit="deg" x="90" y="0" z="0" />
+    </union>
+
+    <union name="FSunionSlim2">
+      <first ref="FSunionSlim1"/>
+      <second ref="FieldShaperShorttube"/>
+   		<position name="esquinapos2" unit="cm" x="-675.1024" y="0" z="1048.24"/>
+   		<rotation name="rot2" unit="deg" x="0" y="90" z="0" />
+    </union>
+
+    <union name="FSunionSlim3">
+      <first ref="FSunionSlim2"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos3" unit="cm" x="-1347.9048" y="0" z="1045.94"/>
+		<rotation name="rot3" unit="deg" x="90" y="270" z="0" />
+    </union>
+
+    <union name="FSunionSlim4">
+      <first ref="FSunionSlim3"/>
+      <second ref="FieldShaperLongtubeSlim"/>
+   		<position name="esquinapos4" unit="cm" x="-1350.2048" y="0" z="0"/>
+    </union>
+
+    <union name="FSunionSlim5">
+      <first ref="FSunionSlim4"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos5" unit="cm" x="-1347.9048" y="0" z="-1045.94"/>
+		<rotation name="rot5" unit="deg" x="90" y="180" z="0" />
+    </union>
+
+    <union name="FSunionSlim6">
+      <first ref="FSunionSlim5"/>
+      <second ref="FieldShaperShorttube"/>
+   		<position name="esquinapos6" unit="cm" x="-675.1024" y="0" z="-1048.24"/>
+		<rotation name="rot6" unit="deg" x="0" y="90" z="0" />
+    </union>
+
+    <union name="FieldShaperSolidSlim">
+      <first ref="FSunionSlim6"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos7" unit="cm" x="-2.3" y="0" z="-1045.94"/>
+		<rotation name="rot7" unit="deg" x="90" y="90" z="0" />
+    </union>
+    
+
+   <box name="CRM"
+      x="650.08" 
+      y="167.7006" 
+      z="148.92"
+      lunit="cm"/>
+   <box name="CRMUPlane" 
+      x="0.02" 
+      y="167.7006" 
+      z="148.92"
+      lunit="cm"/>
+   <box name="CRMVPlane" 
+      x="0.02" 
+      y="167.7006" 
+      z="148.92"
+      lunit="cm"/>
+   <box name="CRMZPlane" 
+      x="0.02"
+      y="167.7006"
+      z="148.92"
+      lunit="cm"/>
+   <box name="CRMActive" 
+      x="650"
+      y="167.7006"
+      z="148.92"
+      lunit="cm"/>
+
+    <box name="ArapucaOut" lunit="cm"
+      x="65"
+      y="2.5"
+      z="65"/>
+
+    <box name="ArapucaIn" lunit="cm"
+      x="60"
+      y="2.5"
+      z="60"/>
+
+     <subtraction name="ArapucaWalls">
+      <first  ref="ArapucaOut"/>
+      <second ref="ArapucaIn"/>
+      <position name="posArapucaSub" x="0" y="1.25" z="0." unit="cm"/>
+      </subtraction>
+
+    <box name="ArapucaAcceptanceWindow" lunit="cm"
+      x="60"
+      y="1"
+      z="60"/>
+
+    <box name="ArapucaDoubleIn" lunit="cm"
+      x="60"
+      y="3.5"
+      z="60"/>
+
+     <subtraction name="ArapucaDoubleWalls">
+      <first  ref="ArapucaOut"/>
+      <second ref="ArapucaDoubleIn"/>
+      <position name="posArapucaDoubleSub" x="0" y="0" z="0" unit="cm"/>
+      </subtraction>
+
+    <box name="ArapucaDoubleAcceptanceWindow" lunit="cm"
+      x="2.48"
+      y="60"
+      z="60"/>
+
+    <box name="ArapucaCathodeAcceptanceWindow" lunit="cm"
+      x="1"
+      y="60"
+      z="60"/>
+
+
+    <box name="Cryostat" lunit="cm" 
+      x="850.32" 
+      y="1545.8448" 
+      z="2292.12"/>
+
+    <box name="ArgonInterior" lunit="cm" 
+      x="850.08"
+      y="1545.6048"
+      z="2291.88"/>
+
+    <box name="GaseousArgon" lunit="cm" 
+      x="100 - 0.01"
+      y="1545.6048"
+      z="2291.88"/>
+
+    <box name="ExternalAuxOut" lunit="cm" 
+      x="850.08 - 100"
+      y="1545.6048 - 2*2.5 - 2*40"
+      z="2291.88"/>
+
+    <box name="ExternalAuxIn" lunit="cm" 
+      x="850.08"
+      y="1356.7748"
+      z="2291.88 + 1"/>
+
+   <subtraction name="ExternalActive">
+      <first ref="ExternalAuxOut"/>
+      <second ref="ExternalAuxIn"/>
+    </subtraction>
+
+    <subtraction name="SteelShell">
+      <first ref="Cryostat"/>
+      <second ref="ArgonInterior"/>
+    </subtraction>
+
+
+
+    <box name="CathodeBlock" lunit="cm"
+      x="4"
+      y="335.4012"
+      z="297.84" />
+
+    <box name="CathodeVoid" lunit="cm"
+      x="5"
+      y="76.35"
+      z="67" />
+
+    <subtraction name="Cathode1">
+      <first ref="CathodeBlock"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub1" x="0" y="-122.525" z="-108.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode2">
+      <first ref="Cathode1"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub2" x="0" y="-122.525" z="-37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode3">
+      <first ref="Cathode2"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub3" x="0" y="-122.525" z="37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode4">
+      <first ref="Cathode3"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub4" x="0" y="-122.525" z="108.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode5">
+      <first ref="Cathode4"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub5" x="0" y="-42.175" z="-108.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode6">
+      <first ref="Cathode5"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub6" x="0" y="-42.175" z="-37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode7">
+      <first ref="Cathode6"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub7" x="0" y="-42.175" z="37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode8">
+      <first ref="Cathode7"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub8" x="0" y="-42.175" z="108.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode9">
+      <first ref="Cathode8"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub9" x="0" y="42.175" z="-108.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode10">
+      <first ref="Cathode9"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub10" x="0" y="42.175" z="-37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode11">
+      <first ref="Cathode10"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub11" x="0" y="42.175" z="37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode12">
+      <first ref="Cathode11"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub12" x="0" y="42.175" z="108.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode13">
+      <first ref="Cathode12"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub13" x="0" y="122.525" z="-108.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode14">
+      <first ref="Cathode13"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub14" x="0" y="122.525" z="-37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode15">
+      <first ref="Cathode14"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub15" x="0" y="122.525" z="37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="CathodeGrid">
+      <first ref="Cathode15"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub16" x="0" y="122.525" z="108.5" unit="cm"/>
+    </subtraction>
+
+   <box name="AnodePlate" 
+      x="0.01"
+      y="335.4012"
+      z="297.84"
+      lunit="cm"/>
+
+    <box name="FoamPadBlock" lunit="cm"
+      x="1010.32"
+      y="1705.8448"
+      z="2452.12" />
+
+    <subtraction name="FoamPadding">
+      <first ref="FoamPadBlock"/>
+      <second ref="Cryostat"/>
+      <positionref ref="posCenter"/>
+    </subtraction>
+
+    <box name="SteelSupportBlock" lunit="cm"
+      x="1210.32"
+      y="1905.8448"
+      z="2652.12" />
+
+    <subtraction name="SteelSupport">
+      <first ref="SteelSupportBlock"/>
+      <second ref="FoamPadBlock"/>
+      <positionref ref="posCenter"/>
+    </subtraction>
+
+    <box name="DetEnclosure" lunit="cm" 
+      x="1310.32"
+      y="2105.8448"
+      z="2852.12"/>
+
+
+    <box name="World" lunit="cm" 
+      x="9310.32" 
+      y="10105.8448" 
+      z="10852.12"/>
+</solids>
+<structure>
+<volume name="volFieldShaper">
+  <materialref ref="Al2O3"/>
+  <solidref ref="FieldShaperSolid"/>
+</volume>
+<volume name="volFieldShaperSlim">
+  <materialref ref="Al2O3"/>
+  <solidref ref="FieldShaperSolidSlim"/>
+</volume>
+
+
+    <volume name="volTPCActive">
+      <materialref ref="LAr"/>
+      <solidref ref="CRMActive"/>
+      <auxiliary auxtype="SensDet" auxvalue="SimEnergyDeposit"/>
+      <auxiliary auxtype="StepLimit" auxunit="cm" auxvalue="0.5208*cm"/>
+      <auxiliary auxtype="Efield" auxunit="V/cm" auxvalue="500*V/cm"/>
+      <colorref ref="blue"/>
+    </volume>
+   <volume name="volTPCPlaneU">
+     <materialref ref="LAr"/>
+     <solidref ref="CRMUPlane"/>
+   </volume>
+  <volume name="volTPCPlaneV">
+    <materialref ref="LAr"/>
+    <solidref ref="CRMVPlane"/>
+  </volume>
+  <volume name="volTPCPlaneZ">
+    <materialref ref="LAr"/>
+    <solidref ref="CRMZPlane"/>
+  </volume>
+   <volume name="volTPC">
+     <materialref ref="LAr"/>
+       <solidref ref="CRM"/>
+       <physvol>
+       <volumeref ref="volTPCPlaneU"/>
+       <position name="posPlaneU" unit="cm" 
+         x="324.99" y="0" z="0"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCPlaneV"/>
+       <position name="posPlaneY" unit="cm" 
+         x="325.01" y="0" z="0"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCPlaneZ"/>
+       <position name="posPlaneZ" unit="cm" 
+         x="325.03" y="0" z="0"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCActive"/>
+       <position name="posActive" unit="cm" 
+        x="-0.04" y="" z="0"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+   </volume>
+ 
+    <volume name="volSteelShell">
+      <materialref ref="STEEL_STAINLESS_Fe7Cr2Ni" />
+      <solidref ref="SteelShell" />
+    </volume>
+    <volume name="volGroundGrid">
+      <materialref ref="STEEL_STAINLESS_Fe7Cr2Ni" />
+      <solidref ref="CathodeGrid" />
+    </volume>
+    <volume name="volAnodePlate">
+     <materialref ref="vm2000"/>
+     <solidref ref="AnodePlate"/>
+    </volume>
+    <volume name="volGaseousArgon">
+      <materialref ref="ArGas"/>
+      <solidref ref="GaseousArgon"/>
+    </volume>
+    <volume name="volExternalActive">
+      <materialref ref="LAr"/>
+      <solidref ref="ExternalActive"/>
+      <auxiliary auxtype="SensDet" auxvalue="SimEnergyDeposit"/>
+      <auxiliary auxtype="StepLimit" auxunit="cm" auxvalue="0.5208*cm"/>
+      <auxiliary auxtype="Efield" auxunit="V/cm" auxvalue="0*V/cm"/>
+      <colorref ref="green"/>
+    </volume>
+    <volume name="volArapucaDouble_0-0-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-0-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-0-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-0-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-0-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-0-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-0-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-0-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-1-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-1-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-1-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-1-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-1-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-1-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-1-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-1-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-2-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-2-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-2-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-2-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-2-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-2-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-2-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-2-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-3-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-3-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-3-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-3-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-3-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-3-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-3-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-3-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-4-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-4-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-4-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-4-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-4-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-4-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-4-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-4-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-5-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-5-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-5-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-5-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-5-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-5-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-5-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-5-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-6-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-6-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-6-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-6-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-6-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-6-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-6-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-6-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-0-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-0-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-0-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-0-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-0-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-0-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-0-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-0-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-1-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-1-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-1-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-1-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-1-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-1-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-1-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-1-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-2-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-2-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-2-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-2-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-2-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-2-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-2-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-2-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-3-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-3-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-3-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-3-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-3-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-3-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-3-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-3-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-4-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-4-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-4-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-4-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-4-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-4-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-4-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-4-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-5-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-5-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-5-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-5-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-5-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-5-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-5-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-5-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-6-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-6-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-6-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-6-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-6-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-6-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-6-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-6-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-0-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-0-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-0-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-0-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-0-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-0-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-0-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-0-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-1-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-1-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-1-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-1-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-1-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-1-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-1-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-1-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-2-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-2-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-2-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-2-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-2-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-2-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-2-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-2-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-3-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-3-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-3-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-3-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-3-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-3-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-3-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-3-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-4-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-4-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-4-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-4-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-4-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-4-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-4-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-4-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-5-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-5-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-5-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-5-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-5-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-5-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-5-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-5-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-6-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-6-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-6-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-6-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-6-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-6-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-6-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-6-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-0-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-0-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-0-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-0-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-0-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-0-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-0-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-0-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-1-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-1-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-1-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-1-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-1-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-1-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-1-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-1-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-2-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-2-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-2-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-2-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-2-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-2-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-2-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-2-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-3-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-3-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-3-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-3-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-3-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-3-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-3-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-3-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-4-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-4-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-4-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-4-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-4-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-4-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-4-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-4-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-5-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-5-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-5-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-5-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-5-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-5-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-5-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-5-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-6-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-6-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-6-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-6-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-6-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-6-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-6-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-6-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_0-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_0-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_0-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_0-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_0-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_0-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_0-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_0-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_0-4">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_0-4">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_0-5">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_0-5">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_0-6">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_0-6">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_0-7">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_0-7">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_1-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_1-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_1-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_1-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_1-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_1-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_1-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_1-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_1-4">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_1-4">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_1-5">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_1-5">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_1-6">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_1-6">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_1-7">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_1-7">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_2-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_2-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_2-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_2-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_2-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_2-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_2-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_2-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_2-4">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_2-4">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_2-5">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_2-5">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_2-6">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_2-6">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_2-7">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_2-7">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_3-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_3-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_3-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_3-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_3-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_3-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_3-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_3-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_3-4">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_3-4">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_3-5">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_3-5">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_3-6">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_3-6">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_3-7">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_3-7">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_4-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_4-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_4-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_4-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_4-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_4-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_4-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_4-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_4-4">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_4-4">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_4-5">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_4-5">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_4-6">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_4-6">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_4-7">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_4-7">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_5-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_5-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_5-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_5-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_5-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_5-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_5-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_5-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_5-4">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_5-4">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_5-5">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_5-5">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_5-6">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_5-6">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_5-7">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_5-7">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_6-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_6-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_6-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_6-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_6-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_6-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_6-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_6-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_6-4">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_6-4">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_6-5">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_6-5">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_6-6">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_6-6">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_6-7">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_6-7">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+
+    <volume name="volCryostat">
+      <materialref ref="LAr" />
+      <solidref ref="Cryostat" />
+      <physvol>
+        <volumeref ref="volGaseousArgon"/>
+        <position name="posGaseousArgon" unit="cm" x="375.045" y="0" z="0"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volSteelShell"/>
+        <position name="posSteelShell" unit="cm" x="0" y="0" z="0"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volExternalActive"/>
+        <position name="posExternalActive" unit="cm" x="-100/2" y="0" z="0"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-0" unit="cm"
+           x="0" y="-588.4521" z="-970.98"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-1" unit="cm"
+           x="0" y="-420.7515" z="-970.98"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-2" unit="cm"
+           x="0" y="-252.0509" z="-970.98"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-3" unit="cm"
+           x="0" y="-84.3502999999999" z="-970.98"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-4" unit="cm"
+           x="0" y="84.3503000000001" z="-970.98"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-5" unit="cm"
+           x="0" y="252.0509" z="-970.98"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-6" unit="cm"
+           x="0" y="420.7515" z="-970.98"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-7" unit="cm"
+           x="0" y="588.4521" z="-970.98"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-8" unit="cm"
+           x="0" y="-588.4521" z="-822.06"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-9" unit="cm"
+           x="0" y="-420.7515" z="-822.06"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-10" unit="cm"
+           x="0" y="-252.0509" z="-822.06"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-11" unit="cm"
+           x="0" y="-84.3502999999999" z="-822.06"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-12" unit="cm"
+           x="0" y="84.3503000000001" z="-822.06"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-13" unit="cm"
+           x="0" y="252.0509" z="-822.06"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-14" unit="cm"
+           x="0" y="420.7515" z="-822.06"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-15" unit="cm"
+           x="0" y="588.4521" z="-822.06"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-16" unit="cm"
+           x="0" y="-588.4521" z="-672.14"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-17" unit="cm"
+           x="0" y="-420.7515" z="-672.14"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-18" unit="cm"
+           x="0" y="-252.0509" z="-672.14"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-19" unit="cm"
+           x="0" y="-84.3502999999999" z="-672.14"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-20" unit="cm"
+           x="0" y="84.3503000000001" z="-672.14"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-21" unit="cm"
+           x="0" y="252.0509" z="-672.14"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-22" unit="cm"
+           x="0" y="420.7515" z="-672.14"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-23" unit="cm"
+           x="0" y="588.4521" z="-672.14"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-24" unit="cm"
+           x="0" y="-588.4521" z="-523.22"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-25" unit="cm"
+           x="0" y="-420.7515" z="-523.22"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-26" unit="cm"
+           x="0" y="-252.0509" z="-523.22"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-27" unit="cm"
+           x="0" y="-84.3502999999999" z="-523.22"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-28" unit="cm"
+           x="0" y="84.3503000000001" z="-523.22"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-29" unit="cm"
+           x="0" y="252.0509" z="-523.22"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-30" unit="cm"
+           x="0" y="420.7515" z="-523.22"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-31" unit="cm"
+           x="0" y="588.4521" z="-523.22"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-32" unit="cm"
+           x="0" y="-588.4521" z="-373.3"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-33" unit="cm"
+           x="0" y="-420.7515" z="-373.3"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-34" unit="cm"
+           x="0" y="-252.0509" z="-373.3"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-35" unit="cm"
+           x="0" y="-84.3502999999999" z="-373.3"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-36" unit="cm"
+           x="0" y="84.3503000000001" z="-373.3"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-37" unit="cm"
+           x="0" y="252.0509" z="-373.3"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-38" unit="cm"
+           x="0" y="420.7515" z="-373.3"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-39" unit="cm"
+           x="0" y="588.4521" z="-373.3"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-40" unit="cm"
+           x="0" y="-588.4521" z="-224.38"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-41" unit="cm"
+           x="0" y="-420.7515" z="-224.38"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-42" unit="cm"
+           x="0" y="-252.0509" z="-224.38"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-43" unit="cm"
+           x="0" y="-84.3502999999999" z="-224.38"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-44" unit="cm"
+           x="0" y="84.3503000000001" z="-224.38"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-45" unit="cm"
+           x="0" y="252.0509" z="-224.38"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-46" unit="cm"
+           x="0" y="420.7515" z="-224.38"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-47" unit="cm"
+           x="0" y="588.4521" z="-224.38"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-48" unit="cm"
+           x="0" y="-588.4521" z="-74.4599999999998"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-49" unit="cm"
+           x="0" y="-420.7515" z="-74.4599999999998"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-50" unit="cm"
+           x="0" y="-252.0509" z="-74.4599999999998"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-51" unit="cm"
+           x="0" y="-84.3502999999999" z="-74.4599999999998"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-52" unit="cm"
+           x="0" y="84.3503000000001" z="-74.4599999999998"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-53" unit="cm"
+           x="0" y="252.0509" z="-74.4599999999998"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-54" unit="cm"
+           x="0" y="420.7515" z="-74.4599999999998"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-55" unit="cm"
+           x="0" y="588.4521" z="-74.4599999999998"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-56" unit="cm"
+           x="0" y="-588.4521" z="74.4600000000003"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-57" unit="cm"
+           x="0" y="-420.7515" z="74.4600000000003"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-58" unit="cm"
+           x="0" y="-252.0509" z="74.4600000000003"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-59" unit="cm"
+           x="0" y="-84.3502999999999" z="74.4600000000003"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-60" unit="cm"
+           x="0" y="84.3503000000001" z="74.4600000000003"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-61" unit="cm"
+           x="0" y="252.0509" z="74.4600000000003"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-62" unit="cm"
+           x="0" y="420.7515" z="74.4600000000003"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-63" unit="cm"
+           x="0" y="588.4521" z="74.4600000000003"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-64" unit="cm"
+           x="0" y="-588.4521" z="224.38"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-65" unit="cm"
+           x="0" y="-420.7515" z="224.38"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-66" unit="cm"
+           x="0" y="-252.0509" z="224.38"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-67" unit="cm"
+           x="0" y="-84.3502999999999" z="224.38"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-68" unit="cm"
+           x="0" y="84.3503000000001" z="224.38"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-69" unit="cm"
+           x="0" y="252.0509" z="224.38"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-70" unit="cm"
+           x="0" y="420.7515" z="224.38"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-71" unit="cm"
+           x="0" y="588.4521" z="224.38"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-72" unit="cm"
+           x="0" y="-588.4521" z="373.3"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-73" unit="cm"
+           x="0" y="-420.7515" z="373.3"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-74" unit="cm"
+           x="0" y="-252.0509" z="373.3"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-75" unit="cm"
+           x="0" y="-84.3502999999999" z="373.3"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-76" unit="cm"
+           x="0" y="84.3503000000001" z="373.3"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-77" unit="cm"
+           x="0" y="252.0509" z="373.3"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-78" unit="cm"
+           x="0" y="420.7515" z="373.3"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-79" unit="cm"
+           x="0" y="588.4521" z="373.3"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-80" unit="cm"
+           x="0" y="-588.4521" z="523.22"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-81" unit="cm"
+           x="0" y="-420.7515" z="523.22"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-82" unit="cm"
+           x="0" y="-252.0509" z="523.22"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-83" unit="cm"
+           x="0" y="-84.3502999999999" z="523.22"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-84" unit="cm"
+           x="0" y="84.3503000000001" z="523.22"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-85" unit="cm"
+           x="0" y="252.0509" z="523.22"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-86" unit="cm"
+           x="0" y="420.7515" z="523.22"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-87" unit="cm"
+           x="0" y="588.4521" z="523.22"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-88" unit="cm"
+           x="0" y="-588.4521" z="672.14"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-89" unit="cm"
+           x="0" y="-420.7515" z="672.14"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-90" unit="cm"
+           x="0" y="-252.0509" z="672.14"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-91" unit="cm"
+           x="0" y="-84.3502999999999" z="672.14"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-92" unit="cm"
+           x="0" y="84.3503000000001" z="672.14"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-93" unit="cm"
+           x="0" y="252.0509" z="672.14"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-94" unit="cm"
+           x="0" y="420.7515" z="672.14"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-95" unit="cm"
+           x="0" y="588.4521" z="672.14"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-96" unit="cm"
+           x="0" y="-588.4521" z="822.06"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-97" unit="cm"
+           x="0" y="-420.7515" z="822.06"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-98" unit="cm"
+           x="0" y="-252.0509" z="822.06"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-99" unit="cm"
+           x="0" y="-84.3502999999999" z="822.06"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-100" unit="cm"
+           x="0" y="84.3503000000001" z="822.06"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-101" unit="cm"
+           x="0" y="252.0509" z="822.06"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-102" unit="cm"
+           x="0" y="420.7515" z="822.06"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-103" unit="cm"
+           x="0" y="588.4521" z="822.06"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-104" unit="cm"
+           x="0" y="-588.4521" z="970.98"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-105" unit="cm"
+           x="0" y="-420.7515" z="970.98"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-106" unit="cm"
+           x="0" y="-252.0509" z="970.98"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-107" unit="cm"
+           x="0" y="-84.3502999999999" z="970.98"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-108" unit="cm"
+           x="0" y="84.3503000000001" z="970.98"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-109" unit="cm"
+           x="0" y="252.0509" z="970.98"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-110" unit="cm"
+           x="0" y="420.7515" z="970.98"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-111" unit="cm"
+           x="0" y="588.4521" z="970.98"/>
+      </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper0" unit="cm"  x="-322.04" y="-675.1024" z="0" />
+     <rotation name="rotFS0" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper1" unit="cm"  x="-316.04" y="-675.1024" z="0" />
+     <rotation name="rotFS1" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper2" unit="cm"  x="-310.04" y="-675.1024" z="0" />
+     <rotation name="rotFS2" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper3" unit="cm"  x="-304.04" y="-675.1024" z="0" />
+     <rotation name="rotFS3" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper4" unit="cm"  x="-298.04" y="-675.1024" z="0" />
+     <rotation name="rotFS4" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper5" unit="cm"  x="-292.04" y="-675.1024" z="0" />
+     <rotation name="rotFS5" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper6" unit="cm"  x="-286.04" y="-675.1024" z="0" />
+     <rotation name="rotFS6" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper7" unit="cm"  x="-280.04" y="-675.1024" z="0" />
+     <rotation name="rotFS7" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper8" unit="cm"  x="-274.04" y="-675.1024" z="0" />
+     <rotation name="rotFS8" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper9" unit="cm"  x="-268.04" y="-675.1024" z="0" />
+     <rotation name="rotFS9" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper10" unit="cm"  x="-262.04" y="-675.1024" z="0" />
+     <rotation name="rotFS10" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper11" unit="cm"  x="-256.04" y="-675.1024" z="0" />
+     <rotation name="rotFS11" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper12" unit="cm"  x="-250.04" y="-675.1024" z="0" />
+     <rotation name="rotFS12" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper13" unit="cm"  x="-244.04" y="-675.1024" z="0" />
+     <rotation name="rotFS13" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper14" unit="cm"  x="-238.04" y="-675.1024" z="0" />
+     <rotation name="rotFS14" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper15" unit="cm"  x="-232.04" y="-675.1024" z="0" />
+     <rotation name="rotFS15" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper16" unit="cm"  x="-226.04" y="-675.1024" z="0" />
+     <rotation name="rotFS16" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper17" unit="cm"  x="-220.04" y="-675.1024" z="0" />
+     <rotation name="rotFS17" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper18" unit="cm"  x="-214.04" y="-675.1024" z="0" />
+     <rotation name="rotFS18" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper19" unit="cm"  x="-208.04" y="-675.1024" z="0" />
+     <rotation name="rotFS19" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper20" unit="cm"  x="-202.04" y="-675.1024" z="0" />
+     <rotation name="rotFS20" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper21" unit="cm"  x="-196.04" y="-675.1024" z="0" />
+     <rotation name="rotFS21" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper22" unit="cm"  x="-190.04" y="-675.1024" z="0" />
+     <rotation name="rotFS22" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper23" unit="cm"  x="-184.04" y="-675.1024" z="0" />
+     <rotation name="rotFS23" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper24" unit="cm"  x="-178.04" y="-675.1024" z="0" />
+     <rotation name="rotFS24" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper25" unit="cm"  x="-172.04" y="-675.1024" z="0" />
+     <rotation name="rotFS25" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper26" unit="cm"  x="-166.04" y="-675.1024" z="0" />
+     <rotation name="rotFS26" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper27" unit="cm"  x="-160.04" y="-675.1024" z="0" />
+     <rotation name="rotFS27" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper28" unit="cm"  x="-154.04" y="-675.1024" z="0" />
+     <rotation name="rotFS28" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper29" unit="cm"  x="-148.04" y="-675.1024" z="0" />
+     <rotation name="rotFS29" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper30" unit="cm"  x="-142.04" y="-675.1024" z="0" />
+     <rotation name="rotFS30" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper31" unit="cm"  x="-136.04" y="-675.1024" z="0" />
+     <rotation name="rotFS31" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper32" unit="cm"  x="-130.04" y="-675.1024" z="0" />
+     <rotation name="rotFS32" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper33" unit="cm"  x="-124.04" y="-675.1024" z="0" />
+     <rotation name="rotFS33" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper34" unit="cm"  x="-118.04" y="-675.1024" z="0" />
+     <rotation name="rotFS34" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper35" unit="cm"  x="-112.04" y="-675.1024" z="0" />
+     <rotation name="rotFS35" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper36" unit="cm"  x="-106.04" y="-675.1024" z="0" />
+     <rotation name="rotFS36" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper37" unit="cm"  x="-100.04" y="-675.1024" z="0" />
+     <rotation name="rotFS37" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper38" unit="cm"  x="-94.04" y="-675.1024" z="0" />
+     <rotation name="rotFS38" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper39" unit="cm"  x="-88.04" y="-675.1024" z="0" />
+     <rotation name="rotFS39" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper40" unit="cm"  x="-82.04" y="-675.1024" z="0" />
+     <rotation name="rotFS40" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper41" unit="cm"  x="-76.04" y="-675.1024" z="0" />
+     <rotation name="rotFS41" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper42" unit="cm"  x="-70.04" y="-675.1024" z="0" />
+     <rotation name="rotFS42" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper43" unit="cm"  x="-64.04" y="-675.1024" z="0" />
+     <rotation name="rotFS43" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper44" unit="cm"  x="-58.04" y="-675.1024" z="0" />
+     <rotation name="rotFS44" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper45" unit="cm"  x="-52.04" y="-675.1024" z="0" />
+     <rotation name="rotFS45" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper46" unit="cm"  x="-46.04" y="-675.1024" z="0" />
+     <rotation name="rotFS46" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper47" unit="cm"  x="-40.04" y="-675.1024" z="0" />
+     <rotation name="rotFS47" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper48" unit="cm"  x="-34.04" y="-675.1024" z="0" />
+     <rotation name="rotFS48" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper49" unit="cm"  x="-28.04" y="-675.1024" z="0" />
+     <rotation name="rotFS49" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper50" unit="cm"  x="-22.04" y="-675.1024" z="0" />
+     <rotation name="rotFS50" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper51" unit="cm"  x="-16.04" y="-675.1024" z="0" />
+     <rotation name="rotFS51" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper52" unit="cm"  x="-10.04" y="-675.1024" z="0" />
+     <rotation name="rotFS52" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper53" unit="cm"  x="-4.04000000000001" y="-675.1024" z="0" />
+     <rotation name="rotFS53" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper54" unit="cm"  x="1.95999999999999" y="-675.1024" z="0" />
+     <rotation name="rotFS54" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper55" unit="cm"  x="7.95999999999999" y="-675.1024" z="0" />
+     <rotation name="rotFS55" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper56" unit="cm"  x="13.96" y="-675.1024" z="0" />
+     <rotation name="rotFS56" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper57" unit="cm"  x="19.96" y="-675.1024" z="0" />
+     <rotation name="rotFS57" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper58" unit="cm"  x="25.96" y="-675.1024" z="0" />
+     <rotation name="rotFS58" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper59" unit="cm"  x="31.96" y="-675.1024" z="0" />
+     <rotation name="rotFS59" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper60" unit="cm"  x="37.96" y="-675.1024" z="0" />
+     <rotation name="rotFS60" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper61" unit="cm"  x="43.96" y="-675.1024" z="0" />
+     <rotation name="rotFS61" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper62" unit="cm"  x="49.96" y="-675.1024" z="0" />
+     <rotation name="rotFS62" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper63" unit="cm"  x="55.96" y="-675.1024" z="0" />
+     <rotation name="rotFS63" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper64" unit="cm"  x="61.96" y="-675.1024" z="0" />
+     <rotation name="rotFS64" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper65" unit="cm"  x="67.96" y="-675.1024" z="0" />
+     <rotation name="rotFS65" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper66" unit="cm"  x="73.96" y="-675.1024" z="0" />
+     <rotation name="rotFS66" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper67" unit="cm"  x="79.96" y="-675.1024" z="0" />
+     <rotation name="rotFS67" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper68" unit="cm"  x="85.96" y="-675.1024" z="0" />
+     <rotation name="rotFS68" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper69" unit="cm"  x="91.96" y="-675.1024" z="0" />
+     <rotation name="rotFS69" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper70" unit="cm"  x="97.96" y="-675.1024" z="0" />
+     <rotation name="rotFS70" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper71" unit="cm"  x="103.96" y="-675.1024" z="0" />
+     <rotation name="rotFS71" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper72" unit="cm"  x="109.96" y="-675.1024" z="0" />
+     <rotation name="rotFS72" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper73" unit="cm"  x="115.96" y="-675.1024" z="0" />
+     <rotation name="rotFS73" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper74" unit="cm"  x="121.96" y="-675.1024" z="0" />
+     <rotation name="rotFS74" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper75" unit="cm"  x="127.96" y="-675.1024" z="0" />
+     <rotation name="rotFS75" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper76" unit="cm"  x="133.96" y="-675.1024" z="0" />
+     <rotation name="rotFS76" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper77" unit="cm"  x="139.96" y="-675.1024" z="0" />
+     <rotation name="rotFS77" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper78" unit="cm"  x="145.96" y="-675.1024" z="0" />
+     <rotation name="rotFS78" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper79" unit="cm"  x="151.96" y="-675.1024" z="0" />
+     <rotation name="rotFS79" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper80" unit="cm"  x="157.96" y="-675.1024" z="0" />
+     <rotation name="rotFS80" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper81" unit="cm"  x="163.96" y="-675.1024" z="0" />
+     <rotation name="rotFS81" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper82" unit="cm"  x="169.96" y="-675.1024" z="0" />
+     <rotation name="rotFS82" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper83" unit="cm"  x="175.96" y="-675.1024" z="0" />
+     <rotation name="rotFS83" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper84" unit="cm"  x="181.96" y="-675.1024" z="0" />
+     <rotation name="rotFS84" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper85" unit="cm"  x="187.96" y="-675.1024" z="0" />
+     <rotation name="rotFS85" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper86" unit="cm"  x="193.96" y="-675.1024" z="0" />
+     <rotation name="rotFS86" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper87" unit="cm"  x="199.96" y="-675.1024" z="0" />
+     <rotation name="rotFS87" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper88" unit="cm"  x="205.96" y="-675.1024" z="0" />
+     <rotation name="rotFS88" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper89" unit="cm"  x="211.96" y="-675.1024" z="0" />
+     <rotation name="rotFS89" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper90" unit="cm"  x="217.96" y="-675.1024" z="0" />
+     <rotation name="rotFS90" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper91" unit="cm"  x="223.96" y="-675.1024" z="0" />
+     <rotation name="rotFS91" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper92" unit="cm"  x="229.96" y="-675.1024" z="0" />
+     <rotation name="rotFS92" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper93" unit="cm"  x="235.96" y="-675.1024" z="0" />
+     <rotation name="rotFS93" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper94" unit="cm"  x="241.96" y="-675.1024" z="0" />
+     <rotation name="rotFS94" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper95" unit="cm"  x="247.96" y="-675.1024" z="0" />
+     <rotation name="rotFS95" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper96" unit="cm"  x="253.96" y="-675.1024" z="0" />
+     <rotation name="rotFS96" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper97" unit="cm"  x="259.96" y="-675.1024" z="0" />
+     <rotation name="rotFS97" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper98" unit="cm"  x="265.96" y="-675.1024" z="0" />
+     <rotation name="rotFS98" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper99" unit="cm"  x="271.96" y="-675.1024" z="0" />
+     <rotation name="rotFS99" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper100" unit="cm"  x="277.96" y="-675.1024" z="0" />
+     <rotation name="rotFS100" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper101" unit="cm"  x="283.96" y="-675.1024" z="0" />
+     <rotation name="rotFS101" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper102" unit="cm"  x="289.96" y="-675.1024" z="0" />
+     <rotation name="rotFS102" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper103" unit="cm"  x="295.96" y="-675.1024" z="0" />
+     <rotation name="rotFS103" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper104" unit="cm"  x="301.96" y="-675.1024" z="0" />
+     <rotation name="rotFS104" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper105" unit="cm"  x="307.96" y="-675.1024" z="0" />
+     <rotation name="rotFS105" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper106" unit="cm"  x="313.96" y="-675.1024" z="0" />
+     <rotation name="rotFS106" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper107" unit="cm"  x="319.96" y="-675.1024" z="0" />
+     <rotation name="rotFS107" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-0" unit="cm" x="-328.04" y="-505.1018" z="-897.02"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-0" unit="cm" x="325.045" y="-505.1018" z="-897.02"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-1" unit="cm" x="-328.04" y="-169.7006" z="-897.02"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-1" unit="cm" x="325.045" y="-169.7006" z="-897.02"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-2" unit="cm" x="-328.04" y="165.7006" z="-897.02"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-2" unit="cm" x="325.045" y="165.7006" z="-897.02"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-3" unit="cm" x="-328.04" y="501.1018" z="-897.02"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-3" unit="cm" x="325.045" y="501.1018" z="-897.02"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-4" unit="cm" x="-328.04" y="-505.1018" z="-599.18"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-4" unit="cm" x="325.045" y="-505.1018" z="-599.18"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-5" unit="cm" x="-328.04" y="-169.7006" z="-599.18"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-5" unit="cm" x="325.045" y="-169.7006" z="-599.18"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-6" unit="cm" x="-328.04" y="165.7006" z="-599.18"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-6" unit="cm" x="325.045" y="165.7006" z="-599.18"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-7" unit="cm" x="-328.04" y="501.1018" z="-599.18"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-7" unit="cm" x="325.045" y="501.1018" z="-599.18"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-8" unit="cm" x="-328.04" y="-505.1018" z="-301.34"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-8" unit="cm" x="325.045" y="-505.1018" z="-301.34"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-9" unit="cm" x="-328.04" y="-169.7006" z="-301.34"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-9" unit="cm" x="325.045" y="-169.7006" z="-301.34"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-10" unit="cm" x="-328.04" y="165.7006" z="-301.34"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-10" unit="cm" x="325.045" y="165.7006" z="-301.34"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-11" unit="cm" x="-328.04" y="501.1018" z="-301.34"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-11" unit="cm" x="325.045" y="501.1018" z="-301.34"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-12" unit="cm" x="-328.04" y="-505.1018" z="-3.49999999999989"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-12" unit="cm" x="325.045" y="-505.1018" z="-3.49999999999989"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-13" unit="cm" x="-328.04" y="-169.7006" z="-3.49999999999989"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-13" unit="cm" x="325.045" y="-169.7006" z="-3.49999999999989"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-14" unit="cm" x="-328.04" y="165.7006" z="-3.49999999999989"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-14" unit="cm" x="325.045" y="165.7006" z="-3.49999999999989"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-15" unit="cm" x="-328.04" y="501.1018" z="-3.49999999999989"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-15" unit="cm" x="325.045" y="501.1018" z="-3.49999999999989"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-16" unit="cm" x="-328.04" y="-505.1018" z="294.34"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-16" unit="cm" x="325.045" y="-505.1018" z="294.34"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-17" unit="cm" x="-328.04" y="-169.7006" z="294.34"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-17" unit="cm" x="325.045" y="-169.7006" z="294.34"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-18" unit="cm" x="-328.04" y="165.7006" z="294.34"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-18" unit="cm" x="325.045" y="165.7006" z="294.34"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-19" unit="cm" x="-328.04" y="501.1018" z="294.34"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-19" unit="cm" x="325.045" y="501.1018" z="294.34"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-20" unit="cm" x="-328.04" y="-505.1018" z="592.18"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-20" unit="cm" x="325.045" y="-505.1018" z="592.18"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-21" unit="cm" x="-328.04" y="-169.7006" z="592.18"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-21" unit="cm" x="325.045" y="-169.7006" z="592.18"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-22" unit="cm" x="-328.04" y="165.7006" z="592.18"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-22" unit="cm" x="325.045" y="165.7006" z="592.18"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-23" unit="cm" x="-328.04" y="501.1018" z="592.18"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-23" unit="cm" x="325.045" y="501.1018" z="592.18"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-24" unit="cm" x="-328.04" y="-505.1018" z="890.02"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-24" unit="cm" x="325.045" y="-505.1018" z="890.02"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-25" unit="cm" x="-328.04" y="-169.7006" z="890.02"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-25" unit="cm" x="325.045" y="-169.7006" z="890.02"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-26" unit="cm" x="-328.04" y="165.7006" z="890.02"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-26" unit="cm" x="325.045" y="165.7006" z="890.02"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-27" unit="cm" x="-328.04" y="501.1018" z="890.02"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-27" unit="cm" x="325.045" y="501.1018" z="890.02"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-0-0"/>
+       <position name="posArapucaDouble0-Frame-0-0" unit="cm" 
+         x="-328.04"
+	 y="-632.8018" 
+	 z="-859.52"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-0"/>
+       <position name="posOpArapucaDouble0-Frame-0-0" unit="cm" 
+         x="-327.3"
+	 y="-632.8018" 
+	 z="-859.52"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-0-1"/>
+       <position name="posArapucaDouble1-Frame-0-0" unit="cm" 
+         x="-328.04"
+	 y="-542.1018" 
+	 z="-1005.52"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-1"/>
+       <position name="posOpArapucaDouble1-Frame-0-0" unit="cm" 
+         x="-327.3"
+	 y="-542.1018" 
+	 z="-1005.52"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-0-2"/>
+       <position name="posArapucaDouble2-Frame-0-0" unit="cm" 
+         x="-328.04"
+	 y="-468.1018" 
+	 z="-788.52"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-2"/>
+       <position name="posOpArapucaDouble2-Frame-0-0" unit="cm" 
+         x="-327.3"
+	 y="-468.1018" 
+	 z="-788.52"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-0-3"/>
+       <position name="posArapucaDouble3-Frame-0-0" unit="cm" 
+         x="-328.04"
+	 y="-377.4018" 
+	 z="-934.52"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-3"/>
+       <position name="posOpArapucaDouble3-Frame-0-0" unit="cm" 
+         x="-327.3"
+	 y="-377.4018" 
+	 z="-934.52"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-1-0"/>
+       <position name="posArapucaDouble0-Frame-0-1" unit="cm" 
+         x="-328.04"
+	 y="-632.8018" 
+	 z="-561.68"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-0"/>
+       <position name="posOpArapucaDouble0-Frame-0-1" unit="cm" 
+         x="-327.3"
+	 y="-632.8018" 
+	 z="-561.68"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-1-1"/>
+       <position name="posArapucaDouble1-Frame-0-1" unit="cm" 
+         x="-328.04"
+	 y="-542.1018" 
+	 z="-707.68"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-1"/>
+       <position name="posOpArapucaDouble1-Frame-0-1" unit="cm" 
+         x="-327.3"
+	 y="-542.1018" 
+	 z="-707.68"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-1-2"/>
+       <position name="posArapucaDouble2-Frame-0-1" unit="cm" 
+         x="-328.04"
+	 y="-468.1018" 
+	 z="-490.68"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-2"/>
+       <position name="posOpArapucaDouble2-Frame-0-1" unit="cm" 
+         x="-327.3"
+	 y="-468.1018" 
+	 z="-490.68"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-1-3"/>
+       <position name="posArapucaDouble3-Frame-0-1" unit="cm" 
+         x="-328.04"
+	 y="-377.4018" 
+	 z="-636.68"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-3"/>
+       <position name="posOpArapucaDouble3-Frame-0-1" unit="cm" 
+         x="-327.3"
+	 y="-377.4018" 
+	 z="-636.68"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-2-0"/>
+       <position name="posArapucaDouble0-Frame-0-2" unit="cm" 
+         x="-328.04"
+	 y="-632.8018" 
+	 z="-263.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-0"/>
+       <position name="posOpArapucaDouble0-Frame-0-2" unit="cm" 
+         x="-327.3"
+	 y="-632.8018" 
+	 z="-263.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-2-1"/>
+       <position name="posArapucaDouble1-Frame-0-2" unit="cm" 
+         x="-328.04"
+	 y="-542.1018" 
+	 z="-409.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-1"/>
+       <position name="posOpArapucaDouble1-Frame-0-2" unit="cm" 
+         x="-327.3"
+	 y="-542.1018" 
+	 z="-409.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-2-2"/>
+       <position name="posArapucaDouble2-Frame-0-2" unit="cm" 
+         x="-328.04"
+	 y="-468.1018" 
+	 z="-192.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-2"/>
+       <position name="posOpArapucaDouble2-Frame-0-2" unit="cm" 
+         x="-327.3"
+	 y="-468.1018" 
+	 z="-192.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-2-3"/>
+       <position name="posArapucaDouble3-Frame-0-2" unit="cm" 
+         x="-328.04"
+	 y="-377.4018" 
+	 z="-338.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-3"/>
+       <position name="posOpArapucaDouble3-Frame-0-2" unit="cm" 
+         x="-327.3"
+	 y="-377.4018" 
+	 z="-338.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-3-0"/>
+       <position name="posArapucaDouble0-Frame-0-3" unit="cm" 
+         x="-328.04"
+	 y="-632.8018" 
+	 z="34.0000000000001"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-3-0"/>
+       <position name="posOpArapucaDouble0-Frame-0-3" unit="cm" 
+         x="-327.3"
+	 y="-632.8018" 
+	 z="34.0000000000001"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-3-1"/>
+       <position name="posArapucaDouble1-Frame-0-3" unit="cm" 
+         x="-328.04"
+	 y="-542.1018" 
+	 z="-112"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-3-1"/>
+       <position name="posOpArapucaDouble1-Frame-0-3" unit="cm" 
+         x="-327.3"
+	 y="-542.1018" 
+	 z="-112"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-3-2"/>
+       <position name="posArapucaDouble2-Frame-0-3" unit="cm" 
+         x="-328.04"
+	 y="-468.1018" 
+	 z="105"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-3-2"/>
+       <position name="posOpArapucaDouble2-Frame-0-3" unit="cm" 
+         x="-327.3"
+	 y="-468.1018" 
+	 z="105"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-3-3"/>
+       <position name="posArapucaDouble3-Frame-0-3" unit="cm" 
+         x="-328.04"
+	 y="-377.4018" 
+	 z="-40.9999999999999"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-3-3"/>
+       <position name="posOpArapucaDouble3-Frame-0-3" unit="cm" 
+         x="-327.3"
+	 y="-377.4018" 
+	 z="-40.9999999999999"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-4-0"/>
+       <position name="posArapucaDouble0-Frame-0-4" unit="cm" 
+         x="-328.04"
+	 y="-632.8018" 
+	 z="331.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-4-0"/>
+       <position name="posOpArapucaDouble0-Frame-0-4" unit="cm" 
+         x="-327.3"
+	 y="-632.8018" 
+	 z="331.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-4-1"/>
+       <position name="posArapucaDouble1-Frame-0-4" unit="cm" 
+         x="-328.04"
+	 y="-542.1018" 
+	 z="185.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-4-1"/>
+       <position name="posOpArapucaDouble1-Frame-0-4" unit="cm" 
+         x="-327.3"
+	 y="-542.1018" 
+	 z="185.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-4-2"/>
+       <position name="posArapucaDouble2-Frame-0-4" unit="cm" 
+         x="-328.04"
+	 y="-468.1018" 
+	 z="402.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-4-2"/>
+       <position name="posOpArapucaDouble2-Frame-0-4" unit="cm" 
+         x="-327.3"
+	 y="-468.1018" 
+	 z="402.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-4-3"/>
+       <position name="posArapucaDouble3-Frame-0-4" unit="cm" 
+         x="-328.04"
+	 y="-377.4018" 
+	 z="256.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-4-3"/>
+       <position name="posOpArapucaDouble3-Frame-0-4" unit="cm" 
+         x="-327.3"
+	 y="-377.4018" 
+	 z="256.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-5-0"/>
+       <position name="posArapucaDouble0-Frame-0-5" unit="cm" 
+         x="-328.04"
+	 y="-632.8018" 
+	 z="629.68"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-5-0"/>
+       <position name="posOpArapucaDouble0-Frame-0-5" unit="cm" 
+         x="-327.3"
+	 y="-632.8018" 
+	 z="629.68"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-5-1"/>
+       <position name="posArapucaDouble1-Frame-0-5" unit="cm" 
+         x="-328.04"
+	 y="-542.1018" 
+	 z="483.68"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-5-1"/>
+       <position name="posOpArapucaDouble1-Frame-0-5" unit="cm" 
+         x="-327.3"
+	 y="-542.1018" 
+	 z="483.68"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-5-2"/>
+       <position name="posArapucaDouble2-Frame-0-5" unit="cm" 
+         x="-328.04"
+	 y="-468.1018" 
+	 z="700.68"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-5-2"/>
+       <position name="posOpArapucaDouble2-Frame-0-5" unit="cm" 
+         x="-327.3"
+	 y="-468.1018" 
+	 z="700.68"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-5-3"/>
+       <position name="posArapucaDouble3-Frame-0-5" unit="cm" 
+         x="-328.04"
+	 y="-377.4018" 
+	 z="554.68"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-5-3"/>
+       <position name="posOpArapucaDouble3-Frame-0-5" unit="cm" 
+         x="-327.3"
+	 y="-377.4018" 
+	 z="554.68"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-6-0"/>
+       <position name="posArapucaDouble0-Frame-0-6" unit="cm" 
+         x="-328.04"
+	 y="-632.8018" 
+	 z="927.52"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-6-0"/>
+       <position name="posOpArapucaDouble0-Frame-0-6" unit="cm" 
+         x="-327.3"
+	 y="-632.8018" 
+	 z="927.52"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-6-1"/>
+       <position name="posArapucaDouble1-Frame-0-6" unit="cm" 
+         x="-328.04"
+	 y="-542.1018" 
+	 z="781.52"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-6-1"/>
+       <position name="posOpArapucaDouble1-Frame-0-6" unit="cm" 
+         x="-327.3"
+	 y="-542.1018" 
+	 z="781.52"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-6-2"/>
+       <position name="posArapucaDouble2-Frame-0-6" unit="cm" 
+         x="-328.04"
+	 y="-468.1018" 
+	 z="998.52"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-6-2"/>
+       <position name="posOpArapucaDouble2-Frame-0-6" unit="cm" 
+         x="-327.3"
+	 y="-468.1018" 
+	 z="998.52"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-6-3"/>
+       <position name="posArapucaDouble3-Frame-0-6" unit="cm" 
+         x="-328.04"
+	 y="-377.4018" 
+	 z="852.52"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-6-3"/>
+       <position name="posOpArapucaDouble3-Frame-0-6" unit="cm" 
+         x="-327.3"
+	 y="-377.4018" 
+	 z="852.52"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-0-0"/>
+       <position name="posArapucaDouble0-Frame-1-0" unit="cm" 
+         x="-328.04"
+	 y="-297.4006" 
+	 z="-859.52"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-0"/>
+       <position name="posOpArapucaDouble0-Frame-1-0" unit="cm" 
+         x="-327.3"
+	 y="-297.4006" 
+	 z="-859.52"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-0-1"/>
+       <position name="posArapucaDouble1-Frame-1-0" unit="cm" 
+         x="-328.04"
+	 y="-206.7006" 
+	 z="-1005.52"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-1"/>
+       <position name="posOpArapucaDouble1-Frame-1-0" unit="cm" 
+         x="-327.3"
+	 y="-206.7006" 
+	 z="-1005.52"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-0-2"/>
+       <position name="posArapucaDouble2-Frame-1-0" unit="cm" 
+         x="-328.04"
+	 y="-132.7006" 
+	 z="-788.52"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-2"/>
+       <position name="posOpArapucaDouble2-Frame-1-0" unit="cm" 
+         x="-327.3"
+	 y="-132.7006" 
+	 z="-788.52"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-0-3"/>
+       <position name="posArapucaDouble3-Frame-1-0" unit="cm" 
+         x="-328.04"
+	 y="-42.0006" 
+	 z="-934.52"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-3"/>
+       <position name="posOpArapucaDouble3-Frame-1-0" unit="cm" 
+         x="-327.3"
+	 y="-42.0006" 
+	 z="-934.52"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-1-0"/>
+       <position name="posArapucaDouble0-Frame-1-1" unit="cm" 
+         x="-328.04"
+	 y="-297.4006" 
+	 z="-561.68"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-0"/>
+       <position name="posOpArapucaDouble0-Frame-1-1" unit="cm" 
+         x="-327.3"
+	 y="-297.4006" 
+	 z="-561.68"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-1-1"/>
+       <position name="posArapucaDouble1-Frame-1-1" unit="cm" 
+         x="-328.04"
+	 y="-206.7006" 
+	 z="-707.68"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-1"/>
+       <position name="posOpArapucaDouble1-Frame-1-1" unit="cm" 
+         x="-327.3"
+	 y="-206.7006" 
+	 z="-707.68"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-1-2"/>
+       <position name="posArapucaDouble2-Frame-1-1" unit="cm" 
+         x="-328.04"
+	 y="-132.7006" 
+	 z="-490.68"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-2"/>
+       <position name="posOpArapucaDouble2-Frame-1-1" unit="cm" 
+         x="-327.3"
+	 y="-132.7006" 
+	 z="-490.68"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-1-3"/>
+       <position name="posArapucaDouble3-Frame-1-1" unit="cm" 
+         x="-328.04"
+	 y="-42.0006" 
+	 z="-636.68"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-3"/>
+       <position name="posOpArapucaDouble3-Frame-1-1" unit="cm" 
+         x="-327.3"
+	 y="-42.0006" 
+	 z="-636.68"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-2-0"/>
+       <position name="posArapucaDouble0-Frame-1-2" unit="cm" 
+         x="-328.04"
+	 y="-297.4006" 
+	 z="-263.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-0"/>
+       <position name="posOpArapucaDouble0-Frame-1-2" unit="cm" 
+         x="-327.3"
+	 y="-297.4006" 
+	 z="-263.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-2-1"/>
+       <position name="posArapucaDouble1-Frame-1-2" unit="cm" 
+         x="-328.04"
+	 y="-206.7006" 
+	 z="-409.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-1"/>
+       <position name="posOpArapucaDouble1-Frame-1-2" unit="cm" 
+         x="-327.3"
+	 y="-206.7006" 
+	 z="-409.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-2-2"/>
+       <position name="posArapucaDouble2-Frame-1-2" unit="cm" 
+         x="-328.04"
+	 y="-132.7006" 
+	 z="-192.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-2"/>
+       <position name="posOpArapucaDouble2-Frame-1-2" unit="cm" 
+         x="-327.3"
+	 y="-132.7006" 
+	 z="-192.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-2-3"/>
+       <position name="posArapucaDouble3-Frame-1-2" unit="cm" 
+         x="-328.04"
+	 y="-42.0006" 
+	 z="-338.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-3"/>
+       <position name="posOpArapucaDouble3-Frame-1-2" unit="cm" 
+         x="-327.3"
+	 y="-42.0006" 
+	 z="-338.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-3-0"/>
+       <position name="posArapucaDouble0-Frame-1-3" unit="cm" 
+         x="-328.04"
+	 y="-297.4006" 
+	 z="34.0000000000001"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-3-0"/>
+       <position name="posOpArapucaDouble0-Frame-1-3" unit="cm" 
+         x="-327.3"
+	 y="-297.4006" 
+	 z="34.0000000000001"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-3-1"/>
+       <position name="posArapucaDouble1-Frame-1-3" unit="cm" 
+         x="-328.04"
+	 y="-206.7006" 
+	 z="-112"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-3-1"/>
+       <position name="posOpArapucaDouble1-Frame-1-3" unit="cm" 
+         x="-327.3"
+	 y="-206.7006" 
+	 z="-112"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-3-2"/>
+       <position name="posArapucaDouble2-Frame-1-3" unit="cm" 
+         x="-328.04"
+	 y="-132.7006" 
+	 z="105"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-3-2"/>
+       <position name="posOpArapucaDouble2-Frame-1-3" unit="cm" 
+         x="-327.3"
+	 y="-132.7006" 
+	 z="105"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-3-3"/>
+       <position name="posArapucaDouble3-Frame-1-3" unit="cm" 
+         x="-328.04"
+	 y="-42.0006" 
+	 z="-40.9999999999999"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-3-3"/>
+       <position name="posOpArapucaDouble3-Frame-1-3" unit="cm" 
+         x="-327.3"
+	 y="-42.0006" 
+	 z="-40.9999999999999"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-4-0"/>
+       <position name="posArapucaDouble0-Frame-1-4" unit="cm" 
+         x="-328.04"
+	 y="-297.4006" 
+	 z="331.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-4-0"/>
+       <position name="posOpArapucaDouble0-Frame-1-4" unit="cm" 
+         x="-327.3"
+	 y="-297.4006" 
+	 z="331.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-4-1"/>
+       <position name="posArapucaDouble1-Frame-1-4" unit="cm" 
+         x="-328.04"
+	 y="-206.7006" 
+	 z="185.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-4-1"/>
+       <position name="posOpArapucaDouble1-Frame-1-4" unit="cm" 
+         x="-327.3"
+	 y="-206.7006" 
+	 z="185.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-4-2"/>
+       <position name="posArapucaDouble2-Frame-1-4" unit="cm" 
+         x="-328.04"
+	 y="-132.7006" 
+	 z="402.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-4-2"/>
+       <position name="posOpArapucaDouble2-Frame-1-4" unit="cm" 
+         x="-327.3"
+	 y="-132.7006" 
+	 z="402.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-4-3"/>
+       <position name="posArapucaDouble3-Frame-1-4" unit="cm" 
+         x="-328.04"
+	 y="-42.0006" 
+	 z="256.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-4-3"/>
+       <position name="posOpArapucaDouble3-Frame-1-4" unit="cm" 
+         x="-327.3"
+	 y="-42.0006" 
+	 z="256.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-5-0"/>
+       <position name="posArapucaDouble0-Frame-1-5" unit="cm" 
+         x="-328.04"
+	 y="-297.4006" 
+	 z="629.68"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-5-0"/>
+       <position name="posOpArapucaDouble0-Frame-1-5" unit="cm" 
+         x="-327.3"
+	 y="-297.4006" 
+	 z="629.68"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-5-1"/>
+       <position name="posArapucaDouble1-Frame-1-5" unit="cm" 
+         x="-328.04"
+	 y="-206.7006" 
+	 z="483.68"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-5-1"/>
+       <position name="posOpArapucaDouble1-Frame-1-5" unit="cm" 
+         x="-327.3"
+	 y="-206.7006" 
+	 z="483.68"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-5-2"/>
+       <position name="posArapucaDouble2-Frame-1-5" unit="cm" 
+         x="-328.04"
+	 y="-132.7006" 
+	 z="700.68"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-5-2"/>
+       <position name="posOpArapucaDouble2-Frame-1-5" unit="cm" 
+         x="-327.3"
+	 y="-132.7006" 
+	 z="700.68"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-5-3"/>
+       <position name="posArapucaDouble3-Frame-1-5" unit="cm" 
+         x="-328.04"
+	 y="-42.0006" 
+	 z="554.68"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-5-3"/>
+       <position name="posOpArapucaDouble3-Frame-1-5" unit="cm" 
+         x="-327.3"
+	 y="-42.0006" 
+	 z="554.68"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-6-0"/>
+       <position name="posArapucaDouble0-Frame-1-6" unit="cm" 
+         x="-328.04"
+	 y="-297.4006" 
+	 z="927.52"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-6-0"/>
+       <position name="posOpArapucaDouble0-Frame-1-6" unit="cm" 
+         x="-327.3"
+	 y="-297.4006" 
+	 z="927.52"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-6-1"/>
+       <position name="posArapucaDouble1-Frame-1-6" unit="cm" 
+         x="-328.04"
+	 y="-206.7006" 
+	 z="781.52"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-6-1"/>
+       <position name="posOpArapucaDouble1-Frame-1-6" unit="cm" 
+         x="-327.3"
+	 y="-206.7006" 
+	 z="781.52"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-6-2"/>
+       <position name="posArapucaDouble2-Frame-1-6" unit="cm" 
+         x="-328.04"
+	 y="-132.7006" 
+	 z="998.52"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-6-2"/>
+       <position name="posOpArapucaDouble2-Frame-1-6" unit="cm" 
+         x="-327.3"
+	 y="-132.7006" 
+	 z="998.52"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-6-3"/>
+       <position name="posArapucaDouble3-Frame-1-6" unit="cm" 
+         x="-328.04"
+	 y="-42.0006" 
+	 z="852.52"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-6-3"/>
+       <position name="posOpArapucaDouble3-Frame-1-6" unit="cm" 
+         x="-327.3"
+	 y="-42.0006" 
+	 z="852.52"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-0-0"/>
+       <position name="posArapucaDouble0-Frame-2-0" unit="cm" 
+         x="-328.04"
+	 y="38.0006" 
+	 z="-859.52"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-0"/>
+       <position name="posOpArapucaDouble0-Frame-2-0" unit="cm" 
+         x="-327.3"
+	 y="38.0006" 
+	 z="-859.52"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-0-1"/>
+       <position name="posArapucaDouble1-Frame-2-0" unit="cm" 
+         x="-328.04"
+	 y="128.7006" 
+	 z="-1005.52"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-1"/>
+       <position name="posOpArapucaDouble1-Frame-2-0" unit="cm" 
+         x="-327.3"
+	 y="128.7006" 
+	 z="-1005.52"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-0-2"/>
+       <position name="posArapucaDouble2-Frame-2-0" unit="cm" 
+         x="-328.04"
+	 y="202.7006" 
+	 z="-788.52"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-2"/>
+       <position name="posOpArapucaDouble2-Frame-2-0" unit="cm" 
+         x="-327.3"
+	 y="202.7006" 
+	 z="-788.52"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-0-3"/>
+       <position name="posArapucaDouble3-Frame-2-0" unit="cm" 
+         x="-328.04"
+	 y="293.4006" 
+	 z="-934.52"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-3"/>
+       <position name="posOpArapucaDouble3-Frame-2-0" unit="cm" 
+         x="-327.3"
+	 y="293.4006" 
+	 z="-934.52"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-1-0"/>
+       <position name="posArapucaDouble0-Frame-2-1" unit="cm" 
+         x="-328.04"
+	 y="38.0006" 
+	 z="-561.68"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-0"/>
+       <position name="posOpArapucaDouble0-Frame-2-1" unit="cm" 
+         x="-327.3"
+	 y="38.0006" 
+	 z="-561.68"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-1-1"/>
+       <position name="posArapucaDouble1-Frame-2-1" unit="cm" 
+         x="-328.04"
+	 y="128.7006" 
+	 z="-707.68"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-1"/>
+       <position name="posOpArapucaDouble1-Frame-2-1" unit="cm" 
+         x="-327.3"
+	 y="128.7006" 
+	 z="-707.68"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-1-2"/>
+       <position name="posArapucaDouble2-Frame-2-1" unit="cm" 
+         x="-328.04"
+	 y="202.7006" 
+	 z="-490.68"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-2"/>
+       <position name="posOpArapucaDouble2-Frame-2-1" unit="cm" 
+         x="-327.3"
+	 y="202.7006" 
+	 z="-490.68"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-1-3"/>
+       <position name="posArapucaDouble3-Frame-2-1" unit="cm" 
+         x="-328.04"
+	 y="293.4006" 
+	 z="-636.68"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-3"/>
+       <position name="posOpArapucaDouble3-Frame-2-1" unit="cm" 
+         x="-327.3"
+	 y="293.4006" 
+	 z="-636.68"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-2-0"/>
+       <position name="posArapucaDouble0-Frame-2-2" unit="cm" 
+         x="-328.04"
+	 y="38.0006" 
+	 z="-263.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-0"/>
+       <position name="posOpArapucaDouble0-Frame-2-2" unit="cm" 
+         x="-327.3"
+	 y="38.0006" 
+	 z="-263.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-2-1"/>
+       <position name="posArapucaDouble1-Frame-2-2" unit="cm" 
+         x="-328.04"
+	 y="128.7006" 
+	 z="-409.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-1"/>
+       <position name="posOpArapucaDouble1-Frame-2-2" unit="cm" 
+         x="-327.3"
+	 y="128.7006" 
+	 z="-409.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-2-2"/>
+       <position name="posArapucaDouble2-Frame-2-2" unit="cm" 
+         x="-328.04"
+	 y="202.7006" 
+	 z="-192.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-2"/>
+       <position name="posOpArapucaDouble2-Frame-2-2" unit="cm" 
+         x="-327.3"
+	 y="202.7006" 
+	 z="-192.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-2-3"/>
+       <position name="posArapucaDouble3-Frame-2-2" unit="cm" 
+         x="-328.04"
+	 y="293.4006" 
+	 z="-338.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-3"/>
+       <position name="posOpArapucaDouble3-Frame-2-2" unit="cm" 
+         x="-327.3"
+	 y="293.4006" 
+	 z="-338.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-3-0"/>
+       <position name="posArapucaDouble0-Frame-2-3" unit="cm" 
+         x="-328.04"
+	 y="38.0006" 
+	 z="34.0000000000001"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-3-0"/>
+       <position name="posOpArapucaDouble0-Frame-2-3" unit="cm" 
+         x="-327.3"
+	 y="38.0006" 
+	 z="34.0000000000001"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-3-1"/>
+       <position name="posArapucaDouble1-Frame-2-3" unit="cm" 
+         x="-328.04"
+	 y="128.7006" 
+	 z="-112"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-3-1"/>
+       <position name="posOpArapucaDouble1-Frame-2-3" unit="cm" 
+         x="-327.3"
+	 y="128.7006" 
+	 z="-112"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-3-2"/>
+       <position name="posArapucaDouble2-Frame-2-3" unit="cm" 
+         x="-328.04"
+	 y="202.7006" 
+	 z="105"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-3-2"/>
+       <position name="posOpArapucaDouble2-Frame-2-3" unit="cm" 
+         x="-327.3"
+	 y="202.7006" 
+	 z="105"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-3-3"/>
+       <position name="posArapucaDouble3-Frame-2-3" unit="cm" 
+         x="-328.04"
+	 y="293.4006" 
+	 z="-40.9999999999999"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-3-3"/>
+       <position name="posOpArapucaDouble3-Frame-2-3" unit="cm" 
+         x="-327.3"
+	 y="293.4006" 
+	 z="-40.9999999999999"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-4-0"/>
+       <position name="posArapucaDouble0-Frame-2-4" unit="cm" 
+         x="-328.04"
+	 y="38.0006" 
+	 z="331.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-4-0"/>
+       <position name="posOpArapucaDouble0-Frame-2-4" unit="cm" 
+         x="-327.3"
+	 y="38.0006" 
+	 z="331.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-4-1"/>
+       <position name="posArapucaDouble1-Frame-2-4" unit="cm" 
+         x="-328.04"
+	 y="128.7006" 
+	 z="185.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-4-1"/>
+       <position name="posOpArapucaDouble1-Frame-2-4" unit="cm" 
+         x="-327.3"
+	 y="128.7006" 
+	 z="185.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-4-2"/>
+       <position name="posArapucaDouble2-Frame-2-4" unit="cm" 
+         x="-328.04"
+	 y="202.7006" 
+	 z="402.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-4-2"/>
+       <position name="posOpArapucaDouble2-Frame-2-4" unit="cm" 
+         x="-327.3"
+	 y="202.7006" 
+	 z="402.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-4-3"/>
+       <position name="posArapucaDouble3-Frame-2-4" unit="cm" 
+         x="-328.04"
+	 y="293.4006" 
+	 z="256.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-4-3"/>
+       <position name="posOpArapucaDouble3-Frame-2-4" unit="cm" 
+         x="-327.3"
+	 y="293.4006" 
+	 z="256.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-5-0"/>
+       <position name="posArapucaDouble0-Frame-2-5" unit="cm" 
+         x="-328.04"
+	 y="38.0006" 
+	 z="629.68"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-5-0"/>
+       <position name="posOpArapucaDouble0-Frame-2-5" unit="cm" 
+         x="-327.3"
+	 y="38.0006" 
+	 z="629.68"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-5-1"/>
+       <position name="posArapucaDouble1-Frame-2-5" unit="cm" 
+         x="-328.04"
+	 y="128.7006" 
+	 z="483.68"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-5-1"/>
+       <position name="posOpArapucaDouble1-Frame-2-5" unit="cm" 
+         x="-327.3"
+	 y="128.7006" 
+	 z="483.68"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-5-2"/>
+       <position name="posArapucaDouble2-Frame-2-5" unit="cm" 
+         x="-328.04"
+	 y="202.7006" 
+	 z="700.68"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-5-2"/>
+       <position name="posOpArapucaDouble2-Frame-2-5" unit="cm" 
+         x="-327.3"
+	 y="202.7006" 
+	 z="700.68"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-5-3"/>
+       <position name="posArapucaDouble3-Frame-2-5" unit="cm" 
+         x="-328.04"
+	 y="293.4006" 
+	 z="554.68"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-5-3"/>
+       <position name="posOpArapucaDouble3-Frame-2-5" unit="cm" 
+         x="-327.3"
+	 y="293.4006" 
+	 z="554.68"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-6-0"/>
+       <position name="posArapucaDouble0-Frame-2-6" unit="cm" 
+         x="-328.04"
+	 y="38.0006" 
+	 z="927.52"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-6-0"/>
+       <position name="posOpArapucaDouble0-Frame-2-6" unit="cm" 
+         x="-327.3"
+	 y="38.0006" 
+	 z="927.52"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-6-1"/>
+       <position name="posArapucaDouble1-Frame-2-6" unit="cm" 
+         x="-328.04"
+	 y="128.7006" 
+	 z="781.52"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-6-1"/>
+       <position name="posOpArapucaDouble1-Frame-2-6" unit="cm" 
+         x="-327.3"
+	 y="128.7006" 
+	 z="781.52"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-6-2"/>
+       <position name="posArapucaDouble2-Frame-2-6" unit="cm" 
+         x="-328.04"
+	 y="202.7006" 
+	 z="998.52"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-6-2"/>
+       <position name="posOpArapucaDouble2-Frame-2-6" unit="cm" 
+         x="-327.3"
+	 y="202.7006" 
+	 z="998.52"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-6-3"/>
+       <position name="posArapucaDouble3-Frame-2-6" unit="cm" 
+         x="-328.04"
+	 y="293.4006" 
+	 z="852.52"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-6-3"/>
+       <position name="posOpArapucaDouble3-Frame-2-6" unit="cm" 
+         x="-327.3"
+	 y="293.4006" 
+	 z="852.52"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-0-0"/>
+       <position name="posArapucaDouble0-Frame-3-0" unit="cm" 
+         x="-328.04"
+	 y="373.4018" 
+	 z="-859.52"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-0"/>
+       <position name="posOpArapucaDouble0-Frame-3-0" unit="cm" 
+         x="-327.3"
+	 y="373.4018" 
+	 z="-859.52"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-0-1"/>
+       <position name="posArapucaDouble1-Frame-3-0" unit="cm" 
+         x="-328.04"
+	 y="464.1018" 
+	 z="-1005.52"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-1"/>
+       <position name="posOpArapucaDouble1-Frame-3-0" unit="cm" 
+         x="-327.3"
+	 y="464.1018" 
+	 z="-1005.52"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-0-2"/>
+       <position name="posArapucaDouble2-Frame-3-0" unit="cm" 
+         x="-328.04"
+	 y="538.1018" 
+	 z="-788.52"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-2"/>
+       <position name="posOpArapucaDouble2-Frame-3-0" unit="cm" 
+         x="-327.3"
+	 y="538.1018" 
+	 z="-788.52"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-0-3"/>
+       <position name="posArapucaDouble3-Frame-3-0" unit="cm" 
+         x="-328.04"
+	 y="628.8018" 
+	 z="-934.52"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-3"/>
+       <position name="posOpArapucaDouble3-Frame-3-0" unit="cm" 
+         x="-327.3"
+	 y="628.8018" 
+	 z="-934.52"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-1-0"/>
+       <position name="posArapucaDouble0-Frame-3-1" unit="cm" 
+         x="-328.04"
+	 y="373.4018" 
+	 z="-561.68"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-0"/>
+       <position name="posOpArapucaDouble0-Frame-3-1" unit="cm" 
+         x="-327.3"
+	 y="373.4018" 
+	 z="-561.68"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-1-1"/>
+       <position name="posArapucaDouble1-Frame-3-1" unit="cm" 
+         x="-328.04"
+	 y="464.1018" 
+	 z="-707.68"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-1"/>
+       <position name="posOpArapucaDouble1-Frame-3-1" unit="cm" 
+         x="-327.3"
+	 y="464.1018" 
+	 z="-707.68"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-1-2"/>
+       <position name="posArapucaDouble2-Frame-3-1" unit="cm" 
+         x="-328.04"
+	 y="538.1018" 
+	 z="-490.68"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-2"/>
+       <position name="posOpArapucaDouble2-Frame-3-1" unit="cm" 
+         x="-327.3"
+	 y="538.1018" 
+	 z="-490.68"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-1-3"/>
+       <position name="posArapucaDouble3-Frame-3-1" unit="cm" 
+         x="-328.04"
+	 y="628.8018" 
+	 z="-636.68"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-3"/>
+       <position name="posOpArapucaDouble3-Frame-3-1" unit="cm" 
+         x="-327.3"
+	 y="628.8018" 
+	 z="-636.68"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-2-0"/>
+       <position name="posArapucaDouble0-Frame-3-2" unit="cm" 
+         x="-328.04"
+	 y="373.4018" 
+	 z="-263.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-0"/>
+       <position name="posOpArapucaDouble0-Frame-3-2" unit="cm" 
+         x="-327.3"
+	 y="373.4018" 
+	 z="-263.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-2-1"/>
+       <position name="posArapucaDouble1-Frame-3-2" unit="cm" 
+         x="-328.04"
+	 y="464.1018" 
+	 z="-409.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-1"/>
+       <position name="posOpArapucaDouble1-Frame-3-2" unit="cm" 
+         x="-327.3"
+	 y="464.1018" 
+	 z="-409.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-2-2"/>
+       <position name="posArapucaDouble2-Frame-3-2" unit="cm" 
+         x="-328.04"
+	 y="538.1018" 
+	 z="-192.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-2"/>
+       <position name="posOpArapucaDouble2-Frame-3-2" unit="cm" 
+         x="-327.3"
+	 y="538.1018" 
+	 z="-192.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-2-3"/>
+       <position name="posArapucaDouble3-Frame-3-2" unit="cm" 
+         x="-328.04"
+	 y="628.8018" 
+	 z="-338.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-3"/>
+       <position name="posOpArapucaDouble3-Frame-3-2" unit="cm" 
+         x="-327.3"
+	 y="628.8018" 
+	 z="-338.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-3-0"/>
+       <position name="posArapucaDouble0-Frame-3-3" unit="cm" 
+         x="-328.04"
+	 y="373.4018" 
+	 z="34.0000000000001"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-3-0"/>
+       <position name="posOpArapucaDouble0-Frame-3-3" unit="cm" 
+         x="-327.3"
+	 y="373.4018" 
+	 z="34.0000000000001"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-3-1"/>
+       <position name="posArapucaDouble1-Frame-3-3" unit="cm" 
+         x="-328.04"
+	 y="464.1018" 
+	 z="-112"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-3-1"/>
+       <position name="posOpArapucaDouble1-Frame-3-3" unit="cm" 
+         x="-327.3"
+	 y="464.1018" 
+	 z="-112"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-3-2"/>
+       <position name="posArapucaDouble2-Frame-3-3" unit="cm" 
+         x="-328.04"
+	 y="538.1018" 
+	 z="105"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-3-2"/>
+       <position name="posOpArapucaDouble2-Frame-3-3" unit="cm" 
+         x="-327.3"
+	 y="538.1018" 
+	 z="105"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-3-3"/>
+       <position name="posArapucaDouble3-Frame-3-3" unit="cm" 
+         x="-328.04"
+	 y="628.8018" 
+	 z="-40.9999999999999"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-3-3"/>
+       <position name="posOpArapucaDouble3-Frame-3-3" unit="cm" 
+         x="-327.3"
+	 y="628.8018" 
+	 z="-40.9999999999999"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-4-0"/>
+       <position name="posArapucaDouble0-Frame-3-4" unit="cm" 
+         x="-328.04"
+	 y="373.4018" 
+	 z="331.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-4-0"/>
+       <position name="posOpArapucaDouble0-Frame-3-4" unit="cm" 
+         x="-327.3"
+	 y="373.4018" 
+	 z="331.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-4-1"/>
+       <position name="posArapucaDouble1-Frame-3-4" unit="cm" 
+         x="-328.04"
+	 y="464.1018" 
+	 z="185.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-4-1"/>
+       <position name="posOpArapucaDouble1-Frame-3-4" unit="cm" 
+         x="-327.3"
+	 y="464.1018" 
+	 z="185.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-4-2"/>
+       <position name="posArapucaDouble2-Frame-3-4" unit="cm" 
+         x="-328.04"
+	 y="538.1018" 
+	 z="402.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-4-2"/>
+       <position name="posOpArapucaDouble2-Frame-3-4" unit="cm" 
+         x="-327.3"
+	 y="538.1018" 
+	 z="402.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-4-3"/>
+       <position name="posArapucaDouble3-Frame-3-4" unit="cm" 
+         x="-328.04"
+	 y="628.8018" 
+	 z="256.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-4-3"/>
+       <position name="posOpArapucaDouble3-Frame-3-4" unit="cm" 
+         x="-327.3"
+	 y="628.8018" 
+	 z="256.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-5-0"/>
+       <position name="posArapucaDouble0-Frame-3-5" unit="cm" 
+         x="-328.04"
+	 y="373.4018" 
+	 z="629.68"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-5-0"/>
+       <position name="posOpArapucaDouble0-Frame-3-5" unit="cm" 
+         x="-327.3"
+	 y="373.4018" 
+	 z="629.68"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-5-1"/>
+       <position name="posArapucaDouble1-Frame-3-5" unit="cm" 
+         x="-328.04"
+	 y="464.1018" 
+	 z="483.68"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-5-1"/>
+       <position name="posOpArapucaDouble1-Frame-3-5" unit="cm" 
+         x="-327.3"
+	 y="464.1018" 
+	 z="483.68"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-5-2"/>
+       <position name="posArapucaDouble2-Frame-3-5" unit="cm" 
+         x="-328.04"
+	 y="538.1018" 
+	 z="700.68"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-5-2"/>
+       <position name="posOpArapucaDouble2-Frame-3-5" unit="cm" 
+         x="-327.3"
+	 y="538.1018" 
+	 z="700.68"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-5-3"/>
+       <position name="posArapucaDouble3-Frame-3-5" unit="cm" 
+         x="-328.04"
+	 y="628.8018" 
+	 z="554.68"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-5-3"/>
+       <position name="posOpArapucaDouble3-Frame-3-5" unit="cm" 
+         x="-327.3"
+	 y="628.8018" 
+	 z="554.68"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-6-0"/>
+       <position name="posArapucaDouble0-Frame-3-6" unit="cm" 
+         x="-328.04"
+	 y="373.4018" 
+	 z="927.52"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-6-0"/>
+       <position name="posOpArapucaDouble0-Frame-3-6" unit="cm" 
+         x="-327.3"
+	 y="373.4018" 
+	 z="927.52"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-6-1"/>
+       <position name="posArapucaDouble1-Frame-3-6" unit="cm" 
+         x="-328.04"
+	 y="464.1018" 
+	 z="781.52"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-6-1"/>
+       <position name="posOpArapucaDouble1-Frame-3-6" unit="cm" 
+         x="-327.3"
+	 y="464.1018" 
+	 z="781.52"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-6-2"/>
+       <position name="posArapucaDouble2-Frame-3-6" unit="cm" 
+         x="-328.04"
+	 y="538.1018" 
+	 z="998.52"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-6-2"/>
+       <position name="posOpArapucaDouble2-Frame-3-6" unit="cm" 
+         x="-327.3"
+	 y="538.1018" 
+	 z="998.52"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-6-3"/>
+       <position name="posArapucaDouble3-Frame-3-6" unit="cm" 
+         x="-328.04"
+	 y="628.8018" 
+	 z="852.52"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-6-3"/>
+       <position name="posOpArapucaDouble3-Frame-3-6" unit="cm" 
+         x="-327.3"
+	 y="628.8018" 
+	 z="852.52"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_0-0"/>
+       <position name="posArapuca0-Lat-0" unit="cm" 
+         x="285.03"
+	 y="-732.8024" 
+	 z="-893.52"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_0-0"/>
+       <position name="posOpArapuca0-Lat-0" unit="cm" 
+         x="285.03"
+	 y="-732.0624" 
+	 z="-893.52"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_0-1"/>
+       <position name="posArapuca1-Lat-0" unit="cm" 
+         x="210.03"
+	 y="-732.8024" 
+	 z="-893.52"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_0-1"/>
+       <position name="posOpArapuca1-Lat-0" unit="cm" 
+         x="210.03"
+	 y="-732.0624" 
+	 z="-893.52"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_0-2"/>
+       <position name="posArapuca2-Lat-0" unit="cm" 
+         x="135.03"
+	 y="-732.8024" 
+	 z="-893.52"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_0-2"/>
+       <position name="posOpArapuca2-Lat-0" unit="cm" 
+         x="135.03"
+	 y="-732.0624" 
+	 z="-893.52"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_0-3"/>
+       <position name="posArapuca3-Lat-0" unit="cm" 
+         x="60.03"
+	 y="-732.8024" 
+	 z="-893.52"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_0-3"/>
+       <position name="posOpArapuca3-Lat-0" unit="cm" 
+         x="60.03"
+	 y="-732.0624" 
+	 z="-893.52"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_0-4"/>
+       <position name="posArapuca4-Lat-0" unit="cm" 
+         x="285.03"
+	 y="732.8024" 
+	 z="-893.52"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_0-4"/>
+       <position name="posOpArapuca4-Lat-0" unit="cm" 
+         x="285.03"
+	 y="732.0624" 
+	 z="-893.52"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_0-5"/>
+       <position name="posArapuca5-Lat-0" unit="cm" 
+         x="210.03"
+	 y="732.8024" 
+	 z="-893.52"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_0-5"/>
+       <position name="posOpArapuca5-Lat-0" unit="cm" 
+         x="210.03"
+	 y="732.0624" 
+	 z="-893.52"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_0-6"/>
+       <position name="posArapuca6-Lat-0" unit="cm" 
+         x="135.03"
+	 y="732.8024" 
+	 z="-893.52"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_0-6"/>
+       <position name="posOpArapuca6-Lat-0" unit="cm" 
+         x="135.03"
+	 y="732.0624" 
+	 z="-893.52"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_0-7"/>
+       <position name="posArapuca7-Lat-0" unit="cm" 
+         x="60.03"
+	 y="732.8024" 
+	 z="-893.52"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_0-7"/>
+       <position name="posOpArapuca7-Lat-0" unit="cm" 
+         x="60.03"
+	 y="732.0624" 
+	 z="-893.52"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_1-0"/>
+       <position name="posArapuca0-Lat-1" unit="cm" 
+         x="285.03"
+	 y="-732.8024" 
+	 z="-595.68"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_1-0"/>
+       <position name="posOpArapuca0-Lat-1" unit="cm" 
+         x="285.03"
+	 y="-732.0624" 
+	 z="-595.68"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_1-1"/>
+       <position name="posArapuca1-Lat-1" unit="cm" 
+         x="210.03"
+	 y="-732.8024" 
+	 z="-595.68"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_1-1"/>
+       <position name="posOpArapuca1-Lat-1" unit="cm" 
+         x="210.03"
+	 y="-732.0624" 
+	 z="-595.68"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_1-2"/>
+       <position name="posArapuca2-Lat-1" unit="cm" 
+         x="135.03"
+	 y="-732.8024" 
+	 z="-595.68"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_1-2"/>
+       <position name="posOpArapuca2-Lat-1" unit="cm" 
+         x="135.03"
+	 y="-732.0624" 
+	 z="-595.68"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_1-3"/>
+       <position name="posArapuca3-Lat-1" unit="cm" 
+         x="60.03"
+	 y="-732.8024" 
+	 z="-595.68"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_1-3"/>
+       <position name="posOpArapuca3-Lat-1" unit="cm" 
+         x="60.03"
+	 y="-732.0624" 
+	 z="-595.68"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_1-4"/>
+       <position name="posArapuca4-Lat-1" unit="cm" 
+         x="285.03"
+	 y="732.8024" 
+	 z="-595.68"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_1-4"/>
+       <position name="posOpArapuca4-Lat-1" unit="cm" 
+         x="285.03"
+	 y="732.0624" 
+	 z="-595.68"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_1-5"/>
+       <position name="posArapuca5-Lat-1" unit="cm" 
+         x="210.03"
+	 y="732.8024" 
+	 z="-595.68"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_1-5"/>
+       <position name="posOpArapuca5-Lat-1" unit="cm" 
+         x="210.03"
+	 y="732.0624" 
+	 z="-595.68"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_1-6"/>
+       <position name="posArapuca6-Lat-1" unit="cm" 
+         x="135.03"
+	 y="732.8024" 
+	 z="-595.68"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_1-6"/>
+       <position name="posOpArapuca6-Lat-1" unit="cm" 
+         x="135.03"
+	 y="732.0624" 
+	 z="-595.68"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_1-7"/>
+       <position name="posArapuca7-Lat-1" unit="cm" 
+         x="60.03"
+	 y="732.8024" 
+	 z="-595.68"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_1-7"/>
+       <position name="posOpArapuca7-Lat-1" unit="cm" 
+         x="60.03"
+	 y="732.0624" 
+	 z="-595.68"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_2-0"/>
+       <position name="posArapuca0-Lat-2" unit="cm" 
+         x="285.03"
+	 y="-732.8024" 
+	 z="-297.84"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_2-0"/>
+       <position name="posOpArapuca0-Lat-2" unit="cm" 
+         x="285.03"
+	 y="-732.0624" 
+	 z="-297.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_2-1"/>
+       <position name="posArapuca1-Lat-2" unit="cm" 
+         x="210.03"
+	 y="-732.8024" 
+	 z="-297.84"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_2-1"/>
+       <position name="posOpArapuca1-Lat-2" unit="cm" 
+         x="210.03"
+	 y="-732.0624" 
+	 z="-297.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_2-2"/>
+       <position name="posArapuca2-Lat-2" unit="cm" 
+         x="135.03"
+	 y="-732.8024" 
+	 z="-297.84"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_2-2"/>
+       <position name="posOpArapuca2-Lat-2" unit="cm" 
+         x="135.03"
+	 y="-732.0624" 
+	 z="-297.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_2-3"/>
+       <position name="posArapuca3-Lat-2" unit="cm" 
+         x="60.03"
+	 y="-732.8024" 
+	 z="-297.84"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_2-3"/>
+       <position name="posOpArapuca3-Lat-2" unit="cm" 
+         x="60.03"
+	 y="-732.0624" 
+	 z="-297.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_2-4"/>
+       <position name="posArapuca4-Lat-2" unit="cm" 
+         x="285.03"
+	 y="732.8024" 
+	 z="-297.84"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_2-4"/>
+       <position name="posOpArapuca4-Lat-2" unit="cm" 
+         x="285.03"
+	 y="732.0624" 
+	 z="-297.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_2-5"/>
+       <position name="posArapuca5-Lat-2" unit="cm" 
+         x="210.03"
+	 y="732.8024" 
+	 z="-297.84"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_2-5"/>
+       <position name="posOpArapuca5-Lat-2" unit="cm" 
+         x="210.03"
+	 y="732.0624" 
+	 z="-297.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_2-6"/>
+       <position name="posArapuca6-Lat-2" unit="cm" 
+         x="135.03"
+	 y="732.8024" 
+	 z="-297.84"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_2-6"/>
+       <position name="posOpArapuca6-Lat-2" unit="cm" 
+         x="135.03"
+	 y="732.0624" 
+	 z="-297.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_2-7"/>
+       <position name="posArapuca7-Lat-2" unit="cm" 
+         x="60.03"
+	 y="732.8024" 
+	 z="-297.84"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_2-7"/>
+       <position name="posOpArapuca7-Lat-2" unit="cm" 
+         x="60.03"
+	 y="732.0624" 
+	 z="-297.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_3-0"/>
+       <position name="posArapuca0-Lat-3" unit="cm" 
+         x="285.03"
+	 y="-732.8024" 
+	 z="-1.13686837721616e-13"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_3-0"/>
+       <position name="posOpArapuca0-Lat-3" unit="cm" 
+         x="285.03"
+	 y="-732.0624" 
+	 z="-1.13686837721616e-13"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_3-1"/>
+       <position name="posArapuca1-Lat-3" unit="cm" 
+         x="210.03"
+	 y="-732.8024" 
+	 z="-1.13686837721616e-13"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_3-1"/>
+       <position name="posOpArapuca1-Lat-3" unit="cm" 
+         x="210.03"
+	 y="-732.0624" 
+	 z="-1.13686837721616e-13"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_3-2"/>
+       <position name="posArapuca2-Lat-3" unit="cm" 
+         x="135.03"
+	 y="-732.8024" 
+	 z="-1.13686837721616e-13"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_3-2"/>
+       <position name="posOpArapuca2-Lat-3" unit="cm" 
+         x="135.03"
+	 y="-732.0624" 
+	 z="-1.13686837721616e-13"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_3-3"/>
+       <position name="posArapuca3-Lat-3" unit="cm" 
+         x="60.03"
+	 y="-732.8024" 
+	 z="-1.13686837721616e-13"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_3-3"/>
+       <position name="posOpArapuca3-Lat-3" unit="cm" 
+         x="60.03"
+	 y="-732.0624" 
+	 z="-1.13686837721616e-13"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_3-4"/>
+       <position name="posArapuca4-Lat-3" unit="cm" 
+         x="285.03"
+	 y="732.8024" 
+	 z="-1.13686837721616e-13"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_3-4"/>
+       <position name="posOpArapuca4-Lat-3" unit="cm" 
+         x="285.03"
+	 y="732.0624" 
+	 z="-1.13686837721616e-13"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_3-5"/>
+       <position name="posArapuca5-Lat-3" unit="cm" 
+         x="210.03"
+	 y="732.8024" 
+	 z="-1.13686837721616e-13"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_3-5"/>
+       <position name="posOpArapuca5-Lat-3" unit="cm" 
+         x="210.03"
+	 y="732.0624" 
+	 z="-1.13686837721616e-13"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_3-6"/>
+       <position name="posArapuca6-Lat-3" unit="cm" 
+         x="135.03"
+	 y="732.8024" 
+	 z="-1.13686837721616e-13"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_3-6"/>
+       <position name="posOpArapuca6-Lat-3" unit="cm" 
+         x="135.03"
+	 y="732.0624" 
+	 z="-1.13686837721616e-13"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_3-7"/>
+       <position name="posArapuca7-Lat-3" unit="cm" 
+         x="60.03"
+	 y="732.8024" 
+	 z="-1.13686837721616e-13"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_3-7"/>
+       <position name="posOpArapuca7-Lat-3" unit="cm" 
+         x="60.03"
+	 y="732.0624" 
+	 z="-1.13686837721616e-13"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_4-0"/>
+       <position name="posArapuca0-Lat-4" unit="cm" 
+         x="285.03"
+	 y="-732.8024" 
+	 z="297.84"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_4-0"/>
+       <position name="posOpArapuca0-Lat-4" unit="cm" 
+         x="285.03"
+	 y="-732.0624" 
+	 z="297.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_4-1"/>
+       <position name="posArapuca1-Lat-4" unit="cm" 
+         x="210.03"
+	 y="-732.8024" 
+	 z="297.84"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_4-1"/>
+       <position name="posOpArapuca1-Lat-4" unit="cm" 
+         x="210.03"
+	 y="-732.0624" 
+	 z="297.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_4-2"/>
+       <position name="posArapuca2-Lat-4" unit="cm" 
+         x="135.03"
+	 y="-732.8024" 
+	 z="297.84"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_4-2"/>
+       <position name="posOpArapuca2-Lat-4" unit="cm" 
+         x="135.03"
+	 y="-732.0624" 
+	 z="297.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_4-3"/>
+       <position name="posArapuca3-Lat-4" unit="cm" 
+         x="60.03"
+	 y="-732.8024" 
+	 z="297.84"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_4-3"/>
+       <position name="posOpArapuca3-Lat-4" unit="cm" 
+         x="60.03"
+	 y="-732.0624" 
+	 z="297.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_4-4"/>
+       <position name="posArapuca4-Lat-4" unit="cm" 
+         x="285.03"
+	 y="732.8024" 
+	 z="297.84"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_4-4"/>
+       <position name="posOpArapuca4-Lat-4" unit="cm" 
+         x="285.03"
+	 y="732.0624" 
+	 z="297.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_4-5"/>
+       <position name="posArapuca5-Lat-4" unit="cm" 
+         x="210.03"
+	 y="732.8024" 
+	 z="297.84"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_4-5"/>
+       <position name="posOpArapuca5-Lat-4" unit="cm" 
+         x="210.03"
+	 y="732.0624" 
+	 z="297.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_4-6"/>
+       <position name="posArapuca6-Lat-4" unit="cm" 
+         x="135.03"
+	 y="732.8024" 
+	 z="297.84"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_4-6"/>
+       <position name="posOpArapuca6-Lat-4" unit="cm" 
+         x="135.03"
+	 y="732.0624" 
+	 z="297.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_4-7"/>
+       <position name="posArapuca7-Lat-4" unit="cm" 
+         x="60.03"
+	 y="732.8024" 
+	 z="297.84"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_4-7"/>
+       <position name="posOpArapuca7-Lat-4" unit="cm" 
+         x="60.03"
+	 y="732.0624" 
+	 z="297.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_5-0"/>
+       <position name="posArapuca0-Lat-5" unit="cm" 
+         x="285.03"
+	 y="-732.8024" 
+	 z="595.68"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_5-0"/>
+       <position name="posOpArapuca0-Lat-5" unit="cm" 
+         x="285.03"
+	 y="-732.0624" 
+	 z="595.68"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_5-1"/>
+       <position name="posArapuca1-Lat-5" unit="cm" 
+         x="210.03"
+	 y="-732.8024" 
+	 z="595.68"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_5-1"/>
+       <position name="posOpArapuca1-Lat-5" unit="cm" 
+         x="210.03"
+	 y="-732.0624" 
+	 z="595.68"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_5-2"/>
+       <position name="posArapuca2-Lat-5" unit="cm" 
+         x="135.03"
+	 y="-732.8024" 
+	 z="595.68"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_5-2"/>
+       <position name="posOpArapuca2-Lat-5" unit="cm" 
+         x="135.03"
+	 y="-732.0624" 
+	 z="595.68"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_5-3"/>
+       <position name="posArapuca3-Lat-5" unit="cm" 
+         x="60.03"
+	 y="-732.8024" 
+	 z="595.68"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_5-3"/>
+       <position name="posOpArapuca3-Lat-5" unit="cm" 
+         x="60.03"
+	 y="-732.0624" 
+	 z="595.68"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_5-4"/>
+       <position name="posArapuca4-Lat-5" unit="cm" 
+         x="285.03"
+	 y="732.8024" 
+	 z="595.68"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_5-4"/>
+       <position name="posOpArapuca4-Lat-5" unit="cm" 
+         x="285.03"
+	 y="732.0624" 
+	 z="595.68"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_5-5"/>
+       <position name="posArapuca5-Lat-5" unit="cm" 
+         x="210.03"
+	 y="732.8024" 
+	 z="595.68"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_5-5"/>
+       <position name="posOpArapuca5-Lat-5" unit="cm" 
+         x="210.03"
+	 y="732.0624" 
+	 z="595.68"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_5-6"/>
+       <position name="posArapuca6-Lat-5" unit="cm" 
+         x="135.03"
+	 y="732.8024" 
+	 z="595.68"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_5-6"/>
+       <position name="posOpArapuca6-Lat-5" unit="cm" 
+         x="135.03"
+	 y="732.0624" 
+	 z="595.68"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_5-7"/>
+       <position name="posArapuca7-Lat-5" unit="cm" 
+         x="60.03"
+	 y="732.8024" 
+	 z="595.68"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_5-7"/>
+       <position name="posOpArapuca7-Lat-5" unit="cm" 
+         x="60.03"
+	 y="732.0624" 
+	 z="595.68"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_6-0"/>
+       <position name="posArapuca0-Lat-6" unit="cm" 
+         x="285.03"
+	 y="-732.8024" 
+	 z="893.52"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_6-0"/>
+       <position name="posOpArapuca0-Lat-6" unit="cm" 
+         x="285.03"
+	 y="-732.0624" 
+	 z="893.52"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_6-1"/>
+       <position name="posArapuca1-Lat-6" unit="cm" 
+         x="210.03"
+	 y="-732.8024" 
+	 z="893.52"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_6-1"/>
+       <position name="posOpArapuca1-Lat-6" unit="cm" 
+         x="210.03"
+	 y="-732.0624" 
+	 z="893.52"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_6-2"/>
+       <position name="posArapuca2-Lat-6" unit="cm" 
+         x="135.03"
+	 y="-732.8024" 
+	 z="893.52"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_6-2"/>
+       <position name="posOpArapuca2-Lat-6" unit="cm" 
+         x="135.03"
+	 y="-732.0624" 
+	 z="893.52"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_6-3"/>
+       <position name="posArapuca3-Lat-6" unit="cm" 
+         x="60.03"
+	 y="-732.8024" 
+	 z="893.52"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_6-3"/>
+       <position name="posOpArapuca3-Lat-6" unit="cm" 
+         x="60.03"
+	 y="-732.0624" 
+	 z="893.52"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_6-4"/>
+       <position name="posArapuca4-Lat-6" unit="cm" 
+         x="285.03"
+	 y="732.8024" 
+	 z="893.52"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_6-4"/>
+       <position name="posOpArapuca4-Lat-6" unit="cm" 
+         x="285.03"
+	 y="732.0624" 
+	 z="893.52"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_6-5"/>
+       <position name="posArapuca5-Lat-6" unit="cm" 
+         x="210.03"
+	 y="732.8024" 
+	 z="893.52"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_6-5"/>
+       <position name="posOpArapuca5-Lat-6" unit="cm" 
+         x="210.03"
+	 y="732.0624" 
+	 z="893.52"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_6-6"/>
+       <position name="posArapuca6-Lat-6" unit="cm" 
+         x="135.03"
+	 y="732.8024" 
+	 z="893.52"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_6-6"/>
+       <position name="posOpArapuca6-Lat-6" unit="cm" 
+         x="135.03"
+	 y="732.0624" 
+	 z="893.52"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_6-7"/>
+       <position name="posArapuca7-Lat-6" unit="cm" 
+         x="60.03"
+	 y="732.8024" 
+	 z="893.52"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_6-7"/>
+       <position name="posOpArapuca7-Lat-6" unit="cm" 
+         x="60.03"
+	 y="732.0624" 
+	 z="893.52"/>
+     </physvol>
+    </volume>
+
+    <volume name="volFoamPadding">
+      <materialref ref="fibrous_glass"/>
+      <solidref ref="FoamPadding"/>
+    </volume>
+
+    <volume name="volSteelSupport">
+      <materialref ref="AirSteelMixture"/>
+      <solidref ref="SteelSupport"/>
+    </volume>
+
+    <volume name="volDetEnclosure">
+      <materialref ref="Air"/>
+      <solidref ref="DetEnclosure"/>
+
+       <physvol>
+           <volumeref ref="volFoamPadding"/>
+           <positionref ref="posCryoInDetEnc"/>
+       </physvol>
+       <physvol>
+           <volumeref ref="volSteelSupport"/>
+           <positionref ref="posCryoInDetEnc"/>
+       </physvol>
+       <physvol>
+           <volumeref ref="volCryostat"/>
+           <positionref ref="posCryoInDetEnc"/>
+       </physvol>
+    </volume>
+
+    <volume name="volWorld" >
+      <materialref ref="DUSEL_Rock"/>
+      <solidref ref="World"/>
+
+      <physvol>
+        <volumeref ref="volDetEnclosure"/>
+	<position name="posDetEnclosure" unit="cm" x="50.04" y="-1.13686837721616e-13" z="1045.94"/>
+      </physvol>
+
+    </volume>
+</structure>
+  <setup name="Default" version="1.0">
+    <world ref="volWorld"/>
+  </setup>
+</gdml_simple_extension>

--- a/dunecore/Geometry/gdml/dunevd10kt_3view_30deg_v4_refactored_1x8x6ref.gdml
+++ b/dunecore/Geometry/gdml/dunevd10kt_3view_30deg_v4_refactored_1x8x6ref.gdml
@@ -1,0 +1,12893 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<gdml_simple_extension xmlns:gdml_simple_extension="http://www.example.org"
+                       xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"          
+                       xs:noNamespaceSchemaLocation="RefactoredGDMLSchema/SimpleExtension.xsd"> 
+<extension>
+   <color name="magenta"     R="0.0"  G="1.0"  B="0.0"  A="1.0" />
+   <color name="green"       R="0.0"  G="1.0"  B="0.0"  A="1.0" />
+   <color name="red"         R="1.0"  G="0.0"  B="0.0"  A="1.0" />
+   <color name="blue"        R="0.0"  G="0.0"  B="1.0"  A="1.0" />
+   <color name="yellow"      R="1.0"  G="1.0"  B="0.0"  A="1.0" />    
+</extension>
+<define>
+
+<!--
+
+
+
+-->
+
+   <position name="posCryoInDetEnc"     unit="cm" x="-50.0000000000001" y="0" z="0"/>
+   <position name="posCenter"           unit="cm" x="0" y="0" z="0"/>
+   <rotation name="rUWireAboutX"        unit="deg" x="150" y="0" z="0"/>
+   <rotation name="rVWireAboutX"        unit="deg" x="30" y="0" z="0"/>
+   <rotation name="rPlus90AboutX"       unit="deg" x="90" y="0" z="0"/>
+   <rotation name="rPlus90AboutY"       unit="deg" x="0" y="90" z="0"/>
+   <rotation name="rPlus90AboutXPlus90AboutY" unit="deg" x="90" y="90" z="0"/>
+   <rotation name="rMinus90AboutX"      unit="deg" x="270" y="0" z="0"/>
+   <rotation name="rMinus90AboutY"      unit="deg" x="0" y="270" z="0"/>
+   <rotation name="rMinus90AboutYMinus90AboutX"       unit="deg" x="270" y="270" z="0"/>
+   <rotation name="rPlus180AboutX"	unit="deg" x="180" y="0"   z="0"/>
+   <rotation name="rPlus180AboutY"	unit="deg" x="0" y="180"   z="0"/>
+   <rotation name="rPlus180AboutXPlus180AboutY"	unit="deg" x="180" y="180"   z="0"/>
+   <rotation name="rIdentity"		unit="deg" x="0" y="0"   z="0"/>
+</define>
+<materials>
+  <element name="videRef" formula="VACUUM" Z="1">  <atom value="1"/> </element>
+  <element name="copper" formula="Cu" Z="29">  <atom value="63.546"/>  </element>
+  <element name="beryllium" formula="Be" Z="4">  <atom value="9.0121831"/>  </element>
+  <element name="bromine" formula="Br" Z="35"> <atom value="79.904"/> </element>
+  <element name="hydrogen" formula="H" Z="1">  <atom value="1.0079"/> </element>
+  <element name="nitrogen" formula="N" Z="7">  <atom value="14.0067"/> </element>
+  <element name="oxygen" formula="O" Z="8">  <atom value="15.999"/> </element>
+  <element name="aluminum" formula="Al" Z="13"> <atom value="26.9815"/>  </element>
+  <element name="silicon" formula="Si" Z="14"> <atom value="28.0855"/>  </element>
+  <element name="carbon" formula="C" Z="6">  <atom value="12.0107"/>  </element>
+  <element name="potassium" formula="K" Z="19"> <atom value="39.0983"/>  </element>
+  <element name="chromium" formula="Cr" Z="24"> <atom value="51.9961"/>  </element>
+  <element name="iron" formula="Fe" Z="26"> <atom value="55.8450"/>  </element>
+  <element name="nickel" formula="Ni" Z="28"> <atom value="58.6934"/>  </element>
+  <element name="calcium" formula="Ca" Z="20"> <atom value="40.078"/>   </element>
+  <element name="magnesium" formula="Mg" Z="12"> <atom value="24.305"/>   </element>
+  <element name="sodium" formula="Na" Z="11"> <atom value="22.99"/>    </element>
+  <element name="titanium" formula="Ti" Z="22"> <atom value="47.867"/>   </element>
+  <element name="argon" formula="Ar" Z="18"> <atom value="39.9480"/>  </element>
+  <element name="sulphur" formula="S" Z="16"> <atom value="32.065"/>  </element>
+  <element name="phosphorus" formula="P" Z="15"> <atom value="30.973"/>  </element>
+
+  <material name="Vacuum" formula="Vacuum">
+   <D value="1.e-25" unit="g/cm3"/>
+   <fraction n="1.0" ref="videRef"/>
+  </material>
+
+  <material name="ALUMINUM_Al" formula="ALUMINUM_Al">
+   <D value="2.6990" unit="g/cm3"/>
+   <fraction n="1.0000" ref="aluminum"/>
+  </material>
+
+  <material name="SILICON_Si" formula="SILICON_Si">
+   <D value="2.3300" unit="g/cm3"/>
+   <fraction n="1.0000" ref="silicon"/>
+  </material>
+
+  <material name="epoxy_resin" formula="C38H40O6Br4">
+   <D value="1.1250" unit="g/cm3"/>
+   <composite n="38" ref="carbon"/>
+   <composite n="40" ref="hydrogen"/>
+   <composite n="6" ref="oxygen"/>
+   <composite n="4" ref="bromine"/>
+  </material>
+
+  <material name="SiO2" formula="SiO2">
+   <D value="2.2" unit="g/cm3"/>
+   <composite n="1" ref="silicon"/>
+   <composite n="2" ref="oxygen"/>
+  </material>
+
+  <material name="Al2O3" formula="Al2O3">
+   <D value="3.97" unit="g/cm3"/>
+   <composite n="2" ref="aluminum"/>
+   <composite n="3" ref="oxygen"/>
+  </material>
+
+  <material name="Fe2O3" formula="Fe2O3">
+   <D value="5.24" unit="g/cm3"/>
+   <composite n="2" ref="iron"/>
+   <composite n="3" ref="oxygen"/>
+  </material>
+
+  <material name="CaO" formula="CaO">
+   <D value="3.35" unit="g/cm3"/>
+   <composite n="1" ref="calcium"/>
+   <composite n="1" ref="oxygen"/>
+  </material>
+
+  <material name="Delrin" formula="CH2O">
+    <D value="1.41" unit="g/cm3"/>
+    <composite n="1" ref="carbon"/>
+    <composite n="2" ref="hydrogen"/>
+    <composite n="1" ref="oxygen"/>
+  </material>
+
+  <material name="MgO" formula="MgO">
+   <D value="3.58" unit="g/cm3"/>
+   <composite n="1" ref="magnesium"/>
+   <composite n="1" ref="oxygen"/>
+  </material>
+
+  <material name="Na2O" formula="Na2O">
+   <D value="2.27" unit="g/cm3"/>
+   <composite n="2" ref="sodium"/>
+   <composite n="1" ref="oxygen"/>
+  </material>
+
+  <material name="TiO2" formula="TiO2">
+   <D value="4.23" unit="g/cm3"/>
+   <composite n="1" ref="titanium"/>
+   <composite n="2" ref="oxygen"/>
+  </material>
+
+  <material name="FeO" formula="FeO">
+   <D value="5.745" unit="g/cm3"/>
+   <composite n="1" ref="iron"/>
+   <composite n="1" ref="oxygen"/>
+  </material>
+
+  <material name="CO2" formula="CO2">
+   <D value="1.562" unit="g/cm3"/>
+   <composite n="1" ref="iron"/>
+   <composite n="2" ref="oxygen"/>
+  </material>
+
+  <material name="P2O5" formula="P2O5">
+   <D value="1.562" unit="g/cm3"/>
+   <composite n="2" ref="phosphorus"/>
+   <composite n="5" ref="oxygen"/>
+  </material>
+
+  <material formula=" " name="DUSEL_Rock">
+    <D value="2.82" unit="g/cm3"/>
+    <fraction n="0.5267" ref="SiO2"/>
+    <fraction n="0.1174" ref="FeO"/>
+    <fraction n="0.1025" ref="Al2O3"/>
+    <fraction n="0.0473" ref="MgO"/>
+    <fraction n="0.0422" ref="CO2"/>
+    <fraction n="0.0382" ref="CaO"/>
+    <fraction n="0.0240" ref="carbon"/>
+    <fraction n="0.0186" ref="sulphur"/>
+    <fraction n="0.0053" ref="Na2O"/>
+    <fraction n="0.00070" ref="P2O5"/>
+    <fraction n="0.0771" ref="oxygen"/>
+  </material> 
+
+  <material formula="Air" name="Air">
+   <D value="0.001205" unit="g/cm3"/>
+   <fraction n="0.781154" ref="nitrogen"/>
+   <fraction n="0.209476" ref="oxygen"/>
+   <fraction n="0.00934" ref="argon"/>
+  </material>
+
+  <material name="fibrous_glass">
+   <D value="2.74351" unit="g/cm3"/>
+   <fraction n="0.600" ref="SiO2"/>
+   <fraction n="0.118" ref="Al2O3"/>
+   <fraction n="0.001" ref="Fe2O3"/>
+   <fraction n="0.224" ref="CaO"/>
+   <fraction n="0.034" ref="MgO"/>
+   <fraction n="0.010" ref="Na2O"/>
+   <fraction n="0.013" ref="TiO2"/>
+  </material>
+
+  <!-- density referenced from EHN1-Cold Cryostats Technical Requirements:
+       https://edms.cern.ch/document/1543254 -->
+  <material name="FD_foam">
+   <D value="0.09" unit="g/cm3"/>
+   <fraction n="0.95" ref="Air"/>
+   <fraction n="0.05" ref="fibrous_glass"/>
+  </material>
+
+  <!-- Foam density is 70 kg / m^3 for the 3x1x1 -->
+  <material name="foam_3x1x1dp">
+   <D value="0.07" unit="g/cm3"/>
+   <fraction n="0.95" ref="Air"/>
+   <fraction n="0.05" ref="fibrous_glass"/>
+  </material>
+
+  <!-- Copied from protodune_v4.gdml -->
+  <material name="foam_protoDUNEdp">
+   <D value="0.135" unit="g/cm3"/>
+   <composite n="17" ref="carbon"/>
+   <composite n="16" ref="hydrogen"/>
+   <composite n="2" ref="nitrogen"/>
+   <composite n="4" ref="oxygen"/>
+  </material>
+
+  <material name="FR4">
+   <D value="1.98281" unit="g/cm3"/>
+   <fraction n="0.47" ref="epoxy_resin"/>
+   <fraction n="0.53" ref="fibrous_glass"/>
+  </material>
+
+  <material name="STEEL_STAINLESS_Fe7Cr2Ni" formula="STEEL_STAINLESS_Fe7Cr2Ni">
+   <D value="7.9300" unit="g/cm3"/>
+   <fraction n="0.0010" ref="carbon"/>
+   <fraction n="0.1792" ref="chromium"/>
+   <fraction n="0.7298" ref="iron"/>
+   <fraction n="0.0900" ref="nickel"/>
+  </material>
+
+  <material name="Copper_Beryllium_alloy25" formula="Copper_Beryllium_alloy25">
+   <D value="8.26" unit="g/cm3"/>
+   <fraction n="0.981" ref="copper"/>
+   <fraction n="0.019" ref="beryllium"/>
+  </material>
+
+  <material name="LAr" formula="LAr">
+   <D value="1.40" unit="g/cm3"/>
+   <fraction n="1.0000" ref="argon"/>
+  </material>
+
+  <material name="ArGas" formula="ArGas">
+   <D value="0.00166" unit="g/cm3"/>
+   <fraction n="1.0" ref="argon"/>
+  </material>
+
+  <material formula=" " name="G10">
+   <D value="1.7" unit="g/cm3"/>
+   <fraction n="0.2805" ref="silicon"/>
+   <fraction n="0.3954" ref="oxygen"/>
+   <fraction n="0.2990" ref="carbon"/>
+   <fraction n="0.0251" ref="hydrogen"/>
+  </material>
+
+  <material formula=" " name="Granite">
+   <D value="2.7" unit="g/cm3"/>
+   <fraction n="0.438" ref="oxygen"/>
+   <fraction n="0.257" ref="silicon"/>
+   <fraction n="0.222" ref="sodium"/>
+   <fraction n="0.049" ref="aluminum"/>
+   <fraction n="0.019" ref="iron"/>
+   <fraction n="0.015" ref="potassium"/>
+  </material>
+
+  <material formula=" " name="ShotRock">
+   <D value="1.62" unit="g/cm3"/>
+   <fraction n="0.438" ref="oxygen"/>
+   <fraction n="0.257" ref="silicon"/>
+   <fraction n="0.222" ref="sodium"/>
+   <fraction n="0.049" ref="aluminum"/>
+   <fraction n="0.019" ref="iron"/>
+   <fraction n="0.015" ref="potassium"/>
+  </material>
+
+  <material formula=" " name="Dirt">
+   <D value="1.7" unit="g/cm3"/>
+   <fraction n="0.438" ref="oxygen"/>
+   <fraction n="0.257" ref="silicon"/>
+   <fraction n="0.222" ref="sodium"/>
+   <fraction n="0.049" ref="aluminum"/>
+   <fraction n="0.019" ref="iron"/>
+   <fraction n="0.015" ref="potassium"/>
+  </material>
+
+  <material formula=" " name="Concrete">
+   <D value="2.3" unit="g/cm3"/>
+   <fraction n="0.530" ref="oxygen"/>
+   <fraction n="0.335" ref="silicon"/>
+   <fraction n="0.060" ref="calcium"/>
+   <fraction n="0.015" ref="sodium"/>
+   <fraction n="0.020" ref="iron"/>
+   <fraction n="0.040" ref="aluminum"/>
+  </material>
+
+  <material formula="H2O" name="Water">
+   <D value="1.0" unit="g/cm3"/>
+   <fraction n="0.1119" ref="hydrogen"/>
+   <fraction n="0.8881" ref="oxygen"/>
+  </material>
+
+  <material formula="Ti" name="Titanium">
+   <D value="4.506" unit="g/cm3"/>
+   <fraction n="1." ref="titanium"/>
+  </material>
+
+  <material name="TPB" formula="TPB">
+   <D value="1.40" unit="g/cm3"/>
+   <fraction n="1.0000" ref="argon"/>
+  </material>
+
+  <material name="Glass">
+   <D value="2.74351" unit="g/cm3"/>
+   <fraction n="0.600" ref="SiO2"/>
+   <fraction n="0.118" ref="Al2O3"/>
+   <fraction n="0.001" ref="Fe2O3"/>
+   <fraction n="0.224" ref="CaO"/>
+   <fraction n="0.034" ref="MgO"/>
+   <fraction n="0.010" ref="Na2O"/>
+   <fraction n="0.013" ref="TiO2"/>
+  </material>
+
+  <material name="Acrylic">
+   <D value="1.19" unit="g/cm3"/>
+   <fraction n="0.600" ref="carbon"/>
+   <fraction n="0.320" ref="oxygen"/>
+   <fraction n="0.080" ref="hydrogen"/>
+  </material>
+
+  <material name="NiGas1atm80K">
+   <D value="0.0039" unit="g/cm3"/>
+   <fraction n="1.000" ref="nitrogen"/>
+  </material>
+
+  <material name="NiGas">
+   <D value="0.001165" unit="g/cm3"/>
+   <fraction n="1.000" ref="nitrogen"/>
+  </material>
+
+  <material name="PolyurethaneFoam">
+   <D value="0.088" unit="g/cm3"/>
+   <composite n="17" ref="carbon"/>
+   <composite n="16" ref="hydrogen"/>
+   <composite n="2" ref="nitrogen"/>
+   <composite n="4" ref="oxygen"/>
+  </material>
+
+  <material name="ProtoDUNEFoam">
+   <D value="0.135" unit="g/cm3"/>
+   <composite n="17" ref="carbon"/>
+   <composite n="16" ref="hydrogen"/>
+   <composite n="2" ref="nitrogen"/>
+   <composite n="4" ref="oxygen"/>
+  </material>
+
+  <material name="LightPolyurethaneFoam">
+   <D value="0.009" unit="g/cm3"/>
+   <composite n="17" ref="carbon"/>
+   <composite n="16" ref="hydrogen"/>
+   <composite n="2" ref="nitrogen"/>
+   <composite n="4" ref="oxygen"/>
+  </material>
+
+  <material name="ProtoDUNEBWFoam">
+   <D value="0.021" unit="g/cm3"/>
+   <composite n="17" ref="carbon"/>
+   <composite n="16" ref="hydrogen"/>
+   <composite n="2" ref="nitrogen"/>
+   <composite n="4" ref="oxygen"/>
+  </material>
+
+  <material name="GlassWool">
+   <D value="0.035" unit="g/cm3"/>
+   <fraction n="0.65" ref="SiO2"/>
+   <fraction n="0.09" ref="Al2O3"/>
+   <fraction n="0.07" ref="CaO"/>
+   <fraction n="0.03" ref="MgO"/>
+   <fraction n="0.16" ref="Na2O"/>
+  </material>
+
+  <material name="Polystyrene">
+   <D value="1.06" unit="g/cm3"/>
+   <composite n="8" ref="carbon"/>
+   <composite n="8" ref="hydrogen"/>
+  </material>
+
+
+
+  <!-- preliminary values -->
+  <material name="AirSteelMixture" formula="AirSteelMixture">
+   <D value=" 0.001205*(1-0.5) + 7.9300*0.5 " unit="g/cm3"/>
+   <fraction n="0.5" ref="STEEL_STAINLESS_Fe7Cr2Ni"/>
+   <fraction n="0.5"   ref="Air"/>
+  </material>
+  <material name="vm2000" formula="vm2000">
+    <D value="1.2" unit="g/cm3"/>
+    <composite n="2" ref="carbon"/>
+    <composite n="4" ref="hydrogen"/>
+  </material>
+
+</materials>
+<solids>
+     <torus name="FieldShaperCorner" rmin="0.5" rmax="2.285" rtor="2.3" deltaphi="90" startphi="0" aunit="deg" lunit="cm"/>
+     <tube name="FieldShaperLongtube" rmin="0.5" rmax="2.285" z="896.52" deltaphi="360" startphi="0" aunit="deg" lunit="cm"/>
+     <tube name="FieldShaperLongtubeSlim" rmin="0.5" rmax="0.75" z="896.52" deltaphi="360" startphi="0" aunit="deg" lunit="cm"/>
+     <tube name="FieldShaperShorttube" rmin="0.5" rmax="2.285" z="1345.6048" deltaphi="360" startphi="0" aunit="deg" lunit="cm"/>
+
+    <union name="FSunion1">
+      <first ref="FieldShaperLongtube"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos1" unit="cm" x="-2.3" y="0" z="448.26"/>
+		<rotation name="rot1" unit="deg" x="90" y="0" z="0" />
+    </union>
+
+    <union name="FSunion2">
+      <first ref="FSunion1"/>
+      <second ref="FieldShaperShorttube"/>
+   		<position name="esquinapos2" unit="cm" x="-675.1024" y="0" z="450.56"/>
+   		<rotation name="rot2" unit="deg" x="0" y="90" z="0" />
+    </union>
+
+    <union name="FSunion3">
+      <first ref="FSunion2"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos3" unit="cm" x="-1347.9048" y="0" z="448.26"/>
+		<rotation name="rot3" unit="deg" x="90" y="270" z="0" />
+    </union>
+
+    <union name="FSunion4">
+      <first ref="FSunion3"/>
+      <second ref="FieldShaperLongtube"/>
+   		<position name="esquinapos4" unit="cm" x="-1350.2048" y="0" z="0"/>
+    </union>
+
+    <union name="FSunion5">
+      <first ref="FSunion4"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos5" unit="cm" x="-1347.9048" y="0" z="-448.26"/>
+		<rotation name="rot5" unit="deg" x="90" y="180" z="0" />
+    </union>
+
+    <union name="FSunion6">
+      <first ref="FSunion5"/>
+      <second ref="FieldShaperShorttube"/>
+   		<position name="esquinapos6" unit="cm" x="-675.1024" y="0" z="-450.56"/>
+		<rotation name="rot6" unit="deg" x="0" y="90" z="0" />
+    </union>
+
+    <union name="FieldShaperSolid">
+      <first ref="FSunion6"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos7" unit="cm" x="-2.3" y="0" z="-448.26"/>
+		<rotation name="rot7" unit="deg" x="90" y="90" z="0" />
+    </union>
+    
+    <union name="FSunionSlim1">
+      <first ref="FieldShaperLongtubeSlim"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos1" unit="cm" x="-2.3" y="0" z="448.26"/>
+		<rotation name="rot1" unit="deg" x="90" y="0" z="0" />
+    </union>
+
+    <union name="FSunionSlim2">
+      <first ref="FSunionSlim1"/>
+      <second ref="FieldShaperShorttube"/>
+   		<position name="esquinapos2" unit="cm" x="-675.1024" y="0" z="450.56"/>
+   		<rotation name="rot2" unit="deg" x="0" y="90" z="0" />
+    </union>
+
+    <union name="FSunionSlim3">
+      <first ref="FSunionSlim2"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos3" unit="cm" x="-1347.9048" y="0" z="448.26"/>
+		<rotation name="rot3" unit="deg" x="90" y="270" z="0" />
+    </union>
+
+    <union name="FSunionSlim4">
+      <first ref="FSunionSlim3"/>
+      <second ref="FieldShaperLongtubeSlim"/>
+   		<position name="esquinapos4" unit="cm" x="-1350.2048" y="0" z="0"/>
+    </union>
+
+    <union name="FSunionSlim5">
+      <first ref="FSunionSlim4"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos5" unit="cm" x="-1347.9048" y="0" z="-448.26"/>
+		<rotation name="rot5" unit="deg" x="90" y="180" z="0" />
+    </union>
+
+    <union name="FSunionSlim6">
+      <first ref="FSunionSlim5"/>
+      <second ref="FieldShaperShorttube"/>
+   		<position name="esquinapos6" unit="cm" x="-675.1024" y="0" z="-450.56"/>
+		<rotation name="rot6" unit="deg" x="0" y="90" z="0" />
+    </union>
+
+    <union name="FieldShaperSolidSlim">
+      <first ref="FSunionSlim6"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos7" unit="cm" x="-2.3" y="0" z="-448.26"/>
+		<rotation name="rot7" unit="deg" x="90" y="90" z="0" />
+    </union>
+    
+
+   <box name="CRM"
+      x="650.08" 
+      y="167.7006" 
+      z="148.92"
+      lunit="cm"/>
+   <box name="CRMUPlane" 
+      x="0.02" 
+      y="167.7006" 
+      z="148.92"
+      lunit="cm"/>
+   <box name="CRMVPlane" 
+      x="0.02" 
+      y="167.7006" 
+      z="148.92"
+      lunit="cm"/>
+   <box name="CRMZPlane" 
+      x="0.02"
+      y="167.7006"
+      z="148.92"
+      lunit="cm"/>
+   <box name="CRMActive" 
+      x="650"
+      y="167.7006"
+      z="148.92"
+      lunit="cm"/>
+   <tube name="CRMWireU0"
+      rmax="0.5*0.02"
+      z="0.883345911860126"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU1"
+      rmax="0.5*0.02"
+      z="2.65003773558038"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU2"
+      rmax="0.5*0.02"
+      z="4.41672955930064"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU3"
+      rmax="0.5*0.02"
+      z="6.18342138302089"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU4"
+      rmax="0.5*0.02"
+      z="7.95011320674115"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU5"
+      rmax="0.5*0.02"
+      z="9.7168050304614"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU6"
+      rmax="0.5*0.02"
+      z="11.4834968541817"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU7"
+      rmax="0.5*0.02"
+      z="13.2501886779019"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU8"
+      rmax="0.5*0.02"
+      z="15.0168805016222"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU9"
+      rmax="0.5*0.02"
+      z="16.7835723253424"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU10"
+      rmax="0.5*0.02"
+      z="18.5502641490627"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU11"
+      rmax="0.5*0.02"
+      z="20.3169559727829"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU12"
+      rmax="0.5*0.02"
+      z="22.0836477965032"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU13"
+      rmax="0.5*0.02"
+      z="23.8503396202234"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU14"
+      rmax="0.5*0.02"
+      z="25.6170314439437"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU15"
+      rmax="0.5*0.02"
+      z="27.383723267664"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU16"
+      rmax="0.5*0.02"
+      z="29.1504150913842"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU17"
+      rmax="0.5*0.02"
+      z="30.9171069151045"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU18"
+      rmax="0.5*0.02"
+      z="32.6837987388247"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU19"
+      rmax="0.5*0.02"
+      z="34.450490562545"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU20"
+      rmax="0.5*0.02"
+      z="36.2171823862652"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU21"
+      rmax="0.5*0.02"
+      z="37.9838742099855"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU22"
+      rmax="0.5*0.02"
+      z="39.7505660337058"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU23"
+      rmax="0.5*0.02"
+      z="41.517257857426"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU24"
+      rmax="0.5*0.02"
+      z="43.2839496811463"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU25"
+      rmax="0.5*0.02"
+      z="45.0506415048665"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU26"
+      rmax="0.5*0.02"
+      z="46.8173333285868"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU27"
+      rmax="0.5*0.02"
+      z="48.584025152307"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU28"
+      rmax="0.5*0.02"
+      z="50.3507169760273"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU29"
+      rmax="0.5*0.02"
+      z="52.1174087997475"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU30"
+      rmax="0.5*0.02"
+      z="53.8841006234678"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU31"
+      rmax="0.5*0.02"
+      z="55.6507924471881"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU32"
+      rmax="0.5*0.02"
+      z="57.4174842709083"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU33"
+      rmax="0.5*0.02"
+      z="59.1841760946286"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU34"
+      rmax="0.5*0.02"
+      z="60.9508679183488"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU35"
+      rmax="0.5*0.02"
+      z="62.7175597420691"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU36"
+      rmax="0.5*0.02"
+      z="64.4842515657894"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU37"
+      rmax="0.5*0.02"
+      z="66.2509433895096"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU38"
+      rmax="0.5*0.02"
+      z="68.0176352132299"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU39"
+      rmax="0.5*0.02"
+      z="69.7843270369501"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU40"
+      rmax="0.5*0.02"
+      z="71.5510188606704"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU41"
+      rmax="0.5*0.02"
+      z="73.3177106843906"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU42"
+      rmax="0.5*0.02"
+      z="75.0844025081109"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU43"
+      rmax="0.5*0.02"
+      z="76.8510943318311"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU44"
+      rmax="0.5*0.02"
+      z="78.6177861555514"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU45"
+      rmax="0.5*0.02"
+      z="80.3844779792717"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU46"
+      rmax="0.5*0.02"
+      z="82.1511698029919"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU47"
+      rmax="0.5*0.02"
+      z="83.9178616267122"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU48"
+      rmax="0.5*0.02"
+      z="85.6845534504324"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU49"
+      rmax="0.5*0.02"
+      z="87.4512452741527"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU50"
+      rmax="0.5*0.02"
+      z="89.2179370978729"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU51"
+      rmax="0.5*0.02"
+      z="90.9846289215932"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU52"
+      rmax="0.5*0.02"
+      z="92.7513207453134"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU53"
+      rmax="0.5*0.02"
+      z="94.5180125690337"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU54"
+      rmax="0.5*0.02"
+      z="96.284704392754"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU55"
+      rmax="0.5*0.02"
+      z="98.0513962164742"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU56"
+      rmax="0.5*0.02"
+      z="99.8180880401945"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU57"
+      rmax="0.5*0.02"
+      z="101.584779863915"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU58"
+      rmax="0.5*0.02"
+      z="103.351471687635"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU59"
+      rmax="0.5*0.02"
+      z="105.118163511355"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU60"
+      rmax="0.5*0.02"
+      z="106.884855335075"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU61"
+      rmax="0.5*0.02"
+      z="108.651547158796"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU62"
+      rmax="0.5*0.02"
+      z="110.418238982516"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU63"
+      rmax="0.5*0.02"
+      z="112.184930806236"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU64"
+      rmax="0.5*0.02"
+      z="113.951622629957"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU65"
+      rmax="0.5*0.02"
+      z="115.718314453677"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU66"
+      rmax="0.5*0.02"
+      z="117.485006277397"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU67"
+      rmax="0.5*0.02"
+      z="119.251698101117"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU68"
+      rmax="0.5*0.02"
+      z="121.018389924838"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU69"
+      rmax="0.5*0.02"
+      z="122.785081748558"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU70"
+      rmax="0.5*0.02"
+      z="124.551773572278"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU71"
+      rmax="0.5*0.02"
+      z="126.318465395998"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU72"
+      rmax="0.5*0.02"
+      z="128.085157219719"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU73"
+      rmax="0.5*0.02"
+      z="129.851849043439"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU74"
+      rmax="0.5*0.02"
+      z="131.618540867159"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU75"
+      rmax="0.5*0.02"
+      z="133.385232690879"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU76"
+      rmax="0.5*0.02"
+      z="135.1519245146"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU77"
+      rmax="0.5*0.02"
+      z="136.91861633832"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU78"
+      rmax="0.5*0.02"
+      z="138.68530816204"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU79"
+      rmax="0.5*0.02"
+      z="140.45199998576"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU80"
+      rmax="0.5*0.02"
+      z="142.218691809481"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU81"
+      rmax="0.5*0.02"
+      z="143.985383633201"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU82"
+      rmax="0.5*0.02"
+      z="145.752075456921"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU83"
+      rmax="0.5*0.02"
+      z="147.518767280641"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU84"
+      rmax="0.5*0.02"
+      z="149.285459104362"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU85"
+      rmax="0.5*0.02"
+      z="151.052150928082"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU86"
+      rmax="0.5*0.02"
+      z="152.818842751802"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU87"
+      rmax="0.5*0.02"
+      z="154.585534575522"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU88"
+      rmax="0.5*0.02"
+      z="156.352226399243"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU89"
+      rmax="0.5*0.02"
+      z="158.118918222963"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU90"
+      rmax="0.5*0.02"
+      z="159.885610046683"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU91"
+      rmax="0.5*0.02"
+      z="161.652301870403"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU92"
+      rmax="0.5*0.02"
+      z="163.418993694124"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU93"
+      rmax="0.5*0.02"
+      z="165.185685517844"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU94"
+      rmax="0.5*0.02"
+      z="166.952377341564"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU95"
+      rmax="0.5*0.02"
+      z="168.719069165284"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU96"
+      rmax="0.5*0.02"
+      z="170.485760989005"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU97"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU98"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU99"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU100"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU101"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU102"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU103"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU104"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU105"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU106"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU107"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU108"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU109"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU110"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU111"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU112"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU113"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU114"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU115"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU116"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU117"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU118"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU119"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU120"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU121"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU122"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU123"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU124"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU125"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU126"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU127"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU128"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU129"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU130"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU131"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU132"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU133"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU134"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU135"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU136"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU137"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU138"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU139"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU140"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU141"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU142"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU143"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU144"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU145"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU146"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU147"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU148"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU149"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU150"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU151"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU152"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU153"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU154"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU155"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU156"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU157"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU158"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU159"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU160"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU161"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU162"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU163"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU164"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU165"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU166"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU167"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU168"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU169"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU170"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU171"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU172"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU173"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU174"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU175"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU176"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU177"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU178"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU179"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU180"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU181"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU182"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU183"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU184"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU185"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU186"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU187"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU188"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU189"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU190"
+      rmax="0.5*0.02"
+      z="171.074658263579"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU191"
+      rmax="0.5*0.02"
+      z="169.307966439858"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU192"
+      rmax="0.5*0.02"
+      z="167.541274616138"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU193"
+      rmax="0.5*0.02"
+      z="165.774582792418"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU194"
+      rmax="0.5*0.02"
+      z="164.007890968698"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU195"
+      rmax="0.5*0.02"
+      z="162.241199144977"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU196"
+      rmax="0.5*0.02"
+      z="160.474507321257"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU197"
+      rmax="0.5*0.02"
+      z="158.707815497537"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU198"
+      rmax="0.5*0.02"
+      z="156.941123673817"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU199"
+      rmax="0.5*0.02"
+      z="155.174431850097"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU200"
+      rmax="0.5*0.02"
+      z="153.407740026376"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU201"
+      rmax="0.5*0.02"
+      z="151.641048202656"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU202"
+      rmax="0.5*0.02"
+      z="149.874356378936"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU203"
+      rmax="0.5*0.02"
+      z="148.107664555216"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU204"
+      rmax="0.5*0.02"
+      z="146.340972731495"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU205"
+      rmax="0.5*0.02"
+      z="144.574280907775"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU206"
+      rmax="0.5*0.02"
+      z="142.807589084055"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU207"
+      rmax="0.5*0.02"
+      z="141.040897260335"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU208"
+      rmax="0.5*0.02"
+      z="139.274205436614"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU209"
+      rmax="0.5*0.02"
+      z="137.507513612894"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU210"
+      rmax="0.5*0.02"
+      z="135.740821789174"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU211"
+      rmax="0.5*0.02"
+      z="133.974129965454"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU212"
+      rmax="0.5*0.02"
+      z="132.207438141734"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU213"
+      rmax="0.5*0.02"
+      z="130.440746318013"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU214"
+      rmax="0.5*0.02"
+      z="128.674054494293"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU215"
+      rmax="0.5*0.02"
+      z="126.907362670573"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU216"
+      rmax="0.5*0.02"
+      z="125.140670846853"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU217"
+      rmax="0.5*0.02"
+      z="123.373979023133"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU218"
+      rmax="0.5*0.02"
+      z="121.607287199412"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU219"
+      rmax="0.5*0.02"
+      z="119.840595375692"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU220"
+      rmax="0.5*0.02"
+      z="118.073903551972"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU221"
+      rmax="0.5*0.02"
+      z="116.307211728252"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU222"
+      rmax="0.5*0.02"
+      z="114.540519904531"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU223"
+      rmax="0.5*0.02"
+      z="112.773828080811"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU224"
+      rmax="0.5*0.02"
+      z="111.007136257091"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU225"
+      rmax="0.5*0.02"
+      z="109.240444433371"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU226"
+      rmax="0.5*0.02"
+      z="107.47375260965"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU227"
+      rmax="0.5*0.02"
+      z="105.70706078593"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU228"
+      rmax="0.5*0.02"
+      z="103.94036896221"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU229"
+      rmax="0.5*0.02"
+      z="102.17367713849"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU230"
+      rmax="0.5*0.02"
+      z="100.40698531477"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU231"
+      rmax="0.5*0.02"
+      z="98.6402934910494"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU232"
+      rmax="0.5*0.02"
+      z="96.8736016673292"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU233"
+      rmax="0.5*0.02"
+      z="95.106909843609"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU234"
+      rmax="0.5*0.02"
+      z="93.3402180198887"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU235"
+      rmax="0.5*0.02"
+      z="91.5735261961685"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU236"
+      rmax="0.5*0.02"
+      z="89.8068343724483"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU237"
+      rmax="0.5*0.02"
+      z="88.040142548728"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU238"
+      rmax="0.5*0.02"
+      z="86.2734507250078"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU239"
+      rmax="0.5*0.02"
+      z="84.5067589012876"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU240"
+      rmax="0.5*0.02"
+      z="82.7400670775674"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU241"
+      rmax="0.5*0.02"
+      z="80.9733752538472"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU242"
+      rmax="0.5*0.02"
+      z="79.2066834301269"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU243"
+      rmax="0.5*0.02"
+      z="77.4399916064067"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU244"
+      rmax="0.5*0.02"
+      z="75.6732997826865"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU245"
+      rmax="0.5*0.02"
+      z="73.9066079589663"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU246"
+      rmax="0.5*0.02"
+      z="72.1399161352461"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU247"
+      rmax="0.5*0.02"
+      z="70.3732243115258"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU248"
+      rmax="0.5*0.02"
+      z="68.6065324878056"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU249"
+      rmax="0.5*0.02"
+      z="66.8398406640853"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU250"
+      rmax="0.5*0.02"
+      z="65.0731488403651"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU251"
+      rmax="0.5*0.02"
+      z="63.3064570166449"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU252"
+      rmax="0.5*0.02"
+      z="61.5397651929247"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU253"
+      rmax="0.5*0.02"
+      z="59.7730733692045"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU254"
+      rmax="0.5*0.02"
+      z="58.0063815454843"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU255"
+      rmax="0.5*0.02"
+      z="56.239689721764"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU256"
+      rmax="0.5*0.02"
+      z="54.4729978980438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU257"
+      rmax="0.5*0.02"
+      z="52.7063060743236"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU258"
+      rmax="0.5*0.02"
+      z="50.9396142506034"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU259"
+      rmax="0.5*0.02"
+      z="49.1729224268832"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU260"
+      rmax="0.5*0.02"
+      z="47.406230603163"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU261"
+      rmax="0.5*0.02"
+      z="45.6395387794427"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU262"
+      rmax="0.5*0.02"
+      z="43.8728469557225"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU263"
+      rmax="0.5*0.02"
+      z="42.1061551320022"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU264"
+      rmax="0.5*0.02"
+      z="40.339463308282"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU265"
+      rmax="0.5*0.02"
+      z="38.5727714845618"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU266"
+      rmax="0.5*0.02"
+      z="36.8060796608416"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU267"
+      rmax="0.5*0.02"
+      z="35.0393878371214"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU268"
+      rmax="0.5*0.02"
+      z="33.2726960134011"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU269"
+      rmax="0.5*0.02"
+      z="31.5060041896809"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU270"
+      rmax="0.5*0.02"
+      z="29.7393123659607"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU271"
+      rmax="0.5*0.02"
+      z="27.9726205422405"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU272"
+      rmax="0.5*0.02"
+      z="26.2059287185202"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU273"
+      rmax="0.5*0.02"
+      z="24.4392368948"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU274"
+      rmax="0.5*0.02"
+      z="22.6725450710797"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU275"
+      rmax="0.5*0.02"
+      z="20.9058532473595"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU276"
+      rmax="0.5*0.02"
+      z="19.1391614236393"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU277"
+      rmax="0.5*0.02"
+      z="17.3724695999191"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU278"
+      rmax="0.5*0.02"
+      z="15.6057777761989"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU279"
+      rmax="0.5*0.02"
+      z="13.8390859524787"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU280"
+      rmax="0.5*0.02"
+      z="12.0723941287584"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU281"
+      rmax="0.5*0.02"
+      z="10.3057023050382"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU282"
+      rmax="0.5*0.02"
+      z="8.53901048131801"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU283"
+      rmax="0.5*0.02"
+      z="6.7723186575978"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU284"
+      rmax="0.5*0.02"
+      z="5.00562683387757"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU285"
+      rmax="0.5*0.02"
+      z="3.23893501015734"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV0"
+      rmax="0.5*0.02"
+      z="0.883345911860106"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV1"
+      rmax="0.5*0.02"
+      z="2.6500377355804"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV2"
+      rmax="0.5*0.02"
+      z="4.41672955930062"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV3"
+      rmax="0.5*0.02"
+      z="6.18342138302091"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV4"
+      rmax="0.5*0.02"
+      z="7.95011320674114"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV5"
+      rmax="0.5*0.02"
+      z="9.71680503046143"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV6"
+      rmax="0.5*0.02"
+      z="11.4834968541816"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV7"
+      rmax="0.5*0.02"
+      z="13.2501886779019"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV8"
+      rmax="0.5*0.02"
+      z="15.0168805016222"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV9"
+      rmax="0.5*0.02"
+      z="16.7835723253424"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV10"
+      rmax="0.5*0.02"
+      z="18.5502641490627"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV11"
+      rmax="0.5*0.02"
+      z="20.3169559727829"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV12"
+      rmax="0.5*0.02"
+      z="22.0836477965032"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV13"
+      rmax="0.5*0.02"
+      z="23.8503396202235"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV14"
+      rmax="0.5*0.02"
+      z="25.6170314439437"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV15"
+      rmax="0.5*0.02"
+      z="27.383723267664"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV16"
+      rmax="0.5*0.02"
+      z="29.1504150913842"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV17"
+      rmax="0.5*0.02"
+      z="30.9171069151045"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV18"
+      rmax="0.5*0.02"
+      z="32.6837987388247"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV19"
+      rmax="0.5*0.02"
+      z="34.450490562545"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV20"
+      rmax="0.5*0.02"
+      z="36.2171823862652"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV21"
+      rmax="0.5*0.02"
+      z="37.9838742099855"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV22"
+      rmax="0.5*0.02"
+      z="39.7505660337057"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV23"
+      rmax="0.5*0.02"
+      z="41.517257857426"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV24"
+      rmax="0.5*0.02"
+      z="43.2839496811462"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV25"
+      rmax="0.5*0.02"
+      z="45.0506415048665"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV26"
+      rmax="0.5*0.02"
+      z="46.8173333285868"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV27"
+      rmax="0.5*0.02"
+      z="48.584025152307"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV28"
+      rmax="0.5*0.02"
+      z="50.3507169760273"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV29"
+      rmax="0.5*0.02"
+      z="52.1174087997476"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV30"
+      rmax="0.5*0.02"
+      z="53.8841006234678"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV31"
+      rmax="0.5*0.02"
+      z="55.6507924471881"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV32"
+      rmax="0.5*0.02"
+      z="57.4174842709083"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV33"
+      rmax="0.5*0.02"
+      z="59.1841760946286"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV34"
+      rmax="0.5*0.02"
+      z="60.9508679183488"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV35"
+      rmax="0.5*0.02"
+      z="62.7175597420691"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV36"
+      rmax="0.5*0.02"
+      z="64.4842515657893"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV37"
+      rmax="0.5*0.02"
+      z="66.2509433895096"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV38"
+      rmax="0.5*0.02"
+      z="68.0176352132298"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV39"
+      rmax="0.5*0.02"
+      z="69.7843270369501"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV40"
+      rmax="0.5*0.02"
+      z="71.5510188606703"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV41"
+      rmax="0.5*0.02"
+      z="73.3177106843906"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV42"
+      rmax="0.5*0.02"
+      z="75.0844025081108"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV43"
+      rmax="0.5*0.02"
+      z="76.8510943318311"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV44"
+      rmax="0.5*0.02"
+      z="78.6177861555514"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV45"
+      rmax="0.5*0.02"
+      z="80.3844779792717"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV46"
+      rmax="0.5*0.02"
+      z="82.1511698029919"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV47"
+      rmax="0.5*0.02"
+      z="83.9178616267122"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV48"
+      rmax="0.5*0.02"
+      z="85.6845534504325"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV49"
+      rmax="0.5*0.02"
+      z="87.4512452741527"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV50"
+      rmax="0.5*0.02"
+      z="89.2179370978729"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV51"
+      rmax="0.5*0.02"
+      z="90.9846289215932"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV52"
+      rmax="0.5*0.02"
+      z="92.7513207453135"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV53"
+      rmax="0.5*0.02"
+      z="94.5180125690337"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV54"
+      rmax="0.5*0.02"
+      z="96.2847043927539"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV55"
+      rmax="0.5*0.02"
+      z="98.0513962164742"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV56"
+      rmax="0.5*0.02"
+      z="99.8180880401945"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV57"
+      rmax="0.5*0.02"
+      z="101.584779863915"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV58"
+      rmax="0.5*0.02"
+      z="103.351471687635"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV59"
+      rmax="0.5*0.02"
+      z="105.118163511355"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV60"
+      rmax="0.5*0.02"
+      z="106.884855335075"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV61"
+      rmax="0.5*0.02"
+      z="108.651547158796"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV62"
+      rmax="0.5*0.02"
+      z="110.418238982516"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV63"
+      rmax="0.5*0.02"
+      z="112.184930806236"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV64"
+      rmax="0.5*0.02"
+      z="113.951622629957"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV65"
+      rmax="0.5*0.02"
+      z="115.718314453677"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV66"
+      rmax="0.5*0.02"
+      z="117.485006277397"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV67"
+      rmax="0.5*0.02"
+      z="119.251698101117"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV68"
+      rmax="0.5*0.02"
+      z="121.018389924838"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV69"
+      rmax="0.5*0.02"
+      z="122.785081748558"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV70"
+      rmax="0.5*0.02"
+      z="124.551773572278"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV71"
+      rmax="0.5*0.02"
+      z="126.318465395998"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV72"
+      rmax="0.5*0.02"
+      z="128.085157219719"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV73"
+      rmax="0.5*0.02"
+      z="129.851849043439"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV74"
+      rmax="0.5*0.02"
+      z="131.618540867159"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV75"
+      rmax="0.5*0.02"
+      z="133.385232690879"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV76"
+      rmax="0.5*0.02"
+      z="135.1519245146"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV77"
+      rmax="0.5*0.02"
+      z="136.91861633832"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV78"
+      rmax="0.5*0.02"
+      z="138.68530816204"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV79"
+      rmax="0.5*0.02"
+      z="140.45199998576"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV80"
+      rmax="0.5*0.02"
+      z="142.218691809481"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV81"
+      rmax="0.5*0.02"
+      z="143.985383633201"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV82"
+      rmax="0.5*0.02"
+      z="145.752075456921"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV83"
+      rmax="0.5*0.02"
+      z="147.518767280641"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV84"
+      rmax="0.5*0.02"
+      z="149.285459104362"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV85"
+      rmax="0.5*0.02"
+      z="151.052150928082"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV86"
+      rmax="0.5*0.02"
+      z="152.818842751802"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV87"
+      rmax="0.5*0.02"
+      z="154.585534575522"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV88"
+      rmax="0.5*0.02"
+      z="156.352226399243"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV89"
+      rmax="0.5*0.02"
+      z="158.118918222963"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV90"
+      rmax="0.5*0.02"
+      z="159.885610046683"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV91"
+      rmax="0.5*0.02"
+      z="161.652301870403"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV92"
+      rmax="0.5*0.02"
+      z="163.418993694124"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV93"
+      rmax="0.5*0.02"
+      z="165.185685517844"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV94"
+      rmax="0.5*0.02"
+      z="166.952377341564"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV95"
+      rmax="0.5*0.02"
+      z="168.719069165284"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV96"
+      rmax="0.5*0.02"
+      z="170.485760989005"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV97"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV98"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV99"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV100"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV101"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV102"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV103"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV104"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV105"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV106"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV107"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV108"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV109"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV110"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV111"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV112"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV113"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV114"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV115"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV116"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV117"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV118"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV119"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV120"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV121"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV122"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV123"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV124"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV125"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV126"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV127"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV128"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV129"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV130"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV131"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV132"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV133"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV134"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV135"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV136"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV137"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV138"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV139"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV140"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV141"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV142"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV143"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV144"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV145"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV146"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV147"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV148"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV149"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV150"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV151"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV152"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV153"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV154"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV155"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV156"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV157"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV158"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV159"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV160"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV161"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV162"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV163"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV164"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV165"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV166"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV167"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV168"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV169"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV170"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV171"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV172"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV173"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV174"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV175"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV176"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV177"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV178"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV179"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV180"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV181"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV182"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV183"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV184"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV185"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV186"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV187"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV188"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV189"
+      rmax="0.5*0.02"
+      z="171.958004175438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV190"
+      rmax="0.5*0.02"
+      z="171.074658263579"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV191"
+      rmax="0.5*0.02"
+      z="169.307966439858"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV192"
+      rmax="0.5*0.02"
+      z="167.541274616138"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV193"
+      rmax="0.5*0.02"
+      z="165.774582792418"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV194"
+      rmax="0.5*0.02"
+      z="164.007890968698"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV195"
+      rmax="0.5*0.02"
+      z="162.241199144977"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV196"
+      rmax="0.5*0.02"
+      z="160.474507321257"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV197"
+      rmax="0.5*0.02"
+      z="158.707815497537"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV198"
+      rmax="0.5*0.02"
+      z="156.941123673817"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV199"
+      rmax="0.5*0.02"
+      z="155.174431850097"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV200"
+      rmax="0.5*0.02"
+      z="153.407740026376"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV201"
+      rmax="0.5*0.02"
+      z="151.641048202656"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV202"
+      rmax="0.5*0.02"
+      z="149.874356378936"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV203"
+      rmax="0.5*0.02"
+      z="148.107664555216"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV204"
+      rmax="0.5*0.02"
+      z="146.340972731495"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV205"
+      rmax="0.5*0.02"
+      z="144.574280907775"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV206"
+      rmax="0.5*0.02"
+      z="142.807589084055"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV207"
+      rmax="0.5*0.02"
+      z="141.040897260335"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV208"
+      rmax="0.5*0.02"
+      z="139.274205436614"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV209"
+      rmax="0.5*0.02"
+      z="137.507513612894"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV210"
+      rmax="0.5*0.02"
+      z="135.740821789174"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV211"
+      rmax="0.5*0.02"
+      z="133.974129965454"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV212"
+      rmax="0.5*0.02"
+      z="132.207438141734"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV213"
+      rmax="0.5*0.02"
+      z="130.440746318013"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV214"
+      rmax="0.5*0.02"
+      z="128.674054494293"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV215"
+      rmax="0.5*0.02"
+      z="126.907362670573"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV216"
+      rmax="0.5*0.02"
+      z="125.140670846853"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV217"
+      rmax="0.5*0.02"
+      z="123.373979023133"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV218"
+      rmax="0.5*0.02"
+      z="121.607287199412"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV219"
+      rmax="0.5*0.02"
+      z="119.840595375692"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV220"
+      rmax="0.5*0.02"
+      z="118.073903551972"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV221"
+      rmax="0.5*0.02"
+      z="116.307211728252"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV222"
+      rmax="0.5*0.02"
+      z="114.540519904531"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV223"
+      rmax="0.5*0.02"
+      z="112.773828080811"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV224"
+      rmax="0.5*0.02"
+      z="111.007136257091"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV225"
+      rmax="0.5*0.02"
+      z="109.240444433371"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV226"
+      rmax="0.5*0.02"
+      z="107.47375260965"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV227"
+      rmax="0.5*0.02"
+      z="105.70706078593"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV228"
+      rmax="0.5*0.02"
+      z="103.94036896221"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV229"
+      rmax="0.5*0.02"
+      z="102.17367713849"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV230"
+      rmax="0.5*0.02"
+      z="100.40698531477"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV231"
+      rmax="0.5*0.02"
+      z="98.6402934910494"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV232"
+      rmax="0.5*0.02"
+      z="96.8736016673292"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV233"
+      rmax="0.5*0.02"
+      z="95.106909843609"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV234"
+      rmax="0.5*0.02"
+      z="93.3402180198887"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV235"
+      rmax="0.5*0.02"
+      z="91.5735261961685"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV236"
+      rmax="0.5*0.02"
+      z="89.8068343724483"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV237"
+      rmax="0.5*0.02"
+      z="88.040142548728"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV238"
+      rmax="0.5*0.02"
+      z="86.2734507250078"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV239"
+      rmax="0.5*0.02"
+      z="84.5067589012876"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV240"
+      rmax="0.5*0.02"
+      z="82.7400670775674"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV241"
+      rmax="0.5*0.02"
+      z="80.9733752538472"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV242"
+      rmax="0.5*0.02"
+      z="79.2066834301269"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV243"
+      rmax="0.5*0.02"
+      z="77.4399916064067"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV244"
+      rmax="0.5*0.02"
+      z="75.6732997826865"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV245"
+      rmax="0.5*0.02"
+      z="73.9066079589663"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV246"
+      rmax="0.5*0.02"
+      z="72.1399161352461"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV247"
+      rmax="0.5*0.02"
+      z="70.3732243115258"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV248"
+      rmax="0.5*0.02"
+      z="68.6065324878056"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV249"
+      rmax="0.5*0.02"
+      z="66.8398406640853"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV250"
+      rmax="0.5*0.02"
+      z="65.0731488403651"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV251"
+      rmax="0.5*0.02"
+      z="63.3064570166449"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV252"
+      rmax="0.5*0.02"
+      z="61.5397651929247"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV253"
+      rmax="0.5*0.02"
+      z="59.7730733692045"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV254"
+      rmax="0.5*0.02"
+      z="58.0063815454843"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV255"
+      rmax="0.5*0.02"
+      z="56.239689721764"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV256"
+      rmax="0.5*0.02"
+      z="54.4729978980438"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV257"
+      rmax="0.5*0.02"
+      z="52.7063060743236"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV258"
+      rmax="0.5*0.02"
+      z="50.9396142506034"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV259"
+      rmax="0.5*0.02"
+      z="49.1729224268832"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV260"
+      rmax="0.5*0.02"
+      z="47.4062306031629"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV261"
+      rmax="0.5*0.02"
+      z="45.6395387794427"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV262"
+      rmax="0.5*0.02"
+      z="43.8728469557225"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV263"
+      rmax="0.5*0.02"
+      z="42.1061551320022"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV264"
+      rmax="0.5*0.02"
+      z="40.339463308282"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV265"
+      rmax="0.5*0.02"
+      z="38.5727714845618"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV266"
+      rmax="0.5*0.02"
+      z="36.8060796608416"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV267"
+      rmax="0.5*0.02"
+      z="35.0393878371214"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV268"
+      rmax="0.5*0.02"
+      z="33.2726960134011"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV269"
+      rmax="0.5*0.02"
+      z="31.5060041896809"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV270"
+      rmax="0.5*0.02"
+      z="29.7393123659607"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV271"
+      rmax="0.5*0.02"
+      z="27.9726205422405"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV272"
+      rmax="0.5*0.02"
+      z="26.2059287185203"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV273"
+      rmax="0.5*0.02"
+      z="24.4392368948"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV274"
+      rmax="0.5*0.02"
+      z="22.6725450710797"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV275"
+      rmax="0.5*0.02"
+      z="20.9058532473596"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV276"
+      rmax="0.5*0.02"
+      z="19.1391614236393"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV277"
+      rmax="0.5*0.02"
+      z="17.3724695999191"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV278"
+      rmax="0.5*0.02"
+      z="15.6057777761989"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV279"
+      rmax="0.5*0.02"
+      z="13.8390859524787"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV280"
+      rmax="0.5*0.02"
+      z="12.0723941287584"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV281"
+      rmax="0.5*0.02"
+      z="10.3057023050382"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV282"
+      rmax="0.5*0.02"
+      z="8.53901048131802"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV283"
+      rmax="0.5*0.02"
+      z="6.7723186575978"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV284"
+      rmax="0.5*0.02"
+      z="5.00562683387757"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV285"
+      rmax="0.5*0.02"
+      z="3.23893501015735"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireZ"
+      rmax="0.5*0.02"
+      z="167.7006"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+
+    <box name="ArapucaOut" lunit="cm"
+      x="65"
+      y="2.5"
+      z="65"/>
+
+    <box name="ArapucaIn" lunit="cm"
+      x="60"
+      y="2.5"
+      z="60"/>
+
+     <subtraction name="ArapucaWalls">
+      <first  ref="ArapucaOut"/>
+      <second ref="ArapucaIn"/>
+      <position name="posArapucaSub" x="0" y="1.25" z="0." unit="cm"/>
+      </subtraction>
+
+    <box name="ArapucaAcceptanceWindow" lunit="cm"
+      x="60"
+      y="1"
+      z="60"/>
+
+    <box name="ArapucaDoubleIn" lunit="cm"
+      x="60"
+      y="3.5"
+      z="60"/>
+
+     <subtraction name="ArapucaDoubleWalls">
+      <first  ref="ArapucaOut"/>
+      <second ref="ArapucaDoubleIn"/>
+      <position name="posArapucaDoubleSub" x="0" y="0" z="0" unit="cm"/>
+      </subtraction>
+
+    <box name="ArapucaDoubleAcceptanceWindow" lunit="cm"
+      x="2.48"
+      y="60"
+      z="60"/>
+
+    <box name="ArapucaCathodeAcceptanceWindow" lunit="cm"
+      x="1"
+      y="60"
+      z="60"/>
+
+
+    <box name="Cryostat" lunit="cm" 
+      x="850.32" 
+      y="1545.8448" 
+      z="1096.76"/>
+
+    <box name="ArgonInterior" lunit="cm" 
+      x="850.08"
+      y="1545.6048"
+      z="1096.52"/>
+
+    <box name="GaseousArgon" lunit="cm" 
+      x="100 - 0.01"
+      y="1545.6048"
+      z="1096.52"/>
+
+    <box name="ExternalAuxOut" lunit="cm" 
+      x="850.08 - 100"
+      y="1545.6048 - 2*2.5 - 2*40"
+      z="1096.52"/>
+
+    <box name="ExternalAuxIn" lunit="cm" 
+      x="850.08"
+      y="1356.7748"
+      z="1096.52 + 1"/>
+
+   <subtraction name="ExternalActive">
+      <first ref="ExternalAuxOut"/>
+      <second ref="ExternalAuxIn"/>
+    </subtraction>
+
+    <subtraction name="SteelShell">
+      <first ref="Cryostat"/>
+      <second ref="ArgonInterior"/>
+    </subtraction>
+
+
+
+    <box name="CathodeBlock" lunit="cm"
+      x="4"
+      y="335.4012"
+      z="297.84" />
+
+    <box name="CathodeVoid" lunit="cm"
+      x="5"
+      y="76.35"
+      z="67" />
+
+    <subtraction name="Cathode1">
+      <first ref="CathodeBlock"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub1" x="0" y="-122.525" z="-108.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode2">
+      <first ref="Cathode1"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub2" x="0" y="-122.525" z="-37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode3">
+      <first ref="Cathode2"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub3" x="0" y="-122.525" z="37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode4">
+      <first ref="Cathode3"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub4" x="0" y="-122.525" z="108.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode5">
+      <first ref="Cathode4"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub5" x="0" y="-42.175" z="-108.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode6">
+      <first ref="Cathode5"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub6" x="0" y="-42.175" z="-37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode7">
+      <first ref="Cathode6"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub7" x="0" y="-42.175" z="37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode8">
+      <first ref="Cathode7"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub8" x="0" y="-42.175" z="108.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode9">
+      <first ref="Cathode8"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub9" x="0" y="42.175" z="-108.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode10">
+      <first ref="Cathode9"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub10" x="0" y="42.175" z="-37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode11">
+      <first ref="Cathode10"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub11" x="0" y="42.175" z="37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode12">
+      <first ref="Cathode11"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub12" x="0" y="42.175" z="108.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode13">
+      <first ref="Cathode12"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub13" x="0" y="122.525" z="-108.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode14">
+      <first ref="Cathode13"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub14" x="0" y="122.525" z="-37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode15">
+      <first ref="Cathode14"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub15" x="0" y="122.525" z="37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="CathodeGrid">
+      <first ref="Cathode15"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub16" x="0" y="122.525" z="108.5" unit="cm"/>
+    </subtraction>
+
+   <box name="AnodePlate" 
+      x="0.01"
+      y="335.4012"
+      z="297.84"
+      lunit="cm"/>
+
+    <box name="FoamPadBlock" lunit="cm"
+      x="1010.32"
+      y="1705.8448"
+      z="1256.76" />
+
+    <subtraction name="FoamPadding">
+      <first ref="FoamPadBlock"/>
+      <second ref="Cryostat"/>
+      <positionref ref="posCenter"/>
+    </subtraction>
+
+    <box name="SteelSupportBlock" lunit="cm"
+      x="1210.32"
+      y="1905.8448"
+      z="1456.76" />
+
+    <subtraction name="SteelSupport">
+      <first ref="SteelSupportBlock"/>
+      <second ref="FoamPadBlock"/>
+      <positionref ref="posCenter"/>
+    </subtraction>
+
+    <box name="DetEnclosure" lunit="cm" 
+      x="1310.32"
+      y="2105.8448"
+      z="1656.76"/>
+
+
+    <box name="World" lunit="cm" 
+      x="9310.32" 
+      y="10105.8448" 
+      z="9656.76"/>
+</solids>
+<structure>
+<volume name="volFieldShaper">
+  <materialref ref="Al2O3"/>
+  <solidref ref="FieldShaperSolid"/>
+</volume>
+<volume name="volFieldShaperSlim">
+  <materialref ref="Al2O3"/>
+  <solidref ref="FieldShaperSolidSlim"/>
+</volume>
+
+
+    <volume name="volTPCActive">
+      <materialref ref="LAr"/>
+      <solidref ref="CRMActive"/>
+      <auxiliary auxtype="SensDet" auxvalue="SimEnergyDeposit"/>
+      <auxiliary auxtype="StepLimit" auxunit="cm" auxvalue="0.5208*cm"/>
+      <auxiliary auxtype="Efield" auxunit="V/cm" auxvalue="500*V/cm"/>
+      <colorref ref="blue"/>
+    </volume>
+    <volume name="volTPCWireU0">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU0"/>
+    </volume>
+    <volume name="volTPCWireU1">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU1"/>
+    </volume>
+    <volume name="volTPCWireU2">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU2"/>
+    </volume>
+    <volume name="volTPCWireU3">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU3"/>
+    </volume>
+    <volume name="volTPCWireU4">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU4"/>
+    </volume>
+    <volume name="volTPCWireU5">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU5"/>
+    </volume>
+    <volume name="volTPCWireU6">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU6"/>
+    </volume>
+    <volume name="volTPCWireU7">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU7"/>
+    </volume>
+    <volume name="volTPCWireU8">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU8"/>
+    </volume>
+    <volume name="volTPCWireU9">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU9"/>
+    </volume>
+    <volume name="volTPCWireU10">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU10"/>
+    </volume>
+    <volume name="volTPCWireU11">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU11"/>
+    </volume>
+    <volume name="volTPCWireU12">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU12"/>
+    </volume>
+    <volume name="volTPCWireU13">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU13"/>
+    </volume>
+    <volume name="volTPCWireU14">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU14"/>
+    </volume>
+    <volume name="volTPCWireU15">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU15"/>
+    </volume>
+    <volume name="volTPCWireU16">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU16"/>
+    </volume>
+    <volume name="volTPCWireU17">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU17"/>
+    </volume>
+    <volume name="volTPCWireU18">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU18"/>
+    </volume>
+    <volume name="volTPCWireU19">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU19"/>
+    </volume>
+    <volume name="volTPCWireU20">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU20"/>
+    </volume>
+    <volume name="volTPCWireU21">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU21"/>
+    </volume>
+    <volume name="volTPCWireU22">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU22"/>
+    </volume>
+    <volume name="volTPCWireU23">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU23"/>
+    </volume>
+    <volume name="volTPCWireU24">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU24"/>
+    </volume>
+    <volume name="volTPCWireU25">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU25"/>
+    </volume>
+    <volume name="volTPCWireU26">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU26"/>
+    </volume>
+    <volume name="volTPCWireU27">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU27"/>
+    </volume>
+    <volume name="volTPCWireU28">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU28"/>
+    </volume>
+    <volume name="volTPCWireU29">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU29"/>
+    </volume>
+    <volume name="volTPCWireU30">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU30"/>
+    </volume>
+    <volume name="volTPCWireU31">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU31"/>
+    </volume>
+    <volume name="volTPCWireU32">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU32"/>
+    </volume>
+    <volume name="volTPCWireU33">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU33"/>
+    </volume>
+    <volume name="volTPCWireU34">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU34"/>
+    </volume>
+    <volume name="volTPCWireU35">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU35"/>
+    </volume>
+    <volume name="volTPCWireU36">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU36"/>
+    </volume>
+    <volume name="volTPCWireU37">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU37"/>
+    </volume>
+    <volume name="volTPCWireU38">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU38"/>
+    </volume>
+    <volume name="volTPCWireU39">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU39"/>
+    </volume>
+    <volume name="volTPCWireU40">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU40"/>
+    </volume>
+    <volume name="volTPCWireU41">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU41"/>
+    </volume>
+    <volume name="volTPCWireU42">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU42"/>
+    </volume>
+    <volume name="volTPCWireU43">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU43"/>
+    </volume>
+    <volume name="volTPCWireU44">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU44"/>
+    </volume>
+    <volume name="volTPCWireU45">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU45"/>
+    </volume>
+    <volume name="volTPCWireU46">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU46"/>
+    </volume>
+    <volume name="volTPCWireU47">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU47"/>
+    </volume>
+    <volume name="volTPCWireU48">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU48"/>
+    </volume>
+    <volume name="volTPCWireU49">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU49"/>
+    </volume>
+    <volume name="volTPCWireU50">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU50"/>
+    </volume>
+    <volume name="volTPCWireU51">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU51"/>
+    </volume>
+    <volume name="volTPCWireU52">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU52"/>
+    </volume>
+    <volume name="volTPCWireU53">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU53"/>
+    </volume>
+    <volume name="volTPCWireU54">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU54"/>
+    </volume>
+    <volume name="volTPCWireU55">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU55"/>
+    </volume>
+    <volume name="volTPCWireU56">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU56"/>
+    </volume>
+    <volume name="volTPCWireU57">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU57"/>
+    </volume>
+    <volume name="volTPCWireU58">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU58"/>
+    </volume>
+    <volume name="volTPCWireU59">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU59"/>
+    </volume>
+    <volume name="volTPCWireU60">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU60"/>
+    </volume>
+    <volume name="volTPCWireU61">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU61"/>
+    </volume>
+    <volume name="volTPCWireU62">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU62"/>
+    </volume>
+    <volume name="volTPCWireU63">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU63"/>
+    </volume>
+    <volume name="volTPCWireU64">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU64"/>
+    </volume>
+    <volume name="volTPCWireU65">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU65"/>
+    </volume>
+    <volume name="volTPCWireU66">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU66"/>
+    </volume>
+    <volume name="volTPCWireU67">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU67"/>
+    </volume>
+    <volume name="volTPCWireU68">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU68"/>
+    </volume>
+    <volume name="volTPCWireU69">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU69"/>
+    </volume>
+    <volume name="volTPCWireU70">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU70"/>
+    </volume>
+    <volume name="volTPCWireU71">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU71"/>
+    </volume>
+    <volume name="volTPCWireU72">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU72"/>
+    </volume>
+    <volume name="volTPCWireU73">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU73"/>
+    </volume>
+    <volume name="volTPCWireU74">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU74"/>
+    </volume>
+    <volume name="volTPCWireU75">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU75"/>
+    </volume>
+    <volume name="volTPCWireU76">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU76"/>
+    </volume>
+    <volume name="volTPCWireU77">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU77"/>
+    </volume>
+    <volume name="volTPCWireU78">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU78"/>
+    </volume>
+    <volume name="volTPCWireU79">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU79"/>
+    </volume>
+    <volume name="volTPCWireU80">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU80"/>
+    </volume>
+    <volume name="volTPCWireU81">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU81"/>
+    </volume>
+    <volume name="volTPCWireU82">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU82"/>
+    </volume>
+    <volume name="volTPCWireU83">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU83"/>
+    </volume>
+    <volume name="volTPCWireU84">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU84"/>
+    </volume>
+    <volume name="volTPCWireU85">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU85"/>
+    </volume>
+    <volume name="volTPCWireU86">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU86"/>
+    </volume>
+    <volume name="volTPCWireU87">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU87"/>
+    </volume>
+    <volume name="volTPCWireU88">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU88"/>
+    </volume>
+    <volume name="volTPCWireU89">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU89"/>
+    </volume>
+    <volume name="volTPCWireU90">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU90"/>
+    </volume>
+    <volume name="volTPCWireU91">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU91"/>
+    </volume>
+    <volume name="volTPCWireU92">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU92"/>
+    </volume>
+    <volume name="volTPCWireU93">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU93"/>
+    </volume>
+    <volume name="volTPCWireU94">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU94"/>
+    </volume>
+    <volume name="volTPCWireU95">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU95"/>
+    </volume>
+    <volume name="volTPCWireU96">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU96"/>
+    </volume>
+    <volume name="volTPCWireU97">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU97"/>
+    </volume>
+    <volume name="volTPCWireU98">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU98"/>
+    </volume>
+    <volume name="volTPCWireU99">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU99"/>
+    </volume>
+    <volume name="volTPCWireU100">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU100"/>
+    </volume>
+    <volume name="volTPCWireU101">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU101"/>
+    </volume>
+    <volume name="volTPCWireU102">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU102"/>
+    </volume>
+    <volume name="volTPCWireU103">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU103"/>
+    </volume>
+    <volume name="volTPCWireU104">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU104"/>
+    </volume>
+    <volume name="volTPCWireU105">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU105"/>
+    </volume>
+    <volume name="volTPCWireU106">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU106"/>
+    </volume>
+    <volume name="volTPCWireU107">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU107"/>
+    </volume>
+    <volume name="volTPCWireU108">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU108"/>
+    </volume>
+    <volume name="volTPCWireU109">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU109"/>
+    </volume>
+    <volume name="volTPCWireU110">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU110"/>
+    </volume>
+    <volume name="volTPCWireU111">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU111"/>
+    </volume>
+    <volume name="volTPCWireU112">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU112"/>
+    </volume>
+    <volume name="volTPCWireU113">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU113"/>
+    </volume>
+    <volume name="volTPCWireU114">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU114"/>
+    </volume>
+    <volume name="volTPCWireU115">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU115"/>
+    </volume>
+    <volume name="volTPCWireU116">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU116"/>
+    </volume>
+    <volume name="volTPCWireU117">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU117"/>
+    </volume>
+    <volume name="volTPCWireU118">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU118"/>
+    </volume>
+    <volume name="volTPCWireU119">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU119"/>
+    </volume>
+    <volume name="volTPCWireU120">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU120"/>
+    </volume>
+    <volume name="volTPCWireU121">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU121"/>
+    </volume>
+    <volume name="volTPCWireU122">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU122"/>
+    </volume>
+    <volume name="volTPCWireU123">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU123"/>
+    </volume>
+    <volume name="volTPCWireU124">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU124"/>
+    </volume>
+    <volume name="volTPCWireU125">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU125"/>
+    </volume>
+    <volume name="volTPCWireU126">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU126"/>
+    </volume>
+    <volume name="volTPCWireU127">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU127"/>
+    </volume>
+    <volume name="volTPCWireU128">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU128"/>
+    </volume>
+    <volume name="volTPCWireU129">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU129"/>
+    </volume>
+    <volume name="volTPCWireU130">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU130"/>
+    </volume>
+    <volume name="volTPCWireU131">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU131"/>
+    </volume>
+    <volume name="volTPCWireU132">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU132"/>
+    </volume>
+    <volume name="volTPCWireU133">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU133"/>
+    </volume>
+    <volume name="volTPCWireU134">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU134"/>
+    </volume>
+    <volume name="volTPCWireU135">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU135"/>
+    </volume>
+    <volume name="volTPCWireU136">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU136"/>
+    </volume>
+    <volume name="volTPCWireU137">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU137"/>
+    </volume>
+    <volume name="volTPCWireU138">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU138"/>
+    </volume>
+    <volume name="volTPCWireU139">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU139"/>
+    </volume>
+    <volume name="volTPCWireU140">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU140"/>
+    </volume>
+    <volume name="volTPCWireU141">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU141"/>
+    </volume>
+    <volume name="volTPCWireU142">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU142"/>
+    </volume>
+    <volume name="volTPCWireU143">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU143"/>
+    </volume>
+    <volume name="volTPCWireU144">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU144"/>
+    </volume>
+    <volume name="volTPCWireU145">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU145"/>
+    </volume>
+    <volume name="volTPCWireU146">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU146"/>
+    </volume>
+    <volume name="volTPCWireU147">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU147"/>
+    </volume>
+    <volume name="volTPCWireU148">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU148"/>
+    </volume>
+    <volume name="volTPCWireU149">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU149"/>
+    </volume>
+    <volume name="volTPCWireU150">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU150"/>
+    </volume>
+    <volume name="volTPCWireU151">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU151"/>
+    </volume>
+    <volume name="volTPCWireU152">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU152"/>
+    </volume>
+    <volume name="volTPCWireU153">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU153"/>
+    </volume>
+    <volume name="volTPCWireU154">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU154"/>
+    </volume>
+    <volume name="volTPCWireU155">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU155"/>
+    </volume>
+    <volume name="volTPCWireU156">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU156"/>
+    </volume>
+    <volume name="volTPCWireU157">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU157"/>
+    </volume>
+    <volume name="volTPCWireU158">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU158"/>
+    </volume>
+    <volume name="volTPCWireU159">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU159"/>
+    </volume>
+    <volume name="volTPCWireU160">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU160"/>
+    </volume>
+    <volume name="volTPCWireU161">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU161"/>
+    </volume>
+    <volume name="volTPCWireU162">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU162"/>
+    </volume>
+    <volume name="volTPCWireU163">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU163"/>
+    </volume>
+    <volume name="volTPCWireU164">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU164"/>
+    </volume>
+    <volume name="volTPCWireU165">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU165"/>
+    </volume>
+    <volume name="volTPCWireU166">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU166"/>
+    </volume>
+    <volume name="volTPCWireU167">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU167"/>
+    </volume>
+    <volume name="volTPCWireU168">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU168"/>
+    </volume>
+    <volume name="volTPCWireU169">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU169"/>
+    </volume>
+    <volume name="volTPCWireU170">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU170"/>
+    </volume>
+    <volume name="volTPCWireU171">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU171"/>
+    </volume>
+    <volume name="volTPCWireU172">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU172"/>
+    </volume>
+    <volume name="volTPCWireU173">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU173"/>
+    </volume>
+    <volume name="volTPCWireU174">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU174"/>
+    </volume>
+    <volume name="volTPCWireU175">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU175"/>
+    </volume>
+    <volume name="volTPCWireU176">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU176"/>
+    </volume>
+    <volume name="volTPCWireU177">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU177"/>
+    </volume>
+    <volume name="volTPCWireU178">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU178"/>
+    </volume>
+    <volume name="volTPCWireU179">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU179"/>
+    </volume>
+    <volume name="volTPCWireU180">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU180"/>
+    </volume>
+    <volume name="volTPCWireU181">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU181"/>
+    </volume>
+    <volume name="volTPCWireU182">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU182"/>
+    </volume>
+    <volume name="volTPCWireU183">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU183"/>
+    </volume>
+    <volume name="volTPCWireU184">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU184"/>
+    </volume>
+    <volume name="volTPCWireU185">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU185"/>
+    </volume>
+    <volume name="volTPCWireU186">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU186"/>
+    </volume>
+    <volume name="volTPCWireU187">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU187"/>
+    </volume>
+    <volume name="volTPCWireU188">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU188"/>
+    </volume>
+    <volume name="volTPCWireU189">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU189"/>
+    </volume>
+    <volume name="volTPCWireU190">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU190"/>
+    </volume>
+    <volume name="volTPCWireU191">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU191"/>
+    </volume>
+    <volume name="volTPCWireU192">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU192"/>
+    </volume>
+    <volume name="volTPCWireU193">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU193"/>
+    </volume>
+    <volume name="volTPCWireU194">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU194"/>
+    </volume>
+    <volume name="volTPCWireU195">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU195"/>
+    </volume>
+    <volume name="volTPCWireU196">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU196"/>
+    </volume>
+    <volume name="volTPCWireU197">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU197"/>
+    </volume>
+    <volume name="volTPCWireU198">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU198"/>
+    </volume>
+    <volume name="volTPCWireU199">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU199"/>
+    </volume>
+    <volume name="volTPCWireU200">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU200"/>
+    </volume>
+    <volume name="volTPCWireU201">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU201"/>
+    </volume>
+    <volume name="volTPCWireU202">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU202"/>
+    </volume>
+    <volume name="volTPCWireU203">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU203"/>
+    </volume>
+    <volume name="volTPCWireU204">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU204"/>
+    </volume>
+    <volume name="volTPCWireU205">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU205"/>
+    </volume>
+    <volume name="volTPCWireU206">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU206"/>
+    </volume>
+    <volume name="volTPCWireU207">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU207"/>
+    </volume>
+    <volume name="volTPCWireU208">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU208"/>
+    </volume>
+    <volume name="volTPCWireU209">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU209"/>
+    </volume>
+    <volume name="volTPCWireU210">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU210"/>
+    </volume>
+    <volume name="volTPCWireU211">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU211"/>
+    </volume>
+    <volume name="volTPCWireU212">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU212"/>
+    </volume>
+    <volume name="volTPCWireU213">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU213"/>
+    </volume>
+    <volume name="volTPCWireU214">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU214"/>
+    </volume>
+    <volume name="volTPCWireU215">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU215"/>
+    </volume>
+    <volume name="volTPCWireU216">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU216"/>
+    </volume>
+    <volume name="volTPCWireU217">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU217"/>
+    </volume>
+    <volume name="volTPCWireU218">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU218"/>
+    </volume>
+    <volume name="volTPCWireU219">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU219"/>
+    </volume>
+    <volume name="volTPCWireU220">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU220"/>
+    </volume>
+    <volume name="volTPCWireU221">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU221"/>
+    </volume>
+    <volume name="volTPCWireU222">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU222"/>
+    </volume>
+    <volume name="volTPCWireU223">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU223"/>
+    </volume>
+    <volume name="volTPCWireU224">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU224"/>
+    </volume>
+    <volume name="volTPCWireU225">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU225"/>
+    </volume>
+    <volume name="volTPCWireU226">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU226"/>
+    </volume>
+    <volume name="volTPCWireU227">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU227"/>
+    </volume>
+    <volume name="volTPCWireU228">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU228"/>
+    </volume>
+    <volume name="volTPCWireU229">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU229"/>
+    </volume>
+    <volume name="volTPCWireU230">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU230"/>
+    </volume>
+    <volume name="volTPCWireU231">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU231"/>
+    </volume>
+    <volume name="volTPCWireU232">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU232"/>
+    </volume>
+    <volume name="volTPCWireU233">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU233"/>
+    </volume>
+    <volume name="volTPCWireU234">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU234"/>
+    </volume>
+    <volume name="volTPCWireU235">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU235"/>
+    </volume>
+    <volume name="volTPCWireU236">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU236"/>
+    </volume>
+    <volume name="volTPCWireU237">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU237"/>
+    </volume>
+    <volume name="volTPCWireU238">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU238"/>
+    </volume>
+    <volume name="volTPCWireU239">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU239"/>
+    </volume>
+    <volume name="volTPCWireU240">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU240"/>
+    </volume>
+    <volume name="volTPCWireU241">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU241"/>
+    </volume>
+    <volume name="volTPCWireU242">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU242"/>
+    </volume>
+    <volume name="volTPCWireU243">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU243"/>
+    </volume>
+    <volume name="volTPCWireU244">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU244"/>
+    </volume>
+    <volume name="volTPCWireU245">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU245"/>
+    </volume>
+    <volume name="volTPCWireU246">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU246"/>
+    </volume>
+    <volume name="volTPCWireU247">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU247"/>
+    </volume>
+    <volume name="volTPCWireU248">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU248"/>
+    </volume>
+    <volume name="volTPCWireU249">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU249"/>
+    </volume>
+    <volume name="volTPCWireU250">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU250"/>
+    </volume>
+    <volume name="volTPCWireU251">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU251"/>
+    </volume>
+    <volume name="volTPCWireU252">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU252"/>
+    </volume>
+    <volume name="volTPCWireU253">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU253"/>
+    </volume>
+    <volume name="volTPCWireU254">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU254"/>
+    </volume>
+    <volume name="volTPCWireU255">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU255"/>
+    </volume>
+    <volume name="volTPCWireU256">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU256"/>
+    </volume>
+    <volume name="volTPCWireU257">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU257"/>
+    </volume>
+    <volume name="volTPCWireU258">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU258"/>
+    </volume>
+    <volume name="volTPCWireU259">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU259"/>
+    </volume>
+    <volume name="volTPCWireU260">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU260"/>
+    </volume>
+    <volume name="volTPCWireU261">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU261"/>
+    </volume>
+    <volume name="volTPCWireU262">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU262"/>
+    </volume>
+    <volume name="volTPCWireU263">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU263"/>
+    </volume>
+    <volume name="volTPCWireU264">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU264"/>
+    </volume>
+    <volume name="volTPCWireU265">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU265"/>
+    </volume>
+    <volume name="volTPCWireU266">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU266"/>
+    </volume>
+    <volume name="volTPCWireU267">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU267"/>
+    </volume>
+    <volume name="volTPCWireU268">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU268"/>
+    </volume>
+    <volume name="volTPCWireU269">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU269"/>
+    </volume>
+    <volume name="volTPCWireU270">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU270"/>
+    </volume>
+    <volume name="volTPCWireU271">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU271"/>
+    </volume>
+    <volume name="volTPCWireU272">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU272"/>
+    </volume>
+    <volume name="volTPCWireU273">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU273"/>
+    </volume>
+    <volume name="volTPCWireU274">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU274"/>
+    </volume>
+    <volume name="volTPCWireU275">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU275"/>
+    </volume>
+    <volume name="volTPCWireU276">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU276"/>
+    </volume>
+    <volume name="volTPCWireU277">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU277"/>
+    </volume>
+    <volume name="volTPCWireU278">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU278"/>
+    </volume>
+    <volume name="volTPCWireU279">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU279"/>
+    </volume>
+    <volume name="volTPCWireU280">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU280"/>
+    </volume>
+    <volume name="volTPCWireU281">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU281"/>
+    </volume>
+    <volume name="volTPCWireU282">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU282"/>
+    </volume>
+    <volume name="volTPCWireU283">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU283"/>
+    </volume>
+    <volume name="volTPCWireU284">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU284"/>
+    </volume>
+    <volume name="volTPCWireU285">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU285"/>
+    </volume>
+    <volume name="volTPCWireV0">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV0"/>
+    </volume>
+    <volume name="volTPCWireV1">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV1"/>
+    </volume>
+    <volume name="volTPCWireV2">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV2"/>
+    </volume>
+    <volume name="volTPCWireV3">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV3"/>
+    </volume>
+    <volume name="volTPCWireV4">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV4"/>
+    </volume>
+    <volume name="volTPCWireV5">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV5"/>
+    </volume>
+    <volume name="volTPCWireV6">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV6"/>
+    </volume>
+    <volume name="volTPCWireV7">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV7"/>
+    </volume>
+    <volume name="volTPCWireV8">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV8"/>
+    </volume>
+    <volume name="volTPCWireV9">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV9"/>
+    </volume>
+    <volume name="volTPCWireV10">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV10"/>
+    </volume>
+    <volume name="volTPCWireV11">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV11"/>
+    </volume>
+    <volume name="volTPCWireV12">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV12"/>
+    </volume>
+    <volume name="volTPCWireV13">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV13"/>
+    </volume>
+    <volume name="volTPCWireV14">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV14"/>
+    </volume>
+    <volume name="volTPCWireV15">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV15"/>
+    </volume>
+    <volume name="volTPCWireV16">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV16"/>
+    </volume>
+    <volume name="volTPCWireV17">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV17"/>
+    </volume>
+    <volume name="volTPCWireV18">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV18"/>
+    </volume>
+    <volume name="volTPCWireV19">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV19"/>
+    </volume>
+    <volume name="volTPCWireV20">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV20"/>
+    </volume>
+    <volume name="volTPCWireV21">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV21"/>
+    </volume>
+    <volume name="volTPCWireV22">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV22"/>
+    </volume>
+    <volume name="volTPCWireV23">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV23"/>
+    </volume>
+    <volume name="volTPCWireV24">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV24"/>
+    </volume>
+    <volume name="volTPCWireV25">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV25"/>
+    </volume>
+    <volume name="volTPCWireV26">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV26"/>
+    </volume>
+    <volume name="volTPCWireV27">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV27"/>
+    </volume>
+    <volume name="volTPCWireV28">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV28"/>
+    </volume>
+    <volume name="volTPCWireV29">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV29"/>
+    </volume>
+    <volume name="volTPCWireV30">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV30"/>
+    </volume>
+    <volume name="volTPCWireV31">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV31"/>
+    </volume>
+    <volume name="volTPCWireV32">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV32"/>
+    </volume>
+    <volume name="volTPCWireV33">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV33"/>
+    </volume>
+    <volume name="volTPCWireV34">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV34"/>
+    </volume>
+    <volume name="volTPCWireV35">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV35"/>
+    </volume>
+    <volume name="volTPCWireV36">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV36"/>
+    </volume>
+    <volume name="volTPCWireV37">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV37"/>
+    </volume>
+    <volume name="volTPCWireV38">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV38"/>
+    </volume>
+    <volume name="volTPCWireV39">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV39"/>
+    </volume>
+    <volume name="volTPCWireV40">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV40"/>
+    </volume>
+    <volume name="volTPCWireV41">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV41"/>
+    </volume>
+    <volume name="volTPCWireV42">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV42"/>
+    </volume>
+    <volume name="volTPCWireV43">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV43"/>
+    </volume>
+    <volume name="volTPCWireV44">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV44"/>
+    </volume>
+    <volume name="volTPCWireV45">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV45"/>
+    </volume>
+    <volume name="volTPCWireV46">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV46"/>
+    </volume>
+    <volume name="volTPCWireV47">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV47"/>
+    </volume>
+    <volume name="volTPCWireV48">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV48"/>
+    </volume>
+    <volume name="volTPCWireV49">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV49"/>
+    </volume>
+    <volume name="volTPCWireV50">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV50"/>
+    </volume>
+    <volume name="volTPCWireV51">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV51"/>
+    </volume>
+    <volume name="volTPCWireV52">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV52"/>
+    </volume>
+    <volume name="volTPCWireV53">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV53"/>
+    </volume>
+    <volume name="volTPCWireV54">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV54"/>
+    </volume>
+    <volume name="volTPCWireV55">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV55"/>
+    </volume>
+    <volume name="volTPCWireV56">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV56"/>
+    </volume>
+    <volume name="volTPCWireV57">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV57"/>
+    </volume>
+    <volume name="volTPCWireV58">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV58"/>
+    </volume>
+    <volume name="volTPCWireV59">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV59"/>
+    </volume>
+    <volume name="volTPCWireV60">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV60"/>
+    </volume>
+    <volume name="volTPCWireV61">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV61"/>
+    </volume>
+    <volume name="volTPCWireV62">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV62"/>
+    </volume>
+    <volume name="volTPCWireV63">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV63"/>
+    </volume>
+    <volume name="volTPCWireV64">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV64"/>
+    </volume>
+    <volume name="volTPCWireV65">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV65"/>
+    </volume>
+    <volume name="volTPCWireV66">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV66"/>
+    </volume>
+    <volume name="volTPCWireV67">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV67"/>
+    </volume>
+    <volume name="volTPCWireV68">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV68"/>
+    </volume>
+    <volume name="volTPCWireV69">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV69"/>
+    </volume>
+    <volume name="volTPCWireV70">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV70"/>
+    </volume>
+    <volume name="volTPCWireV71">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV71"/>
+    </volume>
+    <volume name="volTPCWireV72">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV72"/>
+    </volume>
+    <volume name="volTPCWireV73">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV73"/>
+    </volume>
+    <volume name="volTPCWireV74">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV74"/>
+    </volume>
+    <volume name="volTPCWireV75">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV75"/>
+    </volume>
+    <volume name="volTPCWireV76">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV76"/>
+    </volume>
+    <volume name="volTPCWireV77">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV77"/>
+    </volume>
+    <volume name="volTPCWireV78">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV78"/>
+    </volume>
+    <volume name="volTPCWireV79">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV79"/>
+    </volume>
+    <volume name="volTPCWireV80">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV80"/>
+    </volume>
+    <volume name="volTPCWireV81">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV81"/>
+    </volume>
+    <volume name="volTPCWireV82">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV82"/>
+    </volume>
+    <volume name="volTPCWireV83">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV83"/>
+    </volume>
+    <volume name="volTPCWireV84">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV84"/>
+    </volume>
+    <volume name="volTPCWireV85">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV85"/>
+    </volume>
+    <volume name="volTPCWireV86">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV86"/>
+    </volume>
+    <volume name="volTPCWireV87">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV87"/>
+    </volume>
+    <volume name="volTPCWireV88">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV88"/>
+    </volume>
+    <volume name="volTPCWireV89">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV89"/>
+    </volume>
+    <volume name="volTPCWireV90">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV90"/>
+    </volume>
+    <volume name="volTPCWireV91">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV91"/>
+    </volume>
+    <volume name="volTPCWireV92">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV92"/>
+    </volume>
+    <volume name="volTPCWireV93">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV93"/>
+    </volume>
+    <volume name="volTPCWireV94">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV94"/>
+    </volume>
+    <volume name="volTPCWireV95">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV95"/>
+    </volume>
+    <volume name="volTPCWireV96">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV96"/>
+    </volume>
+    <volume name="volTPCWireV97">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV97"/>
+    </volume>
+    <volume name="volTPCWireV98">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV98"/>
+    </volume>
+    <volume name="volTPCWireV99">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV99"/>
+    </volume>
+    <volume name="volTPCWireV100">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV100"/>
+    </volume>
+    <volume name="volTPCWireV101">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV101"/>
+    </volume>
+    <volume name="volTPCWireV102">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV102"/>
+    </volume>
+    <volume name="volTPCWireV103">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV103"/>
+    </volume>
+    <volume name="volTPCWireV104">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV104"/>
+    </volume>
+    <volume name="volTPCWireV105">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV105"/>
+    </volume>
+    <volume name="volTPCWireV106">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV106"/>
+    </volume>
+    <volume name="volTPCWireV107">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV107"/>
+    </volume>
+    <volume name="volTPCWireV108">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV108"/>
+    </volume>
+    <volume name="volTPCWireV109">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV109"/>
+    </volume>
+    <volume name="volTPCWireV110">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV110"/>
+    </volume>
+    <volume name="volTPCWireV111">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV111"/>
+    </volume>
+    <volume name="volTPCWireV112">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV112"/>
+    </volume>
+    <volume name="volTPCWireV113">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV113"/>
+    </volume>
+    <volume name="volTPCWireV114">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV114"/>
+    </volume>
+    <volume name="volTPCWireV115">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV115"/>
+    </volume>
+    <volume name="volTPCWireV116">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV116"/>
+    </volume>
+    <volume name="volTPCWireV117">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV117"/>
+    </volume>
+    <volume name="volTPCWireV118">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV118"/>
+    </volume>
+    <volume name="volTPCWireV119">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV119"/>
+    </volume>
+    <volume name="volTPCWireV120">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV120"/>
+    </volume>
+    <volume name="volTPCWireV121">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV121"/>
+    </volume>
+    <volume name="volTPCWireV122">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV122"/>
+    </volume>
+    <volume name="volTPCWireV123">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV123"/>
+    </volume>
+    <volume name="volTPCWireV124">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV124"/>
+    </volume>
+    <volume name="volTPCWireV125">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV125"/>
+    </volume>
+    <volume name="volTPCWireV126">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV126"/>
+    </volume>
+    <volume name="volTPCWireV127">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV127"/>
+    </volume>
+    <volume name="volTPCWireV128">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV128"/>
+    </volume>
+    <volume name="volTPCWireV129">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV129"/>
+    </volume>
+    <volume name="volTPCWireV130">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV130"/>
+    </volume>
+    <volume name="volTPCWireV131">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV131"/>
+    </volume>
+    <volume name="volTPCWireV132">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV132"/>
+    </volume>
+    <volume name="volTPCWireV133">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV133"/>
+    </volume>
+    <volume name="volTPCWireV134">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV134"/>
+    </volume>
+    <volume name="volTPCWireV135">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV135"/>
+    </volume>
+    <volume name="volTPCWireV136">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV136"/>
+    </volume>
+    <volume name="volTPCWireV137">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV137"/>
+    </volume>
+    <volume name="volTPCWireV138">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV138"/>
+    </volume>
+    <volume name="volTPCWireV139">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV139"/>
+    </volume>
+    <volume name="volTPCWireV140">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV140"/>
+    </volume>
+    <volume name="volTPCWireV141">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV141"/>
+    </volume>
+    <volume name="volTPCWireV142">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV142"/>
+    </volume>
+    <volume name="volTPCWireV143">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV143"/>
+    </volume>
+    <volume name="volTPCWireV144">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV144"/>
+    </volume>
+    <volume name="volTPCWireV145">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV145"/>
+    </volume>
+    <volume name="volTPCWireV146">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV146"/>
+    </volume>
+    <volume name="volTPCWireV147">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV147"/>
+    </volume>
+    <volume name="volTPCWireV148">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV148"/>
+    </volume>
+    <volume name="volTPCWireV149">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV149"/>
+    </volume>
+    <volume name="volTPCWireV150">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV150"/>
+    </volume>
+    <volume name="volTPCWireV151">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV151"/>
+    </volume>
+    <volume name="volTPCWireV152">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV152"/>
+    </volume>
+    <volume name="volTPCWireV153">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV153"/>
+    </volume>
+    <volume name="volTPCWireV154">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV154"/>
+    </volume>
+    <volume name="volTPCWireV155">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV155"/>
+    </volume>
+    <volume name="volTPCWireV156">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV156"/>
+    </volume>
+    <volume name="volTPCWireV157">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV157"/>
+    </volume>
+    <volume name="volTPCWireV158">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV158"/>
+    </volume>
+    <volume name="volTPCWireV159">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV159"/>
+    </volume>
+    <volume name="volTPCWireV160">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV160"/>
+    </volume>
+    <volume name="volTPCWireV161">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV161"/>
+    </volume>
+    <volume name="volTPCWireV162">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV162"/>
+    </volume>
+    <volume name="volTPCWireV163">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV163"/>
+    </volume>
+    <volume name="volTPCWireV164">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV164"/>
+    </volume>
+    <volume name="volTPCWireV165">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV165"/>
+    </volume>
+    <volume name="volTPCWireV166">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV166"/>
+    </volume>
+    <volume name="volTPCWireV167">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV167"/>
+    </volume>
+    <volume name="volTPCWireV168">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV168"/>
+    </volume>
+    <volume name="volTPCWireV169">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV169"/>
+    </volume>
+    <volume name="volTPCWireV170">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV170"/>
+    </volume>
+    <volume name="volTPCWireV171">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV171"/>
+    </volume>
+    <volume name="volTPCWireV172">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV172"/>
+    </volume>
+    <volume name="volTPCWireV173">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV173"/>
+    </volume>
+    <volume name="volTPCWireV174">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV174"/>
+    </volume>
+    <volume name="volTPCWireV175">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV175"/>
+    </volume>
+    <volume name="volTPCWireV176">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV176"/>
+    </volume>
+    <volume name="volTPCWireV177">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV177"/>
+    </volume>
+    <volume name="volTPCWireV178">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV178"/>
+    </volume>
+    <volume name="volTPCWireV179">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV179"/>
+    </volume>
+    <volume name="volTPCWireV180">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV180"/>
+    </volume>
+    <volume name="volTPCWireV181">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV181"/>
+    </volume>
+    <volume name="volTPCWireV182">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV182"/>
+    </volume>
+    <volume name="volTPCWireV183">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV183"/>
+    </volume>
+    <volume name="volTPCWireV184">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV184"/>
+    </volume>
+    <volume name="volTPCWireV185">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV185"/>
+    </volume>
+    <volume name="volTPCWireV186">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV186"/>
+    </volume>
+    <volume name="volTPCWireV187">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV187"/>
+    </volume>
+    <volume name="volTPCWireV188">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV188"/>
+    </volume>
+    <volume name="volTPCWireV189">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV189"/>
+    </volume>
+    <volume name="volTPCWireV190">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV190"/>
+    </volume>
+    <volume name="volTPCWireV191">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV191"/>
+    </volume>
+    <volume name="volTPCWireV192">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV192"/>
+    </volume>
+    <volume name="volTPCWireV193">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV193"/>
+    </volume>
+    <volume name="volTPCWireV194">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV194"/>
+    </volume>
+    <volume name="volTPCWireV195">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV195"/>
+    </volume>
+    <volume name="volTPCWireV196">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV196"/>
+    </volume>
+    <volume name="volTPCWireV197">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV197"/>
+    </volume>
+    <volume name="volTPCWireV198">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV198"/>
+    </volume>
+    <volume name="volTPCWireV199">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV199"/>
+    </volume>
+    <volume name="volTPCWireV200">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV200"/>
+    </volume>
+    <volume name="volTPCWireV201">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV201"/>
+    </volume>
+    <volume name="volTPCWireV202">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV202"/>
+    </volume>
+    <volume name="volTPCWireV203">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV203"/>
+    </volume>
+    <volume name="volTPCWireV204">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV204"/>
+    </volume>
+    <volume name="volTPCWireV205">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV205"/>
+    </volume>
+    <volume name="volTPCWireV206">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV206"/>
+    </volume>
+    <volume name="volTPCWireV207">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV207"/>
+    </volume>
+    <volume name="volTPCWireV208">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV208"/>
+    </volume>
+    <volume name="volTPCWireV209">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV209"/>
+    </volume>
+    <volume name="volTPCWireV210">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV210"/>
+    </volume>
+    <volume name="volTPCWireV211">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV211"/>
+    </volume>
+    <volume name="volTPCWireV212">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV212"/>
+    </volume>
+    <volume name="volTPCWireV213">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV213"/>
+    </volume>
+    <volume name="volTPCWireV214">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV214"/>
+    </volume>
+    <volume name="volTPCWireV215">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV215"/>
+    </volume>
+    <volume name="volTPCWireV216">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV216"/>
+    </volume>
+    <volume name="volTPCWireV217">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV217"/>
+    </volume>
+    <volume name="volTPCWireV218">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV218"/>
+    </volume>
+    <volume name="volTPCWireV219">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV219"/>
+    </volume>
+    <volume name="volTPCWireV220">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV220"/>
+    </volume>
+    <volume name="volTPCWireV221">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV221"/>
+    </volume>
+    <volume name="volTPCWireV222">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV222"/>
+    </volume>
+    <volume name="volTPCWireV223">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV223"/>
+    </volume>
+    <volume name="volTPCWireV224">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV224"/>
+    </volume>
+    <volume name="volTPCWireV225">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV225"/>
+    </volume>
+    <volume name="volTPCWireV226">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV226"/>
+    </volume>
+    <volume name="volTPCWireV227">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV227"/>
+    </volume>
+    <volume name="volTPCWireV228">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV228"/>
+    </volume>
+    <volume name="volTPCWireV229">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV229"/>
+    </volume>
+    <volume name="volTPCWireV230">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV230"/>
+    </volume>
+    <volume name="volTPCWireV231">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV231"/>
+    </volume>
+    <volume name="volTPCWireV232">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV232"/>
+    </volume>
+    <volume name="volTPCWireV233">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV233"/>
+    </volume>
+    <volume name="volTPCWireV234">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV234"/>
+    </volume>
+    <volume name="volTPCWireV235">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV235"/>
+    </volume>
+    <volume name="volTPCWireV236">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV236"/>
+    </volume>
+    <volume name="volTPCWireV237">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV237"/>
+    </volume>
+    <volume name="volTPCWireV238">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV238"/>
+    </volume>
+    <volume name="volTPCWireV239">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV239"/>
+    </volume>
+    <volume name="volTPCWireV240">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV240"/>
+    </volume>
+    <volume name="volTPCWireV241">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV241"/>
+    </volume>
+    <volume name="volTPCWireV242">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV242"/>
+    </volume>
+    <volume name="volTPCWireV243">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV243"/>
+    </volume>
+    <volume name="volTPCWireV244">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV244"/>
+    </volume>
+    <volume name="volTPCWireV245">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV245"/>
+    </volume>
+    <volume name="volTPCWireV246">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV246"/>
+    </volume>
+    <volume name="volTPCWireV247">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV247"/>
+    </volume>
+    <volume name="volTPCWireV248">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV248"/>
+    </volume>
+    <volume name="volTPCWireV249">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV249"/>
+    </volume>
+    <volume name="volTPCWireV250">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV250"/>
+    </volume>
+    <volume name="volTPCWireV251">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV251"/>
+    </volume>
+    <volume name="volTPCWireV252">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV252"/>
+    </volume>
+    <volume name="volTPCWireV253">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV253"/>
+    </volume>
+    <volume name="volTPCWireV254">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV254"/>
+    </volume>
+    <volume name="volTPCWireV255">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV255"/>
+    </volume>
+    <volume name="volTPCWireV256">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV256"/>
+    </volume>
+    <volume name="volTPCWireV257">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV257"/>
+    </volume>
+    <volume name="volTPCWireV258">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV258"/>
+    </volume>
+    <volume name="volTPCWireV259">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV259"/>
+    </volume>
+    <volume name="volTPCWireV260">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV260"/>
+    </volume>
+    <volume name="volTPCWireV261">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV261"/>
+    </volume>
+    <volume name="volTPCWireV262">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV262"/>
+    </volume>
+    <volume name="volTPCWireV263">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV263"/>
+    </volume>
+    <volume name="volTPCWireV264">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV264"/>
+    </volume>
+    <volume name="volTPCWireV265">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV265"/>
+    </volume>
+    <volume name="volTPCWireV266">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV266"/>
+    </volume>
+    <volume name="volTPCWireV267">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV267"/>
+    </volume>
+    <volume name="volTPCWireV268">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV268"/>
+    </volume>
+    <volume name="volTPCWireV269">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV269"/>
+    </volume>
+    <volume name="volTPCWireV270">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV270"/>
+    </volume>
+    <volume name="volTPCWireV271">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV271"/>
+    </volume>
+    <volume name="volTPCWireV272">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV272"/>
+    </volume>
+    <volume name="volTPCWireV273">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV273"/>
+    </volume>
+    <volume name="volTPCWireV274">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV274"/>
+    </volume>
+    <volume name="volTPCWireV275">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV275"/>
+    </volume>
+    <volume name="volTPCWireV276">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV276"/>
+    </volume>
+    <volume name="volTPCWireV277">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV277"/>
+    </volume>
+    <volume name="volTPCWireV278">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV278"/>
+    </volume>
+    <volume name="volTPCWireV279">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV279"/>
+    </volume>
+    <volume name="volTPCWireV280">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV280"/>
+    </volume>
+    <volume name="volTPCWireV281">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV281"/>
+    </volume>
+    <volume name="volTPCWireV282">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV282"/>
+    </volume>
+    <volume name="volTPCWireV283">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV283"/>
+    </volume>
+    <volume name="volTPCWireV284">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV284"/>
+    </volume>
+    <volume name="volTPCWireV285">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV285"/>
+    </volume>
+    <volume name="volTPCWireZ">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireZ"/>
+    </volume>
+   <volume name="volTPCPlaneU">
+     <materialref ref="LAr"/>
+     <solidref ref="CRMUPlane"/>
+     <physvol>
+       <volumeref ref="volTPCWireU0"/> 
+       <position name="posWireU0" unit="cm" x="0" y="-83.6970251487471" z="-74.0775"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU1"/> 
+       <position name="posWireU1" unit="cm" x="0" y="-83.255352192817" z="-73.3125"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU2"/> 
+       <position name="posWireU2" unit="cm" x="0" y="-82.8136792368869" z="-72.5475"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU3"/> 
+       <position name="posWireU3" unit="cm" x="0" y="-82.3720062809569" z="-71.7825"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU4"/> 
+       <position name="posWireU4" unit="cm" x="0" y="-81.9303333250268" z="-71.0175"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU5"/> 
+       <position name="posWireU5" unit="cm" x="0" y="-81.4886603690967" z="-70.2525"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU6"/> 
+       <position name="posWireU6" unit="cm" x="0" y="-81.0469874131667" z="-69.4875"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU7"/> 
+       <position name="posWireU7" unit="cm" x="0" y="-80.6053144572366" z="-68.7225"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU8"/> 
+       <position name="posWireU8" unit="cm" x="0" y="-80.1636415013066" z="-67.9575"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU9"/> 
+       <position name="posWireU9" unit="cm" x="0" y="-79.7219685453765" z="-67.1925"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU10"/> 
+       <position name="posWireU10" unit="cm" x="0" y="-79.2802955894464" z="-66.4275"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU11"/> 
+       <position name="posWireU11" unit="cm" x="0" y="-78.8386226335164" z="-65.6625"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU12"/> 
+       <position name="posWireU12" unit="cm" x="0" y="-78.3969496775863" z="-64.8975"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU13"/> 
+       <position name="posWireU13" unit="cm" x="0" y="-77.9552767216562" z="-64.1325"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU14"/> 
+       <position name="posWireU14" unit="cm" x="0" y="-77.5136037657262" z="-63.3675"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU15"/> 
+       <position name="posWireU15" unit="cm" x="0" y="-77.0719308097961" z="-62.6025"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU16"/> 
+       <position name="posWireU16" unit="cm" x="0" y="-76.630257853866" z="-61.8375"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU17"/> 
+       <position name="posWireU17" unit="cm" x="0" y="-76.188584897936" z="-61.0725"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU18"/> 
+       <position name="posWireU18" unit="cm" x="0" y="-75.7469119420059" z="-60.3075"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU19"/> 
+       <position name="posWireU19" unit="cm" x="0" y="-75.3052389860758" z="-59.5425"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU20"/> 
+       <position name="posWireU20" unit="cm" x="0" y="-74.8635660301458" z="-58.7775"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU21"/> 
+       <position name="posWireU21" unit="cm" x="0" y="-74.4218930742157" z="-58.0125"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU22"/> 
+       <position name="posWireU22" unit="cm" x="0" y="-73.9802201182857" z="-57.2475"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU23"/> 
+       <position name="posWireU23" unit="cm" x="0" y="-73.5385471623556" z="-56.4825"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU24"/> 
+       <position name="posWireU24" unit="cm" x="0" y="-73.0968742064255" z="-55.7175"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU25"/> 
+       <position name="posWireU25" unit="cm" x="0" y="-72.6552012504955" z="-54.9525"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU26"/> 
+       <position name="posWireU26" unit="cm" x="0" y="-72.2135282945654" z="-54.1875"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU27"/> 
+       <position name="posWireU27" unit="cm" x="0" y="-71.7718553386353" z="-53.4225"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU28"/> 
+       <position name="posWireU28" unit="cm" x="0" y="-71.3301823827053" z="-52.6575"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU29"/> 
+       <position name="posWireU29" unit="cm" x="0" y="-70.8885094267752" z="-51.8925"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU30"/> 
+       <position name="posWireU30" unit="cm" x="0" y="-70.4468364708451" z="-51.1275"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU31"/> 
+       <position name="posWireU31" unit="cm" x="0" y="-70.0051635149151" z="-50.3625"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU32"/> 
+       <position name="posWireU32" unit="cm" x="0" y="-69.563490558985" z="-49.5975"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU33"/> 
+       <position name="posWireU33" unit="cm" x="0" y="-69.121817603055" z="-48.8325"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU34"/> 
+       <position name="posWireU34" unit="cm" x="0" y="-68.6801446471249" z="-48.0675"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU35"/> 
+       <position name="posWireU35" unit="cm" x="0" y="-68.2384716911948" z="-47.3025"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU36"/> 
+       <position name="posWireU36" unit="cm" x="0" y="-67.7967987352648" z="-46.5375"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU37"/> 
+       <position name="posWireU37" unit="cm" x="0" y="-67.3551257793347" z="-45.7725"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU38"/> 
+       <position name="posWireU38" unit="cm" x="0" y="-66.9134528234046" z="-45.0075"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU39"/> 
+       <position name="posWireU39" unit="cm" x="0" y="-66.4717798674746" z="-44.2425"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU40"/> 
+       <position name="posWireU40" unit="cm" x="0" y="-66.0301069115445" z="-43.4775"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU41"/> 
+       <position name="posWireU41" unit="cm" x="0" y="-65.5884339556144" z="-42.7125"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU42"/> 
+       <position name="posWireU42" unit="cm" x="0" y="-65.1467609996844" z="-41.9475"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU43"/> 
+       <position name="posWireU43" unit="cm" x="0" y="-64.7050880437543" z="-41.1825"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU44"/> 
+       <position name="posWireU44" unit="cm" x="0" y="-64.2634150878243" z="-40.4175"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU45"/> 
+       <position name="posWireU45" unit="cm" x="0" y="-63.8217421318942" z="-39.6525"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU46"/> 
+       <position name="posWireU46" unit="cm" x="0" y="-63.3800691759641" z="-38.8875"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU47"/> 
+       <position name="posWireU47" unit="cm" x="0" y="-62.9383962200341" z="-38.1225"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU48"/> 
+       <position name="posWireU48" unit="cm" x="0" y="-62.496723264104" z="-37.3575"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU49"/> 
+       <position name="posWireU49" unit="cm" x="0" y="-62.0550503081739" z="-36.5925"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU50"/> 
+       <position name="posWireU50" unit="cm" x="0" y="-61.6133773522439" z="-35.8275"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU51"/> 
+       <position name="posWireU51" unit="cm" x="0" y="-61.1717043963138" z="-35.0625"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU52"/> 
+       <position name="posWireU52" unit="cm" x="0" y="-60.7300314403837" z="-34.2975"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU53"/> 
+       <position name="posWireU53" unit="cm" x="0" y="-60.2883584844537" z="-33.5325"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU54"/> 
+       <position name="posWireU54" unit="cm" x="0" y="-59.8466855285236" z="-32.7675"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU55"/> 
+       <position name="posWireU55" unit="cm" x="0" y="-59.4050125725935" z="-32.0025"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU56"/> 
+       <position name="posWireU56" unit="cm" x="0" y="-58.9633396166635" z="-31.2375"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU57"/> 
+       <position name="posWireU57" unit="cm" x="0" y="-58.5216666607334" z="-30.4725"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU58"/> 
+       <position name="posWireU58" unit="cm" x="0" y="-58.0799937048034" z="-29.7075"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU59"/> 
+       <position name="posWireU59" unit="cm" x="0" y="-57.6383207488733" z="-28.9425"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU60"/> 
+       <position name="posWireU60" unit="cm" x="0" y="-57.1966477929432" z="-28.1775"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU61"/> 
+       <position name="posWireU61" unit="cm" x="0" y="-56.7549748370132" z="-27.4125"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU62"/> 
+       <position name="posWireU62" unit="cm" x="0" y="-56.3133018810831" z="-26.6475"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU63"/> 
+       <position name="posWireU63" unit="cm" x="0" y="-55.871628925153" z="-25.8825"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU64"/> 
+       <position name="posWireU64" unit="cm" x="0" y="-55.429955969223" z="-25.1175"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU65"/> 
+       <position name="posWireU65" unit="cm" x="0" y="-54.9882830132929" z="-24.3525"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU66"/> 
+       <position name="posWireU66" unit="cm" x="0" y="-54.5466100573628" z="-23.5875"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU67"/> 
+       <position name="posWireU67" unit="cm" x="0" y="-54.1049371014328" z="-22.8225"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU68"/> 
+       <position name="posWireU68" unit="cm" x="0" y="-53.6632641455027" z="-22.0575"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU69"/> 
+       <position name="posWireU69" unit="cm" x="0" y="-53.2215911895726" z="-21.2925"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU70"/> 
+       <position name="posWireU70" unit="cm" x="0" y="-52.7799182336426" z="-20.5275"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU71"/> 
+       <position name="posWireU71" unit="cm" x="0" y="-52.3382452777125" z="-19.7625"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU72"/> 
+       <position name="posWireU72" unit="cm" x="0" y="-51.8965723217825" z="-18.9975"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU73"/> 
+       <position name="posWireU73" unit="cm" x="0" y="-51.4548993658524" z="-18.2325"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU74"/> 
+       <position name="posWireU74" unit="cm" x="0" y="-51.0132264099223" z="-17.4675"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU75"/> 
+       <position name="posWireU75" unit="cm" x="0" y="-50.5715534539923" z="-16.7025"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU76"/> 
+       <position name="posWireU76" unit="cm" x="0" y="-50.1298804980622" z="-15.9375"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU77"/> 
+       <position name="posWireU77" unit="cm" x="0" y="-49.6882075421321" z="-15.1725"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU78"/> 
+       <position name="posWireU78" unit="cm" x="0" y="-49.2465345862021" z="-14.4075"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU79"/> 
+       <position name="posWireU79" unit="cm" x="0" y="-48.804861630272" z="-13.6425"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU80"/> 
+       <position name="posWireU80" unit="cm" x="0" y="-48.3631886743419" z="-12.8775"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU81"/> 
+       <position name="posWireU81" unit="cm" x="0" y="-47.9215157184119" z="-12.1125"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU82"/> 
+       <position name="posWireU82" unit="cm" x="0" y="-47.4798427624818" z="-11.3475"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU83"/> 
+       <position name="posWireU83" unit="cm" x="0" y="-47.0381698065518" z="-10.5825"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU84"/> 
+       <position name="posWireU84" unit="cm" x="0" y="-46.5964968506217" z="-9.81749999999995"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU85"/> 
+       <position name="posWireU85" unit="cm" x="0" y="-46.1548238946916" z="-9.05249999999995"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU86"/> 
+       <position name="posWireU86" unit="cm" x="0" y="-45.7131509387616" z="-8.28749999999995"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU87"/> 
+       <position name="posWireU87" unit="cm" x="0" y="-45.2714779828315" z="-7.52249999999995"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU88"/> 
+       <position name="posWireU88" unit="cm" x="0" y="-44.8298050269014" z="-6.75749999999995"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU89"/> 
+       <position name="posWireU89" unit="cm" x="0" y="-44.3881320709714" z="-5.99249999999995"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU90"/> 
+       <position name="posWireU90" unit="cm" x="0" y="-43.9464591150413" z="-5.22749999999995"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU91"/> 
+       <position name="posWireU91" unit="cm" x="0" y="-43.5047861591112" z="-4.46249999999995"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU92"/> 
+       <position name="posWireU92" unit="cm" x="0" y="-43.0631132031812" z="-3.69749999999995"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU93"/> 
+       <position name="posWireU93" unit="cm" x="0" y="-42.6214402472511" z="-2.93249999999995"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU94"/> 
+       <position name="posWireU94" unit="cm" x="0" y="-42.1797672913211" z="-2.16749999999995"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU95"/> 
+       <position name="posWireU95" unit="cm" x="0" y="-41.738094335391" z="-1.40249999999995"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU96"/> 
+       <position name="posWireU96" unit="cm" x="0" y="-41.2964213794609" z="-0.637499999999946"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU97"/> 
+       <position name="posWireU97" unit="cm" x="0" y="-40.7811362642091" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU98"/> 
+       <position name="posWireU98" unit="cm" x="0" y="-39.897790352349" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU99"/> 
+       <position name="posWireU99" unit="cm" x="0" y="-39.0144444404889" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU100"/> 
+       <position name="posWireU100" unit="cm" x="0" y="-38.1310985286288" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU101"/> 
+       <position name="posWireU101" unit="cm" x="0" y="-37.2477526167686" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU102"/> 
+       <position name="posWireU102" unit="cm" x="0" y="-36.3644067049085" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU103"/> 
+       <position name="posWireU103" unit="cm" x="0" y="-35.4810607930484" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU104"/> 
+       <position name="posWireU104" unit="cm" x="0" y="-34.5977148811883" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU105"/> 
+       <position name="posWireU105" unit="cm" x="0" y="-33.7143689693281" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU106"/> 
+       <position name="posWireU106" unit="cm" x="0" y="-32.831023057468" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU107"/> 
+       <position name="posWireU107" unit="cm" x="0" y="-31.9476771456079" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU108"/> 
+       <position name="posWireU108" unit="cm" x="0" y="-31.0643312337477" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU109"/> 
+       <position name="posWireU109" unit="cm" x="0" y="-30.1809853218876" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU110"/> 
+       <position name="posWireU110" unit="cm" x="0" y="-29.2976394100275" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU111"/> 
+       <position name="posWireU111" unit="cm" x="0" y="-28.4142934981674" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU112"/> 
+       <position name="posWireU112" unit="cm" x="0" y="-27.5309475863072" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU113"/> 
+       <position name="posWireU113" unit="cm" x="0" y="-26.6476016744471" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU114"/> 
+       <position name="posWireU114" unit="cm" x="0" y="-25.764255762587" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU115"/> 
+       <position name="posWireU115" unit="cm" x="0" y="-24.8809098507268" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU116"/> 
+       <position name="posWireU116" unit="cm" x="0" y="-23.9975639388667" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU117"/> 
+       <position name="posWireU117" unit="cm" x="0" y="-23.1142180270066" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU118"/> 
+       <position name="posWireU118" unit="cm" x="0" y="-22.2308721151465" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU119"/> 
+       <position name="posWireU119" unit="cm" x="0" y="-21.3475262032863" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU120"/> 
+       <position name="posWireU120" unit="cm" x="0" y="-20.4641802914262" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU121"/> 
+       <position name="posWireU121" unit="cm" x="0" y="-19.5808343795661" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU122"/> 
+       <position name="posWireU122" unit="cm" x="0" y="-18.697488467706" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU123"/> 
+       <position name="posWireU123" unit="cm" x="0" y="-17.8141425558458" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU124"/> 
+       <position name="posWireU124" unit="cm" x="0" y="-16.9307966439857" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU125"/> 
+       <position name="posWireU125" unit="cm" x="0" y="-16.0474507321256" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU126"/> 
+       <position name="posWireU126" unit="cm" x="0" y="-15.1641048202654" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU127"/> 
+       <position name="posWireU127" unit="cm" x="0" y="-14.2807589084053" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU128"/> 
+       <position name="posWireU128" unit="cm" x="0" y="-13.3974129965452" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU129"/> 
+       <position name="posWireU129" unit="cm" x="0" y="-12.5140670846851" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU130"/> 
+       <position name="posWireU130" unit="cm" x="0" y="-11.6307211728249" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU131"/> 
+       <position name="posWireU131" unit="cm" x="0" y="-10.7473752609648" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU132"/> 
+       <position name="posWireU132" unit="cm" x="0" y="-9.86402934910468" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU133"/> 
+       <position name="posWireU133" unit="cm" x="0" y="-8.98068343724455" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU134"/> 
+       <position name="posWireU134" unit="cm" x="0" y="-8.09733752538442" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU135"/> 
+       <position name="posWireU135" unit="cm" x="0" y="-7.2139916135243" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU136"/> 
+       <position name="posWireU136" unit="cm" x="0" y="-6.33064570166416" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU137"/> 
+       <position name="posWireU137" unit="cm" x="0" y="-5.44729978980403" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU138"/> 
+       <position name="posWireU138" unit="cm" x="0" y="-4.56395387794391" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU139"/> 
+       <position name="posWireU139" unit="cm" x="0" y="-3.68060796608378" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU140"/> 
+       <position name="posWireU140" unit="cm" x="0" y="-2.79726205422365" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU141"/> 
+       <position name="posWireU141" unit="cm" x="0" y="-1.91391614236353" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU142"/> 
+       <position name="posWireU142" unit="cm" x="0" y="-1.0305702305034" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU143"/> 
+       <position name="posWireU143" unit="cm" x="0" y="-0.147224318643268" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU144"/> 
+       <position name="posWireU144" unit="cm" x="0" y="0.736121593216858" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU145"/> 
+       <position name="posWireU145" unit="cm" x="0" y="1.619467505077" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU146"/> 
+       <position name="posWireU146" unit="cm" x="0" y="2.50281341693712" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU147"/> 
+       <position name="posWireU147" unit="cm" x="0" y="3.38615932879726" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU148"/> 
+       <position name="posWireU148" unit="cm" x="0" y="4.26950524065738" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU149"/> 
+       <position name="posWireU149" unit="cm" x="0" y="5.15285115251751" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU150"/> 
+       <position name="posWireU150" unit="cm" x="0" y="6.03619706437765" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU151"/> 
+       <position name="posWireU151" unit="cm" x="0" y="6.91954297623776" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU152"/> 
+       <position name="posWireU152" unit="cm" x="0" y="7.80288888809789" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU153"/> 
+       <position name="posWireU153" unit="cm" x="0" y="8.68623479995803" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU154"/> 
+       <position name="posWireU154" unit="cm" x="0" y="9.56958071181815" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU155"/> 
+       <position name="posWireU155" unit="cm" x="0" y="10.4529266236783" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU156"/> 
+       <position name="posWireU156" unit="cm" x="0" y="11.3362725355384" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU157"/> 
+       <position name="posWireU157" unit="cm" x="0" y="12.2196184473985" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU158"/> 
+       <position name="posWireU158" unit="cm" x="0" y="13.1029643592587" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU159"/> 
+       <position name="posWireU159" unit="cm" x="0" y="13.9863102711188" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU160"/> 
+       <position name="posWireU160" unit="cm" x="0" y="14.8696561829789" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU161"/> 
+       <position name="posWireU161" unit="cm" x="0" y="15.753002094839" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU162"/> 
+       <position name="posWireU162" unit="cm" x="0" y="16.6363480066992" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU163"/> 
+       <position name="posWireU163" unit="cm" x="0" y="17.5196939185593" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU164"/> 
+       <position name="posWireU164" unit="cm" x="0" y="18.4030398304194" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU165"/> 
+       <position name="posWireU165" unit="cm" x="0" y="19.2863857422796" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU166"/> 
+       <position name="posWireU166" unit="cm" x="0" y="20.1697316541397" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU167"/> 
+       <position name="posWireU167" unit="cm" x="0" y="21.0530775659998" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU168"/> 
+       <position name="posWireU168" unit="cm" x="0" y="21.9364234778599" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU169"/> 
+       <position name="posWireU169" unit="cm" x="0" y="22.81976938972" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU170"/> 
+       <position name="posWireU170" unit="cm" x="0" y="23.7031153015801" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU171"/> 
+       <position name="posWireU171" unit="cm" x="0" y="24.5864612134402" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU172"/> 
+       <position name="posWireU172" unit="cm" x="0" y="25.4698071253003" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU173"/> 
+       <position name="posWireU173" unit="cm" x="0" y="26.3531530371605" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU174"/> 
+       <position name="posWireU174" unit="cm" x="0" y="27.2364989490206" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU175"/> 
+       <position name="posWireU175" unit="cm" x="0" y="28.1198448608807" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU176"/> 
+       <position name="posWireU176" unit="cm" x="0" y="29.0031907727408" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU177"/> 
+       <position name="posWireU177" unit="cm" x="0" y="29.8865366846009" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU178"/> 
+       <position name="posWireU178" unit="cm" x="0" y="30.769882596461" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU179"/> 
+       <position name="posWireU179" unit="cm" x="0" y="31.6532285083211" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU180"/> 
+       <position name="posWireU180" unit="cm" x="0" y="32.5365744201812" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU181"/> 
+       <position name="posWireU181" unit="cm" x="0" y="33.4199203320414" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU182"/> 
+       <position name="posWireU182" unit="cm" x="0" y="34.3032662439015" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU183"/> 
+       <position name="posWireU183" unit="cm" x="0" y="35.1866121557616" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU184"/> 
+       <position name="posWireU184" unit="cm" x="0" y="36.0699580676217" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU185"/> 
+       <position name="posWireU185" unit="cm" x="0" y="36.9533039794818" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU186"/> 
+       <position name="posWireU186" unit="cm" x="0" y="37.8366498913419" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU187"/> 
+       <position name="posWireU187" unit="cm" x="0" y="38.719995803202" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU188"/> 
+       <position name="posWireU188" unit="cm" x="0" y="39.6033417150621" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU189"/> 
+       <position name="posWireU189" unit="cm" x="0" y="40.4866876269222" z="0"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU190"/> 
+       <position name="posWireU190" unit="cm" x="0" y="41.1491970608175" z="0.382499999999759"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU191"/> 
+       <position name="posWireU191" unit="cm" x="0" y="41.5908700167475" z="1.14749999999976"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU192"/> 
+       <position name="posWireU192" unit="cm" x="0" y="42.0325429726776" z="1.91249999999975"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU193"/> 
+       <position name="posWireU193" unit="cm" x="0" y="42.4742159286076" z="2.67749999999972"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU194"/> 
+       <position name="posWireU194" unit="cm" x="0" y="42.9158888845377" z="3.44249999999973"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU195"/> 
+       <position name="posWireU195" unit="cm" x="0" y="43.3575618404678" z="4.20749999999971"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU196"/> 
+       <position name="posWireU196" unit="cm" x="0" y="43.7992347963978" z="4.97249999999969"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU197"/> 
+       <position name="posWireU197" unit="cm" x="0" y="44.2409077523279" z="5.73749999999968"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU198"/> 
+       <position name="posWireU198" unit="cm" x="0" y="44.6825807082579" z="6.50249999999967"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU199"/> 
+       <position name="posWireU199" unit="cm" x="0" y="45.124253664188" z="7.26749999999965"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU200"/> 
+       <position name="posWireU200" unit="cm" x="0" y="45.565926620118" z="8.03249999999964"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU201"/> 
+       <position name="posWireU201" unit="cm" x="0" y="46.0075995760481" z="8.79749999999962"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU202"/> 
+       <position name="posWireU202" unit="cm" x="0" y="46.4492725319781" z="9.56249999999961"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU203"/> 
+       <position name="posWireU203" unit="cm" x="0" y="46.8909454879082" z="10.3274999999996"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU204"/> 
+       <position name="posWireU204" unit="cm" x="0" y="47.3326184438382" z="11.0924999999996"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU205"/> 
+       <position name="posWireU205" unit="cm" x="0" y="47.7742913997683" z="11.8574999999996"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU206"/> 
+       <position name="posWireU206" unit="cm" x="0" y="48.2159643556984" z="12.6224999999995"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU207"/> 
+       <position name="posWireU207" unit="cm" x="0" y="48.6576373116284" z="13.3874999999996"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU208"/> 
+       <position name="posWireU208" unit="cm" x="0" y="49.0993102675585" z="14.1524999999995"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU209"/> 
+       <position name="posWireU209" unit="cm" x="0" y="49.5409832234885" z="14.9174999999995"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU210"/> 
+       <position name="posWireU210" unit="cm" x="0" y="49.9826561794186" z="15.6824999999995"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU211"/> 
+       <position name="posWireU211" unit="cm" x="0" y="50.4243291353486" z="16.4474999999995"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU212"/> 
+       <position name="posWireU212" unit="cm" x="0" y="50.8660020912787" z="17.2124999999995"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU213"/> 
+       <position name="posWireU213" unit="cm" x="0" y="51.3076750472087" z="17.9774999999995"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU214"/> 
+       <position name="posWireU214" unit="cm" x="0" y="51.7493480031388" z="18.7424999999994"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU215"/> 
+       <position name="posWireU215" unit="cm" x="0" y="52.1910209590689" z="19.5074999999994"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU216"/> 
+       <position name="posWireU216" unit="cm" x="0" y="52.6326939149989" z="20.2724999999994"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU217"/> 
+       <position name="posWireU217" unit="cm" x="0" y="53.074366870929" z="21.0374999999994"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU218"/> 
+       <position name="posWireU218" unit="cm" x="0" y="53.516039826859" z="21.8024999999994"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU219"/> 
+       <position name="posWireU219" unit="cm" x="0" y="53.9577127827891" z="22.5674999999994"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU220"/> 
+       <position name="posWireU220" unit="cm" x="0" y="54.3993857387191" z="23.3324999999994"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU221"/> 
+       <position name="posWireU221" unit="cm" x="0" y="54.8410586946492" z="24.0974999999994"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU222"/> 
+       <position name="posWireU222" unit="cm" x="0" y="55.2827316505793" z="24.8624999999993"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU223"/> 
+       <position name="posWireU223" unit="cm" x="0" y="55.7244046065093" z="25.6274999999993"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU224"/> 
+       <position name="posWireU224" unit="cm" x="0" y="56.1660775624394" z="26.3924999999993"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU225"/> 
+       <position name="posWireU225" unit="cm" x="0" y="56.6077505183694" z="27.1574999999993"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU226"/> 
+       <position name="posWireU226" unit="cm" x="0" y="57.0494234742995" z="27.9224999999993"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU227"/> 
+       <position name="posWireU227" unit="cm" x="0" y="57.4910964302295" z="28.6874999999993"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU228"/> 
+       <position name="posWireU228" unit="cm" x="0" y="57.9327693861596" z="29.4524999999993"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU229"/> 
+       <position name="posWireU229" unit="cm" x="0" y="58.3744423420896" z="30.2174999999992"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU230"/> 
+       <position name="posWireU230" unit="cm" x="0" y="58.8161152980197" z="30.9824999999992"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU231"/> 
+       <position name="posWireU231" unit="cm" x="0" y="59.2577882539497" z="31.7474999999992"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU232"/> 
+       <position name="posWireU232" unit="cm" x="0" y="59.6994612098798" z="32.5124999999992"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU233"/> 
+       <position name="posWireU233" unit="cm" x="0" y="60.1411341658099" z="33.2774999999992"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU234"/> 
+       <position name="posWireU234" unit="cm" x="0" y="60.5828071217399" z="34.0424999999992"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU235"/> 
+       <position name="posWireU235" unit="cm" x="0" y="61.02448007767" z="34.8074999999992"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU236"/> 
+       <position name="posWireU236" unit="cm" x="0" y="61.4661530336" z="35.5724999999992"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU237"/> 
+       <position name="posWireU237" unit="cm" x="0" y="61.9078259895301" z="36.3374999999991"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU238"/> 
+       <position name="posWireU238" unit="cm" x="0" y="62.3494989454601" z="37.1024999999991"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU239"/> 
+       <position name="posWireU239" unit="cm" x="0" y="62.7911719013902" z="37.8674999999991"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU240"/> 
+       <position name="posWireU240" unit="cm" x="0" y="63.2328448573203" z="38.6324999999991"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU241"/> 
+       <position name="posWireU241" unit="cm" x="0" y="63.6745178132503" z="39.3974999999991"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU242"/> 
+       <position name="posWireU242" unit="cm" x="0" y="64.1161907691804" z="40.1624999999991"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU243"/> 
+       <position name="posWireU243" unit="cm" x="0" y="64.5578637251104" z="40.927499999999"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU244"/> 
+       <position name="posWireU244" unit="cm" x="0" y="64.9995366810405" z="41.692499999999"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU245"/> 
+       <position name="posWireU245" unit="cm" x="0" y="65.4412096369705" z="42.457499999999"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU246"/> 
+       <position name="posWireU246" unit="cm" x="0" y="65.8828825929006" z="43.222499999999"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU247"/> 
+       <position name="posWireU247" unit="cm" x="0" y="66.3245555488307" z="43.987499999999"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU248"/> 
+       <position name="posWireU248" unit="cm" x="0" y="66.7662285047607" z="44.752499999999"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU249"/> 
+       <position name="posWireU249" unit="cm" x="0" y="67.2079014606908" z="45.517499999999"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU250"/> 
+       <position name="posWireU250" unit="cm" x="0" y="67.6495744166208" z="46.282499999999"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU251"/> 
+       <position name="posWireU251" unit="cm" x="0" y="68.0912473725509" z="47.0474999999989"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU252"/> 
+       <position name="posWireU252" unit="cm" x="0" y="68.5329203284809" z="47.8124999999989"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU253"/> 
+       <position name="posWireU253" unit="cm" x="0" y="68.974593284411" z="48.5774999999989"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU254"/> 
+       <position name="posWireU254" unit="cm" x="0" y="69.416266240341" z="49.3424999999989"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU255"/> 
+       <position name="posWireU255" unit="cm" x="0" y="69.8579391962711" z="50.1074999999989"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU256"/> 
+       <position name="posWireU256" unit="cm" x="0" y="70.2996121522011" z="50.8724999999989"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU257"/> 
+       <position name="posWireU257" unit="cm" x="0" y="70.7412851081312" z="51.6374999999989"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU258"/> 
+       <position name="posWireU258" unit="cm" x="0" y="71.1829580640613" z="52.4024999999988"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU259"/> 
+       <position name="posWireU259" unit="cm" x="0" y="71.6246310199913" z="53.1674999999988"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU260"/> 
+       <position name="posWireU260" unit="cm" x="0" y="72.0663039759214" z="53.9324999999988"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU261"/> 
+       <position name="posWireU261" unit="cm" x="0" y="72.5079769318514" z="54.6974999999988"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU262"/> 
+       <position name="posWireU262" unit="cm" x="0" y="72.9496498877815" z="55.4624999999988"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU263"/> 
+       <position name="posWireU263" unit="cm" x="0" y="73.3913228437115" z="56.2274999999988"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU264"/> 
+       <position name="posWireU264" unit="cm" x="0" y="73.8329957996416" z="56.9924999999988"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU265"/> 
+       <position name="posWireU265" unit="cm" x="0" y="74.2746687555717" z="57.7574999999988"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU266"/> 
+       <position name="posWireU266" unit="cm" x="0" y="74.7163417115017" z="58.5224999999987"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU267"/> 
+       <position name="posWireU267" unit="cm" x="0" y="75.1580146674318" z="59.2874999999987"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU268"/> 
+       <position name="posWireU268" unit="cm" x="0" y="75.5996876233618" z="60.0524999999987"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU269"/> 
+       <position name="posWireU269" unit="cm" x="0" y="76.0413605792919" z="60.8174999999987"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU270"/> 
+       <position name="posWireU270" unit="cm" x="0" y="76.4830335352219" z="61.5824999999987"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU271"/> 
+       <position name="posWireU271" unit="cm" x="0" y="76.924706491152" z="62.3474999999987"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU272"/> 
+       <position name="posWireU272" unit="cm" x="0" y="77.366379447082" z="63.1124999999986"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU273"/> 
+       <position name="posWireU273" unit="cm" x="0" y="77.8080524030121" z="63.8774999999986"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU274"/> 
+       <position name="posWireU274" unit="cm" x="0" y="78.2497253589422" z="64.6424999999986"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU275"/> 
+       <position name="posWireU275" unit="cm" x="0" y="78.6913983148722" z="65.4074999999986"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU276"/> 
+       <position name="posWireU276" unit="cm" x="0" y="79.1330712708023" z="66.1724999999986"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU277"/> 
+       <position name="posWireU277" unit="cm" x="0" y="79.5747442267323" z="66.9374999999986"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU278"/> 
+       <position name="posWireU278" unit="cm" x="0" y="80.0164171826624" z="67.7024999999986"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU279"/> 
+       <position name="posWireU279" unit="cm" x="0" y="80.4580901385924" z="68.4674999999986"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU280"/> 
+       <position name="posWireU280" unit="cm" x="0" y="80.8997630945225" z="69.2324999999986"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU281"/> 
+       <position name="posWireU281" unit="cm" x="0" y="81.3414360504525" z="69.9974999999985"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU282"/> 
+       <position name="posWireU282" unit="cm" x="0" y="81.7831090063826" z="70.7624999999985"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU283"/> 
+       <position name="posWireU283" unit="cm" x="0" y="82.2247819623126" z="71.5274999999985"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU284"/> 
+       <position name="posWireU284" unit="cm" x="0" y="82.6664549182427" z="72.2924999999985"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU285"/> 
+       <position name="posWireU285" unit="cm" x="0" y="83.1081278741728" z="73.0574999999985"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+   </volume>
+  <volume name="volTPCPlaneV">
+    <materialref ref="LAr"/>
+    <solidref ref="CRMVPlane"/>
+     <physvol>
+       <volumeref ref="volTPCWireV0"/> 
+       <position name="posWireV0" unit="cm" x="0" y="83.6970251487471" z="-74.0775"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV1"/> 
+       <position name="posWireV1" unit="cm" x="0" y="83.255352192817" z="-73.3125"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV2"/> 
+       <position name="posWireV2" unit="cm" x="0" y="82.8136792368869" z="-72.5475"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV3"/> 
+       <position name="posWireV3" unit="cm" x="0" y="82.3720062809569" z="-71.7825"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV4"/> 
+       <position name="posWireV4" unit="cm" x="0" y="81.9303333250268" z="-71.0175"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV5"/> 
+       <position name="posWireV5" unit="cm" x="0" y="81.4886603690967" z="-70.2525"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV6"/> 
+       <position name="posWireV6" unit="cm" x="0" y="81.0469874131667" z="-69.4875"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV7"/> 
+       <position name="posWireV7" unit="cm" x="0" y="80.6053144572366" z="-68.7225"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV8"/> 
+       <position name="posWireV8" unit="cm" x="0" y="80.1636415013066" z="-67.9575"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV9"/> 
+       <position name="posWireV9" unit="cm" x="0" y="79.7219685453765" z="-67.1925"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV10"/> 
+       <position name="posWireV10" unit="cm" x="0" y="79.2802955894464" z="-66.4275"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV11"/> 
+       <position name="posWireV11" unit="cm" x="0" y="78.8386226335164" z="-65.6625"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV12"/> 
+       <position name="posWireV12" unit="cm" x="0" y="78.3969496775863" z="-64.8975"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV13"/> 
+       <position name="posWireV13" unit="cm" x="0" y="77.9552767216562" z="-64.1325"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV14"/> 
+       <position name="posWireV14" unit="cm" x="0" y="77.5136037657262" z="-63.3675"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV15"/> 
+       <position name="posWireV15" unit="cm" x="0" y="77.0719308097961" z="-62.6025"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV16"/> 
+       <position name="posWireV16" unit="cm" x="0" y="76.630257853866" z="-61.8375"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV17"/> 
+       <position name="posWireV17" unit="cm" x="0" y="76.188584897936" z="-61.0725"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV18"/> 
+       <position name="posWireV18" unit="cm" x="0" y="75.7469119420059" z="-60.3075"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV19"/> 
+       <position name="posWireV19" unit="cm" x="0" y="75.3052389860758" z="-59.5425"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV20"/> 
+       <position name="posWireV20" unit="cm" x="0" y="74.8635660301458" z="-58.7775"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV21"/> 
+       <position name="posWireV21" unit="cm" x="0" y="74.4218930742157" z="-58.0125"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV22"/> 
+       <position name="posWireV22" unit="cm" x="0" y="73.9802201182857" z="-57.2475"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV23"/> 
+       <position name="posWireV23" unit="cm" x="0" y="73.5385471623556" z="-56.4825"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV24"/> 
+       <position name="posWireV24" unit="cm" x="0" y="73.0968742064255" z="-55.7175"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV25"/> 
+       <position name="posWireV25" unit="cm" x="0" y="72.6552012504955" z="-54.9525"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV26"/> 
+       <position name="posWireV26" unit="cm" x="0" y="72.2135282945654" z="-54.1875"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV27"/> 
+       <position name="posWireV27" unit="cm" x="0" y="71.7718553386353" z="-53.4225"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV28"/> 
+       <position name="posWireV28" unit="cm" x="0" y="71.3301823827053" z="-52.6575"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV29"/> 
+       <position name="posWireV29" unit="cm" x="0" y="70.8885094267752" z="-51.8925"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV30"/> 
+       <position name="posWireV30" unit="cm" x="0" y="70.4468364708452" z="-51.1275"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV31"/> 
+       <position name="posWireV31" unit="cm" x="0" y="70.0051635149151" z="-50.3625"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV32"/> 
+       <position name="posWireV32" unit="cm" x="0" y="69.563490558985" z="-49.5975"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV33"/> 
+       <position name="posWireV33" unit="cm" x="0" y="69.121817603055" z="-48.8325"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV34"/> 
+       <position name="posWireV34" unit="cm" x="0" y="68.6801446471249" z="-48.0675"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV35"/> 
+       <position name="posWireV35" unit="cm" x="0" y="68.2384716911948" z="-47.3025"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV36"/> 
+       <position name="posWireV36" unit="cm" x="0" y="67.7967987352648" z="-46.5375"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV37"/> 
+       <position name="posWireV37" unit="cm" x="0" y="67.3551257793347" z="-45.7725"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV38"/> 
+       <position name="posWireV38" unit="cm" x="0" y="66.9134528234046" z="-45.0075"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV39"/> 
+       <position name="posWireV39" unit="cm" x="0" y="66.4717798674746" z="-44.2425"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV40"/> 
+       <position name="posWireV40" unit="cm" x="0" y="66.0301069115445" z="-43.4775"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV41"/> 
+       <position name="posWireV41" unit="cm" x="0" y="65.5884339556144" z="-42.7125"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV42"/> 
+       <position name="posWireV42" unit="cm" x="0" y="65.1467609996844" z="-41.9475"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV43"/> 
+       <position name="posWireV43" unit="cm" x="0" y="64.7050880437543" z="-41.1825"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV44"/> 
+       <position name="posWireV44" unit="cm" x="0" y="64.2634150878243" z="-40.4175"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV45"/> 
+       <position name="posWireV45" unit="cm" x="0" y="63.8217421318942" z="-39.6525"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV46"/> 
+       <position name="posWireV46" unit="cm" x="0" y="63.3800691759641" z="-38.8875"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV47"/> 
+       <position name="posWireV47" unit="cm" x="0" y="62.9383962200341" z="-38.1225"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV48"/> 
+       <position name="posWireV48" unit="cm" x="0" y="62.496723264104" z="-37.3575"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV49"/> 
+       <position name="posWireV49" unit="cm" x="0" y="62.0550503081739" z="-36.5925"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV50"/> 
+       <position name="posWireV50" unit="cm" x="0" y="61.6133773522439" z="-35.8275"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV51"/> 
+       <position name="posWireV51" unit="cm" x="0" y="61.1717043963138" z="-35.0625"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV52"/> 
+       <position name="posWireV52" unit="cm" x="0" y="60.7300314403837" z="-34.2975"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV53"/> 
+       <position name="posWireV53" unit="cm" x="0" y="60.2883584844537" z="-33.5325"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV54"/> 
+       <position name="posWireV54" unit="cm" x="0" y="59.8466855285236" z="-32.7675"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV55"/> 
+       <position name="posWireV55" unit="cm" x="0" y="59.4050125725935" z="-32.0025"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV56"/> 
+       <position name="posWireV56" unit="cm" x="0" y="58.9633396166635" z="-31.2375"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV57"/> 
+       <position name="posWireV57" unit="cm" x="0" y="58.5216666607334" z="-30.4725"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV58"/> 
+       <position name="posWireV58" unit="cm" x="0" y="58.0799937048034" z="-29.7075"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV59"/> 
+       <position name="posWireV59" unit="cm" x="0" y="57.6383207488733" z="-28.9425"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV60"/> 
+       <position name="posWireV60" unit="cm" x="0" y="57.1966477929432" z="-28.1775"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV61"/> 
+       <position name="posWireV61" unit="cm" x="0" y="56.7549748370132" z="-27.4125"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV62"/> 
+       <position name="posWireV62" unit="cm" x="0" y="56.3133018810831" z="-26.6475"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV63"/> 
+       <position name="posWireV63" unit="cm" x="0" y="55.871628925153" z="-25.8825"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV64"/> 
+       <position name="posWireV64" unit="cm" x="0" y="55.429955969223" z="-25.1175"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV65"/> 
+       <position name="posWireV65" unit="cm" x="0" y="54.9882830132929" z="-24.3525"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV66"/> 
+       <position name="posWireV66" unit="cm" x="0" y="54.5466100573628" z="-23.5875"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV67"/> 
+       <position name="posWireV67" unit="cm" x="0" y="54.1049371014328" z="-22.8225"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV68"/> 
+       <position name="posWireV68" unit="cm" x="0" y="53.6632641455027" z="-22.0575"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV69"/> 
+       <position name="posWireV69" unit="cm" x="0" y="53.2215911895726" z="-21.2925"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV70"/> 
+       <position name="posWireV70" unit="cm" x="0" y="52.7799182336426" z="-20.5275"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV71"/> 
+       <position name="posWireV71" unit="cm" x="0" y="52.3382452777125" z="-19.7625"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV72"/> 
+       <position name="posWireV72" unit="cm" x="0" y="51.8965723217825" z="-18.9975"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV73"/> 
+       <position name="posWireV73" unit="cm" x="0" y="51.4548993658524" z="-18.2325"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV74"/> 
+       <position name="posWireV74" unit="cm" x="0" y="51.0132264099223" z="-17.4675"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV75"/> 
+       <position name="posWireV75" unit="cm" x="0" y="50.5715534539923" z="-16.7025"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV76"/> 
+       <position name="posWireV76" unit="cm" x="0" y="50.1298804980622" z="-15.9375"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV77"/> 
+       <position name="posWireV77" unit="cm" x="0" y="49.6882075421321" z="-15.1725"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV78"/> 
+       <position name="posWireV78" unit="cm" x="0" y="49.2465345862021" z="-14.4075"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV79"/> 
+       <position name="posWireV79" unit="cm" x="0" y="48.804861630272" z="-13.6425"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV80"/> 
+       <position name="posWireV80" unit="cm" x="0" y="48.3631886743419" z="-12.8775"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV81"/> 
+       <position name="posWireV81" unit="cm" x="0" y="47.9215157184119" z="-12.1125"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV82"/> 
+       <position name="posWireV82" unit="cm" x="0" y="47.4798427624818" z="-11.3475"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV83"/> 
+       <position name="posWireV83" unit="cm" x="0" y="47.0381698065518" z="-10.5825"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV84"/> 
+       <position name="posWireV84" unit="cm" x="0" y="46.5964968506217" z="-9.81749999999995"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV85"/> 
+       <position name="posWireV85" unit="cm" x="0" y="46.1548238946916" z="-9.05249999999995"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV86"/> 
+       <position name="posWireV86" unit="cm" x="0" y="45.7131509387616" z="-8.28749999999995"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV87"/> 
+       <position name="posWireV87" unit="cm" x="0" y="45.2714779828315" z="-7.52249999999995"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV88"/> 
+       <position name="posWireV88" unit="cm" x="0" y="44.8298050269014" z="-6.75749999999995"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV89"/> 
+       <position name="posWireV89" unit="cm" x="0" y="44.3881320709714" z="-5.99249999999995"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV90"/> 
+       <position name="posWireV90" unit="cm" x="0" y="43.9464591150413" z="-5.22749999999995"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV91"/> 
+       <position name="posWireV91" unit="cm" x="0" y="43.5047861591112" z="-4.46249999999995"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV92"/> 
+       <position name="posWireV92" unit="cm" x="0" y="43.0631132031812" z="-3.69749999999995"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV93"/> 
+       <position name="posWireV93" unit="cm" x="0" y="42.6214402472511" z="-2.93249999999996"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV94"/> 
+       <position name="posWireV94" unit="cm" x="0" y="42.179767291321" z="-2.16749999999995"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV95"/> 
+       <position name="posWireV95" unit="cm" x="0" y="41.738094335391" z="-1.40249999999996"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV96"/> 
+       <position name="posWireV96" unit="cm" x="0" y="41.2964213794609" z="-0.637499999999946"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV97"/> 
+       <position name="posWireV97" unit="cm" x="0" y="40.7811362642091" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV98"/> 
+       <position name="posWireV98" unit="cm" x="0" y="39.897790352349" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV99"/> 
+       <position name="posWireV99" unit="cm" x="0" y="39.0144444404889" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV100"/> 
+       <position name="posWireV100" unit="cm" x="0" y="38.1310985286288" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV101"/> 
+       <position name="posWireV101" unit="cm" x="0" y="37.2477526167686" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV102"/> 
+       <position name="posWireV102" unit="cm" x="0" y="36.3644067049085" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV103"/> 
+       <position name="posWireV103" unit="cm" x="0" y="35.4810607930484" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV104"/> 
+       <position name="posWireV104" unit="cm" x="0" y="34.5977148811883" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV105"/> 
+       <position name="posWireV105" unit="cm" x="0" y="33.7143689693281" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV106"/> 
+       <position name="posWireV106" unit="cm" x="0" y="32.831023057468" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV107"/> 
+       <position name="posWireV107" unit="cm" x="0" y="31.9476771456079" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV108"/> 
+       <position name="posWireV108" unit="cm" x="0" y="31.0643312337477" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV109"/> 
+       <position name="posWireV109" unit="cm" x="0" y="30.1809853218876" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV110"/> 
+       <position name="posWireV110" unit="cm" x="0" y="29.2976394100275" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV111"/> 
+       <position name="posWireV111" unit="cm" x="0" y="28.4142934981674" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV112"/> 
+       <position name="posWireV112" unit="cm" x="0" y="27.5309475863072" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV113"/> 
+       <position name="posWireV113" unit="cm" x="0" y="26.6476016744471" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV114"/> 
+       <position name="posWireV114" unit="cm" x="0" y="25.764255762587" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV115"/> 
+       <position name="posWireV115" unit="cm" x="0" y="24.8809098507268" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV116"/> 
+       <position name="posWireV116" unit="cm" x="0" y="23.9975639388667" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV117"/> 
+       <position name="posWireV117" unit="cm" x="0" y="23.1142180270066" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV118"/> 
+       <position name="posWireV118" unit="cm" x="0" y="22.2308721151465" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV119"/> 
+       <position name="posWireV119" unit="cm" x="0" y="21.3475262032863" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV120"/> 
+       <position name="posWireV120" unit="cm" x="0" y="20.4641802914262" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV121"/> 
+       <position name="posWireV121" unit="cm" x="0" y="19.5808343795661" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV122"/> 
+       <position name="posWireV122" unit="cm" x="0" y="18.697488467706" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV123"/> 
+       <position name="posWireV123" unit="cm" x="0" y="17.8141425558458" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV124"/> 
+       <position name="posWireV124" unit="cm" x="0" y="16.9307966439857" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV125"/> 
+       <position name="posWireV125" unit="cm" x="0" y="16.0474507321256" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV126"/> 
+       <position name="posWireV126" unit="cm" x="0" y="15.1641048202654" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV127"/> 
+       <position name="posWireV127" unit="cm" x="0" y="14.2807589084053" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV128"/> 
+       <position name="posWireV128" unit="cm" x="0" y="13.3974129965452" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV129"/> 
+       <position name="posWireV129" unit="cm" x="0" y="12.5140670846851" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV130"/> 
+       <position name="posWireV130" unit="cm" x="0" y="11.6307211728249" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV131"/> 
+       <position name="posWireV131" unit="cm" x="0" y="10.7473752609648" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV132"/> 
+       <position name="posWireV132" unit="cm" x="0" y="9.86402934910467" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV133"/> 
+       <position name="posWireV133" unit="cm" x="0" y="8.98068343724454" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV134"/> 
+       <position name="posWireV134" unit="cm" x="0" y="8.09733752538442" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV135"/> 
+       <position name="posWireV135" unit="cm" x="0" y="7.2139916135243" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV136"/> 
+       <position name="posWireV136" unit="cm" x="0" y="6.33064570166416" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV137"/> 
+       <position name="posWireV137" unit="cm" x="0" y="5.44729978980404" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV138"/> 
+       <position name="posWireV138" unit="cm" x="0" y="4.5639538779439" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV139"/> 
+       <position name="posWireV139" unit="cm" x="0" y="3.68060796608379" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV140"/> 
+       <position name="posWireV140" unit="cm" x="0" y="2.79726205422365" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV141"/> 
+       <position name="posWireV141" unit="cm" x="0" y="1.91391614236352" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV142"/> 
+       <position name="posWireV142" unit="cm" x="0" y="1.03057023050339" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV143"/> 
+       <position name="posWireV143" unit="cm" x="0" y="0.147224318643268" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV144"/> 
+       <position name="posWireV144" unit="cm" x="0" y="-0.736121593216858" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV145"/> 
+       <position name="posWireV145" unit="cm" x="0" y="-1.61946750507699" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV146"/> 
+       <position name="posWireV146" unit="cm" x="0" y="-2.50281341693713" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV147"/> 
+       <position name="posWireV147" unit="cm" x="0" y="-3.38615932879726" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV148"/> 
+       <position name="posWireV148" unit="cm" x="0" y="-4.26950524065738" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV149"/> 
+       <position name="posWireV149" unit="cm" x="0" y="-5.15285115251752" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV150"/> 
+       <position name="posWireV150" unit="cm" x="0" y="-6.03619706437764" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV151"/> 
+       <position name="posWireV151" unit="cm" x="0" y="-6.91954297623776" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV152"/> 
+       <position name="posWireV152" unit="cm" x="0" y="-7.80288888809789" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV153"/> 
+       <position name="posWireV153" unit="cm" x="0" y="-8.68623479995803" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV154"/> 
+       <position name="posWireV154" unit="cm" x="0" y="-9.56958071181815" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV155"/> 
+       <position name="posWireV155" unit="cm" x="0" y="-10.4529266236783" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV156"/> 
+       <position name="posWireV156" unit="cm" x="0" y="-11.3362725355384" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV157"/> 
+       <position name="posWireV157" unit="cm" x="0" y="-12.2196184473985" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV158"/> 
+       <position name="posWireV158" unit="cm" x="0" y="-13.1029643592587" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV159"/> 
+       <position name="posWireV159" unit="cm" x="0" y="-13.9863102711188" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV160"/> 
+       <position name="posWireV160" unit="cm" x="0" y="-14.8696561829789" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV161"/> 
+       <position name="posWireV161" unit="cm" x="0" y="-15.7530020948391" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV162"/> 
+       <position name="posWireV162" unit="cm" x="0" y="-16.6363480066992" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV163"/> 
+       <position name="posWireV163" unit="cm" x="0" y="-17.5196939185593" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV164"/> 
+       <position name="posWireV164" unit="cm" x="0" y="-18.4030398304194" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV165"/> 
+       <position name="posWireV165" unit="cm" x="0" y="-19.2863857422796" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV166"/> 
+       <position name="posWireV166" unit="cm" x="0" y="-20.1697316541397" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV167"/> 
+       <position name="posWireV167" unit="cm" x="0" y="-21.0530775659998" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV168"/> 
+       <position name="posWireV168" unit="cm" x="0" y="-21.9364234778599" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV169"/> 
+       <position name="posWireV169" unit="cm" x="0" y="-22.81976938972" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV170"/> 
+       <position name="posWireV170" unit="cm" x="0" y="-23.7031153015801" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV171"/> 
+       <position name="posWireV171" unit="cm" x="0" y="-24.5864612134402" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV172"/> 
+       <position name="posWireV172" unit="cm" x="0" y="-25.4698071253004" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV173"/> 
+       <position name="posWireV173" unit="cm" x="0" y="-26.3531530371605" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV174"/> 
+       <position name="posWireV174" unit="cm" x="0" y="-27.2364989490206" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV175"/> 
+       <position name="posWireV175" unit="cm" x="0" y="-28.1198448608807" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV176"/> 
+       <position name="posWireV176" unit="cm" x="0" y="-29.0031907727408" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV177"/> 
+       <position name="posWireV177" unit="cm" x="0" y="-29.8865366846009" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV178"/> 
+       <position name="posWireV178" unit="cm" x="0" y="-30.769882596461" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV179"/> 
+       <position name="posWireV179" unit="cm" x="0" y="-31.6532285083211" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV180"/> 
+       <position name="posWireV180" unit="cm" x="0" y="-32.5365744201812" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV181"/> 
+       <position name="posWireV181" unit="cm" x="0" y="-33.4199203320414" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV182"/> 
+       <position name="posWireV182" unit="cm" x="0" y="-34.3032662439015" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV183"/> 
+       <position name="posWireV183" unit="cm" x="0" y="-35.1866121557616" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV184"/> 
+       <position name="posWireV184" unit="cm" x="0" y="-36.0699580676217" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV185"/> 
+       <position name="posWireV185" unit="cm" x="0" y="-36.9533039794818" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV186"/> 
+       <position name="posWireV186" unit="cm" x="0" y="-37.8366498913419" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV187"/> 
+       <position name="posWireV187" unit="cm" x="0" y="-38.719995803202" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV188"/> 
+       <position name="posWireV188" unit="cm" x="0" y="-39.6033417150621" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV189"/> 
+       <position name="posWireV189" unit="cm" x="0" y="-40.4866876269222" z="0"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV190"/> 
+       <position name="posWireV190" unit="cm" x="0" y="-41.1491970608175" z="0.382499999999759"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV191"/> 
+       <position name="posWireV191" unit="cm" x="0" y="-41.5908700167475" z="1.14749999999976"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV192"/> 
+       <position name="posWireV192" unit="cm" x="0" y="-42.0325429726776" z="1.91249999999975"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV193"/> 
+       <position name="posWireV193" unit="cm" x="0" y="-42.4742159286076" z="2.67749999999972"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV194"/> 
+       <position name="posWireV194" unit="cm" x="0" y="-42.9158888845377" z="3.44249999999973"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV195"/> 
+       <position name="posWireV195" unit="cm" x="0" y="-43.3575618404678" z="4.20749999999971"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV196"/> 
+       <position name="posWireV196" unit="cm" x="0" y="-43.7992347963978" z="4.97249999999969"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV197"/> 
+       <position name="posWireV197" unit="cm" x="0" y="-44.2409077523279" z="5.73749999999968"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV198"/> 
+       <position name="posWireV198" unit="cm" x="0" y="-44.6825807082579" z="6.50249999999967"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV199"/> 
+       <position name="posWireV199" unit="cm" x="0" y="-45.124253664188" z="7.26749999999965"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV200"/> 
+       <position name="posWireV200" unit="cm" x="0" y="-45.565926620118" z="8.03249999999964"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV201"/> 
+       <position name="posWireV201" unit="cm" x="0" y="-46.0075995760481" z="8.79749999999962"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV202"/> 
+       <position name="posWireV202" unit="cm" x="0" y="-46.4492725319781" z="9.56249999999961"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV203"/> 
+       <position name="posWireV203" unit="cm" x="0" y="-46.8909454879082" z="10.3274999999996"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV204"/> 
+       <position name="posWireV204" unit="cm" x="0" y="-47.3326184438382" z="11.0924999999996"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV205"/> 
+       <position name="posWireV205" unit="cm" x="0" y="-47.7742913997683" z="11.8574999999996"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV206"/> 
+       <position name="posWireV206" unit="cm" x="0" y="-48.2159643556984" z="12.6224999999995"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV207"/> 
+       <position name="posWireV207" unit="cm" x="0" y="-48.6576373116284" z="13.3874999999996"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV208"/> 
+       <position name="posWireV208" unit="cm" x="0" y="-49.0993102675585" z="14.1524999999995"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV209"/> 
+       <position name="posWireV209" unit="cm" x="0" y="-49.5409832234885" z="14.9174999999995"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV210"/> 
+       <position name="posWireV210" unit="cm" x="0" y="-49.9826561794186" z="15.6824999999995"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV211"/> 
+       <position name="posWireV211" unit="cm" x="0" y="-50.4243291353486" z="16.4474999999995"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV212"/> 
+       <position name="posWireV212" unit="cm" x="0" y="-50.8660020912787" z="17.2124999999995"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV213"/> 
+       <position name="posWireV213" unit="cm" x="0" y="-51.3076750472087" z="17.9774999999995"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV214"/> 
+       <position name="posWireV214" unit="cm" x="0" y="-51.7493480031388" z="18.7424999999994"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV215"/> 
+       <position name="posWireV215" unit="cm" x="0" y="-52.1910209590689" z="19.5074999999994"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV216"/> 
+       <position name="posWireV216" unit="cm" x="0" y="-52.6326939149989" z="20.2724999999994"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV217"/> 
+       <position name="posWireV217" unit="cm" x="0" y="-53.074366870929" z="21.0374999999994"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV218"/> 
+       <position name="posWireV218" unit="cm" x="0" y="-53.516039826859" z="21.8024999999994"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV219"/> 
+       <position name="posWireV219" unit="cm" x="0" y="-53.9577127827891" z="22.5674999999994"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV220"/> 
+       <position name="posWireV220" unit="cm" x="0" y="-54.3993857387191" z="23.3324999999994"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV221"/> 
+       <position name="posWireV221" unit="cm" x="0" y="-54.8410586946492" z="24.0974999999994"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV222"/> 
+       <position name="posWireV222" unit="cm" x="0" y="-55.2827316505793" z="24.8624999999993"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV223"/> 
+       <position name="posWireV223" unit="cm" x="0" y="-55.7244046065093" z="25.6274999999993"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV224"/> 
+       <position name="posWireV224" unit="cm" x="0" y="-56.1660775624394" z="26.3924999999993"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV225"/> 
+       <position name="posWireV225" unit="cm" x="0" y="-56.6077505183694" z="27.1574999999993"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV226"/> 
+       <position name="posWireV226" unit="cm" x="0" y="-57.0494234742995" z="27.9224999999993"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV227"/> 
+       <position name="posWireV227" unit="cm" x="0" y="-57.4910964302295" z="28.6874999999993"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV228"/> 
+       <position name="posWireV228" unit="cm" x="0" y="-57.9327693861596" z="29.4524999999993"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV229"/> 
+       <position name="posWireV229" unit="cm" x="0" y="-58.3744423420896" z="30.2174999999992"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV230"/> 
+       <position name="posWireV230" unit="cm" x="0" y="-58.8161152980197" z="30.9824999999992"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV231"/> 
+       <position name="posWireV231" unit="cm" x="0" y="-59.2577882539497" z="31.7474999999992"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV232"/> 
+       <position name="posWireV232" unit="cm" x="0" y="-59.6994612098798" z="32.5124999999992"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV233"/> 
+       <position name="posWireV233" unit="cm" x="0" y="-60.1411341658099" z="33.2774999999992"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV234"/> 
+       <position name="posWireV234" unit="cm" x="0" y="-60.5828071217399" z="34.0424999999992"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV235"/> 
+       <position name="posWireV235" unit="cm" x="0" y="-61.02448007767" z="34.8074999999992"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV236"/> 
+       <position name="posWireV236" unit="cm" x="0" y="-61.4661530336" z="35.5724999999992"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV237"/> 
+       <position name="posWireV237" unit="cm" x="0" y="-61.9078259895301" z="36.3374999999991"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV238"/> 
+       <position name="posWireV238" unit="cm" x="0" y="-62.3494989454601" z="37.1024999999991"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV239"/> 
+       <position name="posWireV239" unit="cm" x="0" y="-62.7911719013902" z="37.8674999999991"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV240"/> 
+       <position name="posWireV240" unit="cm" x="0" y="-63.2328448573203" z="38.6324999999991"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV241"/> 
+       <position name="posWireV241" unit="cm" x="0" y="-63.6745178132503" z="39.3974999999991"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV242"/> 
+       <position name="posWireV242" unit="cm" x="0" y="-64.1161907691804" z="40.1624999999991"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV243"/> 
+       <position name="posWireV243" unit="cm" x="0" y="-64.5578637251104" z="40.927499999999"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV244"/> 
+       <position name="posWireV244" unit="cm" x="0" y="-64.9995366810405" z="41.692499999999"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV245"/> 
+       <position name="posWireV245" unit="cm" x="0" y="-65.4412096369705" z="42.457499999999"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV246"/> 
+       <position name="posWireV246" unit="cm" x="0" y="-65.8828825929006" z="43.222499999999"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV247"/> 
+       <position name="posWireV247" unit="cm" x="0" y="-66.3245555488307" z="43.987499999999"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV248"/> 
+       <position name="posWireV248" unit="cm" x="0" y="-66.7662285047607" z="44.752499999999"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV249"/> 
+       <position name="posWireV249" unit="cm" x="0" y="-67.2079014606908" z="45.517499999999"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV250"/> 
+       <position name="posWireV250" unit="cm" x="0" y="-67.6495744166208" z="46.282499999999"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV251"/> 
+       <position name="posWireV251" unit="cm" x="0" y="-68.0912473725509" z="47.0474999999989"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV252"/> 
+       <position name="posWireV252" unit="cm" x="0" y="-68.5329203284809" z="47.8124999999989"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV253"/> 
+       <position name="posWireV253" unit="cm" x="0" y="-68.974593284411" z="48.5774999999989"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV254"/> 
+       <position name="posWireV254" unit="cm" x="0" y="-69.416266240341" z="49.3424999999989"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV255"/> 
+       <position name="posWireV255" unit="cm" x="0" y="-69.8579391962711" z="50.1074999999989"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV256"/> 
+       <position name="posWireV256" unit="cm" x="0" y="-70.2996121522011" z="50.8724999999989"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV257"/> 
+       <position name="posWireV257" unit="cm" x="0" y="-70.7412851081312" z="51.6374999999989"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV258"/> 
+       <position name="posWireV258" unit="cm" x="0" y="-71.1829580640613" z="52.4024999999988"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV259"/> 
+       <position name="posWireV259" unit="cm" x="0" y="-71.6246310199913" z="53.1674999999988"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV260"/> 
+       <position name="posWireV260" unit="cm" x="0" y="-72.0663039759214" z="53.9324999999988"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV261"/> 
+       <position name="posWireV261" unit="cm" x="0" y="-72.5079769318514" z="54.6974999999988"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV262"/> 
+       <position name="posWireV262" unit="cm" x="0" y="-72.9496498877815" z="55.4624999999988"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV263"/> 
+       <position name="posWireV263" unit="cm" x="0" y="-73.3913228437115" z="56.2274999999988"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV264"/> 
+       <position name="posWireV264" unit="cm" x="0" y="-73.8329957996416" z="56.9924999999988"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV265"/> 
+       <position name="posWireV265" unit="cm" x="0" y="-74.2746687555717" z="57.7574999999988"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV266"/> 
+       <position name="posWireV266" unit="cm" x="0" y="-74.7163417115017" z="58.5224999999987"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV267"/> 
+       <position name="posWireV267" unit="cm" x="0" y="-75.1580146674318" z="59.2874999999987"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV268"/> 
+       <position name="posWireV268" unit="cm" x="0" y="-75.5996876233618" z="60.0524999999987"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV269"/> 
+       <position name="posWireV269" unit="cm" x="0" y="-76.0413605792919" z="60.8174999999987"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV270"/> 
+       <position name="posWireV270" unit="cm" x="0" y="-76.4830335352219" z="61.5824999999987"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV271"/> 
+       <position name="posWireV271" unit="cm" x="0" y="-76.924706491152" z="62.3474999999987"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV272"/> 
+       <position name="posWireV272" unit="cm" x="0" y="-77.366379447082" z="63.1124999999986"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV273"/> 
+       <position name="posWireV273" unit="cm" x="0" y="-77.8080524030121" z="63.8774999999986"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV274"/> 
+       <position name="posWireV274" unit="cm" x="0" y="-78.2497253589422" z="64.6424999999986"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV275"/> 
+       <position name="posWireV275" unit="cm" x="0" y="-78.6913983148722" z="65.4074999999986"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV276"/> 
+       <position name="posWireV276" unit="cm" x="0" y="-79.1330712708023" z="66.1724999999986"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV277"/> 
+       <position name="posWireV277" unit="cm" x="0" y="-79.5747442267323" z="66.9374999999986"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV278"/> 
+       <position name="posWireV278" unit="cm" x="0" y="-80.0164171826624" z="67.7024999999986"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV279"/> 
+       <position name="posWireV279" unit="cm" x="0" y="-80.4580901385924" z="68.4674999999986"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV280"/> 
+       <position name="posWireV280" unit="cm" x="0" y="-80.8997630945225" z="69.2324999999986"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV281"/> 
+       <position name="posWireV281" unit="cm" x="0" y="-81.3414360504525" z="69.9974999999985"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV282"/> 
+       <position name="posWireV282" unit="cm" x="0" y="-81.7831090063826" z="70.7624999999985"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV283"/> 
+       <position name="posWireV283" unit="cm" x="0" y="-82.2247819623126" z="71.5274999999985"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV284"/> 
+       <position name="posWireV284" unit="cm" x="0" y="-82.6664549182427" z="72.2924999999985"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV285"/> 
+       <position name="posWireV285" unit="cm" x="0" y="-83.1081278741728" z="73.0574999999985"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+  </volume>
+  <volume name="volTPCPlaneZ">
+    <materialref ref="LAr"/>
+    <solidref ref="CRMZPlane"/>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ0" unit="cm" x="0" y="0" z="-74.205"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ1" unit="cm" x="0" y="0" z="-73.695"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ2" unit="cm" x="0" y="0" z="-73.185"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ3" unit="cm" x="0" y="0" z="-72.675"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ4" unit="cm" x="0" y="0" z="-72.165"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ5" unit="cm" x="0" y="0" z="-71.655"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ6" unit="cm" x="0" y="0" z="-71.145"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ7" unit="cm" x="0" y="0" z="-70.635"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ8" unit="cm" x="0" y="0" z="-70.125"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ9" unit="cm" x="0" y="0" z="-69.615"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ10" unit="cm" x="0" y="0" z="-69.105"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ11" unit="cm" x="0" y="0" z="-68.595"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ12" unit="cm" x="0" y="0" z="-68.085"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ13" unit="cm" x="0" y="0" z="-67.575"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ14" unit="cm" x="0" y="0" z="-67.065"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ15" unit="cm" x="0" y="0" z="-66.555"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ16" unit="cm" x="0" y="0" z="-66.045"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ17" unit="cm" x="0" y="0" z="-65.535"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ18" unit="cm" x="0" y="0" z="-65.025"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ19" unit="cm" x="0" y="0" z="-64.515"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ20" unit="cm" x="0" y="0" z="-64.005"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ21" unit="cm" x="0" y="0" z="-63.495"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ22" unit="cm" x="0" y="0" z="-62.985"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ23" unit="cm" x="0" y="0" z="-62.475"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ24" unit="cm" x="0" y="0" z="-61.965"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ25" unit="cm" x="0" y="0" z="-61.455"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ26" unit="cm" x="0" y="0" z="-60.945"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ27" unit="cm" x="0" y="0" z="-60.435"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ28" unit="cm" x="0" y="0" z="-59.925"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ29" unit="cm" x="0" y="0" z="-59.415"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ30" unit="cm" x="0" y="0" z="-58.905"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ31" unit="cm" x="0" y="0" z="-58.395"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ32" unit="cm" x="0" y="0" z="-57.885"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ33" unit="cm" x="0" y="0" z="-57.375"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ34" unit="cm" x="0" y="0" z="-56.865"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ35" unit="cm" x="0" y="0" z="-56.355"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ36" unit="cm" x="0" y="0" z="-55.845"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ37" unit="cm" x="0" y="0" z="-55.335"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ38" unit="cm" x="0" y="0" z="-54.825"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ39" unit="cm" x="0" y="0" z="-54.315"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ40" unit="cm" x="0" y="0" z="-53.805"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ41" unit="cm" x="0" y="0" z="-53.295"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ42" unit="cm" x="0" y="0" z="-52.785"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ43" unit="cm" x="0" y="0" z="-52.275"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ44" unit="cm" x="0" y="0" z="-51.765"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ45" unit="cm" x="0" y="0" z="-51.255"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ46" unit="cm" x="0" y="0" z="-50.745"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ47" unit="cm" x="0" y="0" z="-50.235"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ48" unit="cm" x="0" y="0" z="-49.725"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ49" unit="cm" x="0" y="0" z="-49.215"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ50" unit="cm" x="0" y="0" z="-48.705"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ51" unit="cm" x="0" y="0" z="-48.195"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ52" unit="cm" x="0" y="0" z="-47.685"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ53" unit="cm" x="0" y="0" z="-47.175"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ54" unit="cm" x="0" y="0" z="-46.665"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ55" unit="cm" x="0" y="0" z="-46.155"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ56" unit="cm" x="0" y="0" z="-45.645"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ57" unit="cm" x="0" y="0" z="-45.135"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ58" unit="cm" x="0" y="0" z="-44.625"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ59" unit="cm" x="0" y="0" z="-44.115"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ60" unit="cm" x="0" y="0" z="-43.605"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ61" unit="cm" x="0" y="0" z="-43.095"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ62" unit="cm" x="0" y="0" z="-42.585"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ63" unit="cm" x="0" y="0" z="-42.075"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ64" unit="cm" x="0" y="0" z="-41.565"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ65" unit="cm" x="0" y="0" z="-41.055"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ66" unit="cm" x="0" y="0" z="-40.545"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ67" unit="cm" x="0" y="0" z="-40.035"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ68" unit="cm" x="0" y="0" z="-39.525"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ69" unit="cm" x="0" y="0" z="-39.015"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ70" unit="cm" x="0" y="0" z="-38.505"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ71" unit="cm" x="0" y="0" z="-37.995"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ72" unit="cm" x="0" y="0" z="-37.485"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ73" unit="cm" x="0" y="0" z="-36.975"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ74" unit="cm" x="0" y="0" z="-36.465"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ75" unit="cm" x="0" y="0" z="-35.955"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ76" unit="cm" x="0" y="0" z="-35.445"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ77" unit="cm" x="0" y="0" z="-34.935"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ78" unit="cm" x="0" y="0" z="-34.425"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ79" unit="cm" x="0" y="0" z="-33.915"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ80" unit="cm" x="0" y="0" z="-33.405"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ81" unit="cm" x="0" y="0" z="-32.895"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ82" unit="cm" x="0" y="0" z="-32.385"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ83" unit="cm" x="0" y="0" z="-31.875"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ84" unit="cm" x="0" y="0" z="-31.365"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ85" unit="cm" x="0" y="0" z="-30.855"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ86" unit="cm" x="0" y="0" z="-30.345"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ87" unit="cm" x="0" y="0" z="-29.835"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ88" unit="cm" x="0" y="0" z="-29.325"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ89" unit="cm" x="0" y="0" z="-28.815"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ90" unit="cm" x="0" y="0" z="-28.305"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ91" unit="cm" x="0" y="0" z="-27.795"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ92" unit="cm" x="0" y="0" z="-27.285"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ93" unit="cm" x="0" y="0" z="-26.775"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ94" unit="cm" x="0" y="0" z="-26.265"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ95" unit="cm" x="0" y="0" z="-25.755"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ96" unit="cm" x="0" y="0" z="-25.245"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ97" unit="cm" x="0" y="0" z="-24.735"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ98" unit="cm" x="0" y="0" z="-24.225"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ99" unit="cm" x="0" y="0" z="-23.715"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ100" unit="cm" x="0" y="0" z="-23.205"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ101" unit="cm" x="0" y="0" z="-22.695"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ102" unit="cm" x="0" y="0" z="-22.185"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ103" unit="cm" x="0" y="0" z="-21.675"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ104" unit="cm" x="0" y="0" z="-21.165"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ105" unit="cm" x="0" y="0" z="-20.655"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ106" unit="cm" x="0" y="0" z="-20.145"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ107" unit="cm" x="0" y="0" z="-19.635"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ108" unit="cm" x="0" y="0" z="-19.125"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ109" unit="cm" x="0" y="0" z="-18.615"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ110" unit="cm" x="0" y="0" z="-18.105"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ111" unit="cm" x="0" y="0" z="-17.595"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ112" unit="cm" x="0" y="0" z="-17.085"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ113" unit="cm" x="0" y="0" z="-16.575"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ114" unit="cm" x="0" y="0" z="-16.065"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ115" unit="cm" x="0" y="0" z="-15.555"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ116" unit="cm" x="0" y="0" z="-15.045"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ117" unit="cm" x="0" y="0" z="-14.535"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ118" unit="cm" x="0" y="0" z="-14.025"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ119" unit="cm" x="0" y="0" z="-13.515"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ120" unit="cm" x="0" y="0" z="-13.005"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ121" unit="cm" x="0" y="0" z="-12.495"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ122" unit="cm" x="0" y="0" z="-11.985"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ123" unit="cm" x="0" y="0" z="-11.475"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ124" unit="cm" x="0" y="0" z="-10.965"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ125" unit="cm" x="0" y="0" z="-10.455"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ126" unit="cm" x="0" y="0" z="-9.945"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ127" unit="cm" x="0" y="0" z="-9.435"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ128" unit="cm" x="0" y="0" z="-8.925"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ129" unit="cm" x="0" y="0" z="-8.415"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ130" unit="cm" x="0" y="0" z="-7.905"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ131" unit="cm" x="0" y="0" z="-7.395"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ132" unit="cm" x="0" y="0" z="-6.885"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ133" unit="cm" x="0" y="0" z="-6.375"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ134" unit="cm" x="0" y="0" z="-5.865"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ135" unit="cm" x="0" y="0" z="-5.355"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ136" unit="cm" x="0" y="0" z="-4.845"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ137" unit="cm" x="0" y="0" z="-4.335"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ138" unit="cm" x="0" y="0" z="-3.825"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ139" unit="cm" x="0" y="0" z="-3.315"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ140" unit="cm" x="0" y="0" z="-2.805"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ141" unit="cm" x="0" y="0" z="-2.295"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ142" unit="cm" x="0" y="0" z="-1.785"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ143" unit="cm" x="0" y="0" z="-1.275"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ144" unit="cm" x="0" y="0" z="-0.765"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ145" unit="cm" x="0" y="0" z="-0.255"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ146" unit="cm" x="0" y="0" z="0.255"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ147" unit="cm" x="0" y="0" z="0.765"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ148" unit="cm" x="0" y="0" z="1.275"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ149" unit="cm" x="0" y="0" z="1.785"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ150" unit="cm" x="0" y="0" z="2.295"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ151" unit="cm" x="0" y="0" z="2.805"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ152" unit="cm" x="0" y="0" z="3.315"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ153" unit="cm" x="0" y="0" z="3.825"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ154" unit="cm" x="0" y="0" z="4.335"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ155" unit="cm" x="0" y="0" z="4.845"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ156" unit="cm" x="0" y="0" z="5.355"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ157" unit="cm" x="0" y="0" z="5.865"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ158" unit="cm" x="0" y="0" z="6.375"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ159" unit="cm" x="0" y="0" z="6.885"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ160" unit="cm" x="0" y="0" z="7.395"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ161" unit="cm" x="0" y="0" z="7.905"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ162" unit="cm" x="0" y="0" z="8.415"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ163" unit="cm" x="0" y="0" z="8.925"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ164" unit="cm" x="0" y="0" z="9.435"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ165" unit="cm" x="0" y="0" z="9.945"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ166" unit="cm" x="0" y="0" z="10.455"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ167" unit="cm" x="0" y="0" z="10.965"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ168" unit="cm" x="0" y="0" z="11.475"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ169" unit="cm" x="0" y="0" z="11.985"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ170" unit="cm" x="0" y="0" z="12.495"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ171" unit="cm" x="0" y="0" z="13.005"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ172" unit="cm" x="0" y="0" z="13.515"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ173" unit="cm" x="0" y="0" z="14.025"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ174" unit="cm" x="0" y="0" z="14.535"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ175" unit="cm" x="0" y="0" z="15.045"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ176" unit="cm" x="0" y="0" z="15.555"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ177" unit="cm" x="0" y="0" z="16.065"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ178" unit="cm" x="0" y="0" z="16.575"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ179" unit="cm" x="0" y="0" z="17.085"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ180" unit="cm" x="0" y="0" z="17.595"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ181" unit="cm" x="0" y="0" z="18.105"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ182" unit="cm" x="0" y="0" z="18.615"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ183" unit="cm" x="0" y="0" z="19.125"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ184" unit="cm" x="0" y="0" z="19.635"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ185" unit="cm" x="0" y="0" z="20.145"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ186" unit="cm" x="0" y="0" z="20.655"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ187" unit="cm" x="0" y="0" z="21.165"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ188" unit="cm" x="0" y="0" z="21.675"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ189" unit="cm" x="0" y="0" z="22.185"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ190" unit="cm" x="0" y="0" z="22.695"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ191" unit="cm" x="0" y="0" z="23.205"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ192" unit="cm" x="0" y="0" z="23.715"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ193" unit="cm" x="0" y="0" z="24.225"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ194" unit="cm" x="0" y="0" z="24.735"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ195" unit="cm" x="0" y="0" z="25.245"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ196" unit="cm" x="0" y="0" z="25.755"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ197" unit="cm" x="0" y="0" z="26.265"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ198" unit="cm" x="0" y="0" z="26.775"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ199" unit="cm" x="0" y="0" z="27.285"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ200" unit="cm" x="0" y="0" z="27.795"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ201" unit="cm" x="0" y="0" z="28.305"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ202" unit="cm" x="0" y="0" z="28.815"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ203" unit="cm" x="0" y="0" z="29.325"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ204" unit="cm" x="0" y="0" z="29.835"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ205" unit="cm" x="0" y="0" z="30.345"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ206" unit="cm" x="0" y="0" z="30.855"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ207" unit="cm" x="0" y="0" z="31.365"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ208" unit="cm" x="0" y="0" z="31.875"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ209" unit="cm" x="0" y="0" z="32.385"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ210" unit="cm" x="0" y="0" z="32.895"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ211" unit="cm" x="0" y="0" z="33.405"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ212" unit="cm" x="0" y="0" z="33.915"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ213" unit="cm" x="0" y="0" z="34.425"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ214" unit="cm" x="0" y="0" z="34.935"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ215" unit="cm" x="0" y="0" z="35.445"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ216" unit="cm" x="0" y="0" z="35.955"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ217" unit="cm" x="0" y="0" z="36.465"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ218" unit="cm" x="0" y="0" z="36.975"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ219" unit="cm" x="0" y="0" z="37.485"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ220" unit="cm" x="0" y="0" z="37.995"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ221" unit="cm" x="0" y="0" z="38.505"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ222" unit="cm" x="0" y="0" z="39.015"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ223" unit="cm" x="0" y="0" z="39.525"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ224" unit="cm" x="0" y="0" z="40.035"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ225" unit="cm" x="0" y="0" z="40.545"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ226" unit="cm" x="0" y="0" z="41.055"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ227" unit="cm" x="0" y="0" z="41.565"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ228" unit="cm" x="0" y="0" z="42.075"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ229" unit="cm" x="0" y="0" z="42.585"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ230" unit="cm" x="0" y="0" z="43.095"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ231" unit="cm" x="0" y="0" z="43.605"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ232" unit="cm" x="0" y="0" z="44.115"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ233" unit="cm" x="0" y="0" z="44.625"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ234" unit="cm" x="0" y="0" z="45.135"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ235" unit="cm" x="0" y="0" z="45.645"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ236" unit="cm" x="0" y="0" z="46.155"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ237" unit="cm" x="0" y="0" z="46.665"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ238" unit="cm" x="0" y="0" z="47.175"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ239" unit="cm" x="0" y="0" z="47.685"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ240" unit="cm" x="0" y="0" z="48.195"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ241" unit="cm" x="0" y="0" z="48.705"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ242" unit="cm" x="0" y="0" z="49.215"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ243" unit="cm" x="0" y="0" z="49.725"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ244" unit="cm" x="0" y="0" z="50.235"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ245" unit="cm" x="0" y="0" z="50.745"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ246" unit="cm" x="0" y="0" z="51.255"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ247" unit="cm" x="0" y="0" z="51.765"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ248" unit="cm" x="0" y="0" z="52.275"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ249" unit="cm" x="0" y="0" z="52.785"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ250" unit="cm" x="0" y="0" z="53.295"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ251" unit="cm" x="0" y="0" z="53.805"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ252" unit="cm" x="0" y="0" z="54.315"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ253" unit="cm" x="0" y="0" z="54.825"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ254" unit="cm" x="0" y="0" z="55.335"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ255" unit="cm" x="0" y="0" z="55.845"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ256" unit="cm" x="0" y="0" z="56.355"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ257" unit="cm" x="0" y="0" z="56.865"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ258" unit="cm" x="0" y="0" z="57.375"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ259" unit="cm" x="0" y="0" z="57.885"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ260" unit="cm" x="0" y="0" z="58.395"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ261" unit="cm" x="0" y="0" z="58.905"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ262" unit="cm" x="0" y="0" z="59.415"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ263" unit="cm" x="0" y="0" z="59.925"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ264" unit="cm" x="0" y="0" z="60.435"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ265" unit="cm" x="0" y="0" z="60.945"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ266" unit="cm" x="0" y="0" z="61.455"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ267" unit="cm" x="0" y="0" z="61.965"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ268" unit="cm" x="0" y="0" z="62.475"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ269" unit="cm" x="0" y="0" z="62.985"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ270" unit="cm" x="0" y="0" z="63.495"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ271" unit="cm" x="0" y="0" z="64.005"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ272" unit="cm" x="0" y="0" z="64.515"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ273" unit="cm" x="0" y="0" z="65.025"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ274" unit="cm" x="0" y="0" z="65.535"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ275" unit="cm" x="0" y="0" z="66.045"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ276" unit="cm" x="0" y="0" z="66.555"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ277" unit="cm" x="0" y="0" z="67.065"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ278" unit="cm" x="0" y="0" z="67.575"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ279" unit="cm" x="0" y="0" z="68.085"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ280" unit="cm" x="0" y="0" z="68.595"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ281" unit="cm" x="0" y="0" z="69.105"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ282" unit="cm" x="0" y="0" z="69.615"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ283" unit="cm" x="0" y="0" z="70.125"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ284" unit="cm" x="0" y="0" z="70.635"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ285" unit="cm" x="0" y="0" z="71.145"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ286" unit="cm" x="0" y="0" z="71.655"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ287" unit="cm" x="0" y="0" z="72.165"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ288" unit="cm" x="0" y="0" z="72.675"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ289" unit="cm" x="0" y="0" z="73.185"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ290" unit="cm" x="0" y="0" z="73.695"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ291" unit="cm" x="0" y="0" z="74.205"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+  </volume>
+   <volume name="volTPC">
+     <materialref ref="LAr"/>
+       <solidref ref="CRM"/>
+       <physvol>
+       <volumeref ref="volTPCPlaneU"/>
+       <position name="posPlaneU" unit="cm" 
+         x="324.99" y="0" z="0"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCPlaneV"/>
+       <position name="posPlaneY" unit="cm" 
+         x="325.01" y="0" z="0"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCPlaneZ"/>
+       <position name="posPlaneZ" unit="cm" 
+         x="325.03" y="0" z="0"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCActive"/>
+       <position name="posActive" unit="cm" 
+        x="-0.04" y="" z="0"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+   </volume>
+ 
+    <volume name="volSteelShell">
+      <materialref ref="STEEL_STAINLESS_Fe7Cr2Ni" />
+      <solidref ref="SteelShell" />
+    </volume>
+    <volume name="volGroundGrid">
+      <materialref ref="STEEL_STAINLESS_Fe7Cr2Ni" />
+      <solidref ref="CathodeGrid" />
+    </volume>
+    <volume name="volAnodePlate">
+     <materialref ref="vm2000"/>
+     <solidref ref="AnodePlate"/>
+    </volume>
+    <volume name="volGaseousArgon">
+      <materialref ref="ArGas"/>
+      <solidref ref="GaseousArgon"/>
+    </volume>
+    <volume name="volExternalActive">
+      <materialref ref="LAr"/>
+      <solidref ref="ExternalActive"/>
+      <auxiliary auxtype="SensDet" auxvalue="SimEnergyDeposit"/>
+      <auxiliary auxtype="StepLimit" auxunit="cm" auxvalue="0.5208*cm"/>
+      <auxiliary auxtype="Efield" auxunit="V/cm" auxvalue="0*V/cm"/>
+      <colorref ref="green"/>
+    </volume>
+    <volume name="volArapucaDouble_0-0-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-0-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-0-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-0-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-0-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-0-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-0-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-0-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-1-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-1-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-1-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-1-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-1-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-1-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-1-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-1-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-2-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-2-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-2-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-2-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-2-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-2-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-2-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-2-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-0-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-0-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-0-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-0-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-0-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-0-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-0-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-0-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-1-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-1-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-1-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-1-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-1-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-1-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-1-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-1-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-2-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-2-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-2-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-2-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-2-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-2-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-2-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-2-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-0-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-0-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-0-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-0-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-0-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-0-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-0-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-0-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-1-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-1-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-1-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-1-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-1-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-1-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-1-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-1-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-2-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-2-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-2-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-2-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-2-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-2-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-2-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-2-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-0-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-0-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-0-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-0-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-0-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-0-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-0-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-0-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-1-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-1-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-1-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-1-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-1-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-1-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-1-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-1-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-2-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-2-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-2-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-2-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-2-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-2-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-2-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-2-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_0-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_0-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_0-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_0-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_0-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_0-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_0-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_0-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_0-4">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_0-4">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_0-5">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_0-5">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_0-6">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_0-6">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_0-7">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_0-7">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_1-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_1-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_1-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_1-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_1-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_1-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_1-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_1-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_1-4">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_1-4">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_1-5">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_1-5">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_1-6">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_1-6">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_1-7">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_1-7">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_2-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_2-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_2-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_2-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_2-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_2-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_2-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_2-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_2-4">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_2-4">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_2-5">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_2-5">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_2-6">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_2-6">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_2-7">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_2-7">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+
+    <volume name="volCryostat">
+      <materialref ref="LAr" />
+      <solidref ref="Cryostat" />
+      <physvol>
+        <volumeref ref="volGaseousArgon"/>
+        <position name="posGaseousArgon" unit="cm" x="375.045" y="0" z="0"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volSteelShell"/>
+        <position name="posSteelShell" unit="cm" x="0" y="0" z="0"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volExternalActive"/>
+        <position name="posExternalActive" unit="cm" x="-100/2" y="0" z="0"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-0" unit="cm"
+           x="0" y="-588.4521" z="-373.3"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-1" unit="cm"
+           x="0" y="-420.7515" z="-373.3"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-2" unit="cm"
+           x="0" y="-252.0509" z="-373.3"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-3" unit="cm"
+           x="0" y="-84.3502999999999" z="-373.3"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-4" unit="cm"
+           x="0" y="84.3503000000001" z="-373.3"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-5" unit="cm"
+           x="0" y="252.0509" z="-373.3"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-6" unit="cm"
+           x="0" y="420.7515" z="-373.3"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-7" unit="cm"
+           x="0" y="588.4521" z="-373.3"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-8" unit="cm"
+           x="0" y="-588.4521" z="-224.38"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-9" unit="cm"
+           x="0" y="-420.7515" z="-224.38"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-10" unit="cm"
+           x="0" y="-252.0509" z="-224.38"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-11" unit="cm"
+           x="0" y="-84.3502999999999" z="-224.38"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-12" unit="cm"
+           x="0" y="84.3503000000001" z="-224.38"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-13" unit="cm"
+           x="0" y="252.0509" z="-224.38"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-14" unit="cm"
+           x="0" y="420.7515" z="-224.38"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-15" unit="cm"
+           x="0" y="588.4521" z="-224.38"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-16" unit="cm"
+           x="0" y="-588.4521" z="-74.46"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-17" unit="cm"
+           x="0" y="-420.7515" z="-74.46"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-18" unit="cm"
+           x="0" y="-252.0509" z="-74.46"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-19" unit="cm"
+           x="0" y="-84.3502999999999" z="-74.46"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-20" unit="cm"
+           x="0" y="84.3503000000001" z="-74.46"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-21" unit="cm"
+           x="0" y="252.0509" z="-74.46"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-22" unit="cm"
+           x="0" y="420.7515" z="-74.46"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-23" unit="cm"
+           x="0" y="588.4521" z="-74.46"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-24" unit="cm"
+           x="0" y="-588.4521" z="74.46"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-25" unit="cm"
+           x="0" y="-420.7515" z="74.46"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-26" unit="cm"
+           x="0" y="-252.0509" z="74.46"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-27" unit="cm"
+           x="0" y="-84.3502999999999" z="74.46"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-28" unit="cm"
+           x="0" y="84.3503000000001" z="74.46"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-29" unit="cm"
+           x="0" y="252.0509" z="74.46"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-30" unit="cm"
+           x="0" y="420.7515" z="74.46"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-31" unit="cm"
+           x="0" y="588.4521" z="74.46"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-32" unit="cm"
+           x="0" y="-588.4521" z="224.38"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-33" unit="cm"
+           x="0" y="-420.7515" z="224.38"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-34" unit="cm"
+           x="0" y="-252.0509" z="224.38"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-35" unit="cm"
+           x="0" y="-84.3502999999999" z="224.38"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-36" unit="cm"
+           x="0" y="84.3503000000001" z="224.38"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-37" unit="cm"
+           x="0" y="252.0509" z="224.38"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-38" unit="cm"
+           x="0" y="420.7515" z="224.38"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-39" unit="cm"
+           x="0" y="588.4521" z="224.38"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-40" unit="cm"
+           x="0" y="-588.4521" z="373.3"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-41" unit="cm"
+           x="0" y="-420.7515" z="373.3"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-42" unit="cm"
+           x="0" y="-252.0509" z="373.3"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-43" unit="cm"
+           x="0" y="-84.3502999999999" z="373.3"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-44" unit="cm"
+           x="0" y="84.3503000000001" z="373.3"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-45" unit="cm"
+           x="0" y="252.0509" z="373.3"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-46" unit="cm"
+           x="0" y="420.7515" z="373.3"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-47" unit="cm"
+           x="0" y="588.4521" z="373.3"/>
+      </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper0" unit="cm"  x="-322.04" y="-675.1024" z="0" />
+     <rotation name="rotFS0" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper1" unit="cm"  x="-316.04" y="-675.1024" z="0" />
+     <rotation name="rotFS1" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper2" unit="cm"  x="-310.04" y="-675.1024" z="0" />
+     <rotation name="rotFS2" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper3" unit="cm"  x="-304.04" y="-675.1024" z="0" />
+     <rotation name="rotFS3" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper4" unit="cm"  x="-298.04" y="-675.1024" z="0" />
+     <rotation name="rotFS4" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper5" unit="cm"  x="-292.04" y="-675.1024" z="0" />
+     <rotation name="rotFS5" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper6" unit="cm"  x="-286.04" y="-675.1024" z="0" />
+     <rotation name="rotFS6" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper7" unit="cm"  x="-280.04" y="-675.1024" z="0" />
+     <rotation name="rotFS7" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper8" unit="cm"  x="-274.04" y="-675.1024" z="0" />
+     <rotation name="rotFS8" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper9" unit="cm"  x="-268.04" y="-675.1024" z="0" />
+     <rotation name="rotFS9" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper10" unit="cm"  x="-262.04" y="-675.1024" z="0" />
+     <rotation name="rotFS10" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper11" unit="cm"  x="-256.04" y="-675.1024" z="0" />
+     <rotation name="rotFS11" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper12" unit="cm"  x="-250.04" y="-675.1024" z="0" />
+     <rotation name="rotFS12" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper13" unit="cm"  x="-244.04" y="-675.1024" z="0" />
+     <rotation name="rotFS13" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper14" unit="cm"  x="-238.04" y="-675.1024" z="0" />
+     <rotation name="rotFS14" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper15" unit="cm"  x="-232.04" y="-675.1024" z="0" />
+     <rotation name="rotFS15" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper16" unit="cm"  x="-226.04" y="-675.1024" z="0" />
+     <rotation name="rotFS16" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper17" unit="cm"  x="-220.04" y="-675.1024" z="0" />
+     <rotation name="rotFS17" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper18" unit="cm"  x="-214.04" y="-675.1024" z="0" />
+     <rotation name="rotFS18" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper19" unit="cm"  x="-208.04" y="-675.1024" z="0" />
+     <rotation name="rotFS19" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper20" unit="cm"  x="-202.04" y="-675.1024" z="0" />
+     <rotation name="rotFS20" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper21" unit="cm"  x="-196.04" y="-675.1024" z="0" />
+     <rotation name="rotFS21" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper22" unit="cm"  x="-190.04" y="-675.1024" z="0" />
+     <rotation name="rotFS22" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper23" unit="cm"  x="-184.04" y="-675.1024" z="0" />
+     <rotation name="rotFS23" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper24" unit="cm"  x="-178.04" y="-675.1024" z="0" />
+     <rotation name="rotFS24" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper25" unit="cm"  x="-172.04" y="-675.1024" z="0" />
+     <rotation name="rotFS25" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper26" unit="cm"  x="-166.04" y="-675.1024" z="0" />
+     <rotation name="rotFS26" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper27" unit="cm"  x="-160.04" y="-675.1024" z="0" />
+     <rotation name="rotFS27" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper28" unit="cm"  x="-154.04" y="-675.1024" z="0" />
+     <rotation name="rotFS28" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper29" unit="cm"  x="-148.04" y="-675.1024" z="0" />
+     <rotation name="rotFS29" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper30" unit="cm"  x="-142.04" y="-675.1024" z="0" />
+     <rotation name="rotFS30" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper31" unit="cm"  x="-136.04" y="-675.1024" z="0" />
+     <rotation name="rotFS31" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper32" unit="cm"  x="-130.04" y="-675.1024" z="0" />
+     <rotation name="rotFS32" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper33" unit="cm"  x="-124.04" y="-675.1024" z="0" />
+     <rotation name="rotFS33" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper34" unit="cm"  x="-118.04" y="-675.1024" z="0" />
+     <rotation name="rotFS34" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper35" unit="cm"  x="-112.04" y="-675.1024" z="0" />
+     <rotation name="rotFS35" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper36" unit="cm"  x="-106.04" y="-675.1024" z="0" />
+     <rotation name="rotFS36" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper37" unit="cm"  x="-100.04" y="-675.1024" z="0" />
+     <rotation name="rotFS37" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper38" unit="cm"  x="-94.04" y="-675.1024" z="0" />
+     <rotation name="rotFS38" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper39" unit="cm"  x="-88.04" y="-675.1024" z="0" />
+     <rotation name="rotFS39" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper40" unit="cm"  x="-82.04" y="-675.1024" z="0" />
+     <rotation name="rotFS40" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper41" unit="cm"  x="-76.04" y="-675.1024" z="0" />
+     <rotation name="rotFS41" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper42" unit="cm"  x="-70.04" y="-675.1024" z="0" />
+     <rotation name="rotFS42" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper43" unit="cm"  x="-64.04" y="-675.1024" z="0" />
+     <rotation name="rotFS43" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper44" unit="cm"  x="-58.04" y="-675.1024" z="0" />
+     <rotation name="rotFS44" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper45" unit="cm"  x="-52.04" y="-675.1024" z="0" />
+     <rotation name="rotFS45" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper46" unit="cm"  x="-46.04" y="-675.1024" z="0" />
+     <rotation name="rotFS46" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper47" unit="cm"  x="-40.04" y="-675.1024" z="0" />
+     <rotation name="rotFS47" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper48" unit="cm"  x="-34.04" y="-675.1024" z="0" />
+     <rotation name="rotFS48" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper49" unit="cm"  x="-28.04" y="-675.1024" z="0" />
+     <rotation name="rotFS49" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper50" unit="cm"  x="-22.04" y="-675.1024" z="0" />
+     <rotation name="rotFS50" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper51" unit="cm"  x="-16.04" y="-675.1024" z="0" />
+     <rotation name="rotFS51" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper52" unit="cm"  x="-10.04" y="-675.1024" z="0" />
+     <rotation name="rotFS52" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper53" unit="cm"  x="-4.04000000000001" y="-675.1024" z="0" />
+     <rotation name="rotFS53" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper54" unit="cm"  x="1.95999999999999" y="-675.1024" z="0" />
+     <rotation name="rotFS54" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper55" unit="cm"  x="7.95999999999999" y="-675.1024" z="0" />
+     <rotation name="rotFS55" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper56" unit="cm"  x="13.96" y="-675.1024" z="0" />
+     <rotation name="rotFS56" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper57" unit="cm"  x="19.96" y="-675.1024" z="0" />
+     <rotation name="rotFS57" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper58" unit="cm"  x="25.96" y="-675.1024" z="0" />
+     <rotation name="rotFS58" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper59" unit="cm"  x="31.96" y="-675.1024" z="0" />
+     <rotation name="rotFS59" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper60" unit="cm"  x="37.96" y="-675.1024" z="0" />
+     <rotation name="rotFS60" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper61" unit="cm"  x="43.96" y="-675.1024" z="0" />
+     <rotation name="rotFS61" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper62" unit="cm"  x="49.96" y="-675.1024" z="0" />
+     <rotation name="rotFS62" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper63" unit="cm"  x="55.96" y="-675.1024" z="0" />
+     <rotation name="rotFS63" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper64" unit="cm"  x="61.96" y="-675.1024" z="0" />
+     <rotation name="rotFS64" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper65" unit="cm"  x="67.96" y="-675.1024" z="0" />
+     <rotation name="rotFS65" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper66" unit="cm"  x="73.96" y="-675.1024" z="0" />
+     <rotation name="rotFS66" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper67" unit="cm"  x="79.96" y="-675.1024" z="0" />
+     <rotation name="rotFS67" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper68" unit="cm"  x="85.96" y="-675.1024" z="0" />
+     <rotation name="rotFS68" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper69" unit="cm"  x="91.96" y="-675.1024" z="0" />
+     <rotation name="rotFS69" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper70" unit="cm"  x="97.96" y="-675.1024" z="0" />
+     <rotation name="rotFS70" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper71" unit="cm"  x="103.96" y="-675.1024" z="0" />
+     <rotation name="rotFS71" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper72" unit="cm"  x="109.96" y="-675.1024" z="0" />
+     <rotation name="rotFS72" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper73" unit="cm"  x="115.96" y="-675.1024" z="0" />
+     <rotation name="rotFS73" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper74" unit="cm"  x="121.96" y="-675.1024" z="0" />
+     <rotation name="rotFS74" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper75" unit="cm"  x="127.96" y="-675.1024" z="0" />
+     <rotation name="rotFS75" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper76" unit="cm"  x="133.96" y="-675.1024" z="0" />
+     <rotation name="rotFS76" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper77" unit="cm"  x="139.96" y="-675.1024" z="0" />
+     <rotation name="rotFS77" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper78" unit="cm"  x="145.96" y="-675.1024" z="0" />
+     <rotation name="rotFS78" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper79" unit="cm"  x="151.96" y="-675.1024" z="0" />
+     <rotation name="rotFS79" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper80" unit="cm"  x="157.96" y="-675.1024" z="0" />
+     <rotation name="rotFS80" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper81" unit="cm"  x="163.96" y="-675.1024" z="0" />
+     <rotation name="rotFS81" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper82" unit="cm"  x="169.96" y="-675.1024" z="0" />
+     <rotation name="rotFS82" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper83" unit="cm"  x="175.96" y="-675.1024" z="0" />
+     <rotation name="rotFS83" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper84" unit="cm"  x="181.96" y="-675.1024" z="0" />
+     <rotation name="rotFS84" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper85" unit="cm"  x="187.96" y="-675.1024" z="0" />
+     <rotation name="rotFS85" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper86" unit="cm"  x="193.96" y="-675.1024" z="0" />
+     <rotation name="rotFS86" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper87" unit="cm"  x="199.96" y="-675.1024" z="0" />
+     <rotation name="rotFS87" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper88" unit="cm"  x="205.96" y="-675.1024" z="0" />
+     <rotation name="rotFS88" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper89" unit="cm"  x="211.96" y="-675.1024" z="0" />
+     <rotation name="rotFS89" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper90" unit="cm"  x="217.96" y="-675.1024" z="0" />
+     <rotation name="rotFS90" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper91" unit="cm"  x="223.96" y="-675.1024" z="0" />
+     <rotation name="rotFS91" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper92" unit="cm"  x="229.96" y="-675.1024" z="0" />
+     <rotation name="rotFS92" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper93" unit="cm"  x="235.96" y="-675.1024" z="0" />
+     <rotation name="rotFS93" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper94" unit="cm"  x="241.96" y="-675.1024" z="0" />
+     <rotation name="rotFS94" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper95" unit="cm"  x="247.96" y="-675.1024" z="0" />
+     <rotation name="rotFS95" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper96" unit="cm"  x="253.96" y="-675.1024" z="0" />
+     <rotation name="rotFS96" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper97" unit="cm"  x="259.96" y="-675.1024" z="0" />
+     <rotation name="rotFS97" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper98" unit="cm"  x="265.96" y="-675.1024" z="0" />
+     <rotation name="rotFS98" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper99" unit="cm"  x="271.96" y="-675.1024" z="0" />
+     <rotation name="rotFS99" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper100" unit="cm"  x="277.96" y="-675.1024" z="0" />
+     <rotation name="rotFS100" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper101" unit="cm"  x="283.96" y="-675.1024" z="0" />
+     <rotation name="rotFS101" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper102" unit="cm"  x="289.96" y="-675.1024" z="0" />
+     <rotation name="rotFS102" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper103" unit="cm"  x="295.96" y="-675.1024" z="0" />
+     <rotation name="rotFS103" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper104" unit="cm"  x="301.96" y="-675.1024" z="0" />
+     <rotation name="rotFS104" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper105" unit="cm"  x="307.96" y="-675.1024" z="0" />
+     <rotation name="rotFS105" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper106" unit="cm"  x="313.96" y="-675.1024" z="0" />
+     <rotation name="rotFS106" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper107" unit="cm"  x="319.96" y="-675.1024" z="0" />
+     <rotation name="rotFS107" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-0" unit="cm" x="-328.04" y="-505.1018" z="-299.34"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-0" unit="cm" x="325.045" y="-505.1018" z="-299.34"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-1" unit="cm" x="-328.04" y="-169.7006" z="-299.34"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-1" unit="cm" x="325.045" y="-169.7006" z="-299.34"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-2" unit="cm" x="-328.04" y="165.7006" z="-299.34"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-2" unit="cm" x="325.045" y="165.7006" z="-299.34"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-3" unit="cm" x="-328.04" y="501.1018" z="-299.34"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-3" unit="cm" x="325.045" y="501.1018" z="-299.34"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-4" unit="cm" x="-328.04" y="-505.1018" z="-1.5"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-4" unit="cm" x="325.045" y="-505.1018" z="-1.5"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-5" unit="cm" x="-328.04" y="-169.7006" z="-1.5"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-5" unit="cm" x="325.045" y="-169.7006" z="-1.5"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-6" unit="cm" x="-328.04" y="165.7006" z="-1.5"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-6" unit="cm" x="325.045" y="165.7006" z="-1.5"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-7" unit="cm" x="-328.04" y="501.1018" z="-1.5"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-7" unit="cm" x="325.045" y="501.1018" z="-1.5"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-8" unit="cm" x="-328.04" y="-505.1018" z="296.34"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-8" unit="cm" x="325.045" y="-505.1018" z="296.34"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-9" unit="cm" x="-328.04" y="-169.7006" z="296.34"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-9" unit="cm" x="325.045" y="-169.7006" z="296.34"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-10" unit="cm" x="-328.04" y="165.7006" z="296.34"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-10" unit="cm" x="325.045" y="165.7006" z="296.34"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-11" unit="cm" x="-328.04" y="501.1018" z="296.34"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-11" unit="cm" x="325.045" y="501.1018" z="296.34"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-0-0"/>
+       <position name="posArapucaDouble0-Frame-0-0" unit="cm" 
+         x="-328.04"
+	 y="-632.8018" 
+	 z="-261.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-0"/>
+       <position name="posOpArapucaDouble0-Frame-0-0" unit="cm" 
+         x="-327.3"
+	 y="-632.8018" 
+	 z="-261.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-0-1"/>
+       <position name="posArapucaDouble1-Frame-0-0" unit="cm" 
+         x="-328.04"
+	 y="-542.1018" 
+	 z="-407.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-1"/>
+       <position name="posOpArapucaDouble1-Frame-0-0" unit="cm" 
+         x="-327.3"
+	 y="-542.1018" 
+	 z="-407.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-0-2"/>
+       <position name="posArapucaDouble2-Frame-0-0" unit="cm" 
+         x="-328.04"
+	 y="-468.1018" 
+	 z="-190.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-2"/>
+       <position name="posOpArapucaDouble2-Frame-0-0" unit="cm" 
+         x="-327.3"
+	 y="-468.1018" 
+	 z="-190.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-0-3"/>
+       <position name="posArapucaDouble3-Frame-0-0" unit="cm" 
+         x="-328.04"
+	 y="-377.4018" 
+	 z="-336.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-3"/>
+       <position name="posOpArapucaDouble3-Frame-0-0" unit="cm" 
+         x="-327.3"
+	 y="-377.4018" 
+	 z="-336.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-1-0"/>
+       <position name="posArapucaDouble0-Frame-0-1" unit="cm" 
+         x="-328.04"
+	 y="-632.8018" 
+	 z="36"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-0"/>
+       <position name="posOpArapucaDouble0-Frame-0-1" unit="cm" 
+         x="-327.3"
+	 y="-632.8018" 
+	 z="36"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-1-1"/>
+       <position name="posArapucaDouble1-Frame-0-1" unit="cm" 
+         x="-328.04"
+	 y="-542.1018" 
+	 z="-110"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-1"/>
+       <position name="posOpArapucaDouble1-Frame-0-1" unit="cm" 
+         x="-327.3"
+	 y="-542.1018" 
+	 z="-110"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-1-2"/>
+       <position name="posArapucaDouble2-Frame-0-1" unit="cm" 
+         x="-328.04"
+	 y="-468.1018" 
+	 z="107"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-2"/>
+       <position name="posOpArapucaDouble2-Frame-0-1" unit="cm" 
+         x="-327.3"
+	 y="-468.1018" 
+	 z="107"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-1-3"/>
+       <position name="posArapucaDouble3-Frame-0-1" unit="cm" 
+         x="-328.04"
+	 y="-377.4018" 
+	 z="-39"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-3"/>
+       <position name="posOpArapucaDouble3-Frame-0-1" unit="cm" 
+         x="-327.3"
+	 y="-377.4018" 
+	 z="-39"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-2-0"/>
+       <position name="posArapucaDouble0-Frame-0-2" unit="cm" 
+         x="-328.04"
+	 y="-632.8018" 
+	 z="333.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-0"/>
+       <position name="posOpArapucaDouble0-Frame-0-2" unit="cm" 
+         x="-327.3"
+	 y="-632.8018" 
+	 z="333.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-2-1"/>
+       <position name="posArapucaDouble1-Frame-0-2" unit="cm" 
+         x="-328.04"
+	 y="-542.1018" 
+	 z="187.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-1"/>
+       <position name="posOpArapucaDouble1-Frame-0-2" unit="cm" 
+         x="-327.3"
+	 y="-542.1018" 
+	 z="187.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-2-2"/>
+       <position name="posArapucaDouble2-Frame-0-2" unit="cm" 
+         x="-328.04"
+	 y="-468.1018" 
+	 z="404.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-2"/>
+       <position name="posOpArapucaDouble2-Frame-0-2" unit="cm" 
+         x="-327.3"
+	 y="-468.1018" 
+	 z="404.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-2-3"/>
+       <position name="posArapucaDouble3-Frame-0-2" unit="cm" 
+         x="-328.04"
+	 y="-377.4018" 
+	 z="258.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-3"/>
+       <position name="posOpArapucaDouble3-Frame-0-2" unit="cm" 
+         x="-327.3"
+	 y="-377.4018" 
+	 z="258.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-0-0"/>
+       <position name="posArapucaDouble0-Frame-1-0" unit="cm" 
+         x="-328.04"
+	 y="-297.4006" 
+	 z="-261.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-0"/>
+       <position name="posOpArapucaDouble0-Frame-1-0" unit="cm" 
+         x="-327.3"
+	 y="-297.4006" 
+	 z="-261.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-0-1"/>
+       <position name="posArapucaDouble1-Frame-1-0" unit="cm" 
+         x="-328.04"
+	 y="-206.7006" 
+	 z="-407.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-1"/>
+       <position name="posOpArapucaDouble1-Frame-1-0" unit="cm" 
+         x="-327.3"
+	 y="-206.7006" 
+	 z="-407.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-0-2"/>
+       <position name="posArapucaDouble2-Frame-1-0" unit="cm" 
+         x="-328.04"
+	 y="-132.7006" 
+	 z="-190.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-2"/>
+       <position name="posOpArapucaDouble2-Frame-1-0" unit="cm" 
+         x="-327.3"
+	 y="-132.7006" 
+	 z="-190.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-0-3"/>
+       <position name="posArapucaDouble3-Frame-1-0" unit="cm" 
+         x="-328.04"
+	 y="-42.0006" 
+	 z="-336.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-3"/>
+       <position name="posOpArapucaDouble3-Frame-1-0" unit="cm" 
+         x="-327.3"
+	 y="-42.0006" 
+	 z="-336.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-1-0"/>
+       <position name="posArapucaDouble0-Frame-1-1" unit="cm" 
+         x="-328.04"
+	 y="-297.4006" 
+	 z="36"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-0"/>
+       <position name="posOpArapucaDouble0-Frame-1-1" unit="cm" 
+         x="-327.3"
+	 y="-297.4006" 
+	 z="36"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-1-1"/>
+       <position name="posArapucaDouble1-Frame-1-1" unit="cm" 
+         x="-328.04"
+	 y="-206.7006" 
+	 z="-110"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-1"/>
+       <position name="posOpArapucaDouble1-Frame-1-1" unit="cm" 
+         x="-327.3"
+	 y="-206.7006" 
+	 z="-110"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-1-2"/>
+       <position name="posArapucaDouble2-Frame-1-1" unit="cm" 
+         x="-328.04"
+	 y="-132.7006" 
+	 z="107"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-2"/>
+       <position name="posOpArapucaDouble2-Frame-1-1" unit="cm" 
+         x="-327.3"
+	 y="-132.7006" 
+	 z="107"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-1-3"/>
+       <position name="posArapucaDouble3-Frame-1-1" unit="cm" 
+         x="-328.04"
+	 y="-42.0006" 
+	 z="-39"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-3"/>
+       <position name="posOpArapucaDouble3-Frame-1-1" unit="cm" 
+         x="-327.3"
+	 y="-42.0006" 
+	 z="-39"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-2-0"/>
+       <position name="posArapucaDouble0-Frame-1-2" unit="cm" 
+         x="-328.04"
+	 y="-297.4006" 
+	 z="333.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-0"/>
+       <position name="posOpArapucaDouble0-Frame-1-2" unit="cm" 
+         x="-327.3"
+	 y="-297.4006" 
+	 z="333.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-2-1"/>
+       <position name="posArapucaDouble1-Frame-1-2" unit="cm" 
+         x="-328.04"
+	 y="-206.7006" 
+	 z="187.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-1"/>
+       <position name="posOpArapucaDouble1-Frame-1-2" unit="cm" 
+         x="-327.3"
+	 y="-206.7006" 
+	 z="187.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-2-2"/>
+       <position name="posArapucaDouble2-Frame-1-2" unit="cm" 
+         x="-328.04"
+	 y="-132.7006" 
+	 z="404.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-2"/>
+       <position name="posOpArapucaDouble2-Frame-1-2" unit="cm" 
+         x="-327.3"
+	 y="-132.7006" 
+	 z="404.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-2-3"/>
+       <position name="posArapucaDouble3-Frame-1-2" unit="cm" 
+         x="-328.04"
+	 y="-42.0006" 
+	 z="258.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-3"/>
+       <position name="posOpArapucaDouble3-Frame-1-2" unit="cm" 
+         x="-327.3"
+	 y="-42.0006" 
+	 z="258.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-0-0"/>
+       <position name="posArapucaDouble0-Frame-2-0" unit="cm" 
+         x="-328.04"
+	 y="38.0006" 
+	 z="-261.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-0"/>
+       <position name="posOpArapucaDouble0-Frame-2-0" unit="cm" 
+         x="-327.3"
+	 y="38.0006" 
+	 z="-261.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-0-1"/>
+       <position name="posArapucaDouble1-Frame-2-0" unit="cm" 
+         x="-328.04"
+	 y="128.7006" 
+	 z="-407.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-1"/>
+       <position name="posOpArapucaDouble1-Frame-2-0" unit="cm" 
+         x="-327.3"
+	 y="128.7006" 
+	 z="-407.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-0-2"/>
+       <position name="posArapucaDouble2-Frame-2-0" unit="cm" 
+         x="-328.04"
+	 y="202.7006" 
+	 z="-190.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-2"/>
+       <position name="posOpArapucaDouble2-Frame-2-0" unit="cm" 
+         x="-327.3"
+	 y="202.7006" 
+	 z="-190.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-0-3"/>
+       <position name="posArapucaDouble3-Frame-2-0" unit="cm" 
+         x="-328.04"
+	 y="293.4006" 
+	 z="-336.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-3"/>
+       <position name="posOpArapucaDouble3-Frame-2-0" unit="cm" 
+         x="-327.3"
+	 y="293.4006" 
+	 z="-336.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-1-0"/>
+       <position name="posArapucaDouble0-Frame-2-1" unit="cm" 
+         x="-328.04"
+	 y="38.0006" 
+	 z="36"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-0"/>
+       <position name="posOpArapucaDouble0-Frame-2-1" unit="cm" 
+         x="-327.3"
+	 y="38.0006" 
+	 z="36"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-1-1"/>
+       <position name="posArapucaDouble1-Frame-2-1" unit="cm" 
+         x="-328.04"
+	 y="128.7006" 
+	 z="-110"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-1"/>
+       <position name="posOpArapucaDouble1-Frame-2-1" unit="cm" 
+         x="-327.3"
+	 y="128.7006" 
+	 z="-110"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-1-2"/>
+       <position name="posArapucaDouble2-Frame-2-1" unit="cm" 
+         x="-328.04"
+	 y="202.7006" 
+	 z="107"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-2"/>
+       <position name="posOpArapucaDouble2-Frame-2-1" unit="cm" 
+         x="-327.3"
+	 y="202.7006" 
+	 z="107"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-1-3"/>
+       <position name="posArapucaDouble3-Frame-2-1" unit="cm" 
+         x="-328.04"
+	 y="293.4006" 
+	 z="-39"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-3"/>
+       <position name="posOpArapucaDouble3-Frame-2-1" unit="cm" 
+         x="-327.3"
+	 y="293.4006" 
+	 z="-39"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-2-0"/>
+       <position name="posArapucaDouble0-Frame-2-2" unit="cm" 
+         x="-328.04"
+	 y="38.0006" 
+	 z="333.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-0"/>
+       <position name="posOpArapucaDouble0-Frame-2-2" unit="cm" 
+         x="-327.3"
+	 y="38.0006" 
+	 z="333.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-2-1"/>
+       <position name="posArapucaDouble1-Frame-2-2" unit="cm" 
+         x="-328.04"
+	 y="128.7006" 
+	 z="187.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-1"/>
+       <position name="posOpArapucaDouble1-Frame-2-2" unit="cm" 
+         x="-327.3"
+	 y="128.7006" 
+	 z="187.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-2-2"/>
+       <position name="posArapucaDouble2-Frame-2-2" unit="cm" 
+         x="-328.04"
+	 y="202.7006" 
+	 z="404.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-2"/>
+       <position name="posOpArapucaDouble2-Frame-2-2" unit="cm" 
+         x="-327.3"
+	 y="202.7006" 
+	 z="404.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-2-3"/>
+       <position name="posArapucaDouble3-Frame-2-2" unit="cm" 
+         x="-328.04"
+	 y="293.4006" 
+	 z="258.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-3"/>
+       <position name="posOpArapucaDouble3-Frame-2-2" unit="cm" 
+         x="-327.3"
+	 y="293.4006" 
+	 z="258.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-0-0"/>
+       <position name="posArapucaDouble0-Frame-3-0" unit="cm" 
+         x="-328.04"
+	 y="373.4018" 
+	 z="-261.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-0"/>
+       <position name="posOpArapucaDouble0-Frame-3-0" unit="cm" 
+         x="-327.3"
+	 y="373.4018" 
+	 z="-261.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-0-1"/>
+       <position name="posArapucaDouble1-Frame-3-0" unit="cm" 
+         x="-328.04"
+	 y="464.1018" 
+	 z="-407.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-1"/>
+       <position name="posOpArapucaDouble1-Frame-3-0" unit="cm" 
+         x="-327.3"
+	 y="464.1018" 
+	 z="-407.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-0-2"/>
+       <position name="posArapucaDouble2-Frame-3-0" unit="cm" 
+         x="-328.04"
+	 y="538.1018" 
+	 z="-190.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-2"/>
+       <position name="posOpArapucaDouble2-Frame-3-0" unit="cm" 
+         x="-327.3"
+	 y="538.1018" 
+	 z="-190.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-0-3"/>
+       <position name="posArapucaDouble3-Frame-3-0" unit="cm" 
+         x="-328.04"
+	 y="628.8018" 
+	 z="-336.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-3"/>
+       <position name="posOpArapucaDouble3-Frame-3-0" unit="cm" 
+         x="-327.3"
+	 y="628.8018" 
+	 z="-336.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-1-0"/>
+       <position name="posArapucaDouble0-Frame-3-1" unit="cm" 
+         x="-328.04"
+	 y="373.4018" 
+	 z="36"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-0"/>
+       <position name="posOpArapucaDouble0-Frame-3-1" unit="cm" 
+         x="-327.3"
+	 y="373.4018" 
+	 z="36"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-1-1"/>
+       <position name="posArapucaDouble1-Frame-3-1" unit="cm" 
+         x="-328.04"
+	 y="464.1018" 
+	 z="-110"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-1"/>
+       <position name="posOpArapucaDouble1-Frame-3-1" unit="cm" 
+         x="-327.3"
+	 y="464.1018" 
+	 z="-110"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-1-2"/>
+       <position name="posArapucaDouble2-Frame-3-1" unit="cm" 
+         x="-328.04"
+	 y="538.1018" 
+	 z="107"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-2"/>
+       <position name="posOpArapucaDouble2-Frame-3-1" unit="cm" 
+         x="-327.3"
+	 y="538.1018" 
+	 z="107"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-1-3"/>
+       <position name="posArapucaDouble3-Frame-3-1" unit="cm" 
+         x="-328.04"
+	 y="628.8018" 
+	 z="-39"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-3"/>
+       <position name="posOpArapucaDouble3-Frame-3-1" unit="cm" 
+         x="-327.3"
+	 y="628.8018" 
+	 z="-39"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-2-0"/>
+       <position name="posArapucaDouble0-Frame-3-2" unit="cm" 
+         x="-328.04"
+	 y="373.4018" 
+	 z="333.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-0"/>
+       <position name="posOpArapucaDouble0-Frame-3-2" unit="cm" 
+         x="-327.3"
+	 y="373.4018" 
+	 z="333.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-2-1"/>
+       <position name="posArapucaDouble1-Frame-3-2" unit="cm" 
+         x="-328.04"
+	 y="464.1018" 
+	 z="187.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-1"/>
+       <position name="posOpArapucaDouble1-Frame-3-2" unit="cm" 
+         x="-327.3"
+	 y="464.1018" 
+	 z="187.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-2-2"/>
+       <position name="posArapucaDouble2-Frame-3-2" unit="cm" 
+         x="-328.04"
+	 y="538.1018" 
+	 z="404.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-2"/>
+       <position name="posOpArapucaDouble2-Frame-3-2" unit="cm" 
+         x="-327.3"
+	 y="538.1018" 
+	 z="404.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-2-3"/>
+       <position name="posArapucaDouble3-Frame-3-2" unit="cm" 
+         x="-328.04"
+	 y="628.8018" 
+	 z="258.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-3"/>
+       <position name="posOpArapucaDouble3-Frame-3-2" unit="cm" 
+         x="-327.3"
+	 y="628.8018" 
+	 z="258.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_0-0"/>
+       <position name="posArapuca0-Lat-0" unit="cm" 
+         x="285.03"
+	 y="-732.8024" 
+	 z="-297.84"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_0-0"/>
+       <position name="posOpArapuca0-Lat-0" unit="cm" 
+         x="285.03"
+	 y="-732.0624" 
+	 z="-297.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_0-1"/>
+       <position name="posArapuca1-Lat-0" unit="cm" 
+         x="210.03"
+	 y="-732.8024" 
+	 z="-297.84"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_0-1"/>
+       <position name="posOpArapuca1-Lat-0" unit="cm" 
+         x="210.03"
+	 y="-732.0624" 
+	 z="-297.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_0-2"/>
+       <position name="posArapuca2-Lat-0" unit="cm" 
+         x="135.03"
+	 y="-732.8024" 
+	 z="-297.84"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_0-2"/>
+       <position name="posOpArapuca2-Lat-0" unit="cm" 
+         x="135.03"
+	 y="-732.0624" 
+	 z="-297.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_0-3"/>
+       <position name="posArapuca3-Lat-0" unit="cm" 
+         x="60.03"
+	 y="-732.8024" 
+	 z="-297.84"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_0-3"/>
+       <position name="posOpArapuca3-Lat-0" unit="cm" 
+         x="60.03"
+	 y="-732.0624" 
+	 z="-297.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_0-4"/>
+       <position name="posArapuca4-Lat-0" unit="cm" 
+         x="285.03"
+	 y="732.8024" 
+	 z="-297.84"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_0-4"/>
+       <position name="posOpArapuca4-Lat-0" unit="cm" 
+         x="285.03"
+	 y="732.0624" 
+	 z="-297.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_0-5"/>
+       <position name="posArapuca5-Lat-0" unit="cm" 
+         x="210.03"
+	 y="732.8024" 
+	 z="-297.84"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_0-5"/>
+       <position name="posOpArapuca5-Lat-0" unit="cm" 
+         x="210.03"
+	 y="732.0624" 
+	 z="-297.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_0-6"/>
+       <position name="posArapuca6-Lat-0" unit="cm" 
+         x="135.03"
+	 y="732.8024" 
+	 z="-297.84"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_0-6"/>
+       <position name="posOpArapuca6-Lat-0" unit="cm" 
+         x="135.03"
+	 y="732.0624" 
+	 z="-297.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_0-7"/>
+       <position name="posArapuca7-Lat-0" unit="cm" 
+         x="60.03"
+	 y="732.8024" 
+	 z="-297.84"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_0-7"/>
+       <position name="posOpArapuca7-Lat-0" unit="cm" 
+         x="60.03"
+	 y="732.0624" 
+	 z="-297.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_1-0"/>
+       <position name="posArapuca0-Lat-1" unit="cm" 
+         x="285.03"
+	 y="-732.8024" 
+	 z="-1.13686837721616e-13"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_1-0"/>
+       <position name="posOpArapuca0-Lat-1" unit="cm" 
+         x="285.03"
+	 y="-732.0624" 
+	 z="-1.13686837721616e-13"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_1-1"/>
+       <position name="posArapuca1-Lat-1" unit="cm" 
+         x="210.03"
+	 y="-732.8024" 
+	 z="-1.13686837721616e-13"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_1-1"/>
+       <position name="posOpArapuca1-Lat-1" unit="cm" 
+         x="210.03"
+	 y="-732.0624" 
+	 z="-1.13686837721616e-13"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_1-2"/>
+       <position name="posArapuca2-Lat-1" unit="cm" 
+         x="135.03"
+	 y="-732.8024" 
+	 z="-1.13686837721616e-13"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_1-2"/>
+       <position name="posOpArapuca2-Lat-1" unit="cm" 
+         x="135.03"
+	 y="-732.0624" 
+	 z="-1.13686837721616e-13"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_1-3"/>
+       <position name="posArapuca3-Lat-1" unit="cm" 
+         x="60.03"
+	 y="-732.8024" 
+	 z="-1.13686837721616e-13"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_1-3"/>
+       <position name="posOpArapuca3-Lat-1" unit="cm" 
+         x="60.03"
+	 y="-732.0624" 
+	 z="-1.13686837721616e-13"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_1-4"/>
+       <position name="posArapuca4-Lat-1" unit="cm" 
+         x="285.03"
+	 y="732.8024" 
+	 z="-1.13686837721616e-13"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_1-4"/>
+       <position name="posOpArapuca4-Lat-1" unit="cm" 
+         x="285.03"
+	 y="732.0624" 
+	 z="-1.13686837721616e-13"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_1-5"/>
+       <position name="posArapuca5-Lat-1" unit="cm" 
+         x="210.03"
+	 y="732.8024" 
+	 z="-1.13686837721616e-13"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_1-5"/>
+       <position name="posOpArapuca5-Lat-1" unit="cm" 
+         x="210.03"
+	 y="732.0624" 
+	 z="-1.13686837721616e-13"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_1-6"/>
+       <position name="posArapuca6-Lat-1" unit="cm" 
+         x="135.03"
+	 y="732.8024" 
+	 z="-1.13686837721616e-13"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_1-6"/>
+       <position name="posOpArapuca6-Lat-1" unit="cm" 
+         x="135.03"
+	 y="732.0624" 
+	 z="-1.13686837721616e-13"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_1-7"/>
+       <position name="posArapuca7-Lat-1" unit="cm" 
+         x="60.03"
+	 y="732.8024" 
+	 z="-1.13686837721616e-13"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_1-7"/>
+       <position name="posOpArapuca7-Lat-1" unit="cm" 
+         x="60.03"
+	 y="732.0624" 
+	 z="-1.13686837721616e-13"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_2-0"/>
+       <position name="posArapuca0-Lat-2" unit="cm" 
+         x="285.03"
+	 y="-732.8024" 
+	 z="297.84"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_2-0"/>
+       <position name="posOpArapuca0-Lat-2" unit="cm" 
+         x="285.03"
+	 y="-732.0624" 
+	 z="297.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_2-1"/>
+       <position name="posArapuca1-Lat-2" unit="cm" 
+         x="210.03"
+	 y="-732.8024" 
+	 z="297.84"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_2-1"/>
+       <position name="posOpArapuca1-Lat-2" unit="cm" 
+         x="210.03"
+	 y="-732.0624" 
+	 z="297.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_2-2"/>
+       <position name="posArapuca2-Lat-2" unit="cm" 
+         x="135.03"
+	 y="-732.8024" 
+	 z="297.84"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_2-2"/>
+       <position name="posOpArapuca2-Lat-2" unit="cm" 
+         x="135.03"
+	 y="-732.0624" 
+	 z="297.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_2-3"/>
+       <position name="posArapuca3-Lat-2" unit="cm" 
+         x="60.03"
+	 y="-732.8024" 
+	 z="297.84"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_2-3"/>
+       <position name="posOpArapuca3-Lat-2" unit="cm" 
+         x="60.03"
+	 y="-732.0624" 
+	 z="297.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_2-4"/>
+       <position name="posArapuca4-Lat-2" unit="cm" 
+         x="285.03"
+	 y="732.8024" 
+	 z="297.84"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_2-4"/>
+       <position name="posOpArapuca4-Lat-2" unit="cm" 
+         x="285.03"
+	 y="732.0624" 
+	 z="297.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_2-5"/>
+       <position name="posArapuca5-Lat-2" unit="cm" 
+         x="210.03"
+	 y="732.8024" 
+	 z="297.84"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_2-5"/>
+       <position name="posOpArapuca5-Lat-2" unit="cm" 
+         x="210.03"
+	 y="732.0624" 
+	 z="297.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_2-6"/>
+       <position name="posArapuca6-Lat-2" unit="cm" 
+         x="135.03"
+	 y="732.8024" 
+	 z="297.84"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_2-6"/>
+       <position name="posOpArapuca6-Lat-2" unit="cm" 
+         x="135.03"
+	 y="732.0624" 
+	 z="297.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_2-7"/>
+       <position name="posArapuca7-Lat-2" unit="cm" 
+         x="60.03"
+	 y="732.8024" 
+	 z="297.84"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_2-7"/>
+       <position name="posOpArapuca7-Lat-2" unit="cm" 
+         x="60.03"
+	 y="732.0624" 
+	 z="297.84"/>
+     </physvol>
+    </volume>
+
+    <volume name="volFoamPadding">
+      <materialref ref="fibrous_glass"/>
+      <solidref ref="FoamPadding"/>
+    </volume>
+
+    <volume name="volSteelSupport">
+      <materialref ref="AirSteelMixture"/>
+      <solidref ref="SteelSupport"/>
+    </volume>
+
+    <volume name="volDetEnclosure">
+      <materialref ref="Air"/>
+      <solidref ref="DetEnclosure"/>
+
+       <physvol>
+           <volumeref ref="volFoamPadding"/>
+           <positionref ref="posCryoInDetEnc"/>
+       </physvol>
+       <physvol>
+           <volumeref ref="volSteelSupport"/>
+           <positionref ref="posCryoInDetEnc"/>
+       </physvol>
+       <physvol>
+           <volumeref ref="volCryostat"/>
+           <positionref ref="posCryoInDetEnc"/>
+       </physvol>
+    </volume>
+
+    <volume name="volWorld" >
+      <materialref ref="DUSEL_Rock"/>
+      <solidref ref="World"/>
+
+      <physvol>
+        <volumeref ref="volDetEnclosure"/>
+	<position name="posDetEnclosure" unit="cm" x="50.04" y="-1.13686837721616e-13" z="448.26"/>
+      </physvol>
+
+    </volume>
+</structure>
+  <setup name="Default" version="1.0">
+    <world ref="volWorld"/>
+  </setup>
+</gdml_simple_extension>

--- a/dunecore/Geometry/gdml/dunevd10kt_3view_30deg_v4_refactored_1x8x6ref_nowires.gdml
+++ b/dunecore/Geometry/gdml/dunevd10kt_3view_30deg_v4_refactored_1x8x6ref_nowires.gdml
@@ -1,0 +1,3416 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<gdml_simple_extension xmlns:gdml_simple_extension="http://www.example.org"
+                       xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"          
+                       xs:noNamespaceSchemaLocation="RefactoredGDMLSchema/SimpleExtension.xsd"> 
+<extension>
+   <color name="magenta"     R="0.0"  G="1.0"  B="0.0"  A="1.0" />
+   <color name="green"       R="0.0"  G="1.0"  B="0.0"  A="1.0" />
+   <color name="red"         R="1.0"  G="0.0"  B="0.0"  A="1.0" />
+   <color name="blue"        R="0.0"  G="0.0"  B="1.0"  A="1.0" />
+   <color name="yellow"      R="1.0"  G="1.0"  B="0.0"  A="1.0" />    
+</extension>
+<define>
+
+<!--
+
+
+
+-->
+
+   <position name="posCryoInDetEnc"     unit="cm" x="-50.0000000000001" y="0" z="0"/>
+   <position name="posCenter"           unit="cm" x="0" y="0" z="0"/>
+   <rotation name="rUWireAboutX"        unit="deg" x="150" y="0" z="0"/>
+   <rotation name="rVWireAboutX"        unit="deg" x="30" y="0" z="0"/>
+   <rotation name="rPlus90AboutX"       unit="deg" x="90" y="0" z="0"/>
+   <rotation name="rPlus90AboutY"       unit="deg" x="0" y="90" z="0"/>
+   <rotation name="rPlus90AboutXPlus90AboutY" unit="deg" x="90" y="90" z="0"/>
+   <rotation name="rMinus90AboutX"      unit="deg" x="270" y="0" z="0"/>
+   <rotation name="rMinus90AboutY"      unit="deg" x="0" y="270" z="0"/>
+   <rotation name="rMinus90AboutYMinus90AboutX"       unit="deg" x="270" y="270" z="0"/>
+   <rotation name="rPlus180AboutX"	unit="deg" x="180" y="0"   z="0"/>
+   <rotation name="rPlus180AboutY"	unit="deg" x="0" y="180"   z="0"/>
+   <rotation name="rPlus180AboutXPlus180AboutY"	unit="deg" x="180" y="180"   z="0"/>
+   <rotation name="rIdentity"		unit="deg" x="0" y="0"   z="0"/>
+</define>
+<materials>
+  <element name="videRef" formula="VACUUM" Z="1">  <atom value="1"/> </element>
+  <element name="copper" formula="Cu" Z="29">  <atom value="63.546"/>  </element>
+  <element name="beryllium" formula="Be" Z="4">  <atom value="9.0121831"/>  </element>
+  <element name="bromine" formula="Br" Z="35"> <atom value="79.904"/> </element>
+  <element name="hydrogen" formula="H" Z="1">  <atom value="1.0079"/> </element>
+  <element name="nitrogen" formula="N" Z="7">  <atom value="14.0067"/> </element>
+  <element name="oxygen" formula="O" Z="8">  <atom value="15.999"/> </element>
+  <element name="aluminum" formula="Al" Z="13"> <atom value="26.9815"/>  </element>
+  <element name="silicon" formula="Si" Z="14"> <atom value="28.0855"/>  </element>
+  <element name="carbon" formula="C" Z="6">  <atom value="12.0107"/>  </element>
+  <element name="potassium" formula="K" Z="19"> <atom value="39.0983"/>  </element>
+  <element name="chromium" formula="Cr" Z="24"> <atom value="51.9961"/>  </element>
+  <element name="iron" formula="Fe" Z="26"> <atom value="55.8450"/>  </element>
+  <element name="nickel" formula="Ni" Z="28"> <atom value="58.6934"/>  </element>
+  <element name="calcium" formula="Ca" Z="20"> <atom value="40.078"/>   </element>
+  <element name="magnesium" formula="Mg" Z="12"> <atom value="24.305"/>   </element>
+  <element name="sodium" formula="Na" Z="11"> <atom value="22.99"/>    </element>
+  <element name="titanium" formula="Ti" Z="22"> <atom value="47.867"/>   </element>
+  <element name="argon" formula="Ar" Z="18"> <atom value="39.9480"/>  </element>
+  <element name="sulphur" formula="S" Z="16"> <atom value="32.065"/>  </element>
+  <element name="phosphorus" formula="P" Z="15"> <atom value="30.973"/>  </element>
+
+  <material name="Vacuum" formula="Vacuum">
+   <D value="1.e-25" unit="g/cm3"/>
+   <fraction n="1.0" ref="videRef"/>
+  </material>
+
+  <material name="ALUMINUM_Al" formula="ALUMINUM_Al">
+   <D value="2.6990" unit="g/cm3"/>
+   <fraction n="1.0000" ref="aluminum"/>
+  </material>
+
+  <material name="SILICON_Si" formula="SILICON_Si">
+   <D value="2.3300" unit="g/cm3"/>
+   <fraction n="1.0000" ref="silicon"/>
+  </material>
+
+  <material name="epoxy_resin" formula="C38H40O6Br4">
+   <D value="1.1250" unit="g/cm3"/>
+   <composite n="38" ref="carbon"/>
+   <composite n="40" ref="hydrogen"/>
+   <composite n="6" ref="oxygen"/>
+   <composite n="4" ref="bromine"/>
+  </material>
+
+  <material name="SiO2" formula="SiO2">
+   <D value="2.2" unit="g/cm3"/>
+   <composite n="1" ref="silicon"/>
+   <composite n="2" ref="oxygen"/>
+  </material>
+
+  <material name="Al2O3" formula="Al2O3">
+   <D value="3.97" unit="g/cm3"/>
+   <composite n="2" ref="aluminum"/>
+   <composite n="3" ref="oxygen"/>
+  </material>
+
+  <material name="Fe2O3" formula="Fe2O3">
+   <D value="5.24" unit="g/cm3"/>
+   <composite n="2" ref="iron"/>
+   <composite n="3" ref="oxygen"/>
+  </material>
+
+  <material name="CaO" formula="CaO">
+   <D value="3.35" unit="g/cm3"/>
+   <composite n="1" ref="calcium"/>
+   <composite n="1" ref="oxygen"/>
+  </material>
+
+  <material name="Delrin" formula="CH2O">
+    <D value="1.41" unit="g/cm3"/>
+    <composite n="1" ref="carbon"/>
+    <composite n="2" ref="hydrogen"/>
+    <composite n="1" ref="oxygen"/>
+  </material>
+
+  <material name="MgO" formula="MgO">
+   <D value="3.58" unit="g/cm3"/>
+   <composite n="1" ref="magnesium"/>
+   <composite n="1" ref="oxygen"/>
+  </material>
+
+  <material name="Na2O" formula="Na2O">
+   <D value="2.27" unit="g/cm3"/>
+   <composite n="2" ref="sodium"/>
+   <composite n="1" ref="oxygen"/>
+  </material>
+
+  <material name="TiO2" formula="TiO2">
+   <D value="4.23" unit="g/cm3"/>
+   <composite n="1" ref="titanium"/>
+   <composite n="2" ref="oxygen"/>
+  </material>
+
+  <material name="FeO" formula="FeO">
+   <D value="5.745" unit="g/cm3"/>
+   <composite n="1" ref="iron"/>
+   <composite n="1" ref="oxygen"/>
+  </material>
+
+  <material name="CO2" formula="CO2">
+   <D value="1.562" unit="g/cm3"/>
+   <composite n="1" ref="iron"/>
+   <composite n="2" ref="oxygen"/>
+  </material>
+
+  <material name="P2O5" formula="P2O5">
+   <D value="1.562" unit="g/cm3"/>
+   <composite n="2" ref="phosphorus"/>
+   <composite n="5" ref="oxygen"/>
+  </material>
+
+  <material formula=" " name="DUSEL_Rock">
+    <D value="2.82" unit="g/cm3"/>
+    <fraction n="0.5267" ref="SiO2"/>
+    <fraction n="0.1174" ref="FeO"/>
+    <fraction n="0.1025" ref="Al2O3"/>
+    <fraction n="0.0473" ref="MgO"/>
+    <fraction n="0.0422" ref="CO2"/>
+    <fraction n="0.0382" ref="CaO"/>
+    <fraction n="0.0240" ref="carbon"/>
+    <fraction n="0.0186" ref="sulphur"/>
+    <fraction n="0.0053" ref="Na2O"/>
+    <fraction n="0.00070" ref="P2O5"/>
+    <fraction n="0.0771" ref="oxygen"/>
+  </material> 
+
+  <material formula="Air" name="Air">
+   <D value="0.001205" unit="g/cm3"/>
+   <fraction n="0.781154" ref="nitrogen"/>
+   <fraction n="0.209476" ref="oxygen"/>
+   <fraction n="0.00934" ref="argon"/>
+  </material>
+
+  <material name="fibrous_glass">
+   <D value="2.74351" unit="g/cm3"/>
+   <fraction n="0.600" ref="SiO2"/>
+   <fraction n="0.118" ref="Al2O3"/>
+   <fraction n="0.001" ref="Fe2O3"/>
+   <fraction n="0.224" ref="CaO"/>
+   <fraction n="0.034" ref="MgO"/>
+   <fraction n="0.010" ref="Na2O"/>
+   <fraction n="0.013" ref="TiO2"/>
+  </material>
+
+  <!-- density referenced from EHN1-Cold Cryostats Technical Requirements:
+       https://edms.cern.ch/document/1543254 -->
+  <material name="FD_foam">
+   <D value="0.09" unit="g/cm3"/>
+   <fraction n="0.95" ref="Air"/>
+   <fraction n="0.05" ref="fibrous_glass"/>
+  </material>
+
+  <!-- Foam density is 70 kg / m^3 for the 3x1x1 -->
+  <material name="foam_3x1x1dp">
+   <D value="0.07" unit="g/cm3"/>
+   <fraction n="0.95" ref="Air"/>
+   <fraction n="0.05" ref="fibrous_glass"/>
+  </material>
+
+  <!-- Copied from protodune_v4.gdml -->
+  <material name="foam_protoDUNEdp">
+   <D value="0.135" unit="g/cm3"/>
+   <composite n="17" ref="carbon"/>
+   <composite n="16" ref="hydrogen"/>
+   <composite n="2" ref="nitrogen"/>
+   <composite n="4" ref="oxygen"/>
+  </material>
+
+  <material name="FR4">
+   <D value="1.98281" unit="g/cm3"/>
+   <fraction n="0.47" ref="epoxy_resin"/>
+   <fraction n="0.53" ref="fibrous_glass"/>
+  </material>
+
+  <material name="STEEL_STAINLESS_Fe7Cr2Ni" formula="STEEL_STAINLESS_Fe7Cr2Ni">
+   <D value="7.9300" unit="g/cm3"/>
+   <fraction n="0.0010" ref="carbon"/>
+   <fraction n="0.1792" ref="chromium"/>
+   <fraction n="0.7298" ref="iron"/>
+   <fraction n="0.0900" ref="nickel"/>
+  </material>
+
+  <material name="Copper_Beryllium_alloy25" formula="Copper_Beryllium_alloy25">
+   <D value="8.26" unit="g/cm3"/>
+   <fraction n="0.981" ref="copper"/>
+   <fraction n="0.019" ref="beryllium"/>
+  </material>
+
+  <material name="LAr" formula="LAr">
+   <D value="1.40" unit="g/cm3"/>
+   <fraction n="1.0000" ref="argon"/>
+  </material>
+
+  <material name="ArGas" formula="ArGas">
+   <D value="0.00166" unit="g/cm3"/>
+   <fraction n="1.0" ref="argon"/>
+  </material>
+
+  <material formula=" " name="G10">
+   <D value="1.7" unit="g/cm3"/>
+   <fraction n="0.2805" ref="silicon"/>
+   <fraction n="0.3954" ref="oxygen"/>
+   <fraction n="0.2990" ref="carbon"/>
+   <fraction n="0.0251" ref="hydrogen"/>
+  </material>
+
+  <material formula=" " name="Granite">
+   <D value="2.7" unit="g/cm3"/>
+   <fraction n="0.438" ref="oxygen"/>
+   <fraction n="0.257" ref="silicon"/>
+   <fraction n="0.222" ref="sodium"/>
+   <fraction n="0.049" ref="aluminum"/>
+   <fraction n="0.019" ref="iron"/>
+   <fraction n="0.015" ref="potassium"/>
+  </material>
+
+  <material formula=" " name="ShotRock">
+   <D value="1.62" unit="g/cm3"/>
+   <fraction n="0.438" ref="oxygen"/>
+   <fraction n="0.257" ref="silicon"/>
+   <fraction n="0.222" ref="sodium"/>
+   <fraction n="0.049" ref="aluminum"/>
+   <fraction n="0.019" ref="iron"/>
+   <fraction n="0.015" ref="potassium"/>
+  </material>
+
+  <material formula=" " name="Dirt">
+   <D value="1.7" unit="g/cm3"/>
+   <fraction n="0.438" ref="oxygen"/>
+   <fraction n="0.257" ref="silicon"/>
+   <fraction n="0.222" ref="sodium"/>
+   <fraction n="0.049" ref="aluminum"/>
+   <fraction n="0.019" ref="iron"/>
+   <fraction n="0.015" ref="potassium"/>
+  </material>
+
+  <material formula=" " name="Concrete">
+   <D value="2.3" unit="g/cm3"/>
+   <fraction n="0.530" ref="oxygen"/>
+   <fraction n="0.335" ref="silicon"/>
+   <fraction n="0.060" ref="calcium"/>
+   <fraction n="0.015" ref="sodium"/>
+   <fraction n="0.020" ref="iron"/>
+   <fraction n="0.040" ref="aluminum"/>
+  </material>
+
+  <material formula="H2O" name="Water">
+   <D value="1.0" unit="g/cm3"/>
+   <fraction n="0.1119" ref="hydrogen"/>
+   <fraction n="0.8881" ref="oxygen"/>
+  </material>
+
+  <material formula="Ti" name="Titanium">
+   <D value="4.506" unit="g/cm3"/>
+   <fraction n="1." ref="titanium"/>
+  </material>
+
+  <material name="TPB" formula="TPB">
+   <D value="1.40" unit="g/cm3"/>
+   <fraction n="1.0000" ref="argon"/>
+  </material>
+
+  <material name="Glass">
+   <D value="2.74351" unit="g/cm3"/>
+   <fraction n="0.600" ref="SiO2"/>
+   <fraction n="0.118" ref="Al2O3"/>
+   <fraction n="0.001" ref="Fe2O3"/>
+   <fraction n="0.224" ref="CaO"/>
+   <fraction n="0.034" ref="MgO"/>
+   <fraction n="0.010" ref="Na2O"/>
+   <fraction n="0.013" ref="TiO2"/>
+  </material>
+
+  <material name="Acrylic">
+   <D value="1.19" unit="g/cm3"/>
+   <fraction n="0.600" ref="carbon"/>
+   <fraction n="0.320" ref="oxygen"/>
+   <fraction n="0.080" ref="hydrogen"/>
+  </material>
+
+  <material name="NiGas1atm80K">
+   <D value="0.0039" unit="g/cm3"/>
+   <fraction n="1.000" ref="nitrogen"/>
+  </material>
+
+  <material name="NiGas">
+   <D value="0.001165" unit="g/cm3"/>
+   <fraction n="1.000" ref="nitrogen"/>
+  </material>
+
+  <material name="PolyurethaneFoam">
+   <D value="0.088" unit="g/cm3"/>
+   <composite n="17" ref="carbon"/>
+   <composite n="16" ref="hydrogen"/>
+   <composite n="2" ref="nitrogen"/>
+   <composite n="4" ref="oxygen"/>
+  </material>
+
+  <material name="ProtoDUNEFoam">
+   <D value="0.135" unit="g/cm3"/>
+   <composite n="17" ref="carbon"/>
+   <composite n="16" ref="hydrogen"/>
+   <composite n="2" ref="nitrogen"/>
+   <composite n="4" ref="oxygen"/>
+  </material>
+
+  <material name="LightPolyurethaneFoam">
+   <D value="0.009" unit="g/cm3"/>
+   <composite n="17" ref="carbon"/>
+   <composite n="16" ref="hydrogen"/>
+   <composite n="2" ref="nitrogen"/>
+   <composite n="4" ref="oxygen"/>
+  </material>
+
+  <material name="ProtoDUNEBWFoam">
+   <D value="0.021" unit="g/cm3"/>
+   <composite n="17" ref="carbon"/>
+   <composite n="16" ref="hydrogen"/>
+   <composite n="2" ref="nitrogen"/>
+   <composite n="4" ref="oxygen"/>
+  </material>
+
+  <material name="GlassWool">
+   <D value="0.035" unit="g/cm3"/>
+   <fraction n="0.65" ref="SiO2"/>
+   <fraction n="0.09" ref="Al2O3"/>
+   <fraction n="0.07" ref="CaO"/>
+   <fraction n="0.03" ref="MgO"/>
+   <fraction n="0.16" ref="Na2O"/>
+  </material>
+
+  <material name="Polystyrene">
+   <D value="1.06" unit="g/cm3"/>
+   <composite n="8" ref="carbon"/>
+   <composite n="8" ref="hydrogen"/>
+  </material>
+
+
+
+  <!-- preliminary values -->
+  <material name="AirSteelMixture" formula="AirSteelMixture">
+   <D value=" 0.001205*(1-0.5) + 7.9300*0.5 " unit="g/cm3"/>
+   <fraction n="0.5" ref="STEEL_STAINLESS_Fe7Cr2Ni"/>
+   <fraction n="0.5"   ref="Air"/>
+  </material>
+  <material name="vm2000" formula="vm2000">
+    <D value="1.2" unit="g/cm3"/>
+    <composite n="2" ref="carbon"/>
+    <composite n="4" ref="hydrogen"/>
+  </material>
+
+</materials>
+<solids>
+     <torus name="FieldShaperCorner" rmin="0.5" rmax="2.285" rtor="2.3" deltaphi="90" startphi="0" aunit="deg" lunit="cm"/>
+     <tube name="FieldShaperLongtube" rmin="0.5" rmax="2.285" z="896.52" deltaphi="360" startphi="0" aunit="deg" lunit="cm"/>
+     <tube name="FieldShaperLongtubeSlim" rmin="0.5" rmax="0.75" z="896.52" deltaphi="360" startphi="0" aunit="deg" lunit="cm"/>
+     <tube name="FieldShaperShorttube" rmin="0.5" rmax="2.285" z="1345.6048" deltaphi="360" startphi="0" aunit="deg" lunit="cm"/>
+
+    <union name="FSunion1">
+      <first ref="FieldShaperLongtube"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos1" unit="cm" x="-2.3" y="0" z="448.26"/>
+		<rotation name="rot1" unit="deg" x="90" y="0" z="0" />
+    </union>
+
+    <union name="FSunion2">
+      <first ref="FSunion1"/>
+      <second ref="FieldShaperShorttube"/>
+   		<position name="esquinapos2" unit="cm" x="-675.1024" y="0" z="450.56"/>
+   		<rotation name="rot2" unit="deg" x="0" y="90" z="0" />
+    </union>
+
+    <union name="FSunion3">
+      <first ref="FSunion2"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos3" unit="cm" x="-1347.9048" y="0" z="448.26"/>
+		<rotation name="rot3" unit="deg" x="90" y="270" z="0" />
+    </union>
+
+    <union name="FSunion4">
+      <first ref="FSunion3"/>
+      <second ref="FieldShaperLongtube"/>
+   		<position name="esquinapos4" unit="cm" x="-1350.2048" y="0" z="0"/>
+    </union>
+
+    <union name="FSunion5">
+      <first ref="FSunion4"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos5" unit="cm" x="-1347.9048" y="0" z="-448.26"/>
+		<rotation name="rot5" unit="deg" x="90" y="180" z="0" />
+    </union>
+
+    <union name="FSunion6">
+      <first ref="FSunion5"/>
+      <second ref="FieldShaperShorttube"/>
+   		<position name="esquinapos6" unit="cm" x="-675.1024" y="0" z="-450.56"/>
+		<rotation name="rot6" unit="deg" x="0" y="90" z="0" />
+    </union>
+
+    <union name="FieldShaperSolid">
+      <first ref="FSunion6"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos7" unit="cm" x="-2.3" y="0" z="-448.26"/>
+		<rotation name="rot7" unit="deg" x="90" y="90" z="0" />
+    </union>
+    
+    <union name="FSunionSlim1">
+      <first ref="FieldShaperLongtubeSlim"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos1" unit="cm" x="-2.3" y="0" z="448.26"/>
+		<rotation name="rot1" unit="deg" x="90" y="0" z="0" />
+    </union>
+
+    <union name="FSunionSlim2">
+      <first ref="FSunionSlim1"/>
+      <second ref="FieldShaperShorttube"/>
+   		<position name="esquinapos2" unit="cm" x="-675.1024" y="0" z="450.56"/>
+   		<rotation name="rot2" unit="deg" x="0" y="90" z="0" />
+    </union>
+
+    <union name="FSunionSlim3">
+      <first ref="FSunionSlim2"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos3" unit="cm" x="-1347.9048" y="0" z="448.26"/>
+		<rotation name="rot3" unit="deg" x="90" y="270" z="0" />
+    </union>
+
+    <union name="FSunionSlim4">
+      <first ref="FSunionSlim3"/>
+      <second ref="FieldShaperLongtubeSlim"/>
+   		<position name="esquinapos4" unit="cm" x="-1350.2048" y="0" z="0"/>
+    </union>
+
+    <union name="FSunionSlim5">
+      <first ref="FSunionSlim4"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos5" unit="cm" x="-1347.9048" y="0" z="-448.26"/>
+		<rotation name="rot5" unit="deg" x="90" y="180" z="0" />
+    </union>
+
+    <union name="FSunionSlim6">
+      <first ref="FSunionSlim5"/>
+      <second ref="FieldShaperShorttube"/>
+   		<position name="esquinapos6" unit="cm" x="-675.1024" y="0" z="-450.56"/>
+		<rotation name="rot6" unit="deg" x="0" y="90" z="0" />
+    </union>
+
+    <union name="FieldShaperSolidSlim">
+      <first ref="FSunionSlim6"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos7" unit="cm" x="-2.3" y="0" z="-448.26"/>
+		<rotation name="rot7" unit="deg" x="90" y="90" z="0" />
+    </union>
+    
+
+   <box name="CRM"
+      x="650.08" 
+      y="167.7006" 
+      z="148.92"
+      lunit="cm"/>
+   <box name="CRMUPlane" 
+      x="0.02" 
+      y="167.7006" 
+      z="148.92"
+      lunit="cm"/>
+   <box name="CRMVPlane" 
+      x="0.02" 
+      y="167.7006" 
+      z="148.92"
+      lunit="cm"/>
+   <box name="CRMZPlane" 
+      x="0.02"
+      y="167.7006"
+      z="148.92"
+      lunit="cm"/>
+   <box name="CRMActive" 
+      x="650"
+      y="167.7006"
+      z="148.92"
+      lunit="cm"/>
+
+    <box name="ArapucaOut" lunit="cm"
+      x="65"
+      y="2.5"
+      z="65"/>
+
+    <box name="ArapucaIn" lunit="cm"
+      x="60"
+      y="2.5"
+      z="60"/>
+
+     <subtraction name="ArapucaWalls">
+      <first  ref="ArapucaOut"/>
+      <second ref="ArapucaIn"/>
+      <position name="posArapucaSub" x="0" y="1.25" z="0." unit="cm"/>
+      </subtraction>
+
+    <box name="ArapucaAcceptanceWindow" lunit="cm"
+      x="60"
+      y="1"
+      z="60"/>
+
+    <box name="ArapucaDoubleIn" lunit="cm"
+      x="60"
+      y="3.5"
+      z="60"/>
+
+     <subtraction name="ArapucaDoubleWalls">
+      <first  ref="ArapucaOut"/>
+      <second ref="ArapucaDoubleIn"/>
+      <position name="posArapucaDoubleSub" x="0" y="0" z="0" unit="cm"/>
+      </subtraction>
+
+    <box name="ArapucaDoubleAcceptanceWindow" lunit="cm"
+      x="2.48"
+      y="60"
+      z="60"/>
+
+    <box name="ArapucaCathodeAcceptanceWindow" lunit="cm"
+      x="1"
+      y="60"
+      z="60"/>
+
+
+    <box name="Cryostat" lunit="cm" 
+      x="850.32" 
+      y="1545.8448" 
+      z="1096.76"/>
+
+    <box name="ArgonInterior" lunit="cm" 
+      x="850.08"
+      y="1545.6048"
+      z="1096.52"/>
+
+    <box name="GaseousArgon" lunit="cm" 
+      x="100 - 0.01"
+      y="1545.6048"
+      z="1096.52"/>
+
+    <box name="ExternalAuxOut" lunit="cm" 
+      x="850.08 - 100"
+      y="1545.6048 - 2*2.5 - 2*40"
+      z="1096.52"/>
+
+    <box name="ExternalAuxIn" lunit="cm" 
+      x="850.08"
+      y="1356.7748"
+      z="1096.52 + 1"/>
+
+   <subtraction name="ExternalActive">
+      <first ref="ExternalAuxOut"/>
+      <second ref="ExternalAuxIn"/>
+    </subtraction>
+
+    <subtraction name="SteelShell">
+      <first ref="Cryostat"/>
+      <second ref="ArgonInterior"/>
+    </subtraction>
+
+
+
+    <box name="CathodeBlock" lunit="cm"
+      x="4"
+      y="335.4012"
+      z="297.84" />
+
+    <box name="CathodeVoid" lunit="cm"
+      x="5"
+      y="76.35"
+      z="67" />
+
+    <subtraction name="Cathode1">
+      <first ref="CathodeBlock"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub1" x="0" y="-122.525" z="-108.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode2">
+      <first ref="Cathode1"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub2" x="0" y="-122.525" z="-37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode3">
+      <first ref="Cathode2"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub3" x="0" y="-122.525" z="37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode4">
+      <first ref="Cathode3"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub4" x="0" y="-122.525" z="108.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode5">
+      <first ref="Cathode4"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub5" x="0" y="-42.175" z="-108.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode6">
+      <first ref="Cathode5"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub6" x="0" y="-42.175" z="-37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode7">
+      <first ref="Cathode6"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub7" x="0" y="-42.175" z="37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode8">
+      <first ref="Cathode7"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub8" x="0" y="-42.175" z="108.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode9">
+      <first ref="Cathode8"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub9" x="0" y="42.175" z="-108.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode10">
+      <first ref="Cathode9"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub10" x="0" y="42.175" z="-37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode11">
+      <first ref="Cathode10"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub11" x="0" y="42.175" z="37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode12">
+      <first ref="Cathode11"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub12" x="0" y="42.175" z="108.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode13">
+      <first ref="Cathode12"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub13" x="0" y="122.525" z="-108.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode14">
+      <first ref="Cathode13"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub14" x="0" y="122.525" z="-37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode15">
+      <first ref="Cathode14"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub15" x="0" y="122.525" z="37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="CathodeGrid">
+      <first ref="Cathode15"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub16" x="0" y="122.525" z="108.5" unit="cm"/>
+    </subtraction>
+
+   <box name="AnodePlate" 
+      x="0.01"
+      y="335.4012"
+      z="297.84"
+      lunit="cm"/>
+
+    <box name="FoamPadBlock" lunit="cm"
+      x="1010.32"
+      y="1705.8448"
+      z="1256.76" />
+
+    <subtraction name="FoamPadding">
+      <first ref="FoamPadBlock"/>
+      <second ref="Cryostat"/>
+      <positionref ref="posCenter"/>
+    </subtraction>
+
+    <box name="SteelSupportBlock" lunit="cm"
+      x="1210.32"
+      y="1905.8448"
+      z="1456.76" />
+
+    <subtraction name="SteelSupport">
+      <first ref="SteelSupportBlock"/>
+      <second ref="FoamPadBlock"/>
+      <positionref ref="posCenter"/>
+    </subtraction>
+
+    <box name="DetEnclosure" lunit="cm" 
+      x="1310.32"
+      y="2105.8448"
+      z="1656.76"/>
+
+
+    <box name="World" lunit="cm" 
+      x="9310.32" 
+      y="10105.8448" 
+      z="9656.76"/>
+</solids>
+<structure>
+<volume name="volFieldShaper">
+  <materialref ref="Al2O3"/>
+  <solidref ref="FieldShaperSolid"/>
+</volume>
+<volume name="volFieldShaperSlim">
+  <materialref ref="Al2O3"/>
+  <solidref ref="FieldShaperSolidSlim"/>
+</volume>
+
+
+    <volume name="volTPCActive">
+      <materialref ref="LAr"/>
+      <solidref ref="CRMActive"/>
+      <auxiliary auxtype="SensDet" auxvalue="SimEnergyDeposit"/>
+      <auxiliary auxtype="StepLimit" auxunit="cm" auxvalue="0.5208*cm"/>
+      <auxiliary auxtype="Efield" auxunit="V/cm" auxvalue="500*V/cm"/>
+      <colorref ref="blue"/>
+    </volume>
+   <volume name="volTPCPlaneU">
+     <materialref ref="LAr"/>
+     <solidref ref="CRMUPlane"/>
+   </volume>
+  <volume name="volTPCPlaneV">
+    <materialref ref="LAr"/>
+    <solidref ref="CRMVPlane"/>
+  </volume>
+  <volume name="volTPCPlaneZ">
+    <materialref ref="LAr"/>
+    <solidref ref="CRMZPlane"/>
+  </volume>
+   <volume name="volTPC">
+     <materialref ref="LAr"/>
+       <solidref ref="CRM"/>
+       <physvol>
+       <volumeref ref="volTPCPlaneU"/>
+       <position name="posPlaneU" unit="cm" 
+         x="324.99" y="0" z="0"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCPlaneV"/>
+       <position name="posPlaneY" unit="cm" 
+         x="325.01" y="0" z="0"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCPlaneZ"/>
+       <position name="posPlaneZ" unit="cm" 
+         x="325.03" y="0" z="0"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCActive"/>
+       <position name="posActive" unit="cm" 
+        x="-0.04" y="" z="0"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+   </volume>
+ 
+    <volume name="volSteelShell">
+      <materialref ref="STEEL_STAINLESS_Fe7Cr2Ni" />
+      <solidref ref="SteelShell" />
+    </volume>
+    <volume name="volGroundGrid">
+      <materialref ref="STEEL_STAINLESS_Fe7Cr2Ni" />
+      <solidref ref="CathodeGrid" />
+    </volume>
+    <volume name="volAnodePlate">
+     <materialref ref="vm2000"/>
+     <solidref ref="AnodePlate"/>
+    </volume>
+    <volume name="volGaseousArgon">
+      <materialref ref="ArGas"/>
+      <solidref ref="GaseousArgon"/>
+    </volume>
+    <volume name="volExternalActive">
+      <materialref ref="LAr"/>
+      <solidref ref="ExternalActive"/>
+      <auxiliary auxtype="SensDet" auxvalue="SimEnergyDeposit"/>
+      <auxiliary auxtype="StepLimit" auxunit="cm" auxvalue="0.5208*cm"/>
+      <auxiliary auxtype="Efield" auxunit="V/cm" auxvalue="0*V/cm"/>
+      <colorref ref="green"/>
+    </volume>
+    <volume name="volArapucaDouble_0-0-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-0-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-0-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-0-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-0-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-0-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-0-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-0-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-1-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-1-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-1-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-1-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-1-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-1-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-1-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-1-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-2-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-2-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-2-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-2-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-2-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-2-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-2-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-2-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-0-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-0-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-0-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-0-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-0-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-0-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-0-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-0-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-1-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-1-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-1-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-1-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-1-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-1-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-1-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-1-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-2-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-2-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-2-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-2-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-2-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-2-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-2-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-2-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-0-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-0-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-0-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-0-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-0-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-0-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-0-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-0-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-1-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-1-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-1-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-1-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-1-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-1-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-1-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-1-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-2-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-2-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-2-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-2-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-2-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-2-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-2-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-2-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-0-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-0-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-0-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-0-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-0-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-0-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-0-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-0-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-1-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-1-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-1-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-1-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-1-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-1-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-1-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-1-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-2-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-2-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-2-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-2-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-2-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-2-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-2-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-2-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_0-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_0-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_0-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_0-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_0-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_0-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_0-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_0-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_0-4">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_0-4">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_0-5">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_0-5">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_0-6">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_0-6">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_0-7">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_0-7">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_1-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_1-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_1-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_1-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_1-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_1-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_1-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_1-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_1-4">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_1-4">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_1-5">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_1-5">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_1-6">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_1-6">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_1-7">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_1-7">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_2-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_2-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_2-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_2-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_2-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_2-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_2-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_2-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_2-4">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_2-4">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_2-5">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_2-5">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_2-6">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_2-6">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_2-7">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_2-7">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+
+    <volume name="volCryostat">
+      <materialref ref="LAr" />
+      <solidref ref="Cryostat" />
+      <physvol>
+        <volumeref ref="volGaseousArgon"/>
+        <position name="posGaseousArgon" unit="cm" x="375.045" y="0" z="0"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volSteelShell"/>
+        <position name="posSteelShell" unit="cm" x="0" y="0" z="0"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volExternalActive"/>
+        <position name="posExternalActive" unit="cm" x="-100/2" y="0" z="0"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-0" unit="cm"
+           x="0" y="-588.4521" z="-373.3"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-1" unit="cm"
+           x="0" y="-420.7515" z="-373.3"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-2" unit="cm"
+           x="0" y="-252.0509" z="-373.3"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-3" unit="cm"
+           x="0" y="-84.3502999999999" z="-373.3"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-4" unit="cm"
+           x="0" y="84.3503000000001" z="-373.3"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-5" unit="cm"
+           x="0" y="252.0509" z="-373.3"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-6" unit="cm"
+           x="0" y="420.7515" z="-373.3"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-7" unit="cm"
+           x="0" y="588.4521" z="-373.3"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-8" unit="cm"
+           x="0" y="-588.4521" z="-224.38"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-9" unit="cm"
+           x="0" y="-420.7515" z="-224.38"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-10" unit="cm"
+           x="0" y="-252.0509" z="-224.38"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-11" unit="cm"
+           x="0" y="-84.3502999999999" z="-224.38"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-12" unit="cm"
+           x="0" y="84.3503000000001" z="-224.38"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-13" unit="cm"
+           x="0" y="252.0509" z="-224.38"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-14" unit="cm"
+           x="0" y="420.7515" z="-224.38"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-15" unit="cm"
+           x="0" y="588.4521" z="-224.38"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-16" unit="cm"
+           x="0" y="-588.4521" z="-74.46"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-17" unit="cm"
+           x="0" y="-420.7515" z="-74.46"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-18" unit="cm"
+           x="0" y="-252.0509" z="-74.46"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-19" unit="cm"
+           x="0" y="-84.3502999999999" z="-74.46"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-20" unit="cm"
+           x="0" y="84.3503000000001" z="-74.46"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-21" unit="cm"
+           x="0" y="252.0509" z="-74.46"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-22" unit="cm"
+           x="0" y="420.7515" z="-74.46"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-23" unit="cm"
+           x="0" y="588.4521" z="-74.46"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-24" unit="cm"
+           x="0" y="-588.4521" z="74.46"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-25" unit="cm"
+           x="0" y="-420.7515" z="74.46"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-26" unit="cm"
+           x="0" y="-252.0509" z="74.46"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-27" unit="cm"
+           x="0" y="-84.3502999999999" z="74.46"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-28" unit="cm"
+           x="0" y="84.3503000000001" z="74.46"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-29" unit="cm"
+           x="0" y="252.0509" z="74.46"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-30" unit="cm"
+           x="0" y="420.7515" z="74.46"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-31" unit="cm"
+           x="0" y="588.4521" z="74.46"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-32" unit="cm"
+           x="0" y="-588.4521" z="224.38"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-33" unit="cm"
+           x="0" y="-420.7515" z="224.38"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-34" unit="cm"
+           x="0" y="-252.0509" z="224.38"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-35" unit="cm"
+           x="0" y="-84.3502999999999" z="224.38"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-36" unit="cm"
+           x="0" y="84.3503000000001" z="224.38"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-37" unit="cm"
+           x="0" y="252.0509" z="224.38"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-38" unit="cm"
+           x="0" y="420.7515" z="224.38"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-39" unit="cm"
+           x="0" y="588.4521" z="224.38"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-40" unit="cm"
+           x="0" y="-588.4521" z="373.3"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-41" unit="cm"
+           x="0" y="-420.7515" z="373.3"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-42" unit="cm"
+           x="0" y="-252.0509" z="373.3"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-43" unit="cm"
+           x="0" y="-84.3502999999999" z="373.3"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-44" unit="cm"
+           x="0" y="84.3503000000001" z="373.3"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-45" unit="cm"
+           x="0" y="252.0509" z="373.3"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-46" unit="cm"
+           x="0" y="420.7515" z="373.3"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-47" unit="cm"
+           x="0" y="588.4521" z="373.3"/>
+      </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper0" unit="cm"  x="-322.04" y="-675.1024" z="0" />
+     <rotation name="rotFS0" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper1" unit="cm"  x="-316.04" y="-675.1024" z="0" />
+     <rotation name="rotFS1" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper2" unit="cm"  x="-310.04" y="-675.1024" z="0" />
+     <rotation name="rotFS2" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper3" unit="cm"  x="-304.04" y="-675.1024" z="0" />
+     <rotation name="rotFS3" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper4" unit="cm"  x="-298.04" y="-675.1024" z="0" />
+     <rotation name="rotFS4" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper5" unit="cm"  x="-292.04" y="-675.1024" z="0" />
+     <rotation name="rotFS5" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper6" unit="cm"  x="-286.04" y="-675.1024" z="0" />
+     <rotation name="rotFS6" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper7" unit="cm"  x="-280.04" y="-675.1024" z="0" />
+     <rotation name="rotFS7" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper8" unit="cm"  x="-274.04" y="-675.1024" z="0" />
+     <rotation name="rotFS8" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper9" unit="cm"  x="-268.04" y="-675.1024" z="0" />
+     <rotation name="rotFS9" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper10" unit="cm"  x="-262.04" y="-675.1024" z="0" />
+     <rotation name="rotFS10" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper11" unit="cm"  x="-256.04" y="-675.1024" z="0" />
+     <rotation name="rotFS11" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper12" unit="cm"  x="-250.04" y="-675.1024" z="0" />
+     <rotation name="rotFS12" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper13" unit="cm"  x="-244.04" y="-675.1024" z="0" />
+     <rotation name="rotFS13" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper14" unit="cm"  x="-238.04" y="-675.1024" z="0" />
+     <rotation name="rotFS14" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper15" unit="cm"  x="-232.04" y="-675.1024" z="0" />
+     <rotation name="rotFS15" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper16" unit="cm"  x="-226.04" y="-675.1024" z="0" />
+     <rotation name="rotFS16" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper17" unit="cm"  x="-220.04" y="-675.1024" z="0" />
+     <rotation name="rotFS17" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper18" unit="cm"  x="-214.04" y="-675.1024" z="0" />
+     <rotation name="rotFS18" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper19" unit="cm"  x="-208.04" y="-675.1024" z="0" />
+     <rotation name="rotFS19" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper20" unit="cm"  x="-202.04" y="-675.1024" z="0" />
+     <rotation name="rotFS20" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper21" unit="cm"  x="-196.04" y="-675.1024" z="0" />
+     <rotation name="rotFS21" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper22" unit="cm"  x="-190.04" y="-675.1024" z="0" />
+     <rotation name="rotFS22" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper23" unit="cm"  x="-184.04" y="-675.1024" z="0" />
+     <rotation name="rotFS23" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper24" unit="cm"  x="-178.04" y="-675.1024" z="0" />
+     <rotation name="rotFS24" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper25" unit="cm"  x="-172.04" y="-675.1024" z="0" />
+     <rotation name="rotFS25" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper26" unit="cm"  x="-166.04" y="-675.1024" z="0" />
+     <rotation name="rotFS26" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper27" unit="cm"  x="-160.04" y="-675.1024" z="0" />
+     <rotation name="rotFS27" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper28" unit="cm"  x="-154.04" y="-675.1024" z="0" />
+     <rotation name="rotFS28" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper29" unit="cm"  x="-148.04" y="-675.1024" z="0" />
+     <rotation name="rotFS29" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper30" unit="cm"  x="-142.04" y="-675.1024" z="0" />
+     <rotation name="rotFS30" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper31" unit="cm"  x="-136.04" y="-675.1024" z="0" />
+     <rotation name="rotFS31" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper32" unit="cm"  x="-130.04" y="-675.1024" z="0" />
+     <rotation name="rotFS32" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper33" unit="cm"  x="-124.04" y="-675.1024" z="0" />
+     <rotation name="rotFS33" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper34" unit="cm"  x="-118.04" y="-675.1024" z="0" />
+     <rotation name="rotFS34" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper35" unit="cm"  x="-112.04" y="-675.1024" z="0" />
+     <rotation name="rotFS35" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper36" unit="cm"  x="-106.04" y="-675.1024" z="0" />
+     <rotation name="rotFS36" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper37" unit="cm"  x="-100.04" y="-675.1024" z="0" />
+     <rotation name="rotFS37" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper38" unit="cm"  x="-94.04" y="-675.1024" z="0" />
+     <rotation name="rotFS38" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper39" unit="cm"  x="-88.04" y="-675.1024" z="0" />
+     <rotation name="rotFS39" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper40" unit="cm"  x="-82.04" y="-675.1024" z="0" />
+     <rotation name="rotFS40" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper41" unit="cm"  x="-76.04" y="-675.1024" z="0" />
+     <rotation name="rotFS41" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper42" unit="cm"  x="-70.04" y="-675.1024" z="0" />
+     <rotation name="rotFS42" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper43" unit="cm"  x="-64.04" y="-675.1024" z="0" />
+     <rotation name="rotFS43" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper44" unit="cm"  x="-58.04" y="-675.1024" z="0" />
+     <rotation name="rotFS44" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper45" unit="cm"  x="-52.04" y="-675.1024" z="0" />
+     <rotation name="rotFS45" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper46" unit="cm"  x="-46.04" y="-675.1024" z="0" />
+     <rotation name="rotFS46" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper47" unit="cm"  x="-40.04" y="-675.1024" z="0" />
+     <rotation name="rotFS47" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper48" unit="cm"  x="-34.04" y="-675.1024" z="0" />
+     <rotation name="rotFS48" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper49" unit="cm"  x="-28.04" y="-675.1024" z="0" />
+     <rotation name="rotFS49" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper50" unit="cm"  x="-22.04" y="-675.1024" z="0" />
+     <rotation name="rotFS50" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper51" unit="cm"  x="-16.04" y="-675.1024" z="0" />
+     <rotation name="rotFS51" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper52" unit="cm"  x="-10.04" y="-675.1024" z="0" />
+     <rotation name="rotFS52" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper53" unit="cm"  x="-4.04000000000001" y="-675.1024" z="0" />
+     <rotation name="rotFS53" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper54" unit="cm"  x="1.95999999999999" y="-675.1024" z="0" />
+     <rotation name="rotFS54" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper55" unit="cm"  x="7.95999999999999" y="-675.1024" z="0" />
+     <rotation name="rotFS55" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper56" unit="cm"  x="13.96" y="-675.1024" z="0" />
+     <rotation name="rotFS56" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper57" unit="cm"  x="19.96" y="-675.1024" z="0" />
+     <rotation name="rotFS57" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper58" unit="cm"  x="25.96" y="-675.1024" z="0" />
+     <rotation name="rotFS58" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper59" unit="cm"  x="31.96" y="-675.1024" z="0" />
+     <rotation name="rotFS59" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper60" unit="cm"  x="37.96" y="-675.1024" z="0" />
+     <rotation name="rotFS60" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper61" unit="cm"  x="43.96" y="-675.1024" z="0" />
+     <rotation name="rotFS61" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper62" unit="cm"  x="49.96" y="-675.1024" z="0" />
+     <rotation name="rotFS62" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper63" unit="cm"  x="55.96" y="-675.1024" z="0" />
+     <rotation name="rotFS63" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper64" unit="cm"  x="61.96" y="-675.1024" z="0" />
+     <rotation name="rotFS64" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper65" unit="cm"  x="67.96" y="-675.1024" z="0" />
+     <rotation name="rotFS65" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper66" unit="cm"  x="73.96" y="-675.1024" z="0" />
+     <rotation name="rotFS66" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper67" unit="cm"  x="79.96" y="-675.1024" z="0" />
+     <rotation name="rotFS67" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper68" unit="cm"  x="85.96" y="-675.1024" z="0" />
+     <rotation name="rotFS68" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper69" unit="cm"  x="91.96" y="-675.1024" z="0" />
+     <rotation name="rotFS69" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper70" unit="cm"  x="97.96" y="-675.1024" z="0" />
+     <rotation name="rotFS70" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper71" unit="cm"  x="103.96" y="-675.1024" z="0" />
+     <rotation name="rotFS71" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper72" unit="cm"  x="109.96" y="-675.1024" z="0" />
+     <rotation name="rotFS72" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper73" unit="cm"  x="115.96" y="-675.1024" z="0" />
+     <rotation name="rotFS73" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper74" unit="cm"  x="121.96" y="-675.1024" z="0" />
+     <rotation name="rotFS74" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper75" unit="cm"  x="127.96" y="-675.1024" z="0" />
+     <rotation name="rotFS75" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper76" unit="cm"  x="133.96" y="-675.1024" z="0" />
+     <rotation name="rotFS76" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper77" unit="cm"  x="139.96" y="-675.1024" z="0" />
+     <rotation name="rotFS77" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper78" unit="cm"  x="145.96" y="-675.1024" z="0" />
+     <rotation name="rotFS78" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper79" unit="cm"  x="151.96" y="-675.1024" z="0" />
+     <rotation name="rotFS79" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper80" unit="cm"  x="157.96" y="-675.1024" z="0" />
+     <rotation name="rotFS80" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper81" unit="cm"  x="163.96" y="-675.1024" z="0" />
+     <rotation name="rotFS81" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper82" unit="cm"  x="169.96" y="-675.1024" z="0" />
+     <rotation name="rotFS82" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper83" unit="cm"  x="175.96" y="-675.1024" z="0" />
+     <rotation name="rotFS83" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper84" unit="cm"  x="181.96" y="-675.1024" z="0" />
+     <rotation name="rotFS84" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper85" unit="cm"  x="187.96" y="-675.1024" z="0" />
+     <rotation name="rotFS85" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper86" unit="cm"  x="193.96" y="-675.1024" z="0" />
+     <rotation name="rotFS86" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper87" unit="cm"  x="199.96" y="-675.1024" z="0" />
+     <rotation name="rotFS87" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper88" unit="cm"  x="205.96" y="-675.1024" z="0" />
+     <rotation name="rotFS88" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper89" unit="cm"  x="211.96" y="-675.1024" z="0" />
+     <rotation name="rotFS89" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper90" unit="cm"  x="217.96" y="-675.1024" z="0" />
+     <rotation name="rotFS90" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper91" unit="cm"  x="223.96" y="-675.1024" z="0" />
+     <rotation name="rotFS91" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper92" unit="cm"  x="229.96" y="-675.1024" z="0" />
+     <rotation name="rotFS92" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper93" unit="cm"  x="235.96" y="-675.1024" z="0" />
+     <rotation name="rotFS93" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper94" unit="cm"  x="241.96" y="-675.1024" z="0" />
+     <rotation name="rotFS94" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper95" unit="cm"  x="247.96" y="-675.1024" z="0" />
+     <rotation name="rotFS95" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper96" unit="cm"  x="253.96" y="-675.1024" z="0" />
+     <rotation name="rotFS96" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper97" unit="cm"  x="259.96" y="-675.1024" z="0" />
+     <rotation name="rotFS97" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper98" unit="cm"  x="265.96" y="-675.1024" z="0" />
+     <rotation name="rotFS98" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper99" unit="cm"  x="271.96" y="-675.1024" z="0" />
+     <rotation name="rotFS99" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper100" unit="cm"  x="277.96" y="-675.1024" z="0" />
+     <rotation name="rotFS100" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper101" unit="cm"  x="283.96" y="-675.1024" z="0" />
+     <rotation name="rotFS101" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper102" unit="cm"  x="289.96" y="-675.1024" z="0" />
+     <rotation name="rotFS102" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper103" unit="cm"  x="295.96" y="-675.1024" z="0" />
+     <rotation name="rotFS103" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper104" unit="cm"  x="301.96" y="-675.1024" z="0" />
+     <rotation name="rotFS104" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper105" unit="cm"  x="307.96" y="-675.1024" z="0" />
+     <rotation name="rotFS105" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper106" unit="cm"  x="313.96" y="-675.1024" z="0" />
+     <rotation name="rotFS106" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper107" unit="cm"  x="319.96" y="-675.1024" z="0" />
+     <rotation name="rotFS107" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-0" unit="cm" x="-328.04" y="-505.1018" z="-299.34"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-0" unit="cm" x="325.045" y="-505.1018" z="-299.34"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-1" unit="cm" x="-328.04" y="-169.7006" z="-299.34"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-1" unit="cm" x="325.045" y="-169.7006" z="-299.34"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-2" unit="cm" x="-328.04" y="165.7006" z="-299.34"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-2" unit="cm" x="325.045" y="165.7006" z="-299.34"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-3" unit="cm" x="-328.04" y="501.1018" z="-299.34"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-3" unit="cm" x="325.045" y="501.1018" z="-299.34"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-4" unit="cm" x="-328.04" y="-505.1018" z="-1.5"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-4" unit="cm" x="325.045" y="-505.1018" z="-1.5"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-5" unit="cm" x="-328.04" y="-169.7006" z="-1.5"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-5" unit="cm" x="325.045" y="-169.7006" z="-1.5"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-6" unit="cm" x="-328.04" y="165.7006" z="-1.5"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-6" unit="cm" x="325.045" y="165.7006" z="-1.5"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-7" unit="cm" x="-328.04" y="501.1018" z="-1.5"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-7" unit="cm" x="325.045" y="501.1018" z="-1.5"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-8" unit="cm" x="-328.04" y="-505.1018" z="296.34"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-8" unit="cm" x="325.045" y="-505.1018" z="296.34"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-9" unit="cm" x="-328.04" y="-169.7006" z="296.34"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-9" unit="cm" x="325.045" y="-169.7006" z="296.34"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-10" unit="cm" x="-328.04" y="165.7006" z="296.34"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-10" unit="cm" x="325.045" y="165.7006" z="296.34"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-11" unit="cm" x="-328.04" y="501.1018" z="296.34"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-11" unit="cm" x="325.045" y="501.1018" z="296.34"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-0-0"/>
+       <position name="posArapucaDouble0-Frame-0-0" unit="cm" 
+         x="-328.04"
+	 y="-632.8018" 
+	 z="-261.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-0"/>
+       <position name="posOpArapucaDouble0-Frame-0-0" unit="cm" 
+         x="-327.3"
+	 y="-632.8018" 
+	 z="-261.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-0-1"/>
+       <position name="posArapucaDouble1-Frame-0-0" unit="cm" 
+         x="-328.04"
+	 y="-542.1018" 
+	 z="-407.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-1"/>
+       <position name="posOpArapucaDouble1-Frame-0-0" unit="cm" 
+         x="-327.3"
+	 y="-542.1018" 
+	 z="-407.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-0-2"/>
+       <position name="posArapucaDouble2-Frame-0-0" unit="cm" 
+         x="-328.04"
+	 y="-468.1018" 
+	 z="-190.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-2"/>
+       <position name="posOpArapucaDouble2-Frame-0-0" unit="cm" 
+         x="-327.3"
+	 y="-468.1018" 
+	 z="-190.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-0-3"/>
+       <position name="posArapucaDouble3-Frame-0-0" unit="cm" 
+         x="-328.04"
+	 y="-377.4018" 
+	 z="-336.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-3"/>
+       <position name="posOpArapucaDouble3-Frame-0-0" unit="cm" 
+         x="-327.3"
+	 y="-377.4018" 
+	 z="-336.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-1-0"/>
+       <position name="posArapucaDouble0-Frame-0-1" unit="cm" 
+         x="-328.04"
+	 y="-632.8018" 
+	 z="36"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-0"/>
+       <position name="posOpArapucaDouble0-Frame-0-1" unit="cm" 
+         x="-327.3"
+	 y="-632.8018" 
+	 z="36"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-1-1"/>
+       <position name="posArapucaDouble1-Frame-0-1" unit="cm" 
+         x="-328.04"
+	 y="-542.1018" 
+	 z="-110"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-1"/>
+       <position name="posOpArapucaDouble1-Frame-0-1" unit="cm" 
+         x="-327.3"
+	 y="-542.1018" 
+	 z="-110"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-1-2"/>
+       <position name="posArapucaDouble2-Frame-0-1" unit="cm" 
+         x="-328.04"
+	 y="-468.1018" 
+	 z="107"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-2"/>
+       <position name="posOpArapucaDouble2-Frame-0-1" unit="cm" 
+         x="-327.3"
+	 y="-468.1018" 
+	 z="107"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-1-3"/>
+       <position name="posArapucaDouble3-Frame-0-1" unit="cm" 
+         x="-328.04"
+	 y="-377.4018" 
+	 z="-39"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-3"/>
+       <position name="posOpArapucaDouble3-Frame-0-1" unit="cm" 
+         x="-327.3"
+	 y="-377.4018" 
+	 z="-39"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-2-0"/>
+       <position name="posArapucaDouble0-Frame-0-2" unit="cm" 
+         x="-328.04"
+	 y="-632.8018" 
+	 z="333.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-0"/>
+       <position name="posOpArapucaDouble0-Frame-0-2" unit="cm" 
+         x="-327.3"
+	 y="-632.8018" 
+	 z="333.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-2-1"/>
+       <position name="posArapucaDouble1-Frame-0-2" unit="cm" 
+         x="-328.04"
+	 y="-542.1018" 
+	 z="187.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-1"/>
+       <position name="posOpArapucaDouble1-Frame-0-2" unit="cm" 
+         x="-327.3"
+	 y="-542.1018" 
+	 z="187.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-2-2"/>
+       <position name="posArapucaDouble2-Frame-0-2" unit="cm" 
+         x="-328.04"
+	 y="-468.1018" 
+	 z="404.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-2"/>
+       <position name="posOpArapucaDouble2-Frame-0-2" unit="cm" 
+         x="-327.3"
+	 y="-468.1018" 
+	 z="404.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-2-3"/>
+       <position name="posArapucaDouble3-Frame-0-2" unit="cm" 
+         x="-328.04"
+	 y="-377.4018" 
+	 z="258.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-3"/>
+       <position name="posOpArapucaDouble3-Frame-0-2" unit="cm" 
+         x="-327.3"
+	 y="-377.4018" 
+	 z="258.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-0-0"/>
+       <position name="posArapucaDouble0-Frame-1-0" unit="cm" 
+         x="-328.04"
+	 y="-297.4006" 
+	 z="-261.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-0"/>
+       <position name="posOpArapucaDouble0-Frame-1-0" unit="cm" 
+         x="-327.3"
+	 y="-297.4006" 
+	 z="-261.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-0-1"/>
+       <position name="posArapucaDouble1-Frame-1-0" unit="cm" 
+         x="-328.04"
+	 y="-206.7006" 
+	 z="-407.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-1"/>
+       <position name="posOpArapucaDouble1-Frame-1-0" unit="cm" 
+         x="-327.3"
+	 y="-206.7006" 
+	 z="-407.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-0-2"/>
+       <position name="posArapucaDouble2-Frame-1-0" unit="cm" 
+         x="-328.04"
+	 y="-132.7006" 
+	 z="-190.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-2"/>
+       <position name="posOpArapucaDouble2-Frame-1-0" unit="cm" 
+         x="-327.3"
+	 y="-132.7006" 
+	 z="-190.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-0-3"/>
+       <position name="posArapucaDouble3-Frame-1-0" unit="cm" 
+         x="-328.04"
+	 y="-42.0006" 
+	 z="-336.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-3"/>
+       <position name="posOpArapucaDouble3-Frame-1-0" unit="cm" 
+         x="-327.3"
+	 y="-42.0006" 
+	 z="-336.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-1-0"/>
+       <position name="posArapucaDouble0-Frame-1-1" unit="cm" 
+         x="-328.04"
+	 y="-297.4006" 
+	 z="36"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-0"/>
+       <position name="posOpArapucaDouble0-Frame-1-1" unit="cm" 
+         x="-327.3"
+	 y="-297.4006" 
+	 z="36"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-1-1"/>
+       <position name="posArapucaDouble1-Frame-1-1" unit="cm" 
+         x="-328.04"
+	 y="-206.7006" 
+	 z="-110"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-1"/>
+       <position name="posOpArapucaDouble1-Frame-1-1" unit="cm" 
+         x="-327.3"
+	 y="-206.7006" 
+	 z="-110"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-1-2"/>
+       <position name="posArapucaDouble2-Frame-1-1" unit="cm" 
+         x="-328.04"
+	 y="-132.7006" 
+	 z="107"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-2"/>
+       <position name="posOpArapucaDouble2-Frame-1-1" unit="cm" 
+         x="-327.3"
+	 y="-132.7006" 
+	 z="107"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-1-3"/>
+       <position name="posArapucaDouble3-Frame-1-1" unit="cm" 
+         x="-328.04"
+	 y="-42.0006" 
+	 z="-39"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-3"/>
+       <position name="posOpArapucaDouble3-Frame-1-1" unit="cm" 
+         x="-327.3"
+	 y="-42.0006" 
+	 z="-39"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-2-0"/>
+       <position name="posArapucaDouble0-Frame-1-2" unit="cm" 
+         x="-328.04"
+	 y="-297.4006" 
+	 z="333.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-0"/>
+       <position name="posOpArapucaDouble0-Frame-1-2" unit="cm" 
+         x="-327.3"
+	 y="-297.4006" 
+	 z="333.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-2-1"/>
+       <position name="posArapucaDouble1-Frame-1-2" unit="cm" 
+         x="-328.04"
+	 y="-206.7006" 
+	 z="187.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-1"/>
+       <position name="posOpArapucaDouble1-Frame-1-2" unit="cm" 
+         x="-327.3"
+	 y="-206.7006" 
+	 z="187.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-2-2"/>
+       <position name="posArapucaDouble2-Frame-1-2" unit="cm" 
+         x="-328.04"
+	 y="-132.7006" 
+	 z="404.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-2"/>
+       <position name="posOpArapucaDouble2-Frame-1-2" unit="cm" 
+         x="-327.3"
+	 y="-132.7006" 
+	 z="404.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-2-3"/>
+       <position name="posArapucaDouble3-Frame-1-2" unit="cm" 
+         x="-328.04"
+	 y="-42.0006" 
+	 z="258.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-3"/>
+       <position name="posOpArapucaDouble3-Frame-1-2" unit="cm" 
+         x="-327.3"
+	 y="-42.0006" 
+	 z="258.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-0-0"/>
+       <position name="posArapucaDouble0-Frame-2-0" unit="cm" 
+         x="-328.04"
+	 y="38.0006" 
+	 z="-261.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-0"/>
+       <position name="posOpArapucaDouble0-Frame-2-0" unit="cm" 
+         x="-327.3"
+	 y="38.0006" 
+	 z="-261.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-0-1"/>
+       <position name="posArapucaDouble1-Frame-2-0" unit="cm" 
+         x="-328.04"
+	 y="128.7006" 
+	 z="-407.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-1"/>
+       <position name="posOpArapucaDouble1-Frame-2-0" unit="cm" 
+         x="-327.3"
+	 y="128.7006" 
+	 z="-407.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-0-2"/>
+       <position name="posArapucaDouble2-Frame-2-0" unit="cm" 
+         x="-328.04"
+	 y="202.7006" 
+	 z="-190.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-2"/>
+       <position name="posOpArapucaDouble2-Frame-2-0" unit="cm" 
+         x="-327.3"
+	 y="202.7006" 
+	 z="-190.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-0-3"/>
+       <position name="posArapucaDouble3-Frame-2-0" unit="cm" 
+         x="-328.04"
+	 y="293.4006" 
+	 z="-336.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-3"/>
+       <position name="posOpArapucaDouble3-Frame-2-0" unit="cm" 
+         x="-327.3"
+	 y="293.4006" 
+	 z="-336.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-1-0"/>
+       <position name="posArapucaDouble0-Frame-2-1" unit="cm" 
+         x="-328.04"
+	 y="38.0006" 
+	 z="36"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-0"/>
+       <position name="posOpArapucaDouble0-Frame-2-1" unit="cm" 
+         x="-327.3"
+	 y="38.0006" 
+	 z="36"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-1-1"/>
+       <position name="posArapucaDouble1-Frame-2-1" unit="cm" 
+         x="-328.04"
+	 y="128.7006" 
+	 z="-110"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-1"/>
+       <position name="posOpArapucaDouble1-Frame-2-1" unit="cm" 
+         x="-327.3"
+	 y="128.7006" 
+	 z="-110"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-1-2"/>
+       <position name="posArapucaDouble2-Frame-2-1" unit="cm" 
+         x="-328.04"
+	 y="202.7006" 
+	 z="107"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-2"/>
+       <position name="posOpArapucaDouble2-Frame-2-1" unit="cm" 
+         x="-327.3"
+	 y="202.7006" 
+	 z="107"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-1-3"/>
+       <position name="posArapucaDouble3-Frame-2-1" unit="cm" 
+         x="-328.04"
+	 y="293.4006" 
+	 z="-39"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-3"/>
+       <position name="posOpArapucaDouble3-Frame-2-1" unit="cm" 
+         x="-327.3"
+	 y="293.4006" 
+	 z="-39"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-2-0"/>
+       <position name="posArapucaDouble0-Frame-2-2" unit="cm" 
+         x="-328.04"
+	 y="38.0006" 
+	 z="333.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-0"/>
+       <position name="posOpArapucaDouble0-Frame-2-2" unit="cm" 
+         x="-327.3"
+	 y="38.0006" 
+	 z="333.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-2-1"/>
+       <position name="posArapucaDouble1-Frame-2-2" unit="cm" 
+         x="-328.04"
+	 y="128.7006" 
+	 z="187.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-1"/>
+       <position name="posOpArapucaDouble1-Frame-2-2" unit="cm" 
+         x="-327.3"
+	 y="128.7006" 
+	 z="187.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-2-2"/>
+       <position name="posArapucaDouble2-Frame-2-2" unit="cm" 
+         x="-328.04"
+	 y="202.7006" 
+	 z="404.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-2"/>
+       <position name="posOpArapucaDouble2-Frame-2-2" unit="cm" 
+         x="-327.3"
+	 y="202.7006" 
+	 z="404.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-2-3"/>
+       <position name="posArapucaDouble3-Frame-2-2" unit="cm" 
+         x="-328.04"
+	 y="293.4006" 
+	 z="258.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-3"/>
+       <position name="posOpArapucaDouble3-Frame-2-2" unit="cm" 
+         x="-327.3"
+	 y="293.4006" 
+	 z="258.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-0-0"/>
+       <position name="posArapucaDouble0-Frame-3-0" unit="cm" 
+         x="-328.04"
+	 y="373.4018" 
+	 z="-261.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-0"/>
+       <position name="posOpArapucaDouble0-Frame-3-0" unit="cm" 
+         x="-327.3"
+	 y="373.4018" 
+	 z="-261.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-0-1"/>
+       <position name="posArapucaDouble1-Frame-3-0" unit="cm" 
+         x="-328.04"
+	 y="464.1018" 
+	 z="-407.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-1"/>
+       <position name="posOpArapucaDouble1-Frame-3-0" unit="cm" 
+         x="-327.3"
+	 y="464.1018" 
+	 z="-407.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-0-2"/>
+       <position name="posArapucaDouble2-Frame-3-0" unit="cm" 
+         x="-328.04"
+	 y="538.1018" 
+	 z="-190.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-2"/>
+       <position name="posOpArapucaDouble2-Frame-3-0" unit="cm" 
+         x="-327.3"
+	 y="538.1018" 
+	 z="-190.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-0-3"/>
+       <position name="posArapucaDouble3-Frame-3-0" unit="cm" 
+         x="-328.04"
+	 y="628.8018" 
+	 z="-336.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-3"/>
+       <position name="posOpArapucaDouble3-Frame-3-0" unit="cm" 
+         x="-327.3"
+	 y="628.8018" 
+	 z="-336.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-1-0"/>
+       <position name="posArapucaDouble0-Frame-3-1" unit="cm" 
+         x="-328.04"
+	 y="373.4018" 
+	 z="36"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-0"/>
+       <position name="posOpArapucaDouble0-Frame-3-1" unit="cm" 
+         x="-327.3"
+	 y="373.4018" 
+	 z="36"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-1-1"/>
+       <position name="posArapucaDouble1-Frame-3-1" unit="cm" 
+         x="-328.04"
+	 y="464.1018" 
+	 z="-110"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-1"/>
+       <position name="posOpArapucaDouble1-Frame-3-1" unit="cm" 
+         x="-327.3"
+	 y="464.1018" 
+	 z="-110"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-1-2"/>
+       <position name="posArapucaDouble2-Frame-3-1" unit="cm" 
+         x="-328.04"
+	 y="538.1018" 
+	 z="107"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-2"/>
+       <position name="posOpArapucaDouble2-Frame-3-1" unit="cm" 
+         x="-327.3"
+	 y="538.1018" 
+	 z="107"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-1-3"/>
+       <position name="posArapucaDouble3-Frame-3-1" unit="cm" 
+         x="-328.04"
+	 y="628.8018" 
+	 z="-39"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-3"/>
+       <position name="posOpArapucaDouble3-Frame-3-1" unit="cm" 
+         x="-327.3"
+	 y="628.8018" 
+	 z="-39"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-2-0"/>
+       <position name="posArapucaDouble0-Frame-3-2" unit="cm" 
+         x="-328.04"
+	 y="373.4018" 
+	 z="333.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-0"/>
+       <position name="posOpArapucaDouble0-Frame-3-2" unit="cm" 
+         x="-327.3"
+	 y="373.4018" 
+	 z="333.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-2-1"/>
+       <position name="posArapucaDouble1-Frame-3-2" unit="cm" 
+         x="-328.04"
+	 y="464.1018" 
+	 z="187.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-1"/>
+       <position name="posOpArapucaDouble1-Frame-3-2" unit="cm" 
+         x="-327.3"
+	 y="464.1018" 
+	 z="187.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-2-2"/>
+       <position name="posArapucaDouble2-Frame-3-2" unit="cm" 
+         x="-328.04"
+	 y="538.1018" 
+	 z="404.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-2"/>
+       <position name="posOpArapucaDouble2-Frame-3-2" unit="cm" 
+         x="-327.3"
+	 y="538.1018" 
+	 z="404.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-2-3"/>
+       <position name="posArapucaDouble3-Frame-3-2" unit="cm" 
+         x="-328.04"
+	 y="628.8018" 
+	 z="258.84"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-3"/>
+       <position name="posOpArapucaDouble3-Frame-3-2" unit="cm" 
+         x="-327.3"
+	 y="628.8018" 
+	 z="258.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_0-0"/>
+       <position name="posArapuca0-Lat-0" unit="cm" 
+         x="285.03"
+	 y="-732.8024" 
+	 z="-297.84"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_0-0"/>
+       <position name="posOpArapuca0-Lat-0" unit="cm" 
+         x="285.03"
+	 y="-732.0624" 
+	 z="-297.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_0-1"/>
+       <position name="posArapuca1-Lat-0" unit="cm" 
+         x="210.03"
+	 y="-732.8024" 
+	 z="-297.84"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_0-1"/>
+       <position name="posOpArapuca1-Lat-0" unit="cm" 
+         x="210.03"
+	 y="-732.0624" 
+	 z="-297.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_0-2"/>
+       <position name="posArapuca2-Lat-0" unit="cm" 
+         x="135.03"
+	 y="-732.8024" 
+	 z="-297.84"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_0-2"/>
+       <position name="posOpArapuca2-Lat-0" unit="cm" 
+         x="135.03"
+	 y="-732.0624" 
+	 z="-297.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_0-3"/>
+       <position name="posArapuca3-Lat-0" unit="cm" 
+         x="60.03"
+	 y="-732.8024" 
+	 z="-297.84"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_0-3"/>
+       <position name="posOpArapuca3-Lat-0" unit="cm" 
+         x="60.03"
+	 y="-732.0624" 
+	 z="-297.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_0-4"/>
+       <position name="posArapuca4-Lat-0" unit="cm" 
+         x="285.03"
+	 y="732.8024" 
+	 z="-297.84"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_0-4"/>
+       <position name="posOpArapuca4-Lat-0" unit="cm" 
+         x="285.03"
+	 y="732.0624" 
+	 z="-297.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_0-5"/>
+       <position name="posArapuca5-Lat-0" unit="cm" 
+         x="210.03"
+	 y="732.8024" 
+	 z="-297.84"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_0-5"/>
+       <position name="posOpArapuca5-Lat-0" unit="cm" 
+         x="210.03"
+	 y="732.0624" 
+	 z="-297.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_0-6"/>
+       <position name="posArapuca6-Lat-0" unit="cm" 
+         x="135.03"
+	 y="732.8024" 
+	 z="-297.84"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_0-6"/>
+       <position name="posOpArapuca6-Lat-0" unit="cm" 
+         x="135.03"
+	 y="732.0624" 
+	 z="-297.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_0-7"/>
+       <position name="posArapuca7-Lat-0" unit="cm" 
+         x="60.03"
+	 y="732.8024" 
+	 z="-297.84"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_0-7"/>
+       <position name="posOpArapuca7-Lat-0" unit="cm" 
+         x="60.03"
+	 y="732.0624" 
+	 z="-297.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_1-0"/>
+       <position name="posArapuca0-Lat-1" unit="cm" 
+         x="285.03"
+	 y="-732.8024" 
+	 z="-1.13686837721616e-13"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_1-0"/>
+       <position name="posOpArapuca0-Lat-1" unit="cm" 
+         x="285.03"
+	 y="-732.0624" 
+	 z="-1.13686837721616e-13"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_1-1"/>
+       <position name="posArapuca1-Lat-1" unit="cm" 
+         x="210.03"
+	 y="-732.8024" 
+	 z="-1.13686837721616e-13"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_1-1"/>
+       <position name="posOpArapuca1-Lat-1" unit="cm" 
+         x="210.03"
+	 y="-732.0624" 
+	 z="-1.13686837721616e-13"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_1-2"/>
+       <position name="posArapuca2-Lat-1" unit="cm" 
+         x="135.03"
+	 y="-732.8024" 
+	 z="-1.13686837721616e-13"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_1-2"/>
+       <position name="posOpArapuca2-Lat-1" unit="cm" 
+         x="135.03"
+	 y="-732.0624" 
+	 z="-1.13686837721616e-13"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_1-3"/>
+       <position name="posArapuca3-Lat-1" unit="cm" 
+         x="60.03"
+	 y="-732.8024" 
+	 z="-1.13686837721616e-13"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_1-3"/>
+       <position name="posOpArapuca3-Lat-1" unit="cm" 
+         x="60.03"
+	 y="-732.0624" 
+	 z="-1.13686837721616e-13"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_1-4"/>
+       <position name="posArapuca4-Lat-1" unit="cm" 
+         x="285.03"
+	 y="732.8024" 
+	 z="-1.13686837721616e-13"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_1-4"/>
+       <position name="posOpArapuca4-Lat-1" unit="cm" 
+         x="285.03"
+	 y="732.0624" 
+	 z="-1.13686837721616e-13"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_1-5"/>
+       <position name="posArapuca5-Lat-1" unit="cm" 
+         x="210.03"
+	 y="732.8024" 
+	 z="-1.13686837721616e-13"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_1-5"/>
+       <position name="posOpArapuca5-Lat-1" unit="cm" 
+         x="210.03"
+	 y="732.0624" 
+	 z="-1.13686837721616e-13"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_1-6"/>
+       <position name="posArapuca6-Lat-1" unit="cm" 
+         x="135.03"
+	 y="732.8024" 
+	 z="-1.13686837721616e-13"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_1-6"/>
+       <position name="posOpArapuca6-Lat-1" unit="cm" 
+         x="135.03"
+	 y="732.0624" 
+	 z="-1.13686837721616e-13"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_1-7"/>
+       <position name="posArapuca7-Lat-1" unit="cm" 
+         x="60.03"
+	 y="732.8024" 
+	 z="-1.13686837721616e-13"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_1-7"/>
+       <position name="posOpArapuca7-Lat-1" unit="cm" 
+         x="60.03"
+	 y="732.0624" 
+	 z="-1.13686837721616e-13"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_2-0"/>
+       <position name="posArapuca0-Lat-2" unit="cm" 
+         x="285.03"
+	 y="-732.8024" 
+	 z="297.84"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_2-0"/>
+       <position name="posOpArapuca0-Lat-2" unit="cm" 
+         x="285.03"
+	 y="-732.0624" 
+	 z="297.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_2-1"/>
+       <position name="posArapuca1-Lat-2" unit="cm" 
+         x="210.03"
+	 y="-732.8024" 
+	 z="297.84"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_2-1"/>
+       <position name="posOpArapuca1-Lat-2" unit="cm" 
+         x="210.03"
+	 y="-732.0624" 
+	 z="297.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_2-2"/>
+       <position name="posArapuca2-Lat-2" unit="cm" 
+         x="135.03"
+	 y="-732.8024" 
+	 z="297.84"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_2-2"/>
+       <position name="posOpArapuca2-Lat-2" unit="cm" 
+         x="135.03"
+	 y="-732.0624" 
+	 z="297.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_2-3"/>
+       <position name="posArapuca3-Lat-2" unit="cm" 
+         x="60.03"
+	 y="-732.8024" 
+	 z="297.84"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_2-3"/>
+       <position name="posOpArapuca3-Lat-2" unit="cm" 
+         x="60.03"
+	 y="-732.0624" 
+	 z="297.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_2-4"/>
+       <position name="posArapuca4-Lat-2" unit="cm" 
+         x="285.03"
+	 y="732.8024" 
+	 z="297.84"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_2-4"/>
+       <position name="posOpArapuca4-Lat-2" unit="cm" 
+         x="285.03"
+	 y="732.0624" 
+	 z="297.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_2-5"/>
+       <position name="posArapuca5-Lat-2" unit="cm" 
+         x="210.03"
+	 y="732.8024" 
+	 z="297.84"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_2-5"/>
+       <position name="posOpArapuca5-Lat-2" unit="cm" 
+         x="210.03"
+	 y="732.0624" 
+	 z="297.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_2-6"/>
+       <position name="posArapuca6-Lat-2" unit="cm" 
+         x="135.03"
+	 y="732.8024" 
+	 z="297.84"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_2-6"/>
+       <position name="posOpArapuca6-Lat-2" unit="cm" 
+         x="135.03"
+	 y="732.0624" 
+	 z="297.84"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_2-7"/>
+       <position name="posArapuca7-Lat-2" unit="cm" 
+         x="60.03"
+	 y="732.8024" 
+	 z="297.84"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_2-7"/>
+       <position name="posOpArapuca7-Lat-2" unit="cm" 
+         x="60.03"
+	 y="732.0624" 
+	 z="297.84"/>
+     </physvol>
+    </volume>
+
+    <volume name="volFoamPadding">
+      <materialref ref="fibrous_glass"/>
+      <solidref ref="FoamPadding"/>
+    </volume>
+
+    <volume name="volSteelSupport">
+      <materialref ref="AirSteelMixture"/>
+      <solidref ref="SteelSupport"/>
+    </volume>
+
+    <volume name="volDetEnclosure">
+      <materialref ref="Air"/>
+      <solidref ref="DetEnclosure"/>
+
+       <physvol>
+           <volumeref ref="volFoamPadding"/>
+           <positionref ref="posCryoInDetEnc"/>
+       </physvol>
+       <physvol>
+           <volumeref ref="volSteelSupport"/>
+           <positionref ref="posCryoInDetEnc"/>
+       </physvol>
+       <physvol>
+           <volumeref ref="volCryostat"/>
+           <positionref ref="posCryoInDetEnc"/>
+       </physvol>
+    </volume>
+
+    <volume name="volWorld" >
+      <materialref ref="DUSEL_Rock"/>
+      <solidref ref="World"/>
+
+      <physvol>
+        <volumeref ref="volDetEnclosure"/>
+	<position name="posDetEnclosure" unit="cm" x="50.04" y="-1.13686837721616e-13" z="448.26"/>
+      </physvol>
+
+    </volume>
+</structure>
+  <setup name="Default" version="1.0">
+    <world ref="volWorld"/>
+  </setup>
+</gdml_simple_extension>

--- a/dunecore/Geometry/gdml/dunevd10kt_3view_v2_refactored_1x8x6ref.gdml
+++ b/dunecore/Geometry/gdml/dunevd10kt_3view_v2_refactored_1x8x6ref.gdml
@@ -1884,97 +1884,6 @@
 
 
 
-    <box name="CathodeBlock" lunit="cm"
-      x="4"
-      y="336"
-      z="297.8018" />
-
-    <box name="CathodeVoid" lunit="cm"
-      x="5"
-      y="76.35"
-      z="67" />
-
-    <subtraction name="Cathode1">
-      <first ref="CathodeBlock"/>
-      <second ref="CathodeVoid"/>
-      <position name="posCathodeSub1" x="0" y="-122.525" z="-108.5" unit="cm"/>
-    </subtraction>
-    <subtraction name="Cathode2">
-      <first ref="Cathode1"/>
-      <second ref="CathodeVoid"/>
-      <position name="posCathodeSub2" x="0" y="-122.525" z="-37.5" unit="cm"/>
-    </subtraction>
-    <subtraction name="Cathode3">
-      <first ref="Cathode2"/>
-      <second ref="CathodeVoid"/>
-      <position name="posCathodeSub3" x="0" y="-122.525" z="37.5" unit="cm"/>
-    </subtraction>
-    <subtraction name="Cathode4">
-      <first ref="Cathode3"/>
-      <second ref="CathodeVoid"/>
-      <position name="posCathodeSub4" x="0" y="-122.525" z="108.5" unit="cm"/>
-    </subtraction>
-    <subtraction name="Cathode5">
-      <first ref="Cathode4"/>
-      <second ref="CathodeVoid"/>
-      <position name="posCathodeSub5" x="0" y="-42.175" z="-108.5" unit="cm"/>
-    </subtraction>
-    <subtraction name="Cathode6">
-      <first ref="Cathode5"/>
-      <second ref="CathodeVoid"/>
-      <position name="posCathodeSub6" x="0" y="-42.175" z="-37.5" unit="cm"/>
-    </subtraction>
-    <subtraction name="Cathode7">
-      <first ref="Cathode6"/>
-      <second ref="CathodeVoid"/>
-      <position name="posCathodeSub7" x="0" y="-42.175" z="37.5" unit="cm"/>
-    </subtraction>
-    <subtraction name="Cathode8">
-      <first ref="Cathode7"/>
-      <second ref="CathodeVoid"/>
-      <position name="posCathodeSub8" x="0" y="-42.175" z="108.5" unit="cm"/>
-    </subtraction>
-    <subtraction name="Cathode9">
-      <first ref="Cathode8"/>
-      <second ref="CathodeVoid"/>
-      <position name="posCathodeSub9" x="0" y="42.175" z="-108.5" unit="cm"/>
-    </subtraction>
-    <subtraction name="Cathode10">
-      <first ref="Cathode9"/>
-      <second ref="CathodeVoid"/>
-      <position name="posCathodeSub10" x="0" y="42.175" z="-37.5" unit="cm"/>
-    </subtraction>
-    <subtraction name="Cathode11">
-      <first ref="Cathode10"/>
-      <second ref="CathodeVoid"/>
-      <position name="posCathodeSub11" x="0" y="42.175" z="37.5" unit="cm"/>
-    </subtraction>
-    <subtraction name="Cathode12">
-      <first ref="Cathode11"/>
-      <second ref="CathodeVoid"/>
-      <position name="posCathodeSub12" x="0" y="42.175" z="108.5" unit="cm"/>
-    </subtraction>
-    <subtraction name="Cathode13">
-      <first ref="Cathode12"/>
-      <second ref="CathodeVoid"/>
-      <position name="posCathodeSub13" x="0" y="122.525" z="-108.5" unit="cm"/>
-    </subtraction>
-    <subtraction name="Cathode14">
-      <first ref="Cathode13"/>
-      <second ref="CathodeVoid"/>
-      <position name="posCathodeSub14" x="0" y="122.525" z="-37.5" unit="cm"/>
-    </subtraction>
-    <subtraction name="Cathode15">
-      <first ref="Cathode14"/>
-      <second ref="CathodeVoid"/>
-      <position name="posCathodeSub15" x="0" y="122.525" z="37.5" unit="cm"/>
-    </subtraction>
-    <subtraction name="CathodeGrid">
-      <first ref="Cathode15"/>
-      <second ref="CathodeVoid"/>
-      <position name="posCathodeSub16" x="0" y="122.525" z="108.5" unit="cm"/>
-    </subtraction>
-
     <box name="FoamPadBlock" lunit="cm"
       x="1010.32"
       y="1708.24"
@@ -7424,10 +7333,6 @@
       <materialref ref="STEEL_STAINLESS_Fe7Cr2Ni" />
       <solidref ref="SteelShell" />
     </volume>
-    <volume name="volGroundGrid">
-      <materialref ref="STEEL_STAINLESS_Fe7Cr2Ni" />
-      <solidref ref="CathodeGrid" />
-    </volume>    
     <volume name="volGaseousArgon">
       <materialref ref="ArGas"/>
       <solidref ref="GaseousArgon"/>
@@ -8812,773 +8717,725 @@
      <position name="posFieldShaper107" unit="cm"  x="319.96" y="-676.3" z="0" />
      <rotation name="rotFS107" unit="deg" x="0" y="0" z="90" />
   </physvol>
-      <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-0" unit="cm" x="-328.04" y="-506" z="-299.3018"/>
-      </physvol>
-      <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-1" unit="cm" x="-328.04" y="-170" z="-299.3018"/>
-      </physvol>
-      <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-2" unit="cm" x="-328.04" y="166" z="-299.3018"/>
-      </physvol>
-      <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-3" unit="cm" x="-328.04" y="502" z="-299.3018"/>
-      </physvol>
-      <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-4" unit="cm" x="-328.04" y="-506" z="-1.50000000000006"/>
-      </physvol>
-      <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-5" unit="cm" x="-328.04" y="-170" z="-1.50000000000006"/>
-      </physvol>
-      <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-6" unit="cm" x="-328.04" y="166" z="-1.50000000000006"/>
-      </physvol>
-      <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-7" unit="cm" x="-328.04" y="502" z="-1.50000000000006"/>
-      </physvol>
-      <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-8" unit="cm" x="-328.04" y="-506" z="296.3018"/>
-      </physvol>
-      <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-9" unit="cm" x="-328.04" y="-170" z="296.3018"/>
-      </physvol>
-      <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-10" unit="cm" x="-328.04" y="166" z="296.3018"/>
-      </physvol>
-      <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-11" unit="cm" x="-328.04" y="502" z="296.3018"/>
-      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-0-0"/>
        <position name="posArapucaDouble0-Frame-0-0" unit="cm" 
-         x="-328.04"
-	 y="-633.7" 
-	 z="-261.8018"/>
+         x="-327.04"
+	 y="-627.55" 
+	 z="-263.201575"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-0"/>
        <position name="posOpArapucaDouble0-Frame-0-0" unit="cm" 
-         x="-327.3"
-	 y="-633.7" 
-	 z="-261.8018"/>
+         x="-326.3"
+	 y="-627.55" 
+	 z="-263.201575"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-0-1"/>
        <position name="posArapucaDouble1-Frame-0-0" unit="cm" 
-         x="-328.04"
-	 y="-543" 
-	 z="-407.8018"/>
+         x="-327.04"
+	 y="-537" 
+	 z="-400.852475"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-1"/>
        <position name="posOpArapucaDouble1-Frame-0-0" unit="cm" 
-         x="-327.3"
-	 y="-543" 
-	 z="-407.8018"/>
+         x="-326.3"
+	 y="-537" 
+	 z="-400.852475"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-0-2"/>
        <position name="posArapucaDouble2-Frame-0-0" unit="cm" 
-         x="-328.04"
-	 y="-469" 
-	 z="-190.8018"/>
+         x="-327.04"
+	 y="-471" 
+	 z="-194.751125"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-2"/>
        <position name="posOpArapucaDouble2-Frame-0-0" unit="cm" 
-         x="-327.3"
-	 y="-469" 
-	 z="-190.8018"/>
+         x="-326.3"
+	 y="-471" 
+	 z="-194.751125"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-0-3"/>
        <position name="posArapucaDouble3-Frame-0-0" unit="cm" 
-         x="-328.04"
-	 y="-378.3" 
-	 z="-336.8018"/>
+         x="-327.04"
+	 y="-380.45" 
+	 z="-332.402025"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-3"/>
        <position name="posOpArapucaDouble3-Frame-0-0" unit="cm" 
-         x="-327.3"
-	 y="-378.3" 
-	 z="-336.8018"/>
+         x="-326.3"
+	 y="-380.45" 
+	 z="-332.402025"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-1-0"/>
        <position name="posArapucaDouble0-Frame-0-1" unit="cm" 
-         x="-328.04"
-	 y="-633.7" 
-	 z="35.9999999999999"/>
+         x="-327.04"
+	 y="-627.55" 
+	 z="34.6002250000003"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-0"/>
        <position name="posOpArapucaDouble0-Frame-0-1" unit="cm" 
-         x="-327.3"
-	 y="-633.7" 
-	 z="35.9999999999999"/>
+         x="-326.3"
+	 y="-627.55" 
+	 z="34.6002250000003"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-1-1"/>
        <position name="posArapucaDouble1-Frame-0-1" unit="cm" 
-         x="-328.04"
-	 y="-543" 
-	 z="-110"/>
+         x="-327.04"
+	 y="-537" 
+	 z="-103.050675"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-1"/>
        <position name="posOpArapucaDouble1-Frame-0-1" unit="cm" 
-         x="-327.3"
-	 y="-543" 
-	 z="-110"/>
+         x="-326.3"
+	 y="-537" 
+	 z="-103.050675"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-1-2"/>
        <position name="posArapucaDouble2-Frame-0-1" unit="cm" 
-         x="-328.04"
-	 y="-469" 
-	 z="107"/>
+         x="-327.04"
+	 y="-471" 
+	 z="103.050675"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-2"/>
        <position name="posOpArapucaDouble2-Frame-0-1" unit="cm" 
-         x="-327.3"
-	 y="-469" 
-	 z="107"/>
+         x="-326.3"
+	 y="-471" 
+	 z="103.050675"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-1-3"/>
        <position name="posArapucaDouble3-Frame-0-1" unit="cm" 
-         x="-328.04"
-	 y="-378.3" 
-	 z="-39.0000000000001"/>
+         x="-327.04"
+	 y="-380.45" 
+	 z="-34.6002249999997"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-3"/>
        <position name="posOpArapucaDouble3-Frame-0-1" unit="cm" 
-         x="-327.3"
-	 y="-378.3" 
-	 z="-39.0000000000001"/>
+         x="-326.3"
+	 y="-380.45" 
+	 z="-34.6002249999997"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-2-0"/>
        <position name="posArapucaDouble0-Frame-0-2" unit="cm" 
-         x="-328.04"
-	 y="-633.7" 
-	 z="333.8018"/>
+         x="-327.04"
+	 y="-627.55" 
+	 z="332.402025"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-0"/>
        <position name="posOpArapucaDouble0-Frame-0-2" unit="cm" 
-         x="-327.3"
-	 y="-633.7" 
-	 z="333.8018"/>
+         x="-326.3"
+	 y="-627.55" 
+	 z="332.402025"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-2-1"/>
        <position name="posArapucaDouble1-Frame-0-2" unit="cm" 
-         x="-328.04"
-	 y="-543" 
-	 z="187.8018"/>
+         x="-327.04"
+	 y="-537" 
+	 z="194.751125"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-1"/>
        <position name="posOpArapucaDouble1-Frame-0-2" unit="cm" 
-         x="-327.3"
-	 y="-543" 
-	 z="187.8018"/>
+         x="-326.3"
+	 y="-537" 
+	 z="194.751125"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-2-2"/>
        <position name="posArapucaDouble2-Frame-0-2" unit="cm" 
-         x="-328.04"
-	 y="-469" 
-	 z="404.8018"/>
+         x="-327.04"
+	 y="-471" 
+	 z="400.852475"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-2"/>
        <position name="posOpArapucaDouble2-Frame-0-2" unit="cm" 
-         x="-327.3"
-	 y="-469" 
-	 z="404.8018"/>
+         x="-326.3"
+	 y="-471" 
+	 z="400.852475"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-2-3"/>
        <position name="posArapucaDouble3-Frame-0-2" unit="cm" 
-         x="-328.04"
-	 y="-378.3" 
-	 z="258.8018"/>
+         x="-327.04"
+	 y="-380.45" 
+	 z="263.201575"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-3"/>
        <position name="posOpArapucaDouble3-Frame-0-2" unit="cm" 
-         x="-327.3"
-	 y="-378.3" 
-	 z="258.8018"/>
+         x="-326.3"
+	 y="-380.45" 
+	 z="263.201575"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-0-0"/>
        <position name="posArapucaDouble0-Frame-1-0" unit="cm" 
-         x="-328.04"
-	 y="-297.7" 
-	 z="-261.8018"/>
+         x="-327.04"
+	 y="-291.55" 
+	 z="-263.201575"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-0"/>
        <position name="posOpArapucaDouble0-Frame-1-0" unit="cm" 
-         x="-327.3"
-	 y="-297.7" 
-	 z="-261.8018"/>
+         x="-326.3"
+	 y="-291.55" 
+	 z="-263.201575"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-0-1"/>
        <position name="posArapucaDouble1-Frame-1-0" unit="cm" 
-         x="-328.04"
-	 y="-207" 
-	 z="-407.8018"/>
+         x="-327.04"
+	 y="-201" 
+	 z="-400.852475"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-1"/>
        <position name="posOpArapucaDouble1-Frame-1-0" unit="cm" 
-         x="-327.3"
-	 y="-207" 
-	 z="-407.8018"/>
+         x="-326.3"
+	 y="-201" 
+	 z="-400.852475"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-0-2"/>
        <position name="posArapucaDouble2-Frame-1-0" unit="cm" 
-         x="-328.04"
-	 y="-133" 
-	 z="-190.8018"/>
+         x="-327.04"
+	 y="-135" 
+	 z="-194.751125"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-2"/>
        <position name="posOpArapucaDouble2-Frame-1-0" unit="cm" 
-         x="-327.3"
-	 y="-133" 
-	 z="-190.8018"/>
+         x="-326.3"
+	 y="-135" 
+	 z="-194.751125"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-0-3"/>
        <position name="posArapucaDouble3-Frame-1-0" unit="cm" 
-         x="-328.04"
-	 y="-42.3" 
-	 z="-336.8018"/>
+         x="-327.04"
+	 y="-44.45" 
+	 z="-332.402025"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-3"/>
        <position name="posOpArapucaDouble3-Frame-1-0" unit="cm" 
-         x="-327.3"
-	 y="-42.3" 
-	 z="-336.8018"/>
+         x="-326.3"
+	 y="-44.45" 
+	 z="-332.402025"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-1-0"/>
        <position name="posArapucaDouble0-Frame-1-1" unit="cm" 
-         x="-328.04"
-	 y="-297.7" 
-	 z="35.9999999999999"/>
+         x="-327.04"
+	 y="-291.55" 
+	 z="34.6002250000003"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-0"/>
        <position name="posOpArapucaDouble0-Frame-1-1" unit="cm" 
-         x="-327.3"
-	 y="-297.7" 
-	 z="35.9999999999999"/>
+         x="-326.3"
+	 y="-291.55" 
+	 z="34.6002250000003"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-1-1"/>
        <position name="posArapucaDouble1-Frame-1-1" unit="cm" 
-         x="-328.04"
-	 y="-207" 
-	 z="-110"/>
+         x="-327.04"
+	 y="-201" 
+	 z="-103.050675"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-1"/>
        <position name="posOpArapucaDouble1-Frame-1-1" unit="cm" 
-         x="-327.3"
-	 y="-207" 
-	 z="-110"/>
+         x="-326.3"
+	 y="-201" 
+	 z="-103.050675"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-1-2"/>
        <position name="posArapucaDouble2-Frame-1-1" unit="cm" 
-         x="-328.04"
-	 y="-133" 
-	 z="107"/>
+         x="-327.04"
+	 y="-135" 
+	 z="103.050675"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-2"/>
        <position name="posOpArapucaDouble2-Frame-1-1" unit="cm" 
-         x="-327.3"
-	 y="-133" 
-	 z="107"/>
+         x="-326.3"
+	 y="-135" 
+	 z="103.050675"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-1-3"/>
        <position name="posArapucaDouble3-Frame-1-1" unit="cm" 
-         x="-328.04"
-	 y="-42.3" 
-	 z="-39.0000000000001"/>
+         x="-327.04"
+	 y="-44.45" 
+	 z="-34.6002249999997"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-3"/>
        <position name="posOpArapucaDouble3-Frame-1-1" unit="cm" 
-         x="-327.3"
-	 y="-42.3" 
-	 z="-39.0000000000001"/>
+         x="-326.3"
+	 y="-44.45" 
+	 z="-34.6002249999997"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-2-0"/>
        <position name="posArapucaDouble0-Frame-1-2" unit="cm" 
-         x="-328.04"
-	 y="-297.7" 
-	 z="333.8018"/>
+         x="-327.04"
+	 y="-291.55" 
+	 z="332.402025"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-0"/>
        <position name="posOpArapucaDouble0-Frame-1-2" unit="cm" 
-         x="-327.3"
-	 y="-297.7" 
-	 z="333.8018"/>
+         x="-326.3"
+	 y="-291.55" 
+	 z="332.402025"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-2-1"/>
        <position name="posArapucaDouble1-Frame-1-2" unit="cm" 
-         x="-328.04"
-	 y="-207" 
-	 z="187.8018"/>
+         x="-327.04"
+	 y="-201" 
+	 z="194.751125"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-1"/>
        <position name="posOpArapucaDouble1-Frame-1-2" unit="cm" 
-         x="-327.3"
-	 y="-207" 
-	 z="187.8018"/>
+         x="-326.3"
+	 y="-201" 
+	 z="194.751125"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-2-2"/>
        <position name="posArapucaDouble2-Frame-1-2" unit="cm" 
-         x="-328.04"
-	 y="-133" 
-	 z="404.8018"/>
+         x="-327.04"
+	 y="-135" 
+	 z="400.852475"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-2"/>
        <position name="posOpArapucaDouble2-Frame-1-2" unit="cm" 
-         x="-327.3"
-	 y="-133" 
-	 z="404.8018"/>
+         x="-326.3"
+	 y="-135" 
+	 z="400.852475"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-2-3"/>
        <position name="posArapucaDouble3-Frame-1-2" unit="cm" 
-         x="-328.04"
-	 y="-42.3" 
-	 z="258.8018"/>
+         x="-327.04"
+	 y="-44.45" 
+	 z="263.201575"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-3"/>
        <position name="posOpArapucaDouble3-Frame-1-2" unit="cm" 
-         x="-327.3"
-	 y="-42.3" 
-	 z="258.8018"/>
+         x="-326.3"
+	 y="-44.45" 
+	 z="263.201575"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-0-0"/>
        <position name="posArapucaDouble0-Frame-2-0" unit="cm" 
-         x="-328.04"
-	 y="38.3" 
-	 z="-261.8018"/>
+         x="-327.04"
+	 y="44.45" 
+	 z="-263.201575"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-0"/>
        <position name="posOpArapucaDouble0-Frame-2-0" unit="cm" 
-         x="-327.3"
-	 y="38.3" 
-	 z="-261.8018"/>
+         x="-326.3"
+	 y="44.45" 
+	 z="-263.201575"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-0-1"/>
        <position name="posArapucaDouble1-Frame-2-0" unit="cm" 
-         x="-328.04"
-	 y="129" 
-	 z="-407.8018"/>
+         x="-327.04"
+	 y="135" 
+	 z="-400.852475"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-1"/>
        <position name="posOpArapucaDouble1-Frame-2-0" unit="cm" 
-         x="-327.3"
-	 y="129" 
-	 z="-407.8018"/>
+         x="-326.3"
+	 y="135" 
+	 z="-400.852475"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-0-2"/>
        <position name="posArapucaDouble2-Frame-2-0" unit="cm" 
-         x="-328.04"
-	 y="203" 
-	 z="-190.8018"/>
+         x="-327.04"
+	 y="201" 
+	 z="-194.751125"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-2"/>
        <position name="posOpArapucaDouble2-Frame-2-0" unit="cm" 
-         x="-327.3"
-	 y="203" 
-	 z="-190.8018"/>
+         x="-326.3"
+	 y="201" 
+	 z="-194.751125"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-0-3"/>
        <position name="posArapucaDouble3-Frame-2-0" unit="cm" 
-         x="-328.04"
-	 y="293.7" 
-	 z="-336.8018"/>
+         x="-327.04"
+	 y="291.55" 
+	 z="-332.402025"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-3"/>
        <position name="posOpArapucaDouble3-Frame-2-0" unit="cm" 
-         x="-327.3"
-	 y="293.7" 
-	 z="-336.8018"/>
+         x="-326.3"
+	 y="291.55" 
+	 z="-332.402025"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-1-0"/>
        <position name="posArapucaDouble0-Frame-2-1" unit="cm" 
-         x="-328.04"
-	 y="38.3" 
-	 z="35.9999999999999"/>
+         x="-327.04"
+	 y="44.45" 
+	 z="34.6002250000003"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-0"/>
        <position name="posOpArapucaDouble0-Frame-2-1" unit="cm" 
-         x="-327.3"
-	 y="38.3" 
-	 z="35.9999999999999"/>
+         x="-326.3"
+	 y="44.45" 
+	 z="34.6002250000003"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-1-1"/>
        <position name="posArapucaDouble1-Frame-2-1" unit="cm" 
-         x="-328.04"
-	 y="129" 
-	 z="-110"/>
+         x="-327.04"
+	 y="135" 
+	 z="-103.050675"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-1"/>
        <position name="posOpArapucaDouble1-Frame-2-1" unit="cm" 
-         x="-327.3"
-	 y="129" 
-	 z="-110"/>
+         x="-326.3"
+	 y="135" 
+	 z="-103.050675"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-1-2"/>
        <position name="posArapucaDouble2-Frame-2-1" unit="cm" 
-         x="-328.04"
-	 y="203" 
-	 z="107"/>
+         x="-327.04"
+	 y="201" 
+	 z="103.050675"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-2"/>
        <position name="posOpArapucaDouble2-Frame-2-1" unit="cm" 
-         x="-327.3"
-	 y="203" 
-	 z="107"/>
+         x="-326.3"
+	 y="201" 
+	 z="103.050675"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-1-3"/>
        <position name="posArapucaDouble3-Frame-2-1" unit="cm" 
-         x="-328.04"
-	 y="293.7" 
-	 z="-39.0000000000001"/>
+         x="-327.04"
+	 y="291.55" 
+	 z="-34.6002249999997"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-3"/>
        <position name="posOpArapucaDouble3-Frame-2-1" unit="cm" 
-         x="-327.3"
-	 y="293.7" 
-	 z="-39.0000000000001"/>
+         x="-326.3"
+	 y="291.55" 
+	 z="-34.6002249999997"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-2-0"/>
        <position name="posArapucaDouble0-Frame-2-2" unit="cm" 
-         x="-328.04"
-	 y="38.3" 
-	 z="333.8018"/>
+         x="-327.04"
+	 y="44.45" 
+	 z="332.402025"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-0"/>
        <position name="posOpArapucaDouble0-Frame-2-2" unit="cm" 
-         x="-327.3"
-	 y="38.3" 
-	 z="333.8018"/>
+         x="-326.3"
+	 y="44.45" 
+	 z="332.402025"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-2-1"/>
        <position name="posArapucaDouble1-Frame-2-2" unit="cm" 
-         x="-328.04"
-	 y="129" 
-	 z="187.8018"/>
+         x="-327.04"
+	 y="135" 
+	 z="194.751125"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-1"/>
        <position name="posOpArapucaDouble1-Frame-2-2" unit="cm" 
-         x="-327.3"
-	 y="129" 
-	 z="187.8018"/>
+         x="-326.3"
+	 y="135" 
+	 z="194.751125"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-2-2"/>
        <position name="posArapucaDouble2-Frame-2-2" unit="cm" 
-         x="-328.04"
-	 y="203" 
-	 z="404.8018"/>
+         x="-327.04"
+	 y="201" 
+	 z="400.852475"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-2"/>
        <position name="posOpArapucaDouble2-Frame-2-2" unit="cm" 
-         x="-327.3"
-	 y="203" 
-	 z="404.8018"/>
+         x="-326.3"
+	 y="201" 
+	 z="400.852475"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-2-3"/>
        <position name="posArapucaDouble3-Frame-2-2" unit="cm" 
-         x="-328.04"
-	 y="293.7" 
-	 z="258.8018"/>
+         x="-327.04"
+	 y="291.55" 
+	 z="263.201575"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-3"/>
        <position name="posOpArapucaDouble3-Frame-2-2" unit="cm" 
-         x="-327.3"
-	 y="293.7" 
-	 z="258.8018"/>
+         x="-326.3"
+	 y="291.55" 
+	 z="263.201575"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-0-0"/>
        <position name="posArapucaDouble0-Frame-3-0" unit="cm" 
-         x="-328.04"
-	 y="374.3" 
-	 z="-261.8018"/>
+         x="-327.04"
+	 y="380.45" 
+	 z="-263.201575"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-0"/>
        <position name="posOpArapucaDouble0-Frame-3-0" unit="cm" 
-         x="-327.3"
-	 y="374.3" 
-	 z="-261.8018"/>
+         x="-326.3"
+	 y="380.45" 
+	 z="-263.201575"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-0-1"/>
        <position name="posArapucaDouble1-Frame-3-0" unit="cm" 
-         x="-328.04"
-	 y="465" 
-	 z="-407.8018"/>
+         x="-327.04"
+	 y="471" 
+	 z="-400.852475"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-1"/>
        <position name="posOpArapucaDouble1-Frame-3-0" unit="cm" 
-         x="-327.3"
-	 y="465" 
-	 z="-407.8018"/>
+         x="-326.3"
+	 y="471" 
+	 z="-400.852475"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-0-2"/>
        <position name="posArapucaDouble2-Frame-3-0" unit="cm" 
-         x="-328.04"
-	 y="539" 
-	 z="-190.8018"/>
+         x="-327.04"
+	 y="537" 
+	 z="-194.751125"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-2"/>
        <position name="posOpArapucaDouble2-Frame-3-0" unit="cm" 
-         x="-327.3"
-	 y="539" 
-	 z="-190.8018"/>
+         x="-326.3"
+	 y="537" 
+	 z="-194.751125"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-0-3"/>
        <position name="posArapucaDouble3-Frame-3-0" unit="cm" 
-         x="-328.04"
-	 y="629.7" 
-	 z="-336.8018"/>
+         x="-327.04"
+	 y="627.55" 
+	 z="-332.402025"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-3"/>
        <position name="posOpArapucaDouble3-Frame-3-0" unit="cm" 
-         x="-327.3"
-	 y="629.7" 
-	 z="-336.8018"/>
+         x="-326.3"
+	 y="627.55" 
+	 z="-332.402025"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-1-0"/>
        <position name="posArapucaDouble0-Frame-3-1" unit="cm" 
-         x="-328.04"
-	 y="374.3" 
-	 z="35.9999999999999"/>
+         x="-327.04"
+	 y="380.45" 
+	 z="34.6002250000003"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-0"/>
        <position name="posOpArapucaDouble0-Frame-3-1" unit="cm" 
-         x="-327.3"
-	 y="374.3" 
-	 z="35.9999999999999"/>
+         x="-326.3"
+	 y="380.45" 
+	 z="34.6002250000003"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-1-1"/>
        <position name="posArapucaDouble1-Frame-3-1" unit="cm" 
-         x="-328.04"
-	 y="465" 
-	 z="-110"/>
+         x="-327.04"
+	 y="471" 
+	 z="-103.050675"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-1"/>
        <position name="posOpArapucaDouble1-Frame-3-1" unit="cm" 
-         x="-327.3"
-	 y="465" 
-	 z="-110"/>
+         x="-326.3"
+	 y="471" 
+	 z="-103.050675"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-1-2"/>
        <position name="posArapucaDouble2-Frame-3-1" unit="cm" 
-         x="-328.04"
-	 y="539" 
-	 z="107"/>
+         x="-327.04"
+	 y="537" 
+	 z="103.050675"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-2"/>
        <position name="posOpArapucaDouble2-Frame-3-1" unit="cm" 
-         x="-327.3"
-	 y="539" 
-	 z="107"/>
+         x="-326.3"
+	 y="537" 
+	 z="103.050675"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-1-3"/>
        <position name="posArapucaDouble3-Frame-3-1" unit="cm" 
-         x="-328.04"
-	 y="629.7" 
-	 z="-39.0000000000001"/>
+         x="-327.04"
+	 y="627.55" 
+	 z="-34.6002249999997"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-3"/>
        <position name="posOpArapucaDouble3-Frame-3-1" unit="cm" 
-         x="-327.3"
-	 y="629.7" 
-	 z="-39.0000000000001"/>
+         x="-326.3"
+	 y="627.55" 
+	 z="-34.6002249999997"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-2-0"/>
        <position name="posArapucaDouble0-Frame-3-2" unit="cm" 
-         x="-328.04"
-	 y="374.3" 
-	 z="333.8018"/>
+         x="-327.04"
+	 y="380.45" 
+	 z="332.402025"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-0"/>
        <position name="posOpArapucaDouble0-Frame-3-2" unit="cm" 
-         x="-327.3"
-	 y="374.3" 
-	 z="333.8018"/>
+         x="-326.3"
+	 y="380.45" 
+	 z="332.402025"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-2-1"/>
        <position name="posArapucaDouble1-Frame-3-2" unit="cm" 
-         x="-328.04"
-	 y="465" 
-	 z="187.8018"/>
+         x="-327.04"
+	 y="471" 
+	 z="194.751125"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-1"/>
        <position name="posOpArapucaDouble1-Frame-3-2" unit="cm" 
-         x="-327.3"
-	 y="465" 
-	 z="187.8018"/>
+         x="-326.3"
+	 y="471" 
+	 z="194.751125"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-2-2"/>
        <position name="posArapucaDouble2-Frame-3-2" unit="cm" 
-         x="-328.04"
-	 y="539" 
-	 z="404.8018"/>
+         x="-327.04"
+	 y="537" 
+	 z="400.852475"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-2"/>
        <position name="posOpArapucaDouble2-Frame-3-2" unit="cm" 
-         x="-327.3"
-	 y="539" 
-	 z="404.8018"/>
+         x="-326.3"
+	 y="537" 
+	 z="400.852475"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-2-3"/>
        <position name="posArapucaDouble3-Frame-3-2" unit="cm" 
-         x="-328.04"
-	 y="629.7" 
-	 z="258.8018"/>
+         x="-327.04"
+	 y="627.55" 
+	 z="263.201575"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-3"/>
        <position name="posOpArapucaDouble3-Frame-3-2" unit="cm" 
-         x="-327.3"
-	 y="629.7" 
-	 z="258.8018"/>
+         x="-326.3"
+	 y="627.55" 
+	 z="263.201575"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-0"/>
@@ -9976,7 +9833,7 @@
 
       <physvol>
         <volumeref ref="volDetEnclosure"/>
-	<position name="posDetEnclosure" unit="cm" x="50.04" y="-1.13686837721616e-13" z="448.2027"/>
+	<position name="posDetEnclosure" unit="cm" x="50.04" y="0" z="448.2027"/>
       </physvol>
 
     </volume>

--- a/dunecore/Geometry/gdml/dunevd10kt_3view_v2_refactored_1x8x6ref_nowires.gdml
+++ b/dunecore/Geometry/gdml/dunevd10kt_3view_v2_refactored_1x8x6ref_nowires.gdml
@@ -594,97 +594,6 @@
 
 
 
-    <box name="CathodeBlock" lunit="cm"
-      x="4"
-      y="336"
-      z="297.8018" />
-
-    <box name="CathodeVoid" lunit="cm"
-      x="5"
-      y="76.35"
-      z="67" />
-
-    <subtraction name="Cathode1">
-      <first ref="CathodeBlock"/>
-      <second ref="CathodeVoid"/>
-      <position name="posCathodeSub1" x="0" y="-122.525" z="-108.5" unit="cm"/>
-    </subtraction>
-    <subtraction name="Cathode2">
-      <first ref="Cathode1"/>
-      <second ref="CathodeVoid"/>
-      <position name="posCathodeSub2" x="0" y="-122.525" z="-37.5" unit="cm"/>
-    </subtraction>
-    <subtraction name="Cathode3">
-      <first ref="Cathode2"/>
-      <second ref="CathodeVoid"/>
-      <position name="posCathodeSub3" x="0" y="-122.525" z="37.5" unit="cm"/>
-    </subtraction>
-    <subtraction name="Cathode4">
-      <first ref="Cathode3"/>
-      <second ref="CathodeVoid"/>
-      <position name="posCathodeSub4" x="0" y="-122.525" z="108.5" unit="cm"/>
-    </subtraction>
-    <subtraction name="Cathode5">
-      <first ref="Cathode4"/>
-      <second ref="CathodeVoid"/>
-      <position name="posCathodeSub5" x="0" y="-42.175" z="-108.5" unit="cm"/>
-    </subtraction>
-    <subtraction name="Cathode6">
-      <first ref="Cathode5"/>
-      <second ref="CathodeVoid"/>
-      <position name="posCathodeSub6" x="0" y="-42.175" z="-37.5" unit="cm"/>
-    </subtraction>
-    <subtraction name="Cathode7">
-      <first ref="Cathode6"/>
-      <second ref="CathodeVoid"/>
-      <position name="posCathodeSub7" x="0" y="-42.175" z="37.5" unit="cm"/>
-    </subtraction>
-    <subtraction name="Cathode8">
-      <first ref="Cathode7"/>
-      <second ref="CathodeVoid"/>
-      <position name="posCathodeSub8" x="0" y="-42.175" z="108.5" unit="cm"/>
-    </subtraction>
-    <subtraction name="Cathode9">
-      <first ref="Cathode8"/>
-      <second ref="CathodeVoid"/>
-      <position name="posCathodeSub9" x="0" y="42.175" z="-108.5" unit="cm"/>
-    </subtraction>
-    <subtraction name="Cathode10">
-      <first ref="Cathode9"/>
-      <second ref="CathodeVoid"/>
-      <position name="posCathodeSub10" x="0" y="42.175" z="-37.5" unit="cm"/>
-    </subtraction>
-    <subtraction name="Cathode11">
-      <first ref="Cathode10"/>
-      <second ref="CathodeVoid"/>
-      <position name="posCathodeSub11" x="0" y="42.175" z="37.5" unit="cm"/>
-    </subtraction>
-    <subtraction name="Cathode12">
-      <first ref="Cathode11"/>
-      <second ref="CathodeVoid"/>
-      <position name="posCathodeSub12" x="0" y="42.175" z="108.5" unit="cm"/>
-    </subtraction>
-    <subtraction name="Cathode13">
-      <first ref="Cathode12"/>
-      <second ref="CathodeVoid"/>
-      <position name="posCathodeSub13" x="0" y="122.525" z="-108.5" unit="cm"/>
-    </subtraction>
-    <subtraction name="Cathode14">
-      <first ref="Cathode13"/>
-      <second ref="CathodeVoid"/>
-      <position name="posCathodeSub14" x="0" y="122.525" z="-37.5" unit="cm"/>
-    </subtraction>
-    <subtraction name="Cathode15">
-      <first ref="Cathode14"/>
-      <second ref="CathodeVoid"/>
-      <position name="posCathodeSub15" x="0" y="122.525" z="37.5" unit="cm"/>
-    </subtraction>
-    <subtraction name="CathodeGrid">
-      <first ref="Cathode15"/>
-      <second ref="CathodeVoid"/>
-      <position name="posCathodeSub16" x="0" y="122.525" z="108.5" unit="cm"/>
-    </subtraction>
-
     <box name="FoamPadBlock" lunit="cm"
       x="1010.32"
       y="1708.24"
@@ -782,10 +691,6 @@
       <materialref ref="STEEL_STAINLESS_Fe7Cr2Ni" />
       <solidref ref="SteelShell" />
     </volume>
-    <volume name="volGroundGrid">
-      <materialref ref="STEEL_STAINLESS_Fe7Cr2Ni" />
-      <solidref ref="CathodeGrid" />
-    </volume>    
     <volume name="volGaseousArgon">
       <materialref ref="ArGas"/>
       <solidref ref="GaseousArgon"/>
@@ -2170,773 +2075,725 @@
      <position name="posFieldShaper107" unit="cm"  x="319.96" y="-676.3" z="0" />
      <rotation name="rotFS107" unit="deg" x="0" y="0" z="90" />
   </physvol>
-      <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-0" unit="cm" x="-328.04" y="-506" z="-299.3018"/>
-      </physvol>
-      <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-1" unit="cm" x="-328.04" y="-170" z="-299.3018"/>
-      </physvol>
-      <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-2" unit="cm" x="-328.04" y="166" z="-299.3018"/>
-      </physvol>
-      <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-3" unit="cm" x="-328.04" y="502" z="-299.3018"/>
-      </physvol>
-      <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-4" unit="cm" x="-328.04" y="-506" z="-1.50000000000006"/>
-      </physvol>
-      <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-5" unit="cm" x="-328.04" y="-170" z="-1.50000000000006"/>
-      </physvol>
-      <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-6" unit="cm" x="-328.04" y="166" z="-1.50000000000006"/>
-      </physvol>
-      <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-7" unit="cm" x="-328.04" y="502" z="-1.50000000000006"/>
-      </physvol>
-      <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-8" unit="cm" x="-328.04" y="-506" z="296.3018"/>
-      </physvol>
-      <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-9" unit="cm" x="-328.04" y="-170" z="296.3018"/>
-      </physvol>
-      <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-10" unit="cm" x="-328.04" y="166" z="296.3018"/>
-      </physvol>
-      <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-11" unit="cm" x="-328.04" y="502" z="296.3018"/>
-      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-0-0"/>
        <position name="posArapucaDouble0-Frame-0-0" unit="cm" 
-         x="-328.04"
-	 y="-633.7" 
-	 z="-261.8018"/>
+         x="-327.04"
+	 y="-627.55" 
+	 z="-263.201575"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-0"/>
        <position name="posOpArapucaDouble0-Frame-0-0" unit="cm" 
-         x="-327.3"
-	 y="-633.7" 
-	 z="-261.8018"/>
+         x="-326.3"
+	 y="-627.55" 
+	 z="-263.201575"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-0-1"/>
        <position name="posArapucaDouble1-Frame-0-0" unit="cm" 
-         x="-328.04"
-	 y="-543" 
-	 z="-407.8018"/>
+         x="-327.04"
+	 y="-537" 
+	 z="-400.852475"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-1"/>
        <position name="posOpArapucaDouble1-Frame-0-0" unit="cm" 
-         x="-327.3"
-	 y="-543" 
-	 z="-407.8018"/>
+         x="-326.3"
+	 y="-537" 
+	 z="-400.852475"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-0-2"/>
        <position name="posArapucaDouble2-Frame-0-0" unit="cm" 
-         x="-328.04"
-	 y="-469" 
-	 z="-190.8018"/>
+         x="-327.04"
+	 y="-471" 
+	 z="-194.751125"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-2"/>
        <position name="posOpArapucaDouble2-Frame-0-0" unit="cm" 
-         x="-327.3"
-	 y="-469" 
-	 z="-190.8018"/>
+         x="-326.3"
+	 y="-471" 
+	 z="-194.751125"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-0-3"/>
        <position name="posArapucaDouble3-Frame-0-0" unit="cm" 
-         x="-328.04"
-	 y="-378.3" 
-	 z="-336.8018"/>
+         x="-327.04"
+	 y="-380.45" 
+	 z="-332.402025"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-3"/>
        <position name="posOpArapucaDouble3-Frame-0-0" unit="cm" 
-         x="-327.3"
-	 y="-378.3" 
-	 z="-336.8018"/>
+         x="-326.3"
+	 y="-380.45" 
+	 z="-332.402025"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-1-0"/>
        <position name="posArapucaDouble0-Frame-0-1" unit="cm" 
-         x="-328.04"
-	 y="-633.7" 
-	 z="35.9999999999999"/>
+         x="-327.04"
+	 y="-627.55" 
+	 z="34.6002250000003"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-0"/>
        <position name="posOpArapucaDouble0-Frame-0-1" unit="cm" 
-         x="-327.3"
-	 y="-633.7" 
-	 z="35.9999999999999"/>
+         x="-326.3"
+	 y="-627.55" 
+	 z="34.6002250000003"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-1-1"/>
        <position name="posArapucaDouble1-Frame-0-1" unit="cm" 
-         x="-328.04"
-	 y="-543" 
-	 z="-110"/>
+         x="-327.04"
+	 y="-537" 
+	 z="-103.050675"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-1"/>
        <position name="posOpArapucaDouble1-Frame-0-1" unit="cm" 
-         x="-327.3"
-	 y="-543" 
-	 z="-110"/>
+         x="-326.3"
+	 y="-537" 
+	 z="-103.050675"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-1-2"/>
        <position name="posArapucaDouble2-Frame-0-1" unit="cm" 
-         x="-328.04"
-	 y="-469" 
-	 z="107"/>
+         x="-327.04"
+	 y="-471" 
+	 z="103.050675"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-2"/>
        <position name="posOpArapucaDouble2-Frame-0-1" unit="cm" 
-         x="-327.3"
-	 y="-469" 
-	 z="107"/>
+         x="-326.3"
+	 y="-471" 
+	 z="103.050675"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-1-3"/>
        <position name="posArapucaDouble3-Frame-0-1" unit="cm" 
-         x="-328.04"
-	 y="-378.3" 
-	 z="-39.0000000000001"/>
+         x="-327.04"
+	 y="-380.45" 
+	 z="-34.6002249999997"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-3"/>
        <position name="posOpArapucaDouble3-Frame-0-1" unit="cm" 
-         x="-327.3"
-	 y="-378.3" 
-	 z="-39.0000000000001"/>
+         x="-326.3"
+	 y="-380.45" 
+	 z="-34.6002249999997"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-2-0"/>
        <position name="posArapucaDouble0-Frame-0-2" unit="cm" 
-         x="-328.04"
-	 y="-633.7" 
-	 z="333.8018"/>
+         x="-327.04"
+	 y="-627.55" 
+	 z="332.402025"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-0"/>
        <position name="posOpArapucaDouble0-Frame-0-2" unit="cm" 
-         x="-327.3"
-	 y="-633.7" 
-	 z="333.8018"/>
+         x="-326.3"
+	 y="-627.55" 
+	 z="332.402025"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-2-1"/>
        <position name="posArapucaDouble1-Frame-0-2" unit="cm" 
-         x="-328.04"
-	 y="-543" 
-	 z="187.8018"/>
+         x="-327.04"
+	 y="-537" 
+	 z="194.751125"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-1"/>
        <position name="posOpArapucaDouble1-Frame-0-2" unit="cm" 
-         x="-327.3"
-	 y="-543" 
-	 z="187.8018"/>
+         x="-326.3"
+	 y="-537" 
+	 z="194.751125"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-2-2"/>
        <position name="posArapucaDouble2-Frame-0-2" unit="cm" 
-         x="-328.04"
-	 y="-469" 
-	 z="404.8018"/>
+         x="-327.04"
+	 y="-471" 
+	 z="400.852475"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-2"/>
        <position name="posOpArapucaDouble2-Frame-0-2" unit="cm" 
-         x="-327.3"
-	 y="-469" 
-	 z="404.8018"/>
+         x="-326.3"
+	 y="-471" 
+	 z="400.852475"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-2-3"/>
        <position name="posArapucaDouble3-Frame-0-2" unit="cm" 
-         x="-328.04"
-	 y="-378.3" 
-	 z="258.8018"/>
+         x="-327.04"
+	 y="-380.45" 
+	 z="263.201575"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-3"/>
        <position name="posOpArapucaDouble3-Frame-0-2" unit="cm" 
-         x="-327.3"
-	 y="-378.3" 
-	 z="258.8018"/>
+         x="-326.3"
+	 y="-380.45" 
+	 z="263.201575"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-0-0"/>
        <position name="posArapucaDouble0-Frame-1-0" unit="cm" 
-         x="-328.04"
-	 y="-297.7" 
-	 z="-261.8018"/>
+         x="-327.04"
+	 y="-291.55" 
+	 z="-263.201575"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-0"/>
        <position name="posOpArapucaDouble0-Frame-1-0" unit="cm" 
-         x="-327.3"
-	 y="-297.7" 
-	 z="-261.8018"/>
+         x="-326.3"
+	 y="-291.55" 
+	 z="-263.201575"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-0-1"/>
        <position name="posArapucaDouble1-Frame-1-0" unit="cm" 
-         x="-328.04"
-	 y="-207" 
-	 z="-407.8018"/>
+         x="-327.04"
+	 y="-201" 
+	 z="-400.852475"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-1"/>
        <position name="posOpArapucaDouble1-Frame-1-0" unit="cm" 
-         x="-327.3"
-	 y="-207" 
-	 z="-407.8018"/>
+         x="-326.3"
+	 y="-201" 
+	 z="-400.852475"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-0-2"/>
        <position name="posArapucaDouble2-Frame-1-0" unit="cm" 
-         x="-328.04"
-	 y="-133" 
-	 z="-190.8018"/>
+         x="-327.04"
+	 y="-135" 
+	 z="-194.751125"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-2"/>
        <position name="posOpArapucaDouble2-Frame-1-0" unit="cm" 
-         x="-327.3"
-	 y="-133" 
-	 z="-190.8018"/>
+         x="-326.3"
+	 y="-135" 
+	 z="-194.751125"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-0-3"/>
        <position name="posArapucaDouble3-Frame-1-0" unit="cm" 
-         x="-328.04"
-	 y="-42.3" 
-	 z="-336.8018"/>
+         x="-327.04"
+	 y="-44.45" 
+	 z="-332.402025"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-3"/>
        <position name="posOpArapucaDouble3-Frame-1-0" unit="cm" 
-         x="-327.3"
-	 y="-42.3" 
-	 z="-336.8018"/>
+         x="-326.3"
+	 y="-44.45" 
+	 z="-332.402025"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-1-0"/>
        <position name="posArapucaDouble0-Frame-1-1" unit="cm" 
-         x="-328.04"
-	 y="-297.7" 
-	 z="35.9999999999999"/>
+         x="-327.04"
+	 y="-291.55" 
+	 z="34.6002250000003"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-0"/>
        <position name="posOpArapucaDouble0-Frame-1-1" unit="cm" 
-         x="-327.3"
-	 y="-297.7" 
-	 z="35.9999999999999"/>
+         x="-326.3"
+	 y="-291.55" 
+	 z="34.6002250000003"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-1-1"/>
        <position name="posArapucaDouble1-Frame-1-1" unit="cm" 
-         x="-328.04"
-	 y="-207" 
-	 z="-110"/>
+         x="-327.04"
+	 y="-201" 
+	 z="-103.050675"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-1"/>
        <position name="posOpArapucaDouble1-Frame-1-1" unit="cm" 
-         x="-327.3"
-	 y="-207" 
-	 z="-110"/>
+         x="-326.3"
+	 y="-201" 
+	 z="-103.050675"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-1-2"/>
        <position name="posArapucaDouble2-Frame-1-1" unit="cm" 
-         x="-328.04"
-	 y="-133" 
-	 z="107"/>
+         x="-327.04"
+	 y="-135" 
+	 z="103.050675"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-2"/>
        <position name="posOpArapucaDouble2-Frame-1-1" unit="cm" 
-         x="-327.3"
-	 y="-133" 
-	 z="107"/>
+         x="-326.3"
+	 y="-135" 
+	 z="103.050675"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-1-3"/>
        <position name="posArapucaDouble3-Frame-1-1" unit="cm" 
-         x="-328.04"
-	 y="-42.3" 
-	 z="-39.0000000000001"/>
+         x="-327.04"
+	 y="-44.45" 
+	 z="-34.6002249999997"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-3"/>
        <position name="posOpArapucaDouble3-Frame-1-1" unit="cm" 
-         x="-327.3"
-	 y="-42.3" 
-	 z="-39.0000000000001"/>
+         x="-326.3"
+	 y="-44.45" 
+	 z="-34.6002249999997"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-2-0"/>
        <position name="posArapucaDouble0-Frame-1-2" unit="cm" 
-         x="-328.04"
-	 y="-297.7" 
-	 z="333.8018"/>
+         x="-327.04"
+	 y="-291.55" 
+	 z="332.402025"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-0"/>
        <position name="posOpArapucaDouble0-Frame-1-2" unit="cm" 
-         x="-327.3"
-	 y="-297.7" 
-	 z="333.8018"/>
+         x="-326.3"
+	 y="-291.55" 
+	 z="332.402025"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-2-1"/>
        <position name="posArapucaDouble1-Frame-1-2" unit="cm" 
-         x="-328.04"
-	 y="-207" 
-	 z="187.8018"/>
+         x="-327.04"
+	 y="-201" 
+	 z="194.751125"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-1"/>
        <position name="posOpArapucaDouble1-Frame-1-2" unit="cm" 
-         x="-327.3"
-	 y="-207" 
-	 z="187.8018"/>
+         x="-326.3"
+	 y="-201" 
+	 z="194.751125"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-2-2"/>
        <position name="posArapucaDouble2-Frame-1-2" unit="cm" 
-         x="-328.04"
-	 y="-133" 
-	 z="404.8018"/>
+         x="-327.04"
+	 y="-135" 
+	 z="400.852475"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-2"/>
        <position name="posOpArapucaDouble2-Frame-1-2" unit="cm" 
-         x="-327.3"
-	 y="-133" 
-	 z="404.8018"/>
+         x="-326.3"
+	 y="-135" 
+	 z="400.852475"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-2-3"/>
        <position name="posArapucaDouble3-Frame-1-2" unit="cm" 
-         x="-328.04"
-	 y="-42.3" 
-	 z="258.8018"/>
+         x="-327.04"
+	 y="-44.45" 
+	 z="263.201575"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-3"/>
        <position name="posOpArapucaDouble3-Frame-1-2" unit="cm" 
-         x="-327.3"
-	 y="-42.3" 
-	 z="258.8018"/>
+         x="-326.3"
+	 y="-44.45" 
+	 z="263.201575"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-0-0"/>
        <position name="posArapucaDouble0-Frame-2-0" unit="cm" 
-         x="-328.04"
-	 y="38.3" 
-	 z="-261.8018"/>
+         x="-327.04"
+	 y="44.45" 
+	 z="-263.201575"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-0"/>
        <position name="posOpArapucaDouble0-Frame-2-0" unit="cm" 
-         x="-327.3"
-	 y="38.3" 
-	 z="-261.8018"/>
+         x="-326.3"
+	 y="44.45" 
+	 z="-263.201575"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-0-1"/>
        <position name="posArapucaDouble1-Frame-2-0" unit="cm" 
-         x="-328.04"
-	 y="129" 
-	 z="-407.8018"/>
+         x="-327.04"
+	 y="135" 
+	 z="-400.852475"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-1"/>
        <position name="posOpArapucaDouble1-Frame-2-0" unit="cm" 
-         x="-327.3"
-	 y="129" 
-	 z="-407.8018"/>
+         x="-326.3"
+	 y="135" 
+	 z="-400.852475"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-0-2"/>
        <position name="posArapucaDouble2-Frame-2-0" unit="cm" 
-         x="-328.04"
-	 y="203" 
-	 z="-190.8018"/>
+         x="-327.04"
+	 y="201" 
+	 z="-194.751125"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-2"/>
        <position name="posOpArapucaDouble2-Frame-2-0" unit="cm" 
-         x="-327.3"
-	 y="203" 
-	 z="-190.8018"/>
+         x="-326.3"
+	 y="201" 
+	 z="-194.751125"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-0-3"/>
        <position name="posArapucaDouble3-Frame-2-0" unit="cm" 
-         x="-328.04"
-	 y="293.7" 
-	 z="-336.8018"/>
+         x="-327.04"
+	 y="291.55" 
+	 z="-332.402025"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-3"/>
        <position name="posOpArapucaDouble3-Frame-2-0" unit="cm" 
-         x="-327.3"
-	 y="293.7" 
-	 z="-336.8018"/>
+         x="-326.3"
+	 y="291.55" 
+	 z="-332.402025"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-1-0"/>
        <position name="posArapucaDouble0-Frame-2-1" unit="cm" 
-         x="-328.04"
-	 y="38.3" 
-	 z="35.9999999999999"/>
+         x="-327.04"
+	 y="44.45" 
+	 z="34.6002250000003"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-0"/>
        <position name="posOpArapucaDouble0-Frame-2-1" unit="cm" 
-         x="-327.3"
-	 y="38.3" 
-	 z="35.9999999999999"/>
+         x="-326.3"
+	 y="44.45" 
+	 z="34.6002250000003"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-1-1"/>
        <position name="posArapucaDouble1-Frame-2-1" unit="cm" 
-         x="-328.04"
-	 y="129" 
-	 z="-110"/>
+         x="-327.04"
+	 y="135" 
+	 z="-103.050675"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-1"/>
        <position name="posOpArapucaDouble1-Frame-2-1" unit="cm" 
-         x="-327.3"
-	 y="129" 
-	 z="-110"/>
+         x="-326.3"
+	 y="135" 
+	 z="-103.050675"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-1-2"/>
        <position name="posArapucaDouble2-Frame-2-1" unit="cm" 
-         x="-328.04"
-	 y="203" 
-	 z="107"/>
+         x="-327.04"
+	 y="201" 
+	 z="103.050675"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-2"/>
        <position name="posOpArapucaDouble2-Frame-2-1" unit="cm" 
-         x="-327.3"
-	 y="203" 
-	 z="107"/>
+         x="-326.3"
+	 y="201" 
+	 z="103.050675"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-1-3"/>
        <position name="posArapucaDouble3-Frame-2-1" unit="cm" 
-         x="-328.04"
-	 y="293.7" 
-	 z="-39.0000000000001"/>
+         x="-327.04"
+	 y="291.55" 
+	 z="-34.6002249999997"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-3"/>
        <position name="posOpArapucaDouble3-Frame-2-1" unit="cm" 
-         x="-327.3"
-	 y="293.7" 
-	 z="-39.0000000000001"/>
+         x="-326.3"
+	 y="291.55" 
+	 z="-34.6002249999997"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-2-0"/>
        <position name="posArapucaDouble0-Frame-2-2" unit="cm" 
-         x="-328.04"
-	 y="38.3" 
-	 z="333.8018"/>
+         x="-327.04"
+	 y="44.45" 
+	 z="332.402025"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-0"/>
        <position name="posOpArapucaDouble0-Frame-2-2" unit="cm" 
-         x="-327.3"
-	 y="38.3" 
-	 z="333.8018"/>
+         x="-326.3"
+	 y="44.45" 
+	 z="332.402025"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-2-1"/>
        <position name="posArapucaDouble1-Frame-2-2" unit="cm" 
-         x="-328.04"
-	 y="129" 
-	 z="187.8018"/>
+         x="-327.04"
+	 y="135" 
+	 z="194.751125"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-1"/>
        <position name="posOpArapucaDouble1-Frame-2-2" unit="cm" 
-         x="-327.3"
-	 y="129" 
-	 z="187.8018"/>
+         x="-326.3"
+	 y="135" 
+	 z="194.751125"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-2-2"/>
        <position name="posArapucaDouble2-Frame-2-2" unit="cm" 
-         x="-328.04"
-	 y="203" 
-	 z="404.8018"/>
+         x="-327.04"
+	 y="201" 
+	 z="400.852475"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-2"/>
        <position name="posOpArapucaDouble2-Frame-2-2" unit="cm" 
-         x="-327.3"
-	 y="203" 
-	 z="404.8018"/>
+         x="-326.3"
+	 y="201" 
+	 z="400.852475"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-2-3"/>
        <position name="posArapucaDouble3-Frame-2-2" unit="cm" 
-         x="-328.04"
-	 y="293.7" 
-	 z="258.8018"/>
+         x="-327.04"
+	 y="291.55" 
+	 z="263.201575"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-3"/>
        <position name="posOpArapucaDouble3-Frame-2-2" unit="cm" 
-         x="-327.3"
-	 y="293.7" 
-	 z="258.8018"/>
+         x="-326.3"
+	 y="291.55" 
+	 z="263.201575"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-0-0"/>
        <position name="posArapucaDouble0-Frame-3-0" unit="cm" 
-         x="-328.04"
-	 y="374.3" 
-	 z="-261.8018"/>
+         x="-327.04"
+	 y="380.45" 
+	 z="-263.201575"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-0"/>
        <position name="posOpArapucaDouble0-Frame-3-0" unit="cm" 
-         x="-327.3"
-	 y="374.3" 
-	 z="-261.8018"/>
+         x="-326.3"
+	 y="380.45" 
+	 z="-263.201575"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-0-1"/>
        <position name="posArapucaDouble1-Frame-3-0" unit="cm" 
-         x="-328.04"
-	 y="465" 
-	 z="-407.8018"/>
+         x="-327.04"
+	 y="471" 
+	 z="-400.852475"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-1"/>
        <position name="posOpArapucaDouble1-Frame-3-0" unit="cm" 
-         x="-327.3"
-	 y="465" 
-	 z="-407.8018"/>
+         x="-326.3"
+	 y="471" 
+	 z="-400.852475"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-0-2"/>
        <position name="posArapucaDouble2-Frame-3-0" unit="cm" 
-         x="-328.04"
-	 y="539" 
-	 z="-190.8018"/>
+         x="-327.04"
+	 y="537" 
+	 z="-194.751125"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-2"/>
        <position name="posOpArapucaDouble2-Frame-3-0" unit="cm" 
-         x="-327.3"
-	 y="539" 
-	 z="-190.8018"/>
+         x="-326.3"
+	 y="537" 
+	 z="-194.751125"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-0-3"/>
        <position name="posArapucaDouble3-Frame-3-0" unit="cm" 
-         x="-328.04"
-	 y="629.7" 
-	 z="-336.8018"/>
+         x="-327.04"
+	 y="627.55" 
+	 z="-332.402025"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-3"/>
        <position name="posOpArapucaDouble3-Frame-3-0" unit="cm" 
-         x="-327.3"
-	 y="629.7" 
-	 z="-336.8018"/>
+         x="-326.3"
+	 y="627.55" 
+	 z="-332.402025"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-1-0"/>
        <position name="posArapucaDouble0-Frame-3-1" unit="cm" 
-         x="-328.04"
-	 y="374.3" 
-	 z="35.9999999999999"/>
+         x="-327.04"
+	 y="380.45" 
+	 z="34.6002250000003"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-0"/>
        <position name="posOpArapucaDouble0-Frame-3-1" unit="cm" 
-         x="-327.3"
-	 y="374.3" 
-	 z="35.9999999999999"/>
+         x="-326.3"
+	 y="380.45" 
+	 z="34.6002250000003"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-1-1"/>
        <position name="posArapucaDouble1-Frame-3-1" unit="cm" 
-         x="-328.04"
-	 y="465" 
-	 z="-110"/>
+         x="-327.04"
+	 y="471" 
+	 z="-103.050675"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-1"/>
        <position name="posOpArapucaDouble1-Frame-3-1" unit="cm" 
-         x="-327.3"
-	 y="465" 
-	 z="-110"/>
+         x="-326.3"
+	 y="471" 
+	 z="-103.050675"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-1-2"/>
        <position name="posArapucaDouble2-Frame-3-1" unit="cm" 
-         x="-328.04"
-	 y="539" 
-	 z="107"/>
+         x="-327.04"
+	 y="537" 
+	 z="103.050675"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-2"/>
        <position name="posOpArapucaDouble2-Frame-3-1" unit="cm" 
-         x="-327.3"
-	 y="539" 
-	 z="107"/>
+         x="-326.3"
+	 y="537" 
+	 z="103.050675"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-1-3"/>
        <position name="posArapucaDouble3-Frame-3-1" unit="cm" 
-         x="-328.04"
-	 y="629.7" 
-	 z="-39.0000000000001"/>
+         x="-327.04"
+	 y="627.55" 
+	 z="-34.6002249999997"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-3"/>
        <position name="posOpArapucaDouble3-Frame-3-1" unit="cm" 
-         x="-327.3"
-	 y="629.7" 
-	 z="-39.0000000000001"/>
+         x="-326.3"
+	 y="627.55" 
+	 z="-34.6002249999997"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-2-0"/>
        <position name="posArapucaDouble0-Frame-3-2" unit="cm" 
-         x="-328.04"
-	 y="374.3" 
-	 z="333.8018"/>
+         x="-327.04"
+	 y="380.45" 
+	 z="332.402025"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-0"/>
        <position name="posOpArapucaDouble0-Frame-3-2" unit="cm" 
-         x="-327.3"
-	 y="374.3" 
-	 z="333.8018"/>
+         x="-326.3"
+	 y="380.45" 
+	 z="332.402025"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-2-1"/>
        <position name="posArapucaDouble1-Frame-3-2" unit="cm" 
-         x="-328.04"
-	 y="465" 
-	 z="187.8018"/>
+         x="-327.04"
+	 y="471" 
+	 z="194.751125"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-1"/>
        <position name="posOpArapucaDouble1-Frame-3-2" unit="cm" 
-         x="-327.3"
-	 y="465" 
-	 z="187.8018"/>
+         x="-326.3"
+	 y="471" 
+	 z="194.751125"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-2-2"/>
        <position name="posArapucaDouble2-Frame-3-2" unit="cm" 
-         x="-328.04"
-	 y="539" 
-	 z="404.8018"/>
+         x="-327.04"
+	 y="537" 
+	 z="400.852475"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-2"/>
        <position name="posOpArapucaDouble2-Frame-3-2" unit="cm" 
-         x="-327.3"
-	 y="539" 
-	 z="404.8018"/>
+         x="-326.3"
+	 y="537" 
+	 z="400.852475"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-2-3"/>
        <position name="posArapucaDouble3-Frame-3-2" unit="cm" 
-         x="-328.04"
-	 y="629.7" 
-	 z="258.8018"/>
+         x="-327.04"
+	 y="627.55" 
+	 z="263.201575"/>
        <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-3"/>
        <position name="posOpArapucaDouble3-Frame-3-2" unit="cm" 
-         x="-327.3"
-	 y="629.7" 
-	 z="258.8018"/>
+         x="-326.3"
+	 y="627.55" 
+	 z="263.201575"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-0"/>

--- a/dunecore/Geometry/gdml/dunevd10kt_3view_v3_refactored_1x8x6ref.gdml
+++ b/dunecore/Geometry/gdml/dunevd10kt_3view_v3_refactored_1x8x6ref.gdml
@@ -1,0 +1,9987 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<gdml_simple_extension xmlns:gdml_simple_extension="http://www.example.org"
+                       xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"          
+                       xs:noNamespaceSchemaLocation="RefactoredGDMLSchema/SimpleExtension.xsd"> 
+<extension>
+   <color name="magenta"     R="0.0"  G="1.0"  B="0.0"  A="1.0" />
+   <color name="green"       R="0.0"  G="1.0"  B="0.0"  A="1.0" />
+   <color name="red"         R="1.0"  G="0.0"  B="0.0"  A="1.0" />
+   <color name="blue"        R="0.0"  G="0.0"  B="1.0"  A="1.0" />
+   <color name="yellow"      R="1.0"  G="1.0"  B="0.0"  A="1.0" />    
+</extension>
+<define>
+
+<!--
+
+
+
+-->
+
+   <position name="posCryoInDetEnc"     unit="cm" x="-50.0000000000001" y="0" z="0"/>
+   <position name="posCenter"           unit="cm" x="0" y="0" z="0"/>
+   <rotation name="rUWireAboutX"        unit="deg" x="131.63" y="0" z="0"/>
+   <rotation name="rPlus90AboutX"       unit="deg" x="90" y="0" z="0"/>
+   <rotation name="rPlus90AboutY"       unit="deg" x="0" y="90" z="0"/>
+   <rotation name="rPlus90AboutXPlus90AboutY" unit="deg" x="90" y="90" z="0"/>
+   <rotation name="rMinus90AboutX"      unit="deg" x="270" y="0" z="0"/>
+   <rotation name="rMinus90AboutY"      unit="deg" x="0" y="270" z="0"/>
+   <rotation name="rMinus90AboutYMinus90AboutX"       unit="deg" x="270" y="270" z="0"/>
+   <rotation name="rPlus180AboutX"	unit="deg" x="180" y="0"   z="0"/>
+   <rotation name="rPlus180AboutY"	unit="deg" x="0" y="180"   z="0"/>
+   <rotation name="rPlus180AboutXPlus180AboutY"	unit="deg" x="180" y="180"   z="0"/>
+   <rotation name="rIdentity"		unit="deg" x="0" y="0"   z="0"/>
+</define>
+<materials>
+  <element name="videRef" formula="VACUUM" Z="1">  <atom value="1"/> </element>
+  <element name="copper" formula="Cu" Z="29">  <atom value="63.546"/>  </element>
+  <element name="beryllium" formula="Be" Z="4">  <atom value="9.0121831"/>  </element>
+  <element name="bromine" formula="Br" Z="35"> <atom value="79.904"/> </element>
+  <element name="hydrogen" formula="H" Z="1">  <atom value="1.0079"/> </element>
+  <element name="nitrogen" formula="N" Z="7">  <atom value="14.0067"/> </element>
+  <element name="oxygen" formula="O" Z="8">  <atom value="15.999"/> </element>
+  <element name="aluminum" formula="Al" Z="13"> <atom value="26.9815"/>  </element>
+  <element name="silicon" formula="Si" Z="14"> <atom value="28.0855"/>  </element>
+  <element name="carbon" formula="C" Z="6">  <atom value="12.0107"/>  </element>
+  <element name="potassium" formula="K" Z="19"> <atom value="39.0983"/>  </element>
+  <element name="chromium" formula="Cr" Z="24"> <atom value="51.9961"/>  </element>
+  <element name="iron" formula="Fe" Z="26"> <atom value="55.8450"/>  </element>
+  <element name="nickel" formula="Ni" Z="28"> <atom value="58.6934"/>  </element>
+  <element name="calcium" formula="Ca" Z="20"> <atom value="40.078"/>   </element>
+  <element name="magnesium" formula="Mg" Z="12"> <atom value="24.305"/>   </element>
+  <element name="sodium" formula="Na" Z="11"> <atom value="22.99"/>    </element>
+  <element name="titanium" formula="Ti" Z="22"> <atom value="47.867"/>   </element>
+  <element name="argon" formula="Ar" Z="18"> <atom value="39.9480"/>  </element>
+  <element name="sulphur" formula="S" Z="16"> <atom value="32.065"/>  </element>
+  <element name="phosphorus" formula="P" Z="15"> <atom value="30.973"/>  </element>
+
+  <material name="Vacuum" formula="Vacuum">
+   <D value="1.e-25" unit="g/cm3"/>
+   <fraction n="1.0" ref="videRef"/>
+  </material>
+
+  <material name="ALUMINUM_Al" formula="ALUMINUM_Al">
+   <D value="2.6990" unit="g/cm3"/>
+   <fraction n="1.0000" ref="aluminum"/>
+  </material>
+
+  <material name="SILICON_Si" formula="SILICON_Si">
+   <D value="2.3300" unit="g/cm3"/>
+   <fraction n="1.0000" ref="silicon"/>
+  </material>
+
+  <material name="epoxy_resin" formula="C38H40O6Br4">
+   <D value="1.1250" unit="g/cm3"/>
+   <composite n="38" ref="carbon"/>
+   <composite n="40" ref="hydrogen"/>
+   <composite n="6" ref="oxygen"/>
+   <composite n="4" ref="bromine"/>
+  </material>
+
+  <material name="SiO2" formula="SiO2">
+   <D value="2.2" unit="g/cm3"/>
+   <composite n="1" ref="silicon"/>
+   <composite n="2" ref="oxygen"/>
+  </material>
+
+  <material name="Al2O3" formula="Al2O3">
+   <D value="3.97" unit="g/cm3"/>
+   <composite n="2" ref="aluminum"/>
+   <composite n="3" ref="oxygen"/>
+  </material>
+
+  <material name="Fe2O3" formula="Fe2O3">
+   <D value="5.24" unit="g/cm3"/>
+   <composite n="2" ref="iron"/>
+   <composite n="3" ref="oxygen"/>
+  </material>
+
+  <material name="CaO" formula="CaO">
+   <D value="3.35" unit="g/cm3"/>
+   <composite n="1" ref="calcium"/>
+   <composite n="1" ref="oxygen"/>
+  </material>
+
+  <material name="Delrin" formula="CH2O">
+    <D value="1.41" unit="g/cm3"/>
+    <composite n="1" ref="carbon"/>
+    <composite n="2" ref="hydrogen"/>
+    <composite n="1" ref="oxygen"/>
+  </material>
+
+  <material name="MgO" formula="MgO">
+   <D value="3.58" unit="g/cm3"/>
+   <composite n="1" ref="magnesium"/>
+   <composite n="1" ref="oxygen"/>
+  </material>
+
+  <material name="Na2O" formula="Na2O">
+   <D value="2.27" unit="g/cm3"/>
+   <composite n="2" ref="sodium"/>
+   <composite n="1" ref="oxygen"/>
+  </material>
+
+  <material name="TiO2" formula="TiO2">
+   <D value="4.23" unit="g/cm3"/>
+   <composite n="1" ref="titanium"/>
+   <composite n="2" ref="oxygen"/>
+  </material>
+
+  <material name="FeO" formula="FeO">
+   <D value="5.745" unit="g/cm3"/>
+   <composite n="1" ref="iron"/>
+   <composite n="1" ref="oxygen"/>
+  </material>
+
+  <material name="CO2" formula="CO2">
+   <D value="1.562" unit="g/cm3"/>
+   <composite n="1" ref="iron"/>
+   <composite n="2" ref="oxygen"/>
+  </material>
+
+  <material name="P2O5" formula="P2O5">
+   <D value="1.562" unit="g/cm3"/>
+   <composite n="2" ref="phosphorus"/>
+   <composite n="5" ref="oxygen"/>
+  </material>
+
+  <material formula=" " name="DUSEL_Rock">
+    <D value="2.82" unit="g/cm3"/>
+    <fraction n="0.5267" ref="SiO2"/>
+    <fraction n="0.1174" ref="FeO"/>
+    <fraction n="0.1025" ref="Al2O3"/>
+    <fraction n="0.0473" ref="MgO"/>
+    <fraction n="0.0422" ref="CO2"/>
+    <fraction n="0.0382" ref="CaO"/>
+    <fraction n="0.0240" ref="carbon"/>
+    <fraction n="0.0186" ref="sulphur"/>
+    <fraction n="0.0053" ref="Na2O"/>
+    <fraction n="0.00070" ref="P2O5"/>
+    <fraction n="0.0771" ref="oxygen"/>
+  </material> 
+
+  <material formula="Air" name="Air">
+   <D value="0.001205" unit="g/cm3"/>
+   <fraction n="0.781154" ref="nitrogen"/>
+   <fraction n="0.209476" ref="oxygen"/>
+   <fraction n="0.00934" ref="argon"/>
+  </material>
+
+  <material name="fibrous_glass">
+   <D value="2.74351" unit="g/cm3"/>
+   <fraction n="0.600" ref="SiO2"/>
+   <fraction n="0.118" ref="Al2O3"/>
+   <fraction n="0.001" ref="Fe2O3"/>
+   <fraction n="0.224" ref="CaO"/>
+   <fraction n="0.034" ref="MgO"/>
+   <fraction n="0.010" ref="Na2O"/>
+   <fraction n="0.013" ref="TiO2"/>
+  </material>
+
+  <!-- density referenced from EHN1-Cold Cryostats Technical Requirements:
+       https://edms.cern.ch/document/1543254 -->
+  <material name="FD_foam">
+   <D value="0.09" unit="g/cm3"/>
+   <fraction n="0.95" ref="Air"/>
+   <fraction n="0.05" ref="fibrous_glass"/>
+  </material>
+
+  <!-- Foam density is 70 kg / m^3 for the 3x1x1 -->
+  <material name="foam_3x1x1dp">
+   <D value="0.07" unit="g/cm3"/>
+   <fraction n="0.95" ref="Air"/>
+   <fraction n="0.05" ref="fibrous_glass"/>
+  </material>
+
+  <!-- Copied from protodune_v4.gdml -->
+  <material name="foam_protoDUNEdp">
+   <D value="0.135" unit="g/cm3"/>
+   <composite n="17" ref="carbon"/>
+   <composite n="16" ref="hydrogen"/>
+   <composite n="2" ref="nitrogen"/>
+   <composite n="4" ref="oxygen"/>
+  </material>
+
+  <material name="FR4">
+   <D value="1.98281" unit="g/cm3"/>
+   <fraction n="0.47" ref="epoxy_resin"/>
+   <fraction n="0.53" ref="fibrous_glass"/>
+  </material>
+
+  <material name="STEEL_STAINLESS_Fe7Cr2Ni" formula="STEEL_STAINLESS_Fe7Cr2Ni">
+   <D value="7.9300" unit="g/cm3"/>
+   <fraction n="0.0010" ref="carbon"/>
+   <fraction n="0.1792" ref="chromium"/>
+   <fraction n="0.7298" ref="iron"/>
+   <fraction n="0.0900" ref="nickel"/>
+  </material>
+
+  <material name="Copper_Beryllium_alloy25" formula="Copper_Beryllium_alloy25">
+   <D value="8.26" unit="g/cm3"/>
+   <fraction n="0.981" ref="copper"/>
+   <fraction n="0.019" ref="beryllium"/>
+  </material>
+
+  <material name="LAr" formula="LAr">
+   <D value="1.40" unit="g/cm3"/>
+   <fraction n="1.0000" ref="argon"/>
+  </material>
+
+  <material name="ArGas" formula="ArGas">
+   <D value="0.00166" unit="g/cm3"/>
+   <fraction n="1.0" ref="argon"/>
+  </material>
+
+  <material formula=" " name="G10">
+   <D value="1.7" unit="g/cm3"/>
+   <fraction n="0.2805" ref="silicon"/>
+   <fraction n="0.3954" ref="oxygen"/>
+   <fraction n="0.2990" ref="carbon"/>
+   <fraction n="0.0251" ref="hydrogen"/>
+  </material>
+
+  <material formula=" " name="Granite">
+   <D value="2.7" unit="g/cm3"/>
+   <fraction n="0.438" ref="oxygen"/>
+   <fraction n="0.257" ref="silicon"/>
+   <fraction n="0.222" ref="sodium"/>
+   <fraction n="0.049" ref="aluminum"/>
+   <fraction n="0.019" ref="iron"/>
+   <fraction n="0.015" ref="potassium"/>
+  </material>
+
+  <material formula=" " name="ShotRock">
+   <D value="1.62" unit="g/cm3"/>
+   <fraction n="0.438" ref="oxygen"/>
+   <fraction n="0.257" ref="silicon"/>
+   <fraction n="0.222" ref="sodium"/>
+   <fraction n="0.049" ref="aluminum"/>
+   <fraction n="0.019" ref="iron"/>
+   <fraction n="0.015" ref="potassium"/>
+  </material>
+
+  <material formula=" " name="Dirt">
+   <D value="1.7" unit="g/cm3"/>
+   <fraction n="0.438" ref="oxygen"/>
+   <fraction n="0.257" ref="silicon"/>
+   <fraction n="0.222" ref="sodium"/>
+   <fraction n="0.049" ref="aluminum"/>
+   <fraction n="0.019" ref="iron"/>
+   <fraction n="0.015" ref="potassium"/>
+  </material>
+
+  <material formula=" " name="Concrete">
+   <D value="2.3" unit="g/cm3"/>
+   <fraction n="0.530" ref="oxygen"/>
+   <fraction n="0.335" ref="silicon"/>
+   <fraction n="0.060" ref="calcium"/>
+   <fraction n="0.015" ref="sodium"/>
+   <fraction n="0.020" ref="iron"/>
+   <fraction n="0.040" ref="aluminum"/>
+  </material>
+
+  <material formula="H2O" name="Water">
+   <D value="1.0" unit="g/cm3"/>
+   <fraction n="0.1119" ref="hydrogen"/>
+   <fraction n="0.8881" ref="oxygen"/>
+  </material>
+
+  <material formula="Ti" name="Titanium">
+   <D value="4.506" unit="g/cm3"/>
+   <fraction n="1." ref="titanium"/>
+  </material>
+
+  <material name="TPB" formula="TPB">
+   <D value="1.40" unit="g/cm3"/>
+   <fraction n="1.0000" ref="argon"/>
+  </material>
+
+  <material name="Glass">
+   <D value="2.74351" unit="g/cm3"/>
+   <fraction n="0.600" ref="SiO2"/>
+   <fraction n="0.118" ref="Al2O3"/>
+   <fraction n="0.001" ref="Fe2O3"/>
+   <fraction n="0.224" ref="CaO"/>
+   <fraction n="0.034" ref="MgO"/>
+   <fraction n="0.010" ref="Na2O"/>
+   <fraction n="0.013" ref="TiO2"/>
+  </material>
+
+  <material name="Acrylic">
+   <D value="1.19" unit="g/cm3"/>
+   <fraction n="0.600" ref="carbon"/>
+   <fraction n="0.320" ref="oxygen"/>
+   <fraction n="0.080" ref="hydrogen"/>
+  </material>
+
+  <material name="NiGas1atm80K">
+   <D value="0.0039" unit="g/cm3"/>
+   <fraction n="1.000" ref="nitrogen"/>
+  </material>
+
+  <material name="NiGas">
+   <D value="0.001165" unit="g/cm3"/>
+   <fraction n="1.000" ref="nitrogen"/>
+  </material>
+
+  <material name="PolyurethaneFoam">
+   <D value="0.088" unit="g/cm3"/>
+   <composite n="17" ref="carbon"/>
+   <composite n="16" ref="hydrogen"/>
+   <composite n="2" ref="nitrogen"/>
+   <composite n="4" ref="oxygen"/>
+  </material>
+
+  <material name="ProtoDUNEFoam">
+   <D value="0.135" unit="g/cm3"/>
+   <composite n="17" ref="carbon"/>
+   <composite n="16" ref="hydrogen"/>
+   <composite n="2" ref="nitrogen"/>
+   <composite n="4" ref="oxygen"/>
+  </material>
+
+  <material name="LightPolyurethaneFoam">
+   <D value="0.009" unit="g/cm3"/>
+   <composite n="17" ref="carbon"/>
+   <composite n="16" ref="hydrogen"/>
+   <composite n="2" ref="nitrogen"/>
+   <composite n="4" ref="oxygen"/>
+  </material>
+
+  <material name="ProtoDUNEBWFoam">
+   <D value="0.021" unit="g/cm3"/>
+   <composite n="17" ref="carbon"/>
+   <composite n="16" ref="hydrogen"/>
+   <composite n="2" ref="nitrogen"/>
+   <composite n="4" ref="oxygen"/>
+  </material>
+
+  <material name="GlassWool">
+   <D value="0.035" unit="g/cm3"/>
+   <fraction n="0.65" ref="SiO2"/>
+   <fraction n="0.09" ref="Al2O3"/>
+   <fraction n="0.07" ref="CaO"/>
+   <fraction n="0.03" ref="MgO"/>
+   <fraction n="0.16" ref="Na2O"/>
+  </material>
+
+  <material name="Polystyrene">
+   <D value="1.06" unit="g/cm3"/>
+   <composite n="8" ref="carbon"/>
+   <composite n="8" ref="hydrogen"/>
+  </material>
+
+
+
+  <!-- preliminary values -->
+  <material name="AirSteelMixture" formula="AirSteelMixture">
+   <D value=" 0.001205*(1-0.5) + 7.9300*0.5 " unit="g/cm3"/>
+   <fraction n="0.5" ref="STEEL_STAINLESS_Fe7Cr2Ni"/>
+   <fraction n="0.5"   ref="Air"/>
+  </material>
+  <material name="vm2000" formula="vm2000">
+    <D value="1.2" unit="g/cm3"/>
+    <composite n="2" ref="carbon"/>
+    <composite n="4" ref="hydrogen"/>
+  </material>
+
+</materials>
+<solids>
+     <torus name="FieldShaperCorner" rmin="0.5" rmax="2.285" rtor="2.3" deltaphi="90" startphi="0" aunit="deg" lunit="cm"/>
+     <tube name="FieldShaperLongtube" rmin="0.5" rmax="2.285" z="896.4054" deltaphi="360" startphi="0" aunit="deg" lunit="cm"/>
+     <tube name="FieldShaperLongtubeSlim" rmin="0.5" rmax="0.75" z="896.4054" deltaphi="360" startphi="0" aunit="deg" lunit="cm"/>
+     <tube name="FieldShaperShorttube" rmin="0.5" rmax="2.285" z="1348" deltaphi="360" startphi="0" aunit="deg" lunit="cm"/>
+
+    <union name="FSunion1">
+      <first ref="FieldShaperLongtube"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos1" unit="cm" x="-2.3" y="0" z="448.2027"/>
+		<rotation name="rot1" unit="deg" x="90" y="0" z="0" />
+    </union>
+
+    <union name="FSunion2">
+      <first ref="FSunion1"/>
+      <second ref="FieldShaperShorttube"/>
+   		<position name="esquinapos2" unit="cm" x="-676.3" y="0" z="450.5027"/>
+   		<rotation name="rot2" unit="deg" x="0" y="90" z="0" />
+    </union>
+
+    <union name="FSunion3">
+      <first ref="FSunion2"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos3" unit="cm" x="-1350.3" y="0" z="448.2027"/>
+		<rotation name="rot3" unit="deg" x="90" y="270" z="0" />
+    </union>
+
+    <union name="FSunion4">
+      <first ref="FSunion3"/>
+      <second ref="FieldShaperLongtube"/>
+   		<position name="esquinapos4" unit="cm" x="-1352.6" y="0" z="0"/>
+    </union>
+
+    <union name="FSunion5">
+      <first ref="FSunion4"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos5" unit="cm" x="-1350.3" y="0" z="-448.2027"/>
+		<rotation name="rot5" unit="deg" x="90" y="180" z="0" />
+    </union>
+
+    <union name="FSunion6">
+      <first ref="FSunion5"/>
+      <second ref="FieldShaperShorttube"/>
+   		<position name="esquinapos6" unit="cm" x="-676.3" y="0" z="-450.5027"/>
+		<rotation name="rot6" unit="deg" x="0" y="90" z="0" />
+    </union>
+
+    <union name="FieldShaperSolid">
+      <first ref="FSunion6"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos7" unit="cm" x="-2.3" y="0" z="-448.2027"/>
+		<rotation name="rot7" unit="deg" x="90" y="90" z="0" />
+    </union>
+    
+    <union name="FSunionSlim1">
+      <first ref="FieldShaperLongtubeSlim"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos1" unit="cm" x="-2.3" y="0" z="448.2027"/>
+		<rotation name="rot1" unit="deg" x="90" y="0" z="0" />
+    </union>
+
+    <union name="FSunionSlim2">
+      <first ref="FSunionSlim1"/>
+      <second ref="FieldShaperShorttube"/>
+   		<position name="esquinapos2" unit="cm" x="-676.3" y="0" z="450.5027"/>
+   		<rotation name="rot2" unit="deg" x="0" y="90" z="0" />
+    </union>
+
+    <union name="FSunionSlim3">
+      <first ref="FSunionSlim2"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos3" unit="cm" x="-1350.3" y="0" z="448.2027"/>
+		<rotation name="rot3" unit="deg" x="90" y="270" z="0" />
+    </union>
+
+    <union name="FSunionSlim4">
+      <first ref="FSunionSlim3"/>
+      <second ref="FieldShaperLongtubeSlim"/>
+   		<position name="esquinapos4" unit="cm" x="-1352.6" y="0" z="0"/>
+    </union>
+
+    <union name="FSunionSlim5">
+      <first ref="FSunionSlim4"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos5" unit="cm" x="-1350.3" y="0" z="-448.2027"/>
+		<rotation name="rot5" unit="deg" x="90" y="180" z="0" />
+    </union>
+
+    <union name="FSunionSlim6">
+      <first ref="FSunionSlim5"/>
+      <second ref="FieldShaperShorttube"/>
+   		<position name="esquinapos6" unit="cm" x="-676.3" y="0" z="-450.5027"/>
+		<rotation name="rot6" unit="deg" x="0" y="90" z="0" />
+    </union>
+
+    <union name="FieldShaperSolidSlim">
+      <first ref="FSunionSlim6"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos7" unit="cm" x="-2.3" y="0" z="-448.2027"/>
+		<rotation name="rot7" unit="deg" x="90" y="90" z="0" />
+    </union>
+    
+
+   <box name="CRM"
+      x="650.08" 
+      y="168" 
+      z="148.9009"
+      lunit="cm"/>
+   <box name="CRMUPlane" 
+      x="0.02" 
+      y="168" 
+      z="148.9009"
+      lunit="cm"/>
+   <box name="CRMYPlane" 
+      x="0.02" 
+      y="168" 
+      z="148.9009"
+      lunit="cm"/>
+   <box name="CRMZPlane" 
+      x="0.02"
+      y="168"
+      z="148.9009"
+      lunit="cm"/>
+   <box name="CRMActive" 
+      x="650"
+      y="168"
+      z="148.9009"
+      lunit="cm"/>
+   <tube name="CRMWireU0"
+      rmax="0.5*0.02"
+      z="0.875550971308563"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU1"
+      rmax="0.5*0.02"
+      z="2.62665291392569"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU2"
+      rmax="0.5*0.02"
+      z="4.37775485654281"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU3"
+      rmax="0.5*0.02"
+      z="6.12885679915994"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU4"
+      rmax="0.5*0.02"
+      z="7.87995874177706"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU5"
+      rmax="0.5*0.02"
+      z="9.63106068439417"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU6"
+      rmax="0.5*0.02"
+      z="11.3821626270113"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU7"
+      rmax="0.5*0.02"
+      z="13.1332645696284"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU8"
+      rmax="0.5*0.02"
+      z="14.8843665122456"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU9"
+      rmax="0.5*0.02"
+      z="16.6354684548627"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU10"
+      rmax="0.5*0.02"
+      z="18.3865703974798"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU11"
+      rmax="0.5*0.02"
+      z="20.1376723400969"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU12"
+      rmax="0.5*0.02"
+      z="21.8887742827141"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU13"
+      rmax="0.5*0.02"
+      z="23.6398762253312"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU14"
+      rmax="0.5*0.02"
+      z="25.3909781679483"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU15"
+      rmax="0.5*0.02"
+      z="27.1420801105654"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU16"
+      rmax="0.5*0.02"
+      z="28.8931820531826"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU17"
+      rmax="0.5*0.02"
+      z="30.6442839957997"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU18"
+      rmax="0.5*0.02"
+      z="32.3953859384168"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU19"
+      rmax="0.5*0.02"
+      z="34.1464878810339"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU20"
+      rmax="0.5*0.02"
+      z="35.897589823651"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU21"
+      rmax="0.5*0.02"
+      z="37.6486917662682"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU22"
+      rmax="0.5*0.02"
+      z="39.3997937088853"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU23"
+      rmax="0.5*0.02"
+      z="41.1508956515024"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU24"
+      rmax="0.5*0.02"
+      z="42.9019975941195"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU25"
+      rmax="0.5*0.02"
+      z="44.6530995367366"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU26"
+      rmax="0.5*0.02"
+      z="46.4042014793538"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU27"
+      rmax="0.5*0.02"
+      z="48.1553034219709"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU28"
+      rmax="0.5*0.02"
+      z="49.906405364588"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU29"
+      rmax="0.5*0.02"
+      z="51.6575073072051"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU30"
+      rmax="0.5*0.02"
+      z="53.4086092498223"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU31"
+      rmax="0.5*0.02"
+      z="55.1597111924394"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU32"
+      rmax="0.5*0.02"
+      z="56.9108131350565"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU33"
+      rmax="0.5*0.02"
+      z="58.6619150776736"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU34"
+      rmax="0.5*0.02"
+      z="60.4130170202907"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU35"
+      rmax="0.5*0.02"
+      z="62.1641189629079"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU36"
+      rmax="0.5*0.02"
+      z="63.915220905525"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU37"
+      rmax="0.5*0.02"
+      z="65.6663228481421"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU38"
+      rmax="0.5*0.02"
+      z="67.4174247907592"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU39"
+      rmax="0.5*0.02"
+      z="69.1685267333764"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU40"
+      rmax="0.5*0.02"
+      z="70.9196286759935"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU41"
+      rmax="0.5*0.02"
+      z="72.6707306186106"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU42"
+      rmax="0.5*0.02"
+      z="74.4218325612277"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU43"
+      rmax="0.5*0.02"
+      z="76.1729345038449"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU44"
+      rmax="0.5*0.02"
+      z="77.924036446462"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU45"
+      rmax="0.5*0.02"
+      z="79.6751383890791"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU46"
+      rmax="0.5*0.02"
+      z="81.4262403316963"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU47"
+      rmax="0.5*0.02"
+      z="83.1773422743134"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU48"
+      rmax="0.5*0.02"
+      z="84.9284442169305"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU49"
+      rmax="0.5*0.02"
+      z="86.6795461595477"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU50"
+      rmax="0.5*0.02"
+      z="88.4306481021648"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU51"
+      rmax="0.5*0.02"
+      z="90.1817500447819"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU52"
+      rmax="0.5*0.02"
+      z="91.932851987399"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU53"
+      rmax="0.5*0.02"
+      z="93.6839539300162"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU54"
+      rmax="0.5*0.02"
+      z="95.4350558726333"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU55"
+      rmax="0.5*0.02"
+      z="97.1861578152504"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU56"
+      rmax="0.5*0.02"
+      z="98.9372597578676"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU57"
+      rmax="0.5*0.02"
+      z="100.688361700485"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU58"
+      rmax="0.5*0.02"
+      z="102.439463643102"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU59"
+      rmax="0.5*0.02"
+      z="104.190565585719"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU60"
+      rmax="0.5*0.02"
+      z="105.941667528336"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU61"
+      rmax="0.5*0.02"
+      z="107.692769470953"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU62"
+      rmax="0.5*0.02"
+      z="109.44387141357"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU63"
+      rmax="0.5*0.02"
+      z="111.194973356187"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU64"
+      rmax="0.5*0.02"
+      z="112.946075298805"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU65"
+      rmax="0.5*0.02"
+      z="114.697177241422"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU66"
+      rmax="0.5*0.02"
+      z="116.448279184039"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU67"
+      rmax="0.5*0.02"
+      z="118.199381126656"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU68"
+      rmax="0.5*0.02"
+      z="119.950483069273"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU69"
+      rmax="0.5*0.02"
+      z="121.70158501189"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU70"
+      rmax="0.5*0.02"
+      z="123.452686954507"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU71"
+      rmax="0.5*0.02"
+      z="125.203788897124"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU72"
+      rmax="0.5*0.02"
+      z="126.954890839742"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU73"
+      rmax="0.5*0.02"
+      z="128.705992782359"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU74"
+      rmax="0.5*0.02"
+      z="130.457094724976"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU75"
+      rmax="0.5*0.02"
+      z="132.208196667593"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU76"
+      rmax="0.5*0.02"
+      z="133.95929861021"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU77"
+      rmax="0.5*0.02"
+      z="135.710400552827"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU78"
+      rmax="0.5*0.02"
+      z="137.461502495444"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU79"
+      rmax="0.5*0.02"
+      z="139.212604438061"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU80"
+      rmax="0.5*0.02"
+      z="140.963706380679"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU81"
+      rmax="0.5*0.02"
+      z="142.714808323296"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU82"
+      rmax="0.5*0.02"
+      z="144.465910265913"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU83"
+      rmax="0.5*0.02"
+      z="146.21701220853"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU84"
+      rmax="0.5*0.02"
+      z="147.968114151147"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU85"
+      rmax="0.5*0.02"
+      z="149.719216093764"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU86"
+      rmax="0.5*0.02"
+      z="151.470318036381"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU87"
+      rmax="0.5*0.02"
+      z="153.221419978999"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU88"
+      rmax="0.5*0.02"
+      z="154.972521921616"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU89"
+      rmax="0.5*0.02"
+      z="156.723623864233"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU90"
+      rmax="0.5*0.02"
+      z="158.47472580685"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU91"
+      rmax="0.5*0.02"
+      z="160.225827749467"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU92"
+      rmax="0.5*0.02"
+      z="161.976929692084"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU93"
+      rmax="0.5*0.02"
+      z="163.728031634701"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU94"
+      rmax="0.5*0.02"
+      z="165.479133577318"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU95"
+      rmax="0.5*0.02"
+      z="167.230235519936"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU96"
+      rmax="0.5*0.02"
+      z="168.981337462553"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU97"
+      rmax="0.5*0.02"
+      z="170.73243940517"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU98"
+      rmax="0.5*0.02"
+      z="172.483541347787"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU99"
+      rmax="0.5*0.02"
+      z="174.234643290404"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU100"
+      rmax="0.5*0.02"
+      z="175.985745233021"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU101"
+      rmax="0.5*0.02"
+      z="177.736847175638"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU102"
+      rmax="0.5*0.02"
+      z="179.487949118255"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU103"
+      rmax="0.5*0.02"
+      z="181.239051060873"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU104"
+      rmax="0.5*0.02"
+      z="182.99015300349"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU105"
+      rmax="0.5*0.02"
+      z="184.741254946107"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU106"
+      rmax="0.5*0.02"
+      z="186.492356888724"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU107"
+      rmax="0.5*0.02"
+      z="188.243458831341"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU108"
+      rmax="0.5*0.02"
+      z="189.994560773958"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU109"
+      rmax="0.5*0.02"
+      z="191.745662716575"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU110"
+      rmax="0.5*0.02"
+      z="193.496764659192"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU111"
+      rmax="0.5*0.02"
+      z="195.24786660181"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU112"
+      rmax="0.5*0.02"
+      z="196.998968544427"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU113"
+      rmax="0.5*0.02"
+      z="198.750070487044"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU114"
+      rmax="0.5*0.02"
+      z="200.501172429661"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU115"
+      rmax="0.5*0.02"
+      z="202.252274372278"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU116"
+      rmax="0.5*0.02"
+      z="204.003376314895"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU117"
+      rmax="0.5*0.02"
+      z="205.754478257512"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU118"
+      rmax="0.5*0.02"
+      z="207.505580200129"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU119"
+      rmax="0.5*0.02"
+      z="209.256682142747"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU120"
+      rmax="0.5*0.02"
+      z="211.007784085364"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU121"
+      rmax="0.5*0.02"
+      z="212.758886027981"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU122"
+      rmax="0.5*0.02"
+      z="214.509987970598"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU123"
+      rmax="0.5*0.02"
+      z="216.261089913215"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU124"
+      rmax="0.5*0.02"
+      z="218.012191855832"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU125"
+      rmax="0.5*0.02"
+      z="219.763293798449"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU126"
+      rmax="0.5*0.02"
+      z="221.514395741067"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU127"
+      rmax="0.5*0.02"
+      z="223.265497683684"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU128"
+      rmax="0.5*0.02"
+      z="223.265497683683"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU129"
+      rmax="0.5*0.02"
+      z="221.514395741066"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU130"
+      rmax="0.5*0.02"
+      z="219.763293798449"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU131"
+      rmax="0.5*0.02"
+      z="218.012191855832"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU132"
+      rmax="0.5*0.02"
+      z="216.261089913215"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU133"
+      rmax="0.5*0.02"
+      z="214.509987970597"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU134"
+      rmax="0.5*0.02"
+      z="212.75888602798"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU135"
+      rmax="0.5*0.02"
+      z="211.007784085363"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU136"
+      rmax="0.5*0.02"
+      z="209.256682142746"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU137"
+      rmax="0.5*0.02"
+      z="207.505580200129"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU138"
+      rmax="0.5*0.02"
+      z="205.754478257512"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU139"
+      rmax="0.5*0.02"
+      z="204.003376314895"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU140"
+      rmax="0.5*0.02"
+      z="202.252274372277"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU141"
+      rmax="0.5*0.02"
+      z="200.50117242966"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU142"
+      rmax="0.5*0.02"
+      z="198.750070487043"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU143"
+      rmax="0.5*0.02"
+      z="196.998968544426"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU144"
+      rmax="0.5*0.02"
+      z="195.247866601809"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU145"
+      rmax="0.5*0.02"
+      z="193.496764659192"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU146"
+      rmax="0.5*0.02"
+      z="191.745662716575"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU147"
+      rmax="0.5*0.02"
+      z="189.994560773958"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU148"
+      rmax="0.5*0.02"
+      z="188.243458831341"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU149"
+      rmax="0.5*0.02"
+      z="186.492356888723"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU150"
+      rmax="0.5*0.02"
+      z="184.741254946106"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU151"
+      rmax="0.5*0.02"
+      z="182.990153003489"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU152"
+      rmax="0.5*0.02"
+      z="181.239051060872"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU153"
+      rmax="0.5*0.02"
+      z="179.487949118255"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU154"
+      rmax="0.5*0.02"
+      z="177.736847175638"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU155"
+      rmax="0.5*0.02"
+      z="175.985745233021"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU156"
+      rmax="0.5*0.02"
+      z="174.234643290404"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU157"
+      rmax="0.5*0.02"
+      z="172.483541347787"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU158"
+      rmax="0.5*0.02"
+      z="170.73243940517"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU159"
+      rmax="0.5*0.02"
+      z="168.981337462552"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU160"
+      rmax="0.5*0.02"
+      z="167.230235519935"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU161"
+      rmax="0.5*0.02"
+      z="165.479133577318"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU162"
+      rmax="0.5*0.02"
+      z="163.728031634701"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU163"
+      rmax="0.5*0.02"
+      z="161.976929692084"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU164"
+      rmax="0.5*0.02"
+      z="160.225827749467"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU165"
+      rmax="0.5*0.02"
+      z="158.47472580685"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU166"
+      rmax="0.5*0.02"
+      z="156.723623864233"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU167"
+      rmax="0.5*0.02"
+      z="154.972521921616"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU168"
+      rmax="0.5*0.02"
+      z="153.221419978999"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU169"
+      rmax="0.5*0.02"
+      z="151.470318036381"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU170"
+      rmax="0.5*0.02"
+      z="149.719216093764"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU171"
+      rmax="0.5*0.02"
+      z="147.968114151147"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU172"
+      rmax="0.5*0.02"
+      z="146.21701220853"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU173"
+      rmax="0.5*0.02"
+      z="144.465910265913"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU174"
+      rmax="0.5*0.02"
+      z="142.714808323296"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU175"
+      rmax="0.5*0.02"
+      z="140.963706380679"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU176"
+      rmax="0.5*0.02"
+      z="139.212604438062"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU177"
+      rmax="0.5*0.02"
+      z="137.461502495445"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU178"
+      rmax="0.5*0.02"
+      z="135.710400552828"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU179"
+      rmax="0.5*0.02"
+      z="133.95929861021"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU180"
+      rmax="0.5*0.02"
+      z="132.208196667593"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU181"
+      rmax="0.5*0.02"
+      z="130.457094724976"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU182"
+      rmax="0.5*0.02"
+      z="128.705992782359"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU183"
+      rmax="0.5*0.02"
+      z="126.954890839742"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU184"
+      rmax="0.5*0.02"
+      z="125.203788897125"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU185"
+      rmax="0.5*0.02"
+      z="123.452686954508"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU186"
+      rmax="0.5*0.02"
+      z="121.701585011891"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU187"
+      rmax="0.5*0.02"
+      z="119.950483069274"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU188"
+      rmax="0.5*0.02"
+      z="118.199381126657"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU189"
+      rmax="0.5*0.02"
+      z="116.448279184039"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU190"
+      rmax="0.5*0.02"
+      z="114.697177241422"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU191"
+      rmax="0.5*0.02"
+      z="112.946075298805"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU192"
+      rmax="0.5*0.02"
+      z="111.194973356188"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU193"
+      rmax="0.5*0.02"
+      z="109.443871413571"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU194"
+      rmax="0.5*0.02"
+      z="107.692769470954"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU195"
+      rmax="0.5*0.02"
+      z="105.941667528337"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU196"
+      rmax="0.5*0.02"
+      z="104.19056558572"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU197"
+      rmax="0.5*0.02"
+      z="102.439463643103"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU198"
+      rmax="0.5*0.02"
+      z="100.688361700486"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU199"
+      rmax="0.5*0.02"
+      z="98.9372597578684"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU200"
+      rmax="0.5*0.02"
+      z="97.1861578152513"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU201"
+      rmax="0.5*0.02"
+      z="95.4350558726343"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU202"
+      rmax="0.5*0.02"
+      z="93.6839539300172"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU203"
+      rmax="0.5*0.02"
+      z="91.9328519874001"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU204"
+      rmax="0.5*0.02"
+      z="90.181750044783"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU205"
+      rmax="0.5*0.02"
+      z="88.4306481021658"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU206"
+      rmax="0.5*0.02"
+      z="86.6795461595488"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU207"
+      rmax="0.5*0.02"
+      z="84.9284442169317"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU208"
+      rmax="0.5*0.02"
+      z="83.1773422743145"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU209"
+      rmax="0.5*0.02"
+      z="81.4262403316975"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU210"
+      rmax="0.5*0.02"
+      z="79.6751383890803"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU211"
+      rmax="0.5*0.02"
+      z="77.9240364464633"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU212"
+      rmax="0.5*0.02"
+      z="76.1729345038461"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU213"
+      rmax="0.5*0.02"
+      z="74.4218325612291"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU214"
+      rmax="0.5*0.02"
+      z="72.670730618612"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU215"
+      rmax="0.5*0.02"
+      z="70.9196286759948"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU216"
+      rmax="0.5*0.02"
+      z="69.1685267333778"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU217"
+      rmax="0.5*0.02"
+      z="67.4174247907606"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU218"
+      rmax="0.5*0.02"
+      z="65.6663228481435"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU219"
+      rmax="0.5*0.02"
+      z="63.9152209055265"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU220"
+      rmax="0.5*0.02"
+      z="62.1641189629093"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU221"
+      rmax="0.5*0.02"
+      z="60.4130170202923"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU222"
+      rmax="0.5*0.02"
+      z="58.6619150776752"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU223"
+      rmax="0.5*0.02"
+      z="56.910813135058"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU224"
+      rmax="0.5*0.02"
+      z="55.159711192441"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU225"
+      rmax="0.5*0.02"
+      z="53.4086092498239"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU226"
+      rmax="0.5*0.02"
+      z="51.6575073072067"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU227"
+      rmax="0.5*0.02"
+      z="49.9064053645897"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU228"
+      rmax="0.5*0.02"
+      z="48.1553034219725"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU229"
+      rmax="0.5*0.02"
+      z="46.4042014793555"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU230"
+      rmax="0.5*0.02"
+      z="44.6530995367384"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU231"
+      rmax="0.5*0.02"
+      z="42.9019975941212"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU232"
+      rmax="0.5*0.02"
+      z="41.1508956515042"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU233"
+      rmax="0.5*0.02"
+      z="39.399793708887"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU234"
+      rmax="0.5*0.02"
+      z="37.64869176627"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU235"
+      rmax="0.5*0.02"
+      z="35.8975898236529"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU236"
+      rmax="0.5*0.02"
+      z="34.1464878810357"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU237"
+      rmax="0.5*0.02"
+      z="32.3953859384187"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU238"
+      rmax="0.5*0.02"
+      z="30.6442839958015"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU239"
+      rmax="0.5*0.02"
+      z="28.8931820531845"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU240"
+      rmax="0.5*0.02"
+      z="27.1420801105674"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU241"
+      rmax="0.5*0.02"
+      z="25.3909781679502"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU242"
+      rmax="0.5*0.02"
+      z="23.6398762253332"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU243"
+      rmax="0.5*0.02"
+      z="21.888774282716"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU244"
+      rmax="0.5*0.02"
+      z="20.1376723400989"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU245"
+      rmax="0.5*0.02"
+      z="18.3865703974819"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU246"
+      rmax="0.5*0.02"
+      z="16.6354684548648"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU247"
+      rmax="0.5*0.02"
+      z="14.8843665122477"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU248"
+      rmax="0.5*0.02"
+      z="13.1332645696306"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU249"
+      rmax="0.5*0.02"
+      z="11.3821626270135"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU250"
+      rmax="0.5*0.02"
+      z="9.63106068439639"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU251"
+      rmax="0.5*0.02"
+      z="7.87995874177926"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU252"
+      rmax="0.5*0.02"
+      z="6.12885679916218"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU253"
+      rmax="0.5*0.02"
+      z="4.37775485654507"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU254"
+      rmax="0.5*0.02"
+      z="2.62665291392794"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU255"
+      rmax="0.5*0.02"
+      z="0.875550971310878"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireY"
+      rmax="0.5*0.02"
+      z="148.9009"               
+      deltaphi="360" 
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireZ"
+      rmax="0.5*0.02"
+      z="168"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+
+    <box name="ArapucaOut" lunit="cm"
+      x="65"
+      y="2.5"
+      z="65"/>
+
+    <box name="ArapucaIn" lunit="cm"
+      x="60"
+      y="2.5"
+      z="60"/>
+
+     <subtraction name="ArapucaWalls">
+      <first  ref="ArapucaOut"/>
+      <second ref="ArapucaIn"/>
+      <position name="posArapucaSub" x="0" y="1.25" z="0." unit="cm"/>
+      </subtraction>
+
+    <box name="ArapucaAcceptanceWindow" lunit="cm"
+      x="60"
+      y="1"
+      z="60"/>
+
+    <box name="ArapucaDoubleIn" lunit="cm"
+      x="60"
+      y="3.5"
+      z="60"/>
+
+     <subtraction name="ArapucaDoubleWalls">
+      <first  ref="ArapucaOut"/>
+      <second ref="ArapucaDoubleIn"/>
+      <position name="posArapucaDoubleSub" x="0" y="0" z="0" unit="cm"/>
+      </subtraction>
+
+    <box name="ArapucaDoubleAcceptanceWindow" lunit="cm"
+      x="2.48"
+      y="60"
+      z="60"/>
+
+    <box name="ArapucaCathodeAcceptanceWindow" lunit="cm"
+      x="1"
+      y="60"
+      z="60"/>
+
+
+    <box name="Cryostat" lunit="cm" 
+      x="850.32" 
+      y="1548.24" 
+      z="1096.6454"/>
+
+    <box name="ArgonInterior" lunit="cm" 
+      x="850.08"
+      y="1548"
+      z="1096.4054"/>
+
+    <box name="GaseousArgon" lunit="cm" 
+      x="100"
+      y="1548"
+      z="1096.4054"/>
+
+    <box name="ExternalAuxOut" lunit="cm" 
+      x="850.08 - 100"
+      y="1548 - 2*2.5 - 2*40"
+      z="1096.4054"/>
+
+    <box name="ExternalAuxIn" lunit="cm" 
+      x="850.08"
+      y="1359.17"
+      z="1096.4054 + 1"/>
+
+   <subtraction name="ExternalActive">
+      <first ref="ExternalAuxOut"/>
+      <second ref="ExternalAuxIn"/>
+    </subtraction>
+
+    <subtraction name="SteelShell">
+      <first ref="Cryostat"/>
+      <second ref="ArgonInterior"/>
+    </subtraction>
+
+
+
+    <box name="CathodeBlock" lunit="cm"
+      x="4"
+      y="336"
+      z="297.8018" />
+
+    <box name="CathodeVoid" lunit="cm"
+      x="5"
+      y="76.35"
+      z="67" />
+
+    <subtraction name="Cathode1">
+      <first ref="CathodeBlock"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub1" x="0" y="-122.525" z="-108.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode2">
+      <first ref="Cathode1"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub2" x="0" y="-122.525" z="-37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode3">
+      <first ref="Cathode2"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub3" x="0" y="-122.525" z="37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode4">
+      <first ref="Cathode3"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub4" x="0" y="-122.525" z="108.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode5">
+      <first ref="Cathode4"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub5" x="0" y="-42.175" z="-108.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode6">
+      <first ref="Cathode5"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub6" x="0" y="-42.175" z="-37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode7">
+      <first ref="Cathode6"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub7" x="0" y="-42.175" z="37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode8">
+      <first ref="Cathode7"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub8" x="0" y="-42.175" z="108.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode9">
+      <first ref="Cathode8"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub9" x="0" y="42.175" z="-108.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode10">
+      <first ref="Cathode9"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub10" x="0" y="42.175" z="-37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode11">
+      <first ref="Cathode10"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub11" x="0" y="42.175" z="37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode12">
+      <first ref="Cathode11"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub12" x="0" y="42.175" z="108.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode13">
+      <first ref="Cathode12"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub13" x="0" y="122.525" z="-108.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode14">
+      <first ref="Cathode13"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub14" x="0" y="122.525" z="-37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode15">
+      <first ref="Cathode14"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub15" x="0" y="122.525" z="37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="CathodeGrid">
+      <first ref="Cathode15"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub16" x="0" y="122.525" z="108.5" unit="cm"/>
+    </subtraction>
+
+    <box name="FoamPadBlock" lunit="cm"
+      x="1010.32"
+      y="1708.24"
+      z="1256.6454" />
+
+    <subtraction name="FoamPadding">
+      <first ref="FoamPadBlock"/>
+      <second ref="Cryostat"/>
+      <positionref ref="posCenter"/>
+    </subtraction>
+
+    <box name="SteelSupportBlock" lunit="cm"
+      x="1210.32"
+      y="1908.24"
+      z="1456.6454" />
+
+    <subtraction name="SteelSupport">
+      <first ref="SteelSupportBlock"/>
+      <second ref="FoamPadBlock"/>
+      <positionref ref="posCenter"/>
+    </subtraction>
+
+    <box name="DetEnclosure" lunit="cm" 
+      x="1310.32"
+      y="2108.24"
+      z="1656.6454"/>
+
+
+    <box name="World" lunit="cm" 
+      x="9310.32" 
+      y="10108.24" 
+      z="9656.6454"/>
+</solids>
+<structure>
+<volume name="volFieldShaper">
+  <materialref ref="Al2O3"/>
+  <solidref ref="FieldShaperSolid"/>
+</volume>
+<volume name="volFieldShaperSlim">
+  <materialref ref="Al2O3"/>
+  <solidref ref="FieldShaperSolidSlim"/>
+</volume>
+
+
+    <volume name="volTPCActive">
+      <materialref ref="LAr"/>
+      <solidref ref="CRMActive"/>
+      <auxiliary auxtype="SensDet" auxvalue="SimEnergyDeposit"/>
+      <auxiliary auxtype="StepLimit" auxunit="cm" auxvalue="0.5208*cm"/>
+      <auxiliary auxtype="Efield" auxunit="V/cm" auxvalue="500*V/cm"/>
+      <colorref ref="blue"/>
+    </volume>
+    <volume name="volTPCWireU0">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU0"/>
+    </volume>
+    <volume name="volTPCWireU1">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU1"/>
+    </volume>
+    <volume name="volTPCWireU2">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU2"/>
+    </volume>
+    <volume name="volTPCWireU3">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU3"/>
+    </volume>
+    <volume name="volTPCWireU4">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU4"/>
+    </volume>
+    <volume name="volTPCWireU5">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU5"/>
+    </volume>
+    <volume name="volTPCWireU6">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU6"/>
+    </volume>
+    <volume name="volTPCWireU7">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU7"/>
+    </volume>
+    <volume name="volTPCWireU8">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU8"/>
+    </volume>
+    <volume name="volTPCWireU9">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU9"/>
+    </volume>
+    <volume name="volTPCWireU10">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU10"/>
+    </volume>
+    <volume name="volTPCWireU11">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU11"/>
+    </volume>
+    <volume name="volTPCWireU12">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU12"/>
+    </volume>
+    <volume name="volTPCWireU13">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU13"/>
+    </volume>
+    <volume name="volTPCWireU14">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU14"/>
+    </volume>
+    <volume name="volTPCWireU15">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU15"/>
+    </volume>
+    <volume name="volTPCWireU16">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU16"/>
+    </volume>
+    <volume name="volTPCWireU17">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU17"/>
+    </volume>
+    <volume name="volTPCWireU18">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU18"/>
+    </volume>
+    <volume name="volTPCWireU19">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU19"/>
+    </volume>
+    <volume name="volTPCWireU20">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU20"/>
+    </volume>
+    <volume name="volTPCWireU21">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU21"/>
+    </volume>
+    <volume name="volTPCWireU22">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU22"/>
+    </volume>
+    <volume name="volTPCWireU23">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU23"/>
+    </volume>
+    <volume name="volTPCWireU24">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU24"/>
+    </volume>
+    <volume name="volTPCWireU25">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU25"/>
+    </volume>
+    <volume name="volTPCWireU26">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU26"/>
+    </volume>
+    <volume name="volTPCWireU27">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU27"/>
+    </volume>
+    <volume name="volTPCWireU28">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU28"/>
+    </volume>
+    <volume name="volTPCWireU29">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU29"/>
+    </volume>
+    <volume name="volTPCWireU30">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU30"/>
+    </volume>
+    <volume name="volTPCWireU31">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU31"/>
+    </volume>
+    <volume name="volTPCWireU32">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU32"/>
+    </volume>
+    <volume name="volTPCWireU33">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU33"/>
+    </volume>
+    <volume name="volTPCWireU34">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU34"/>
+    </volume>
+    <volume name="volTPCWireU35">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU35"/>
+    </volume>
+    <volume name="volTPCWireU36">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU36"/>
+    </volume>
+    <volume name="volTPCWireU37">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU37"/>
+    </volume>
+    <volume name="volTPCWireU38">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU38"/>
+    </volume>
+    <volume name="volTPCWireU39">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU39"/>
+    </volume>
+    <volume name="volTPCWireU40">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU40"/>
+    </volume>
+    <volume name="volTPCWireU41">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU41"/>
+    </volume>
+    <volume name="volTPCWireU42">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU42"/>
+    </volume>
+    <volume name="volTPCWireU43">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU43"/>
+    </volume>
+    <volume name="volTPCWireU44">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU44"/>
+    </volume>
+    <volume name="volTPCWireU45">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU45"/>
+    </volume>
+    <volume name="volTPCWireU46">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU46"/>
+    </volume>
+    <volume name="volTPCWireU47">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU47"/>
+    </volume>
+    <volume name="volTPCWireU48">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU48"/>
+    </volume>
+    <volume name="volTPCWireU49">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU49"/>
+    </volume>
+    <volume name="volTPCWireU50">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU50"/>
+    </volume>
+    <volume name="volTPCWireU51">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU51"/>
+    </volume>
+    <volume name="volTPCWireU52">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU52"/>
+    </volume>
+    <volume name="volTPCWireU53">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU53"/>
+    </volume>
+    <volume name="volTPCWireU54">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU54"/>
+    </volume>
+    <volume name="volTPCWireU55">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU55"/>
+    </volume>
+    <volume name="volTPCWireU56">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU56"/>
+    </volume>
+    <volume name="volTPCWireU57">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU57"/>
+    </volume>
+    <volume name="volTPCWireU58">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU58"/>
+    </volume>
+    <volume name="volTPCWireU59">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU59"/>
+    </volume>
+    <volume name="volTPCWireU60">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU60"/>
+    </volume>
+    <volume name="volTPCWireU61">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU61"/>
+    </volume>
+    <volume name="volTPCWireU62">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU62"/>
+    </volume>
+    <volume name="volTPCWireU63">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU63"/>
+    </volume>
+    <volume name="volTPCWireU64">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU64"/>
+    </volume>
+    <volume name="volTPCWireU65">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU65"/>
+    </volume>
+    <volume name="volTPCWireU66">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU66"/>
+    </volume>
+    <volume name="volTPCWireU67">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU67"/>
+    </volume>
+    <volume name="volTPCWireU68">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU68"/>
+    </volume>
+    <volume name="volTPCWireU69">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU69"/>
+    </volume>
+    <volume name="volTPCWireU70">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU70"/>
+    </volume>
+    <volume name="volTPCWireU71">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU71"/>
+    </volume>
+    <volume name="volTPCWireU72">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU72"/>
+    </volume>
+    <volume name="volTPCWireU73">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU73"/>
+    </volume>
+    <volume name="volTPCWireU74">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU74"/>
+    </volume>
+    <volume name="volTPCWireU75">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU75"/>
+    </volume>
+    <volume name="volTPCWireU76">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU76"/>
+    </volume>
+    <volume name="volTPCWireU77">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU77"/>
+    </volume>
+    <volume name="volTPCWireU78">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU78"/>
+    </volume>
+    <volume name="volTPCWireU79">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU79"/>
+    </volume>
+    <volume name="volTPCWireU80">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU80"/>
+    </volume>
+    <volume name="volTPCWireU81">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU81"/>
+    </volume>
+    <volume name="volTPCWireU82">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU82"/>
+    </volume>
+    <volume name="volTPCWireU83">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU83"/>
+    </volume>
+    <volume name="volTPCWireU84">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU84"/>
+    </volume>
+    <volume name="volTPCWireU85">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU85"/>
+    </volume>
+    <volume name="volTPCWireU86">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU86"/>
+    </volume>
+    <volume name="volTPCWireU87">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU87"/>
+    </volume>
+    <volume name="volTPCWireU88">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU88"/>
+    </volume>
+    <volume name="volTPCWireU89">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU89"/>
+    </volume>
+    <volume name="volTPCWireU90">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU90"/>
+    </volume>
+    <volume name="volTPCWireU91">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU91"/>
+    </volume>
+    <volume name="volTPCWireU92">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU92"/>
+    </volume>
+    <volume name="volTPCWireU93">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU93"/>
+    </volume>
+    <volume name="volTPCWireU94">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU94"/>
+    </volume>
+    <volume name="volTPCWireU95">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU95"/>
+    </volume>
+    <volume name="volTPCWireU96">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU96"/>
+    </volume>
+    <volume name="volTPCWireU97">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU97"/>
+    </volume>
+    <volume name="volTPCWireU98">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU98"/>
+    </volume>
+    <volume name="volTPCWireU99">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU99"/>
+    </volume>
+    <volume name="volTPCWireU100">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU100"/>
+    </volume>
+    <volume name="volTPCWireU101">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU101"/>
+    </volume>
+    <volume name="volTPCWireU102">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU102"/>
+    </volume>
+    <volume name="volTPCWireU103">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU103"/>
+    </volume>
+    <volume name="volTPCWireU104">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU104"/>
+    </volume>
+    <volume name="volTPCWireU105">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU105"/>
+    </volume>
+    <volume name="volTPCWireU106">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU106"/>
+    </volume>
+    <volume name="volTPCWireU107">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU107"/>
+    </volume>
+    <volume name="volTPCWireU108">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU108"/>
+    </volume>
+    <volume name="volTPCWireU109">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU109"/>
+    </volume>
+    <volume name="volTPCWireU110">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU110"/>
+    </volume>
+    <volume name="volTPCWireU111">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU111"/>
+    </volume>
+    <volume name="volTPCWireU112">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU112"/>
+    </volume>
+    <volume name="volTPCWireU113">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU113"/>
+    </volume>
+    <volume name="volTPCWireU114">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU114"/>
+    </volume>
+    <volume name="volTPCWireU115">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU115"/>
+    </volume>
+    <volume name="volTPCWireU116">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU116"/>
+    </volume>
+    <volume name="volTPCWireU117">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU117"/>
+    </volume>
+    <volume name="volTPCWireU118">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU118"/>
+    </volume>
+    <volume name="volTPCWireU119">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU119"/>
+    </volume>
+    <volume name="volTPCWireU120">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU120"/>
+    </volume>
+    <volume name="volTPCWireU121">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU121"/>
+    </volume>
+    <volume name="volTPCWireU122">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU122"/>
+    </volume>
+    <volume name="volTPCWireU123">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU123"/>
+    </volume>
+    <volume name="volTPCWireU124">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU124"/>
+    </volume>
+    <volume name="volTPCWireU125">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU125"/>
+    </volume>
+    <volume name="volTPCWireU126">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU126"/>
+    </volume>
+    <volume name="volTPCWireU127">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU127"/>
+    </volume>
+    <volume name="volTPCWireU128">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU128"/>
+    </volume>
+    <volume name="volTPCWireU129">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU129"/>
+    </volume>
+    <volume name="volTPCWireU130">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU130"/>
+    </volume>
+    <volume name="volTPCWireU131">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU131"/>
+    </volume>
+    <volume name="volTPCWireU132">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU132"/>
+    </volume>
+    <volume name="volTPCWireU133">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU133"/>
+    </volume>
+    <volume name="volTPCWireU134">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU134"/>
+    </volume>
+    <volume name="volTPCWireU135">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU135"/>
+    </volume>
+    <volume name="volTPCWireU136">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU136"/>
+    </volume>
+    <volume name="volTPCWireU137">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU137"/>
+    </volume>
+    <volume name="volTPCWireU138">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU138"/>
+    </volume>
+    <volume name="volTPCWireU139">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU139"/>
+    </volume>
+    <volume name="volTPCWireU140">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU140"/>
+    </volume>
+    <volume name="volTPCWireU141">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU141"/>
+    </volume>
+    <volume name="volTPCWireU142">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU142"/>
+    </volume>
+    <volume name="volTPCWireU143">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU143"/>
+    </volume>
+    <volume name="volTPCWireU144">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU144"/>
+    </volume>
+    <volume name="volTPCWireU145">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU145"/>
+    </volume>
+    <volume name="volTPCWireU146">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU146"/>
+    </volume>
+    <volume name="volTPCWireU147">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU147"/>
+    </volume>
+    <volume name="volTPCWireU148">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU148"/>
+    </volume>
+    <volume name="volTPCWireU149">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU149"/>
+    </volume>
+    <volume name="volTPCWireU150">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU150"/>
+    </volume>
+    <volume name="volTPCWireU151">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU151"/>
+    </volume>
+    <volume name="volTPCWireU152">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU152"/>
+    </volume>
+    <volume name="volTPCWireU153">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU153"/>
+    </volume>
+    <volume name="volTPCWireU154">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU154"/>
+    </volume>
+    <volume name="volTPCWireU155">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU155"/>
+    </volume>
+    <volume name="volTPCWireU156">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU156"/>
+    </volume>
+    <volume name="volTPCWireU157">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU157"/>
+    </volume>
+    <volume name="volTPCWireU158">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU158"/>
+    </volume>
+    <volume name="volTPCWireU159">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU159"/>
+    </volume>
+    <volume name="volTPCWireU160">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU160"/>
+    </volume>
+    <volume name="volTPCWireU161">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU161"/>
+    </volume>
+    <volume name="volTPCWireU162">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU162"/>
+    </volume>
+    <volume name="volTPCWireU163">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU163"/>
+    </volume>
+    <volume name="volTPCWireU164">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU164"/>
+    </volume>
+    <volume name="volTPCWireU165">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU165"/>
+    </volume>
+    <volume name="volTPCWireU166">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU166"/>
+    </volume>
+    <volume name="volTPCWireU167">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU167"/>
+    </volume>
+    <volume name="volTPCWireU168">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU168"/>
+    </volume>
+    <volume name="volTPCWireU169">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU169"/>
+    </volume>
+    <volume name="volTPCWireU170">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU170"/>
+    </volume>
+    <volume name="volTPCWireU171">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU171"/>
+    </volume>
+    <volume name="volTPCWireU172">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU172"/>
+    </volume>
+    <volume name="volTPCWireU173">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU173"/>
+    </volume>
+    <volume name="volTPCWireU174">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU174"/>
+    </volume>
+    <volume name="volTPCWireU175">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU175"/>
+    </volume>
+    <volume name="volTPCWireU176">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU176"/>
+    </volume>
+    <volume name="volTPCWireU177">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU177"/>
+    </volume>
+    <volume name="volTPCWireU178">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU178"/>
+    </volume>
+    <volume name="volTPCWireU179">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU179"/>
+    </volume>
+    <volume name="volTPCWireU180">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU180"/>
+    </volume>
+    <volume name="volTPCWireU181">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU181"/>
+    </volume>
+    <volume name="volTPCWireU182">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU182"/>
+    </volume>
+    <volume name="volTPCWireU183">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU183"/>
+    </volume>
+    <volume name="volTPCWireU184">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU184"/>
+    </volume>
+    <volume name="volTPCWireU185">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU185"/>
+    </volume>
+    <volume name="volTPCWireU186">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU186"/>
+    </volume>
+    <volume name="volTPCWireU187">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU187"/>
+    </volume>
+    <volume name="volTPCWireU188">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU188"/>
+    </volume>
+    <volume name="volTPCWireU189">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU189"/>
+    </volume>
+    <volume name="volTPCWireU190">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU190"/>
+    </volume>
+    <volume name="volTPCWireU191">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU191"/>
+    </volume>
+    <volume name="volTPCWireU192">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU192"/>
+    </volume>
+    <volume name="volTPCWireU193">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU193"/>
+    </volume>
+    <volume name="volTPCWireU194">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU194"/>
+    </volume>
+    <volume name="volTPCWireU195">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU195"/>
+    </volume>
+    <volume name="volTPCWireU196">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU196"/>
+    </volume>
+    <volume name="volTPCWireU197">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU197"/>
+    </volume>
+    <volume name="volTPCWireU198">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU198"/>
+    </volume>
+    <volume name="volTPCWireU199">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU199"/>
+    </volume>
+    <volume name="volTPCWireU200">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU200"/>
+    </volume>
+    <volume name="volTPCWireU201">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU201"/>
+    </volume>
+    <volume name="volTPCWireU202">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU202"/>
+    </volume>
+    <volume name="volTPCWireU203">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU203"/>
+    </volume>
+    <volume name="volTPCWireU204">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU204"/>
+    </volume>
+    <volume name="volTPCWireU205">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU205"/>
+    </volume>
+    <volume name="volTPCWireU206">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU206"/>
+    </volume>
+    <volume name="volTPCWireU207">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU207"/>
+    </volume>
+    <volume name="volTPCWireU208">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU208"/>
+    </volume>
+    <volume name="volTPCWireU209">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU209"/>
+    </volume>
+    <volume name="volTPCWireU210">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU210"/>
+    </volume>
+    <volume name="volTPCWireU211">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU211"/>
+    </volume>
+    <volume name="volTPCWireU212">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU212"/>
+    </volume>
+    <volume name="volTPCWireU213">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU213"/>
+    </volume>
+    <volume name="volTPCWireU214">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU214"/>
+    </volume>
+    <volume name="volTPCWireU215">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU215"/>
+    </volume>
+    <volume name="volTPCWireU216">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU216"/>
+    </volume>
+    <volume name="volTPCWireU217">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU217"/>
+    </volume>
+    <volume name="volTPCWireU218">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU218"/>
+    </volume>
+    <volume name="volTPCWireU219">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU219"/>
+    </volume>
+    <volume name="volTPCWireU220">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU220"/>
+    </volume>
+    <volume name="volTPCWireU221">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU221"/>
+    </volume>
+    <volume name="volTPCWireU222">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU222"/>
+    </volume>
+    <volume name="volTPCWireU223">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU223"/>
+    </volume>
+    <volume name="volTPCWireU224">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU224"/>
+    </volume>
+    <volume name="volTPCWireU225">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU225"/>
+    </volume>
+    <volume name="volTPCWireU226">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU226"/>
+    </volume>
+    <volume name="volTPCWireU227">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU227"/>
+    </volume>
+    <volume name="volTPCWireU228">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU228"/>
+    </volume>
+    <volume name="volTPCWireU229">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU229"/>
+    </volume>
+    <volume name="volTPCWireU230">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU230"/>
+    </volume>
+    <volume name="volTPCWireU231">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU231"/>
+    </volume>
+    <volume name="volTPCWireU232">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU232"/>
+    </volume>
+    <volume name="volTPCWireU233">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU233"/>
+    </volume>
+    <volume name="volTPCWireU234">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU234"/>
+    </volume>
+    <volume name="volTPCWireU235">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU235"/>
+    </volume>
+    <volume name="volTPCWireU236">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU236"/>
+    </volume>
+    <volume name="volTPCWireU237">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU237"/>
+    </volume>
+    <volume name="volTPCWireU238">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU238"/>
+    </volume>
+    <volume name="volTPCWireU239">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU239"/>
+    </volume>
+    <volume name="volTPCWireU240">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU240"/>
+    </volume>
+    <volume name="volTPCWireU241">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU241"/>
+    </volume>
+    <volume name="volTPCWireU242">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU242"/>
+    </volume>
+    <volume name="volTPCWireU243">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU243"/>
+    </volume>
+    <volume name="volTPCWireU244">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU244"/>
+    </volume>
+    <volume name="volTPCWireU245">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU245"/>
+    </volume>
+    <volume name="volTPCWireU246">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU246"/>
+    </volume>
+    <volume name="volTPCWireU247">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU247"/>
+    </volume>
+    <volume name="volTPCWireU248">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU248"/>
+    </volume>
+    <volume name="volTPCWireU249">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU249"/>
+    </volume>
+    <volume name="volTPCWireU250">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU250"/>
+    </volume>
+    <volume name="volTPCWireU251">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU251"/>
+    </volume>
+    <volume name="volTPCWireU252">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU252"/>
+    </volume>
+    <volume name="volTPCWireU253">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU253"/>
+    </volume>
+    <volume name="volTPCWireU254">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU254"/>
+    </volume>
+    <volume name="volTPCWireU255">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU255"/>
+    </volume>
+    <volume name="volTPCWireY">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireY"/>
+    </volume>
+    <volume name="volTPCWireZ">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireZ"/>
+    </volume>
+   <volume name="volTPCPlaneU">
+     <materialref ref="LAr"/>
+     <solidref ref="CRMUPlane"/>
+     <physvol>
+       <volumeref ref="volTPCWireU0"/> 
+       <position name="posWireU0" unit="cm" x="0" y="-83.4399379809595" z="-74.1596073595279"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU1"/> 
+       <position name="posWireU1" unit="cm" x="0" y="-82.7855070948343" z="-73.5779633802374"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU2"/> 
+       <position name="posWireU2" unit="cm" x="0" y="-82.1310762087091" z="-72.996319400947"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU3"/> 
+       <position name="posWireU3" unit="cm" x="0" y="-81.476645322584" z="-72.4146754216566"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU4"/> 
+       <position name="posWireU4" unit="cm" x="0" y="-80.8222144364588" z="-71.8330314423662"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU5"/> 
+       <position name="posWireU5" unit="cm" x="0" y="-80.1677835503336" z="-71.2513874630758"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU6"/> 
+       <position name="posWireU6" unit="cm" x="0" y="-79.5133526642084" z="-70.6697434837854"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU7"/> 
+       <position name="posWireU7" unit="cm" x="0" y="-78.8589217780833" z="-70.0880995044949"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU8"/> 
+       <position name="posWireU8" unit="cm" x="0" y="-78.2044908919581" z="-69.5064555252045"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU9"/> 
+       <position name="posWireU9" unit="cm" x="0" y="-77.5500600058329" z="-68.9248115459141"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU10"/> 
+       <position name="posWireU10" unit="cm" x="0" y="-76.8956291197078" z="-68.3431675666237"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU11"/> 
+       <position name="posWireU11" unit="cm" x="0" y="-76.2411982335826" z="-67.7615235873333"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU12"/> 
+       <position name="posWireU12" unit="cm" x="0" y="-75.5867673474574" z="-67.1798796080429"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU13"/> 
+       <position name="posWireU13" unit="cm" x="0" y="-74.9323364613322" z="-66.5982356287525"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU14"/> 
+       <position name="posWireU14" unit="cm" x="0" y="-74.2779055752071" z="-66.016591649462"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU15"/> 
+       <position name="posWireU15" unit="cm" x="0" y="-73.6234746890819" z="-65.4349476701716"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU16"/> 
+       <position name="posWireU16" unit="cm" x="0" y="-72.9690438029567" z="-64.8533036908812"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU17"/> 
+       <position name="posWireU17" unit="cm" x="0" y="-72.3146129168315" z="-64.2716597115908"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU18"/> 
+       <position name="posWireU18" unit="cm" x="0" y="-71.6601820307064" z="-63.6900157323004"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU19"/> 
+       <position name="posWireU19" unit="cm" x="0" y="-71.0057511445812" z="-63.10837175301"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU20"/> 
+       <position name="posWireU20" unit="cm" x="0" y="-70.351320258456" z="-62.5267277737196"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU21"/> 
+       <position name="posWireU21" unit="cm" x="0" y="-69.6968893723309" z="-61.9450837944292"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU22"/> 
+       <position name="posWireU22" unit="cm" x="0" y="-69.0424584862057" z="-61.3634398151387"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU23"/> 
+       <position name="posWireU23" unit="cm" x="0" y="-68.3880276000805" z="-60.7817958358483"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU24"/> 
+       <position name="posWireU24" unit="cm" x="0" y="-67.7335967139554" z="-60.2001518565579"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU25"/> 
+       <position name="posWireU25" unit="cm" x="0" y="-67.0791658278302" z="-59.6185078772675"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU26"/> 
+       <position name="posWireU26" unit="cm" x="0" y="-66.424734941705" z="-59.0368638979771"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU27"/> 
+       <position name="posWireU27" unit="cm" x="0" y="-65.7703040555798" z="-58.4552199186867"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU28"/> 
+       <position name="posWireU28" unit="cm" x="0" y="-65.1158731694547" z="-57.8735759393963"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU29"/> 
+       <position name="posWireU29" unit="cm" x="0" y="-64.4614422833295" z="-57.2919319601058"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU30"/> 
+       <position name="posWireU30" unit="cm" x="0" y="-63.8070113972043" z="-56.7102879808154"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU31"/> 
+       <position name="posWireU31" unit="cm" x="0" y="-63.1525805110792" z="-56.128644001525"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU32"/> 
+       <position name="posWireU32" unit="cm" x="0" y="-62.498149624954" z="-55.5470000222346"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU33"/> 
+       <position name="posWireU33" unit="cm" x="0" y="-61.8437187388288" z="-54.9653560429442"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU34"/> 
+       <position name="posWireU34" unit="cm" x="0" y="-61.1892878527036" z="-54.3837120636538"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU35"/> 
+       <position name="posWireU35" unit="cm" x="0" y="-60.5348569665785" z="-53.8020680843634"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU36"/> 
+       <position name="posWireU36" unit="cm" x="0" y="-59.8804260804533" z="-53.220424105073"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU37"/> 
+       <position name="posWireU37" unit="cm" x="0" y="-59.2259951943281" z="-52.6387801257825"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU38"/> 
+       <position name="posWireU38" unit="cm" x="0" y="-58.571564308203" z="-52.0571361464921"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU39"/> 
+       <position name="posWireU39" unit="cm" x="0" y="-57.9171334220778" z="-51.4754921672017"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU40"/> 
+       <position name="posWireU40" unit="cm" x="0" y="-57.2627025359526" z="-50.8938481879113"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU41"/> 
+       <position name="posWireU41" unit="cm" x="0" y="-56.6082716498274" z="-50.3122042086209"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU42"/> 
+       <position name="posWireU42" unit="cm" x="0" y="-55.9538407637023" z="-49.7305602293305"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU43"/> 
+       <position name="posWireU43" unit="cm" x="0" y="-55.2994098775771" z="-49.14891625004"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU44"/> 
+       <position name="posWireU44" unit="cm" x="0" y="-54.6449789914519" z="-48.5672722707496"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU45"/> 
+       <position name="posWireU45" unit="cm" x="0" y="-53.9905481053267" z="-47.9856282914592"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU46"/> 
+       <position name="posWireU46" unit="cm" x="0" y="-53.3361172192016" z="-47.4039843121688"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU47"/> 
+       <position name="posWireU47" unit="cm" x="0" y="-52.6816863330764" z="-46.8223403328784"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU48"/> 
+       <position name="posWireU48" unit="cm" x="0" y="-52.0272554469512" z="-46.240696353588"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU49"/> 
+       <position name="posWireU49" unit="cm" x="0" y="-51.372824560826" z="-45.6590523742975"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU50"/> 
+       <position name="posWireU50" unit="cm" x="0" y="-50.7183936747009" z="-45.0774083950071"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU51"/> 
+       <position name="posWireU51" unit="cm" x="0" y="-50.0639627885757" z="-44.4957644157167"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU52"/> 
+       <position name="posWireU52" unit="cm" x="0" y="-49.4095319024505" z="-43.9141204364263"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU53"/> 
+       <position name="posWireU53" unit="cm" x="0" y="-48.7551010163253" z="-43.3324764571359"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU54"/> 
+       <position name="posWireU54" unit="cm" x="0" y="-48.1006701302002" z="-42.7508324778455"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU55"/> 
+       <position name="posWireU55" unit="cm" x="0" y="-47.446239244075" z="-42.1691884985551"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU56"/> 
+       <position name="posWireU56" unit="cm" x="0" y="-46.7918083579498" z="-41.5875445192646"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU57"/> 
+       <position name="posWireU57" unit="cm" x="0" y="-46.1373774718246" z="-41.0059005399742"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU58"/> 
+       <position name="posWireU58" unit="cm" x="0" y="-45.4829465856995" z="-40.4242565606838"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU59"/> 
+       <position name="posWireU59" unit="cm" x="0" y="-44.8285156995743" z="-39.8426125813934"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU60"/> 
+       <position name="posWireU60" unit="cm" x="0" y="-44.1740848134491" z="-39.260968602103"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU61"/> 
+       <position name="posWireU61" unit="cm" x="0" y="-43.5196539273239" z="-38.6793246228126"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU62"/> 
+       <position name="posWireU62" unit="cm" x="0" y="-42.8652230411988" z="-38.0976806435221"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU63"/> 
+       <position name="posWireU63" unit="cm" x="0" y="-42.2107921550736" z="-37.5160366642317"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU64"/> 
+       <position name="posWireU64" unit="cm" x="0" y="-41.5563612689484" z="-36.9343926849413"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU65"/> 
+       <position name="posWireU65" unit="cm" x="0" y="-40.9019303828233" z="-36.3527487056509"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU66"/> 
+       <position name="posWireU66" unit="cm" x="0" y="-40.2474994966981" z="-35.7711047263605"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU67"/> 
+       <position name="posWireU67" unit="cm" x="0" y="-39.5930686105729" z="-35.1894607470701"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU68"/> 
+       <position name="posWireU68" unit="cm" x="0" y="-38.9386377244477" z="-34.6078167677796"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU69"/> 
+       <position name="posWireU69" unit="cm" x="0" y="-38.2842068383226" z="-34.0261727884892"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU70"/> 
+       <position name="posWireU70" unit="cm" x="0" y="-37.6297759521974" z="-33.4445288091988"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU71"/> 
+       <position name="posWireU71" unit="cm" x="0" y="-36.9753450660722" z="-32.8628848299084"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU72"/> 
+       <position name="posWireU72" unit="cm" x="0" y="-36.320914179947" z="-32.281240850618"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU73"/> 
+       <position name="posWireU73" unit="cm" x="0" y="-35.6664832938219" z="-31.6995968713276"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU74"/> 
+       <position name="posWireU74" unit="cm" x="0" y="-35.0120524076967" z="-31.1179528920372"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU75"/> 
+       <position name="posWireU75" unit="cm" x="0" y="-34.3576215215715" z="-30.5363089127467"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU76"/> 
+       <position name="posWireU76" unit="cm" x="0" y="-33.7031906354463" z="-29.9546649334563"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU77"/> 
+       <position name="posWireU77" unit="cm" x="0" y="-33.0487597493212" z="-29.3730209541659"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU78"/> 
+       <position name="posWireU78" unit="cm" x="0" y="-32.394328863196" z="-28.7913769748755"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU79"/> 
+       <position name="posWireU79" unit="cm" x="0" y="-31.7398979770708" z="-28.2097329955851"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU80"/> 
+       <position name="posWireU80" unit="cm" x="0" y="-31.0854670909456" z="-27.6280890162947"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU81"/> 
+       <position name="posWireU81" unit="cm" x="0" y="-30.4310362048205" z="-27.0464450370042"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU82"/> 
+       <position name="posWireU82" unit="cm" x="0" y="-29.7766053186953" z="-26.4648010577138"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU83"/> 
+       <position name="posWireU83" unit="cm" x="0" y="-29.1221744325701" z="-25.8831570784234"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU84"/> 
+       <position name="posWireU84" unit="cm" x="0" y="-28.467743546445" z="-25.301513099133"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU85"/> 
+       <position name="posWireU85" unit="cm" x="0" y="-27.8133126603198" z="-24.7198691198426"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU86"/> 
+       <position name="posWireU86" unit="cm" x="0" y="-27.1588817741946" z="-24.1382251405522"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU87"/> 
+       <position name="posWireU87" unit="cm" x="0" y="-26.5044508880694" z="-23.5565811612617"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU88"/> 
+       <position name="posWireU88" unit="cm" x="0" y="-25.8500200019443" z="-22.9749371819713"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU89"/> 
+       <position name="posWireU89" unit="cm" x="0" y="-25.1955891158191" z="-22.3932932026809"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU90"/> 
+       <position name="posWireU90" unit="cm" x="0" y="-24.5411582296939" z="-21.8116492233905"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU91"/> 
+       <position name="posWireU91" unit="cm" x="0" y="-23.8867273435687" z="-21.2300052441001"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU92"/> 
+       <position name="posWireU92" unit="cm" x="0" y="-23.2322964574436" z="-20.6483612648097"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU93"/> 
+       <position name="posWireU93" unit="cm" x="0" y="-22.5778655713184" z="-20.0667172855192"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU94"/> 
+       <position name="posWireU94" unit="cm" x="0" y="-21.9234346851932" z="-19.4850733062288"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU95"/> 
+       <position name="posWireU95" unit="cm" x="0" y="-21.269003799068" z="-18.9034293269384"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU96"/> 
+       <position name="posWireU96" unit="cm" x="0" y="-20.6145729129429" z="-18.321785347648"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU97"/> 
+       <position name="posWireU97" unit="cm" x="0" y="-19.9601420268177" z="-17.7401413683576"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU98"/> 
+       <position name="posWireU98" unit="cm" x="0" y="-19.3057111406925" z="-17.1584973890672"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU99"/> 
+       <position name="posWireU99" unit="cm" x="0" y="-18.6512802545673" z="-16.5768534097767"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU100"/> 
+       <position name="posWireU100" unit="cm" x="0" y="-17.9968493684422" z="-15.9952094304863"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU101"/> 
+       <position name="posWireU101" unit="cm" x="0" y="-17.342418482317" z="-15.4135654511959"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU102"/> 
+       <position name="posWireU102" unit="cm" x="0" y="-16.6879875961918" z="-14.8319214719055"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU103"/> 
+       <position name="posWireU103" unit="cm" x="0" y="-16.0335567100666" z="-14.2502774926151"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU104"/> 
+       <position name="posWireU104" unit="cm" x="0" y="-15.3791258239415" z="-13.6686335133247"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU105"/> 
+       <position name="posWireU105" unit="cm" x="0" y="-14.7246949378163" z="-13.0869895340343"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU106"/> 
+       <position name="posWireU106" unit="cm" x="0" y="-14.0702640516911" z="-12.5053455547438"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU107"/> 
+       <position name="posWireU107" unit="cm" x="0" y="-13.415833165566" z="-11.9237015754534"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU108"/> 
+       <position name="posWireU108" unit="cm" x="0" y="-12.7614022794408" z="-11.342057596163"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU109"/> 
+       <position name="posWireU109" unit="cm" x="0" y="-12.1069713933156" z="-10.7604136168726"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU110"/> 
+       <position name="posWireU110" unit="cm" x="0" y="-11.4525405071904" z="-10.1787696375822"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU111"/> 
+       <position name="posWireU111" unit="cm" x="0" y="-10.7981096210653" z="-9.59712565829176"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU112"/> 
+       <position name="posWireU112" unit="cm" x="0" y="-10.1436787349401" z="-9.01548167900135"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU113"/> 
+       <position name="posWireU113" unit="cm" x="0" y="-9.4892478488149" z="-8.43383769971093"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU114"/> 
+       <position name="posWireU114" unit="cm" x="0" y="-8.83481696268973" z="-7.85219372042052"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU115"/> 
+       <position name="posWireU115" unit="cm" x="0" y="-8.18038607656456" z="-7.2705497411301"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU116"/> 
+       <position name="posWireU116" unit="cm" x="0" y="-7.52595519043939" z="-6.68890576183968"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU117"/> 
+       <position name="posWireU117" unit="cm" x="0" y="-6.87152430431422" z="-6.10726178254927"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU118"/> 
+       <position name="posWireU118" unit="cm" x="0" y="-6.21709341818904" z="-5.52561780325885"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU119"/> 
+       <position name="posWireU119" unit="cm" x="0" y="-5.56266253206387" z="-4.94397382396843"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU120"/> 
+       <position name="posWireU120" unit="cm" x="0" y="-4.90823164593868" z="-4.36232984467803"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU121"/> 
+       <position name="posWireU121" unit="cm" x="0" y="-4.25380075981352" z="-3.78068586538761"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU122"/> 
+       <position name="posWireU122" unit="cm" x="0" y="-3.59936987368835" z="-3.19904188609719"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU123"/> 
+       <position name="posWireU123" unit="cm" x="0" y="-2.94493898756318" z="-2.61739790680677"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU124"/> 
+       <position name="posWireU124" unit="cm" x="0" y="-2.29050810143798" z="-2.03575392751635"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU125"/> 
+       <position name="posWireU125" unit="cm" x="0" y="-1.63607721531281" z="-1.45410994822593"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU126"/> 
+       <position name="posWireU126" unit="cm" x="0" y="-0.98164632918764" z="-0.872465968935515"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU127"/> 
+       <position name="posWireU127" unit="cm" x="0" y="-0.327215443062471" z="-0.290821989645096"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU128"/> 
+       <position name="posWireU128" unit="cm" x="0" y="0.327215443062705" z="0.290821989645316"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU129"/> 
+       <position name="posWireU129" unit="cm" x="0" y="0.981646329187875" z="0.872465968935728"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU130"/> 
+       <position name="posWireU130" unit="cm" x="0" y="1.63607721531305" z="1.45410994822615"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU131"/> 
+       <position name="posWireU131" unit="cm" x="0" y="2.29050810143823" z="2.03575392751656"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU132"/> 
+       <position name="posWireU132" unit="cm" x="0" y="2.9449389875634" z="2.61739790680698"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU133"/> 
+       <position name="posWireU133" unit="cm" x="0" y="3.59936987368857" z="3.19904188609739"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU134"/> 
+       <position name="posWireU134" unit="cm" x="0" y="4.25380075981374" z="3.7806858653878"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU135"/> 
+       <position name="posWireU135" unit="cm" x="0" y="4.90823164593891" z="4.36232984467821"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU136"/> 
+       <position name="posWireU136" unit="cm" x="0" y="5.56266253206409" z="4.94397382396863"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU137"/> 
+       <position name="posWireU137" unit="cm" x="0" y="6.21709341818926" z="5.52561780325905"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU138"/> 
+       <position name="posWireU138" unit="cm" x="0" y="6.87152430431443" z="6.10726178254946"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU139"/> 
+       <position name="posWireU139" unit="cm" x="0" y="7.5259551904396" z="6.68890576183988"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU140"/> 
+       <position name="posWireU140" unit="cm" x="0" y="8.18038607656479" z="7.2705497411303"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU141"/> 
+       <position name="posWireU141" unit="cm" x="0" y="8.83481696268996" z="7.85219372042071"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU142"/> 
+       <position name="posWireU142" unit="cm" x="0" y="9.48924784881513" z="8.43383769971113"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU143"/> 
+       <position name="posWireU143" unit="cm" x="0" y="10.1436787349403" z="9.01548167900155"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU144"/> 
+       <position name="posWireU144" unit="cm" x="0" y="10.7981096210655" z="9.59712565829196"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU145"/> 
+       <position name="posWireU145" unit="cm" x="0" y="11.4525405071907" z="10.1787696375824"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU146"/> 
+       <position name="posWireU146" unit="cm" x="0" y="12.1069713933158" z="10.7604136168728"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU147"/> 
+       <position name="posWireU147" unit="cm" x="0" y="12.761402279441" z="11.3420575961632"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU148"/> 
+       <position name="posWireU148" unit="cm" x="0" y="13.4158331655662" z="11.9237015754536"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU149"/> 
+       <position name="posWireU149" unit="cm" x="0" y="14.0702640516913" z="12.505345554744"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU150"/> 
+       <position name="posWireU150" unit="cm" x="0" y="14.7246949378165" z="13.0869895340344"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU151"/> 
+       <position name="posWireU151" unit="cm" x="0" y="15.3791258239416" z="13.6686335133248"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU152"/> 
+       <position name="posWireU152" unit="cm" x="0" y="16.0335567100668" z="14.2502774926152"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU153"/> 
+       <position name="posWireU153" unit="cm" x="0" y="16.687987596192" z="14.8319214719056"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU154"/> 
+       <position name="posWireU154" unit="cm" x="0" y="17.3424184823171" z="15.413565451196"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU155"/> 
+       <position name="posWireU155" unit="cm" x="0" y="17.9968493684423" z="15.9952094304864"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU156"/> 
+       <position name="posWireU156" unit="cm" x="0" y="18.6512802545675" z="16.5768534097769"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU157"/> 
+       <position name="posWireU157" unit="cm" x="0" y="19.3057111406926" z="17.1584973890673"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU158"/> 
+       <position name="posWireU158" unit="cm" x="0" y="19.9601420268178" z="17.7401413683577"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU159"/> 
+       <position name="posWireU159" unit="cm" x="0" y="20.614572912943" z="18.3217853476481"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU160"/> 
+       <position name="posWireU160" unit="cm" x="0" y="21.2690037990681" z="18.9034293269385"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU161"/> 
+       <position name="posWireU161" unit="cm" x="0" y="21.9234346851933" z="19.4850733062289"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU162"/> 
+       <position name="posWireU162" unit="cm" x="0" y="22.5778655713184" z="20.0667172855193"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU163"/> 
+       <position name="posWireU163" unit="cm" x="0" y="23.2322964574436" z="20.6483612648097"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU164"/> 
+       <position name="posWireU164" unit="cm" x="0" y="23.8867273435688" z="21.2300052441001"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU165"/> 
+       <position name="posWireU165" unit="cm" x="0" y="24.5411582296939" z="21.8116492233905"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU166"/> 
+       <position name="posWireU166" unit="cm" x="0" y="25.1955891158191" z="22.3932932026809"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU167"/> 
+       <position name="posWireU167" unit="cm" x="0" y="25.8500200019443" z="22.9749371819713"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU168"/> 
+       <position name="posWireU168" unit="cm" x="0" y="26.5044508880694" z="23.5565811612617"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU169"/> 
+       <position name="posWireU169" unit="cm" x="0" y="27.1588817741946" z="24.1382251405521"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU170"/> 
+       <position name="posWireU170" unit="cm" x="0" y="27.8133126603198" z="24.7198691198426"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU171"/> 
+       <position name="posWireU171" unit="cm" x="0" y="28.4677435464449" z="25.301513099133"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU172"/> 
+       <position name="posWireU172" unit="cm" x="0" y="29.1221744325701" z="25.8831570784234"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU173"/> 
+       <position name="posWireU173" unit="cm" x="0" y="29.7766053186952" z="26.4648010577138"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU174"/> 
+       <position name="posWireU174" unit="cm" x="0" y="30.4310362048204" z="27.0464450370042"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU175"/> 
+       <position name="posWireU175" unit="cm" x="0" y="31.0854670909456" z="27.6280890162946"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU176"/> 
+       <position name="posWireU176" unit="cm" x="0" y="31.7398979770707" z="28.209732995585"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU177"/> 
+       <position name="posWireU177" unit="cm" x="0" y="32.3943288631959" z="28.7913769748754"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU178"/> 
+       <position name="posWireU178" unit="cm" x="0" y="33.0487597493211" z="29.3730209541658"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU179"/> 
+       <position name="posWireU179" unit="cm" x="0" y="33.7031906354462" z="29.9546649334562"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU180"/> 
+       <position name="posWireU180" unit="cm" x="0" y="34.3576215215714" z="30.5363089127466"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU181"/> 
+       <position name="posWireU181" unit="cm" x="0" y="35.0120524076965" z="31.117952892037"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU182"/> 
+       <position name="posWireU182" unit="cm" x="0" y="35.6664832938217" z="31.6995968713274"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU183"/> 
+       <position name="posWireU183" unit="cm" x="0" y="36.3209141799469" z="32.2812408506178"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU184"/> 
+       <position name="posWireU184" unit="cm" x="0" y="36.975345066072" z="32.8628848299082"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU185"/> 
+       <position name="posWireU185" unit="cm" x="0" y="37.6297759521972" z="33.4445288091987"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU186"/> 
+       <position name="posWireU186" unit="cm" x="0" y="38.2842068383224" z="34.026172788489"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU187"/> 
+       <position name="posWireU187" unit="cm" x="0" y="38.9386377244475" z="34.6078167677795"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU188"/> 
+       <position name="posWireU188" unit="cm" x="0" y="39.5930686105727" z="35.1894607470699"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU189"/> 
+       <position name="posWireU189" unit="cm" x="0" y="40.2474994966978" z="35.7711047263603"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU190"/> 
+       <position name="posWireU190" unit="cm" x="0" y="40.901930382823" z="36.3527487056507"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU191"/> 
+       <position name="posWireU191" unit="cm" x="0" y="41.5563612689482" z="36.9343926849411"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU192"/> 
+       <position name="posWireU192" unit="cm" x="0" y="42.2107921550733" z="37.5160366642315"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU193"/> 
+       <position name="posWireU193" unit="cm" x="0" y="42.8652230411985" z="38.0976806435219"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU194"/> 
+       <position name="posWireU194" unit="cm" x="0" y="43.5196539273237" z="38.6793246228123"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU195"/> 
+       <position name="posWireU195" unit="cm" x="0" y="44.1740848134488" z="39.2609686021027"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU196"/> 
+       <position name="posWireU196" unit="cm" x="0" y="44.828515699574" z="39.8426125813931"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU197"/> 
+       <position name="posWireU197" unit="cm" x="0" y="45.4829465856992" z="40.4242565606835"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU198"/> 
+       <position name="posWireU198" unit="cm" x="0" y="46.1373774718243" z="41.0059005399739"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU199"/> 
+       <position name="posWireU199" unit="cm" x="0" y="46.7918083579495" z="41.5875445192643"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU200"/> 
+       <position name="posWireU200" unit="cm" x="0" y="47.4462392440746" z="42.1691884985547"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU201"/> 
+       <position name="posWireU201" unit="cm" x="0" y="48.1006701301998" z="42.7508324778452"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU202"/> 
+       <position name="posWireU202" unit="cm" x="0" y="48.755101016325" z="43.3324764571356"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU203"/> 
+       <position name="posWireU203" unit="cm" x="0" y="49.4095319024501" z="43.9141204364259"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU204"/> 
+       <position name="posWireU204" unit="cm" x="0" y="50.0639627885753" z="44.4957644157164"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU205"/> 
+       <position name="posWireU205" unit="cm" x="0" y="50.7183936747005" z="45.0774083950068"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU206"/> 
+       <position name="posWireU206" unit="cm" x="0" y="51.3728245608256" z="45.6590523742972"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU207"/> 
+       <position name="posWireU207" unit="cm" x="0" y="52.0272554469508" z="46.2406963535876"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU208"/> 
+       <position name="posWireU208" unit="cm" x="0" y="52.681686333076" z="46.822340332878"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU209"/> 
+       <position name="posWireU209" unit="cm" x="0" y="53.3361172192011" z="47.4039843121684"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU210"/> 
+       <position name="posWireU210" unit="cm" x="0" y="53.9905481053263" z="47.9856282914588"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU211"/> 
+       <position name="posWireU211" unit="cm" x="0" y="54.6449789914514" z="48.5672722707492"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU212"/> 
+       <position name="posWireU212" unit="cm" x="0" y="55.2994098775766" z="49.1489162500396"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU213"/> 
+       <position name="posWireU213" unit="cm" x="0" y="55.9538407637018" z="49.73056022933"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU214"/> 
+       <position name="posWireU214" unit="cm" x="0" y="56.6082716498269" z="50.3122042086204"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU215"/> 
+       <position name="posWireU215" unit="cm" x="0" y="57.2627025359521" z="50.8938481879108"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU216"/> 
+       <position name="posWireU216" unit="cm" x="0" y="57.9171334220772" z="51.4754921672012"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU217"/> 
+       <position name="posWireU217" unit="cm" x="0" y="58.5715643082024" z="52.0571361464917"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU218"/> 
+       <position name="posWireU218" unit="cm" x="0" y="59.2259951943276" z="52.6387801257821"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU219"/> 
+       <position name="posWireU219" unit="cm" x="0" y="59.8804260804527" z="53.2204241050725"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU220"/> 
+       <position name="posWireU220" unit="cm" x="0" y="60.5348569665779" z="53.8020680843629"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU221"/> 
+       <position name="posWireU221" unit="cm" x="0" y="61.1892878527031" z="54.3837120636533"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU222"/> 
+       <position name="posWireU222" unit="cm" x="0" y="61.8437187388282" z="54.9653560429437"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU223"/> 
+       <position name="posWireU223" unit="cm" x="0" y="62.4981496249534" z="55.5470000222341"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU224"/> 
+       <position name="posWireU224" unit="cm" x="0" y="63.1525805110786" z="56.1286440015245"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU225"/> 
+       <position name="posWireU225" unit="cm" x="0" y="63.8070113972037" z="56.7102879808149"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU226"/> 
+       <position name="posWireU226" unit="cm" x="0" y="64.4614422833289" z="57.2919319601053"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU227"/> 
+       <position name="posWireU227" unit="cm" x="0" y="65.115873169454" z="57.8735759393957"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU228"/> 
+       <position name="posWireU228" unit="cm" x="0" y="65.7703040555792" z="58.4552199186861"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU229"/> 
+       <position name="posWireU229" unit="cm" x="0" y="66.4247349417044" z="59.0368638979765"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU230"/> 
+       <position name="posWireU230" unit="cm" x="0" y="67.0791658278295" z="59.6185078772669"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU231"/> 
+       <position name="posWireU231" unit="cm" x="0" y="67.7335967139547" z="60.2001518565573"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU232"/> 
+       <position name="posWireU232" unit="cm" x="0" y="68.3880276000799" z="60.7817958358477"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU233"/> 
+       <position name="posWireU233" unit="cm" x="0" y="69.042458486205" z="61.3634398151382"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU234"/> 
+       <position name="posWireU234" unit="cm" x="0" y="69.6968893723302" z="61.9450837944285"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU235"/> 
+       <position name="posWireU235" unit="cm" x="0" y="70.3513202584554" z="62.526727773719"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU236"/> 
+       <position name="posWireU236" unit="cm" x="0" y="71.0057511445805" z="63.1083717530094"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU237"/> 
+       <position name="posWireU237" unit="cm" x="0" y="71.6601820307057" z="63.6900157322998"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU238"/> 
+       <position name="posWireU238" unit="cm" x="0" y="72.3146129168309" z="64.2716597115902"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU239"/> 
+       <position name="posWireU239" unit="cm" x="0" y="72.969043802956" z="64.8533036908806"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU240"/> 
+       <position name="posWireU240" unit="cm" x="0" y="73.6234746890812" z="65.434947670171"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU241"/> 
+       <position name="posWireU241" unit="cm" x="0" y="74.2779055752063" z="66.0165916494614"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU242"/> 
+       <position name="posWireU242" unit="cm" x="0" y="74.9323364613315" z="66.5982356287518"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU243"/> 
+       <position name="posWireU243" unit="cm" x="0" y="75.5867673474567" z="67.1798796080422"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU244"/> 
+       <position name="posWireU244" unit="cm" x="0" y="76.2411982335818" z="67.7615235873326"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU245"/> 
+       <position name="posWireU245" unit="cm" x="0" y="76.895629119707" z="68.343167566623"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU246"/> 
+       <position name="posWireU246" unit="cm" x="0" y="77.5500600058322" z="68.9248115459134"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU247"/> 
+       <position name="posWireU247" unit="cm" x="0" y="78.2044908919573" z="69.5064555252038"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU248"/> 
+       <position name="posWireU248" unit="cm" x="0" y="78.8589217780825" z="70.0880995044943"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU249"/> 
+       <position name="posWireU249" unit="cm" x="0" y="79.5133526642076" z="70.6697434837847"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU250"/> 
+       <position name="posWireU250" unit="cm" x="0" y="80.1677835503328" z="71.251387463075"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU251"/> 
+       <position name="posWireU251" unit="cm" x="0" y="80.822214436458" z="71.8330314423655"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU252"/> 
+       <position name="posWireU252" unit="cm" x="0" y="81.4766453225831" z="72.4146754216559"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU253"/> 
+       <position name="posWireU253" unit="cm" x="0" y="82.1310762087083" z="72.9963194009463"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU254"/> 
+       <position name="posWireU254" unit="cm" x="0" y="82.7855070948335" z="73.5779633802367"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU255"/> 
+       <position name="posWireU255" unit="cm" x="0" y="83.4399379809586" z="74.1596073595271"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+   </volume>
+  <volume name="volTPCPlaneY">
+    <materialref ref="LAr"/>
+    <solidref ref="CRMYPlane"/>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY0" unit="cm" x="0" y="-83.7375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY1" unit="cm" x="0" y="-83.2125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY2" unit="cm" x="0" y="-82.6875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY3" unit="cm" x="0" y="-82.1625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY4" unit="cm" x="0" y="-81.6375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY5" unit="cm" x="0" y="-81.1125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY6" unit="cm" x="0" y="-80.5875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY7" unit="cm" x="0" y="-80.0625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY8" unit="cm" x="0" y="-79.5375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY9" unit="cm" x="0" y="-79.0125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY10" unit="cm" x="0" y="-78.4875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY11" unit="cm" x="0" y="-77.9625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY12" unit="cm" x="0" y="-77.4375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY13" unit="cm" x="0" y="-76.9125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY14" unit="cm" x="0" y="-76.3875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY15" unit="cm" x="0" y="-75.8625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY16" unit="cm" x="0" y="-75.3375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY17" unit="cm" x="0" y="-74.8125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY18" unit="cm" x="0" y="-74.2875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY19" unit="cm" x="0" y="-73.7625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY20" unit="cm" x="0" y="-73.2375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY21" unit="cm" x="0" y="-72.7125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY22" unit="cm" x="0" y="-72.1875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY23" unit="cm" x="0" y="-71.6625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY24" unit="cm" x="0" y="-71.1375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY25" unit="cm" x="0" y="-70.6125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY26" unit="cm" x="0" y="-70.0875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY27" unit="cm" x="0" y="-69.5625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY28" unit="cm" x="0" y="-69.0375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY29" unit="cm" x="0" y="-68.5125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY30" unit="cm" x="0" y="-67.9875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY31" unit="cm" x="0" y="-67.4625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY32" unit="cm" x="0" y="-66.9375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY33" unit="cm" x="0" y="-66.4125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY34" unit="cm" x="0" y="-65.8875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY35" unit="cm" x="0" y="-65.3625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY36" unit="cm" x="0" y="-64.8375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY37" unit="cm" x="0" y="-64.3125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY38" unit="cm" x="0" y="-63.7875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY39" unit="cm" x="0" y="-63.2625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY40" unit="cm" x="0" y="-62.7375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY41" unit="cm" x="0" y="-62.2125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY42" unit="cm" x="0" y="-61.6875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY43" unit="cm" x="0" y="-61.1625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY44" unit="cm" x="0" y="-60.6375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY45" unit="cm" x="0" y="-60.1125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY46" unit="cm" x="0" y="-59.5875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY47" unit="cm" x="0" y="-59.0625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY48" unit="cm" x="0" y="-58.5375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY49" unit="cm" x="0" y="-58.0125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY50" unit="cm" x="0" y="-57.4875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY51" unit="cm" x="0" y="-56.9625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY52" unit="cm" x="0" y="-56.4375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY53" unit="cm" x="0" y="-55.9125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY54" unit="cm" x="0" y="-55.3875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY55" unit="cm" x="0" y="-54.8625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY56" unit="cm" x="0" y="-54.3375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY57" unit="cm" x="0" y="-53.8125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY58" unit="cm" x="0" y="-53.2875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY59" unit="cm" x="0" y="-52.7625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY60" unit="cm" x="0" y="-52.2375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY61" unit="cm" x="0" y="-51.7125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY62" unit="cm" x="0" y="-51.1875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY63" unit="cm" x="0" y="-50.6625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY64" unit="cm" x="0" y="-50.1375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY65" unit="cm" x="0" y="-49.6125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY66" unit="cm" x="0" y="-49.0875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY67" unit="cm" x="0" y="-48.5625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY68" unit="cm" x="0" y="-48.0375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY69" unit="cm" x="0" y="-47.5125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY70" unit="cm" x="0" y="-46.9875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY71" unit="cm" x="0" y="-46.4625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY72" unit="cm" x="0" y="-45.9375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY73" unit="cm" x="0" y="-45.4125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY74" unit="cm" x="0" y="-44.8875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY75" unit="cm" x="0" y="-44.3625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY76" unit="cm" x="0" y="-43.8375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY77" unit="cm" x="0" y="-43.3125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY78" unit="cm" x="0" y="-42.7875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY79" unit="cm" x="0" y="-42.2625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY80" unit="cm" x="0" y="-41.7375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY81" unit="cm" x="0" y="-41.2125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY82" unit="cm" x="0" y="-40.6875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY83" unit="cm" x="0" y="-40.1625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY84" unit="cm" x="0" y="-39.6375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY85" unit="cm" x="0" y="-39.1125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY86" unit="cm" x="0" y="-38.5875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY87" unit="cm" x="0" y="-38.0625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY88" unit="cm" x="0" y="-37.5375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY89" unit="cm" x="0" y="-37.0125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY90" unit="cm" x="0" y="-36.4875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY91" unit="cm" x="0" y="-35.9625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY92" unit="cm" x="0" y="-35.4375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY93" unit="cm" x="0" y="-34.9125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY94" unit="cm" x="0" y="-34.3875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY95" unit="cm" x="0" y="-33.8625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY96" unit="cm" x="0" y="-33.3375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY97" unit="cm" x="0" y="-32.8125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY98" unit="cm" x="0" y="-32.2875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY99" unit="cm" x="0" y="-31.7625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY100" unit="cm" x="0" y="-31.2375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY101" unit="cm" x="0" y="-30.7125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY102" unit="cm" x="0" y="-30.1875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY103" unit="cm" x="0" y="-29.6625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY104" unit="cm" x="0" y="-29.1375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY105" unit="cm" x="0" y="-28.6125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY106" unit="cm" x="0" y="-28.0875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY107" unit="cm" x="0" y="-27.5625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY108" unit="cm" x="0" y="-27.0375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY109" unit="cm" x="0" y="-26.5125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY110" unit="cm" x="0" y="-25.9875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY111" unit="cm" x="0" y="-25.4625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY112" unit="cm" x="0" y="-24.9375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY113" unit="cm" x="0" y="-24.4125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY114" unit="cm" x="0" y="-23.8875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY115" unit="cm" x="0" y="-23.3625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY116" unit="cm" x="0" y="-22.8375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY117" unit="cm" x="0" y="-22.3125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY118" unit="cm" x="0" y="-21.7875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY119" unit="cm" x="0" y="-21.2625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY120" unit="cm" x="0" y="-20.7375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY121" unit="cm" x="0" y="-20.2125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY122" unit="cm" x="0" y="-19.6875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY123" unit="cm" x="0" y="-19.1625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY124" unit="cm" x="0" y="-18.6375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY125" unit="cm" x="0" y="-18.1125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY126" unit="cm" x="0" y="-17.5875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY127" unit="cm" x="0" y="-17.0625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY128" unit="cm" x="0" y="-16.5375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY129" unit="cm" x="0" y="-16.0125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY130" unit="cm" x="0" y="-15.4875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY131" unit="cm" x="0" y="-14.9625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY132" unit="cm" x="0" y="-14.4375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY133" unit="cm" x="0" y="-13.9125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY134" unit="cm" x="0" y="-13.3875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY135" unit="cm" x="0" y="-12.8625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY136" unit="cm" x="0" y="-12.3375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY137" unit="cm" x="0" y="-11.8125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY138" unit="cm" x="0" y="-11.2875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY139" unit="cm" x="0" y="-10.7625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY140" unit="cm" x="0" y="-10.2375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY141" unit="cm" x="0" y="-9.7125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY142" unit="cm" x="0" y="-9.1875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY143" unit="cm" x="0" y="-8.6625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY144" unit="cm" x="0" y="-8.1375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY145" unit="cm" x="0" y="-7.6125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY146" unit="cm" x="0" y="-7.0875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY147" unit="cm" x="0" y="-6.5625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY148" unit="cm" x="0" y="-6.0375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY149" unit="cm" x="0" y="-5.5125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY150" unit="cm" x="0" y="-4.9875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY151" unit="cm" x="0" y="-4.4625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY152" unit="cm" x="0" y="-3.9375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY153" unit="cm" x="0" y="-3.4125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY154" unit="cm" x="0" y="-2.8875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY155" unit="cm" x="0" y="-2.3625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY156" unit="cm" x="0" y="-1.8375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY157" unit="cm" x="0" y="-1.3125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY158" unit="cm" x="0" y="-0.7875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY159" unit="cm" x="0" y="-0.2625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY160" unit="cm" x="0" y="0.2625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY161" unit="cm" x="0" y="0.7875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY162" unit="cm" x="0" y="1.3125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY163" unit="cm" x="0" y="1.8375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY164" unit="cm" x="0" y="2.3625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY165" unit="cm" x="0" y="2.8875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY166" unit="cm" x="0" y="3.4125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY167" unit="cm" x="0" y="3.9375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY168" unit="cm" x="0" y="4.4625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY169" unit="cm" x="0" y="4.9875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY170" unit="cm" x="0" y="5.5125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY171" unit="cm" x="0" y="6.0375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY172" unit="cm" x="0" y="6.5625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY173" unit="cm" x="0" y="7.0875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY174" unit="cm" x="0" y="7.6125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY175" unit="cm" x="0" y="8.1375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY176" unit="cm" x="0" y="8.6625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY177" unit="cm" x="0" y="9.1875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY178" unit="cm" x="0" y="9.7125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY179" unit="cm" x="0" y="10.2375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY180" unit="cm" x="0" y="10.7625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY181" unit="cm" x="0" y="11.2875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY182" unit="cm" x="0" y="11.8125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY183" unit="cm" x="0" y="12.3375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY184" unit="cm" x="0" y="12.8625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY185" unit="cm" x="0" y="13.3875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY186" unit="cm" x="0" y="13.9125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY187" unit="cm" x="0" y="14.4375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY188" unit="cm" x="0" y="14.9625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY189" unit="cm" x="0" y="15.4875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY190" unit="cm" x="0" y="16.0125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY191" unit="cm" x="0" y="16.5375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY192" unit="cm" x="0" y="17.0625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY193" unit="cm" x="0" y="17.5875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY194" unit="cm" x="0" y="18.1125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY195" unit="cm" x="0" y="18.6375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY196" unit="cm" x="0" y="19.1625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY197" unit="cm" x="0" y="19.6875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY198" unit="cm" x="0" y="20.2125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY199" unit="cm" x="0" y="20.7375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY200" unit="cm" x="0" y="21.2625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY201" unit="cm" x="0" y="21.7875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY202" unit="cm" x="0" y="22.3125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY203" unit="cm" x="0" y="22.8375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY204" unit="cm" x="0" y="23.3625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY205" unit="cm" x="0" y="23.8875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY206" unit="cm" x="0" y="24.4125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY207" unit="cm" x="0" y="24.9375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY208" unit="cm" x="0" y="25.4625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY209" unit="cm" x="0" y="25.9875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY210" unit="cm" x="0" y="26.5125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY211" unit="cm" x="0" y="27.0375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY212" unit="cm" x="0" y="27.5625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY213" unit="cm" x="0" y="28.0875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY214" unit="cm" x="0" y="28.6125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY215" unit="cm" x="0" y="29.1375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY216" unit="cm" x="0" y="29.6625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY217" unit="cm" x="0" y="30.1875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY218" unit="cm" x="0" y="30.7125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY219" unit="cm" x="0" y="31.2375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY220" unit="cm" x="0" y="31.7625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY221" unit="cm" x="0" y="32.2875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY222" unit="cm" x="0" y="32.8125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY223" unit="cm" x="0" y="33.3375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY224" unit="cm" x="0" y="33.8625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY225" unit="cm" x="0" y="34.3875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY226" unit="cm" x="0" y="34.9125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY227" unit="cm" x="0" y="35.4375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY228" unit="cm" x="0" y="35.9625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY229" unit="cm" x="0" y="36.4875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY230" unit="cm" x="0" y="37.0125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY231" unit="cm" x="0" y="37.5375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY232" unit="cm" x="0" y="38.0625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY233" unit="cm" x="0" y="38.5875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY234" unit="cm" x="0" y="39.1125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY235" unit="cm" x="0" y="39.6375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY236" unit="cm" x="0" y="40.1625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY237" unit="cm" x="0" y="40.6875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY238" unit="cm" x="0" y="41.2125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY239" unit="cm" x="0" y="41.7375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY240" unit="cm" x="0" y="42.2625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY241" unit="cm" x="0" y="42.7875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY242" unit="cm" x="0" y="43.3125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY243" unit="cm" x="0" y="43.8375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY244" unit="cm" x="0" y="44.3625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY245" unit="cm" x="0" y="44.8875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY246" unit="cm" x="0" y="45.4125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY247" unit="cm" x="0" y="45.9375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY248" unit="cm" x="0" y="46.4625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY249" unit="cm" x="0" y="46.9875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY250" unit="cm" x="0" y="47.5125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY251" unit="cm" x="0" y="48.0375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY252" unit="cm" x="0" y="48.5625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY253" unit="cm" x="0" y="49.0875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY254" unit="cm" x="0" y="49.6125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY255" unit="cm" x="0" y="50.1375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY256" unit="cm" x="0" y="50.6625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY257" unit="cm" x="0" y="51.1875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY258" unit="cm" x="0" y="51.7125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY259" unit="cm" x="0" y="52.2375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY260" unit="cm" x="0" y="52.7625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY261" unit="cm" x="0" y="53.2875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY262" unit="cm" x="0" y="53.8125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY263" unit="cm" x="0" y="54.3375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY264" unit="cm" x="0" y="54.8625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY265" unit="cm" x="0" y="55.3875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY266" unit="cm" x="0" y="55.9125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY267" unit="cm" x="0" y="56.4375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY268" unit="cm" x="0" y="56.9625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY269" unit="cm" x="0" y="57.4875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY270" unit="cm" x="0" y="58.0125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY271" unit="cm" x="0" y="58.5375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY272" unit="cm" x="0" y="59.0625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY273" unit="cm" x="0" y="59.5875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY274" unit="cm" x="0" y="60.1125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY275" unit="cm" x="0" y="60.6375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY276" unit="cm" x="0" y="61.1625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY277" unit="cm" x="0" y="61.6875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY278" unit="cm" x="0" y="62.2125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY279" unit="cm" x="0" y="62.7375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY280" unit="cm" x="0" y="63.2625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY281" unit="cm" x="0" y="63.7875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY282" unit="cm" x="0" y="64.3125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY283" unit="cm" x="0" y="64.8375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY284" unit="cm" x="0" y="65.3625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY285" unit="cm" x="0" y="65.8875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY286" unit="cm" x="0" y="66.4125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY287" unit="cm" x="0" y="66.9375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY288" unit="cm" x="0" y="67.4625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY289" unit="cm" x="0" y="67.9875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY290" unit="cm" x="0" y="68.5125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY291" unit="cm" x="0" y="69.0375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY292" unit="cm" x="0" y="69.5625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY293" unit="cm" x="0" y="70.0875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY294" unit="cm" x="0" y="70.6125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY295" unit="cm" x="0" y="71.1375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY296" unit="cm" x="0" y="71.6625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY297" unit="cm" x="0" y="72.1875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY298" unit="cm" x="0" y="72.7125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY299" unit="cm" x="0" y="73.2375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY300" unit="cm" x="0" y="73.7625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY301" unit="cm" x="0" y="74.2875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY302" unit="cm" x="0" y="74.8125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY303" unit="cm" x="0" y="75.3375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY304" unit="cm" x="0" y="75.8625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY305" unit="cm" x="0" y="76.3875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY306" unit="cm" x="0" y="76.9125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY307" unit="cm" x="0" y="77.4375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY308" unit="cm" x="0" y="77.9625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY309" unit="cm" x="0" y="78.4875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY310" unit="cm" x="0" y="79.0125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY311" unit="cm" x="0" y="79.5375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY312" unit="cm" x="0" y="80.0625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY313" unit="cm" x="0" y="80.5875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY314" unit="cm" x="0" y="81.1125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY315" unit="cm" x="0" y="81.6375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY316" unit="cm" x="0" y="82.1625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY317" unit="cm" x="0" y="82.6875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY318" unit="cm" x="0" y="83.2125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY319" unit="cm" x="0" y="83.7375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+  </volume>
+  <volume name="volTPCPlaneZ">
+    <materialref ref="LAr"/>
+    <solidref ref="CRMZPlane"/>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ0" unit="cm" x="0" y="0" z="-74.1895"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ1" unit="cm" x="0" y="0" z="-73.6725"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ2" unit="cm" x="0" y="0" z="-73.1555"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ3" unit="cm" x="0" y="0" z="-72.6385"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ4" unit="cm" x="0" y="0" z="-72.1215"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ5" unit="cm" x="0" y="0" z="-71.6045"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ6" unit="cm" x="0" y="0" z="-71.0875"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ7" unit="cm" x="0" y="0" z="-70.5705"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ8" unit="cm" x="0" y="0" z="-70.0535"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ9" unit="cm" x="0" y="0" z="-69.5365"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ10" unit="cm" x="0" y="0" z="-69.0195"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ11" unit="cm" x="0" y="0" z="-68.5025"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ12" unit="cm" x="0" y="0" z="-67.9855"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ13" unit="cm" x="0" y="0" z="-67.4685"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ14" unit="cm" x="0" y="0" z="-66.9515"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ15" unit="cm" x="0" y="0" z="-66.4345"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ16" unit="cm" x="0" y="0" z="-65.9175"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ17" unit="cm" x="0" y="0" z="-65.4005"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ18" unit="cm" x="0" y="0" z="-64.8835"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ19" unit="cm" x="0" y="0" z="-64.3665"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ20" unit="cm" x="0" y="0" z="-63.8495"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ21" unit="cm" x="0" y="0" z="-63.3325"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ22" unit="cm" x="0" y="0" z="-62.8155"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ23" unit="cm" x="0" y="0" z="-62.2985"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ24" unit="cm" x="0" y="0" z="-61.7815"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ25" unit="cm" x="0" y="0" z="-61.2645"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ26" unit="cm" x="0" y="0" z="-60.7475"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ27" unit="cm" x="0" y="0" z="-60.2305"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ28" unit="cm" x="0" y="0" z="-59.7135"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ29" unit="cm" x="0" y="0" z="-59.1965"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ30" unit="cm" x="0" y="0" z="-58.6795"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ31" unit="cm" x="0" y="0" z="-58.1625"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ32" unit="cm" x="0" y="0" z="-57.6455"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ33" unit="cm" x="0" y="0" z="-57.1285"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ34" unit="cm" x="0" y="0" z="-56.6115"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ35" unit="cm" x="0" y="0" z="-56.0945"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ36" unit="cm" x="0" y="0" z="-55.5775"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ37" unit="cm" x="0" y="0" z="-55.0605"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ38" unit="cm" x="0" y="0" z="-54.5435"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ39" unit="cm" x="0" y="0" z="-54.0265"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ40" unit="cm" x="0" y="0" z="-53.5095"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ41" unit="cm" x="0" y="0" z="-52.9925"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ42" unit="cm" x="0" y="0" z="-52.4755"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ43" unit="cm" x="0" y="0" z="-51.9585"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ44" unit="cm" x="0" y="0" z="-51.4415"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ45" unit="cm" x="0" y="0" z="-50.9245"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ46" unit="cm" x="0" y="0" z="-50.4075"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ47" unit="cm" x="0" y="0" z="-49.8905"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ48" unit="cm" x="0" y="0" z="-49.3735"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ49" unit="cm" x="0" y="0" z="-48.8565"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ50" unit="cm" x="0" y="0" z="-48.3395"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ51" unit="cm" x="0" y="0" z="-47.8225"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ52" unit="cm" x="0" y="0" z="-47.3055"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ53" unit="cm" x="0" y="0" z="-46.7885"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ54" unit="cm" x="0" y="0" z="-46.2715"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ55" unit="cm" x="0" y="0" z="-45.7545"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ56" unit="cm" x="0" y="0" z="-45.2375"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ57" unit="cm" x="0" y="0" z="-44.7205"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ58" unit="cm" x="0" y="0" z="-44.2035"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ59" unit="cm" x="0" y="0" z="-43.6865"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ60" unit="cm" x="0" y="0" z="-43.1695"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ61" unit="cm" x="0" y="0" z="-42.6525"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ62" unit="cm" x="0" y="0" z="-42.1355"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ63" unit="cm" x="0" y="0" z="-41.6185"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ64" unit="cm" x="0" y="0" z="-41.1015"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ65" unit="cm" x="0" y="0" z="-40.5845"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ66" unit="cm" x="0" y="0" z="-40.0675"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ67" unit="cm" x="0" y="0" z="-39.5505"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ68" unit="cm" x="0" y="0" z="-39.0335"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ69" unit="cm" x="0" y="0" z="-38.5165"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ70" unit="cm" x="0" y="0" z="-37.9995"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ71" unit="cm" x="0" y="0" z="-37.4825"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ72" unit="cm" x="0" y="0" z="-36.9655"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ73" unit="cm" x="0" y="0" z="-36.4485"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ74" unit="cm" x="0" y="0" z="-35.9315"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ75" unit="cm" x="0" y="0" z="-35.4145"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ76" unit="cm" x="0" y="0" z="-34.8975"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ77" unit="cm" x="0" y="0" z="-34.3805"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ78" unit="cm" x="0" y="0" z="-33.8635"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ79" unit="cm" x="0" y="0" z="-33.3465"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ80" unit="cm" x="0" y="0" z="-32.8295"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ81" unit="cm" x="0" y="0" z="-32.3125"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ82" unit="cm" x="0" y="0" z="-31.7955"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ83" unit="cm" x="0" y="0" z="-31.2785"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ84" unit="cm" x="0" y="0" z="-30.7615"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ85" unit="cm" x="0" y="0" z="-30.2445"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ86" unit="cm" x="0" y="0" z="-29.7275"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ87" unit="cm" x="0" y="0" z="-29.2105"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ88" unit="cm" x="0" y="0" z="-28.6935"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ89" unit="cm" x="0" y="0" z="-28.1765"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ90" unit="cm" x="0" y="0" z="-27.6595"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ91" unit="cm" x="0" y="0" z="-27.1425"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ92" unit="cm" x="0" y="0" z="-26.6255"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ93" unit="cm" x="0" y="0" z="-26.1085"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ94" unit="cm" x="0" y="0" z="-25.5915"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ95" unit="cm" x="0" y="0" z="-25.0745"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ96" unit="cm" x="0" y="0" z="-24.5575"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ97" unit="cm" x="0" y="0" z="-24.0405"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ98" unit="cm" x="0" y="0" z="-23.5235"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ99" unit="cm" x="0" y="0" z="-23.0065"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ100" unit="cm" x="0" y="0" z="-22.4895"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ101" unit="cm" x="0" y="0" z="-21.9725"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ102" unit="cm" x="0" y="0" z="-21.4555"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ103" unit="cm" x="0" y="0" z="-20.9385"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ104" unit="cm" x="0" y="0" z="-20.4215"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ105" unit="cm" x="0" y="0" z="-19.9045"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ106" unit="cm" x="0" y="0" z="-19.3875"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ107" unit="cm" x="0" y="0" z="-18.8705"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ108" unit="cm" x="0" y="0" z="-18.3535"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ109" unit="cm" x="0" y="0" z="-17.8365"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ110" unit="cm" x="0" y="0" z="-17.3195"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ111" unit="cm" x="0" y="0" z="-16.8025"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ112" unit="cm" x="0" y="0" z="-16.2855"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ113" unit="cm" x="0" y="0" z="-15.7685"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ114" unit="cm" x="0" y="0" z="-15.2515"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ115" unit="cm" x="0" y="0" z="-14.7345"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ116" unit="cm" x="0" y="0" z="-14.2175"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ117" unit="cm" x="0" y="0" z="-13.7005"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ118" unit="cm" x="0" y="0" z="-13.1835"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ119" unit="cm" x="0" y="0" z="-12.6665"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ120" unit="cm" x="0" y="0" z="-12.1495"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ121" unit="cm" x="0" y="0" z="-11.6325"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ122" unit="cm" x="0" y="0" z="-11.1155"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ123" unit="cm" x="0" y="0" z="-10.5985"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ124" unit="cm" x="0" y="0" z="-10.0815"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ125" unit="cm" x="0" y="0" z="-9.5645"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ126" unit="cm" x="0" y="0" z="-9.0475"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ127" unit="cm" x="0" y="0" z="-8.5305"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ128" unit="cm" x="0" y="0" z="-8.0135"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ129" unit="cm" x="0" y="0" z="-7.4965"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ130" unit="cm" x="0" y="0" z="-6.9795"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ131" unit="cm" x="0" y="0" z="-6.4625"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ132" unit="cm" x="0" y="0" z="-5.9455"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ133" unit="cm" x="0" y="0" z="-5.4285"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ134" unit="cm" x="0" y="0" z="-4.9115"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ135" unit="cm" x="0" y="0" z="-4.3945"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ136" unit="cm" x="0" y="0" z="-3.8775"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ137" unit="cm" x="0" y="0" z="-3.3605"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ138" unit="cm" x="0" y="0" z="-2.8435"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ139" unit="cm" x="0" y="0" z="-2.3265"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ140" unit="cm" x="0" y="0" z="-1.8095"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ141" unit="cm" x="0" y="0" z="-1.2925"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ142" unit="cm" x="0" y="0" z="-0.7755"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ143" unit="cm" x="0" y="0" z="-0.2585"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ144" unit="cm" x="0" y="0" z="0.2585"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ145" unit="cm" x="0" y="0" z="0.7755"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ146" unit="cm" x="0" y="0" z="1.2925"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ147" unit="cm" x="0" y="0" z="1.8095"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ148" unit="cm" x="0" y="0" z="2.3265"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ149" unit="cm" x="0" y="0" z="2.8435"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ150" unit="cm" x="0" y="0" z="3.3605"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ151" unit="cm" x="0" y="0" z="3.8775"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ152" unit="cm" x="0" y="0" z="4.3945"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ153" unit="cm" x="0" y="0" z="4.9115"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ154" unit="cm" x="0" y="0" z="5.4285"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ155" unit="cm" x="0" y="0" z="5.9455"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ156" unit="cm" x="0" y="0" z="6.4625"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ157" unit="cm" x="0" y="0" z="6.9795"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ158" unit="cm" x="0" y="0" z="7.4965"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ159" unit="cm" x="0" y="0" z="8.0135"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ160" unit="cm" x="0" y="0" z="8.5305"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ161" unit="cm" x="0" y="0" z="9.0475"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ162" unit="cm" x="0" y="0" z="9.5645"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ163" unit="cm" x="0" y="0" z="10.0815"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ164" unit="cm" x="0" y="0" z="10.5985"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ165" unit="cm" x="0" y="0" z="11.1155"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ166" unit="cm" x="0" y="0" z="11.6325"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ167" unit="cm" x="0" y="0" z="12.1495"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ168" unit="cm" x="0" y="0" z="12.6665"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ169" unit="cm" x="0" y="0" z="13.1835"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ170" unit="cm" x="0" y="0" z="13.7005"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ171" unit="cm" x="0" y="0" z="14.2175"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ172" unit="cm" x="0" y="0" z="14.7345"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ173" unit="cm" x="0" y="0" z="15.2515"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ174" unit="cm" x="0" y="0" z="15.7685"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ175" unit="cm" x="0" y="0" z="16.2855"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ176" unit="cm" x="0" y="0" z="16.8025"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ177" unit="cm" x="0" y="0" z="17.3195"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ178" unit="cm" x="0" y="0" z="17.8365"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ179" unit="cm" x="0" y="0" z="18.3535"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ180" unit="cm" x="0" y="0" z="18.8705"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ181" unit="cm" x="0" y="0" z="19.3875"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ182" unit="cm" x="0" y="0" z="19.9045"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ183" unit="cm" x="0" y="0" z="20.4215"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ184" unit="cm" x="0" y="0" z="20.9385"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ185" unit="cm" x="0" y="0" z="21.4555"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ186" unit="cm" x="0" y="0" z="21.9725"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ187" unit="cm" x="0" y="0" z="22.4895"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ188" unit="cm" x="0" y="0" z="23.0065"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ189" unit="cm" x="0" y="0" z="23.5235"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ190" unit="cm" x="0" y="0" z="24.0405"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ191" unit="cm" x="0" y="0" z="24.5575"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ192" unit="cm" x="0" y="0" z="25.0745"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ193" unit="cm" x="0" y="0" z="25.5915"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ194" unit="cm" x="0" y="0" z="26.1085"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ195" unit="cm" x="0" y="0" z="26.6255"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ196" unit="cm" x="0" y="0" z="27.1425"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ197" unit="cm" x="0" y="0" z="27.6595"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ198" unit="cm" x="0" y="0" z="28.1765"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ199" unit="cm" x="0" y="0" z="28.6935"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ200" unit="cm" x="0" y="0" z="29.2105"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ201" unit="cm" x="0" y="0" z="29.7275"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ202" unit="cm" x="0" y="0" z="30.2445"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ203" unit="cm" x="0" y="0" z="30.7615"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ204" unit="cm" x="0" y="0" z="31.2785"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ205" unit="cm" x="0" y="0" z="31.7955"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ206" unit="cm" x="0" y="0" z="32.3125"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ207" unit="cm" x="0" y="0" z="32.8295"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ208" unit="cm" x="0" y="0" z="33.3465"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ209" unit="cm" x="0" y="0" z="33.8635"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ210" unit="cm" x="0" y="0" z="34.3805"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ211" unit="cm" x="0" y="0" z="34.8975"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ212" unit="cm" x="0" y="0" z="35.4145"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ213" unit="cm" x="0" y="0" z="35.9315"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ214" unit="cm" x="0" y="0" z="36.4485"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ215" unit="cm" x="0" y="0" z="36.9655"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ216" unit="cm" x="0" y="0" z="37.4825"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ217" unit="cm" x="0" y="0" z="37.9995"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ218" unit="cm" x="0" y="0" z="38.5165"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ219" unit="cm" x="0" y="0" z="39.0335"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ220" unit="cm" x="0" y="0" z="39.5505"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ221" unit="cm" x="0" y="0" z="40.0675"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ222" unit="cm" x="0" y="0" z="40.5845"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ223" unit="cm" x="0" y="0" z="41.1015"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ224" unit="cm" x="0" y="0" z="41.6185"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ225" unit="cm" x="0" y="0" z="42.1355"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ226" unit="cm" x="0" y="0" z="42.6525"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ227" unit="cm" x="0" y="0" z="43.1695"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ228" unit="cm" x="0" y="0" z="43.6865"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ229" unit="cm" x="0" y="0" z="44.2035"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ230" unit="cm" x="0" y="0" z="44.7205"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ231" unit="cm" x="0" y="0" z="45.2375"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ232" unit="cm" x="0" y="0" z="45.7545"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ233" unit="cm" x="0" y="0" z="46.2715"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ234" unit="cm" x="0" y="0" z="46.7885"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ235" unit="cm" x="0" y="0" z="47.3055"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ236" unit="cm" x="0" y="0" z="47.8225"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ237" unit="cm" x="0" y="0" z="48.3395"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ238" unit="cm" x="0" y="0" z="48.8565"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ239" unit="cm" x="0" y="0" z="49.3735"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ240" unit="cm" x="0" y="0" z="49.8905"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ241" unit="cm" x="0" y="0" z="50.4075"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ242" unit="cm" x="0" y="0" z="50.9245"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ243" unit="cm" x="0" y="0" z="51.4415"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ244" unit="cm" x="0" y="0" z="51.9585"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ245" unit="cm" x="0" y="0" z="52.4755"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ246" unit="cm" x="0" y="0" z="52.9925"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ247" unit="cm" x="0" y="0" z="53.5095"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ248" unit="cm" x="0" y="0" z="54.0265"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ249" unit="cm" x="0" y="0" z="54.5435"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ250" unit="cm" x="0" y="0" z="55.0605"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ251" unit="cm" x="0" y="0" z="55.5775"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ252" unit="cm" x="0" y="0" z="56.0945"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ253" unit="cm" x="0" y="0" z="56.6115"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ254" unit="cm" x="0" y="0" z="57.1285"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ255" unit="cm" x="0" y="0" z="57.6455"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ256" unit="cm" x="0" y="0" z="58.1625"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ257" unit="cm" x="0" y="0" z="58.6795"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ258" unit="cm" x="0" y="0" z="59.1965"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ259" unit="cm" x="0" y="0" z="59.7135"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ260" unit="cm" x="0" y="0" z="60.2305"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ261" unit="cm" x="0" y="0" z="60.7475"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ262" unit="cm" x="0" y="0" z="61.2645"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ263" unit="cm" x="0" y="0" z="61.7815"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ264" unit="cm" x="0" y="0" z="62.2985"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ265" unit="cm" x="0" y="0" z="62.8155"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ266" unit="cm" x="0" y="0" z="63.3325"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ267" unit="cm" x="0" y="0" z="63.8495"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ268" unit="cm" x="0" y="0" z="64.3665"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ269" unit="cm" x="0" y="0" z="64.8835"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ270" unit="cm" x="0" y="0" z="65.4005"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ271" unit="cm" x="0" y="0" z="65.9175"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ272" unit="cm" x="0" y="0" z="66.4345"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ273" unit="cm" x="0" y="0" z="66.9515"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ274" unit="cm" x="0" y="0" z="67.4685"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ275" unit="cm" x="0" y="0" z="67.9855"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ276" unit="cm" x="0" y="0" z="68.5025"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ277" unit="cm" x="0" y="0" z="69.0195"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ278" unit="cm" x="0" y="0" z="69.5365"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ279" unit="cm" x="0" y="0" z="70.0535"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ280" unit="cm" x="0" y="0" z="70.5705"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ281" unit="cm" x="0" y="0" z="71.0875"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ282" unit="cm" x="0" y="0" z="71.6045"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ283" unit="cm" x="0" y="0" z="72.1215"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ284" unit="cm" x="0" y="0" z="72.6385"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ285" unit="cm" x="0" y="0" z="73.1555"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ286" unit="cm" x="0" y="0" z="73.6725"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ287" unit="cm" x="0" y="0" z="74.1895"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+  </volume>
+   <volume name="volTPC">
+     <materialref ref="LAr"/>
+       <solidref ref="CRM"/>
+       <physvol>
+       <volumeref ref="volTPCPlaneU"/>
+       <position name="posPlaneU" unit="cm" 
+         x="324.99" y="0" z="0"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCPlaneY"/>
+       <position name="posPlaneY" unit="cm" 
+         x="325.01" y="0" z="0"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCPlaneZ"/>
+       <position name="posPlaneZ" unit="cm" 
+         x="325.03" y="0" z="0"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCActive"/>
+       <position name="posActive" unit="cm" 
+        x="-0.04" y="" z="0"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+   </volume>
+ 
+    <volume name="volSteelShell">
+      <materialref ref="STEEL_STAINLESS_Fe7Cr2Ni" />
+      <solidref ref="SteelShell" />
+    </volume>
+    <volume name="volGroundGrid">
+      <materialref ref="STEEL_STAINLESS_Fe7Cr2Ni" />
+      <solidref ref="CathodeGrid" />
+    </volume>    
+    <volume name="volGaseousArgon">
+      <materialref ref="ArGas"/>
+      <solidref ref="GaseousArgon"/>
+    </volume>
+    <volume name="volExternalActive">
+      <materialref ref="LAr"/>
+      <solidref ref="ExternalActive"/>
+      <auxiliary auxtype="SensDet" auxvalue="SimEnergyDeposit"/>
+      <auxiliary auxtype="StepLimit" auxunit="cm" auxvalue="0.5208*cm"/>
+      <auxiliary auxtype="Efield" auxunit="V/cm" auxvalue="0*V/cm"/>
+      <colorref ref="green"/>
+    </volume>
+    <volume name="volArapucaDouble_0-0-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-0-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-0-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-0-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-0-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-0-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-0-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-0-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-1-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-1-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-1-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-1-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-1-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-1-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-1-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-1-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-2-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-2-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-2-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-2-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-2-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-2-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-2-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-2-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-0-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-0-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-0-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-0-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-0-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-0-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-0-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-0-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-1-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-1-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-1-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-1-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-1-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-1-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-1-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-1-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-2-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-2-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-2-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-2-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-2-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-2-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-2-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-2-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-0-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-0-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-0-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-0-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-0-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-0-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-0-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-0-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-1-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-1-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-1-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-1-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-1-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-1-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-1-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-1-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-2-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-2-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-2-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-2-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-2-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-2-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-2-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-2-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-0-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-0-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-0-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-0-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-0-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-0-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-0-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-0-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-1-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-1-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-1-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-1-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-1-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-1-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-1-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-1-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-2-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-2-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-2-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-2-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-2-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-2-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-2-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-2-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_0-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_0-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_0-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_0-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_0-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_0-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_0-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_0-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_0-4">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_0-4">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_0-5">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_0-5">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_0-6">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_0-6">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_0-7">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_0-7">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_1-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_1-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_1-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_1-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_1-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_1-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_1-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_1-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_1-4">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_1-4">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_1-5">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_1-5">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_1-6">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_1-6">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_1-7">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_1-7">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_2-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_2-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_2-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_2-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_2-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_2-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_2-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_2-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_2-4">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_2-4">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_2-5">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_2-5">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_2-6">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_2-6">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_2-7">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_2-7">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+
+    <volume name="volCryostat">
+      <materialref ref="LAr" />
+      <solidref ref="Cryostat" />
+      <physvol>
+        <volumeref ref="volGaseousArgon"/>
+        <position name="posGaseousArgon" unit="cm" x="375.04" y="0" z="0"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volSteelShell"/>
+        <position name="posSteelShell" unit="cm" x="0" y="0" z="0"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volExternalActive"/>
+        <position name="posExternalActive" unit="cm" x="-100/2" y="0" z="0"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-0" unit="cm"
+           x="0" y="-589.5" z="-373.25225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-1" unit="cm"
+           x="0" y="-421.5" z="-373.25225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-2" unit="cm"
+           x="0" y="-252.5" z="-373.25225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-3" unit="cm"
+           x="0" y="-84.5" z="-373.25225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-4" unit="cm"
+           x="0" y="84.5" z="-373.25225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-5" unit="cm"
+           x="0" y="252.5" z="-373.25225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-6" unit="cm"
+           x="0" y="421.5" z="-373.25225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-7" unit="cm"
+           x="0" y="589.5" z="-373.25225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-8" unit="cm"
+           x="0" y="-589.5" z="-224.35135"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-9" unit="cm"
+           x="0" y="-421.5" z="-224.35135"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-10" unit="cm"
+           x="0" y="-252.5" z="-224.35135"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-11" unit="cm"
+           x="0" y="-84.5" z="-224.35135"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-12" unit="cm"
+           x="0" y="84.5" z="-224.35135"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-13" unit="cm"
+           x="0" y="252.5" z="-224.35135"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-14" unit="cm"
+           x="0" y="421.5" z="-224.35135"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-15" unit="cm"
+           x="0" y="589.5" z="-224.35135"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-16" unit="cm"
+           x="0" y="-589.5" z="-74.45045"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-17" unit="cm"
+           x="0" y="-421.5" z="-74.45045"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-18" unit="cm"
+           x="0" y="-252.5" z="-74.45045"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-19" unit="cm"
+           x="0" y="-84.5" z="-74.45045"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-20" unit="cm"
+           x="0" y="84.5" z="-74.45045"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-21" unit="cm"
+           x="0" y="252.5" z="-74.45045"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-22" unit="cm"
+           x="0" y="421.5" z="-74.45045"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-23" unit="cm"
+           x="0" y="589.5" z="-74.45045"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-24" unit="cm"
+           x="0" y="-589.5" z="74.45045"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-25" unit="cm"
+           x="0" y="-421.5" z="74.45045"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-26" unit="cm"
+           x="0" y="-252.5" z="74.45045"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-27" unit="cm"
+           x="0" y="-84.5" z="74.45045"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-28" unit="cm"
+           x="0" y="84.5" z="74.45045"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-29" unit="cm"
+           x="0" y="252.5" z="74.45045"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-30" unit="cm"
+           x="0" y="421.5" z="74.45045"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-31" unit="cm"
+           x="0" y="589.5" z="74.45045"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-32" unit="cm"
+           x="0" y="-589.5" z="224.35135"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-33" unit="cm"
+           x="0" y="-421.5" z="224.35135"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-34" unit="cm"
+           x="0" y="-252.5" z="224.35135"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-35" unit="cm"
+           x="0" y="-84.5" z="224.35135"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-36" unit="cm"
+           x="0" y="84.5" z="224.35135"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-37" unit="cm"
+           x="0" y="252.5" z="224.35135"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-38" unit="cm"
+           x="0" y="421.5" z="224.35135"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-39" unit="cm"
+           x="0" y="589.5" z="224.35135"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-40" unit="cm"
+           x="0" y="-589.5" z="373.25225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-41" unit="cm"
+           x="0" y="-421.5" z="373.25225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-42" unit="cm"
+           x="0" y="-252.5" z="373.25225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-43" unit="cm"
+           x="0" y="-84.5" z="373.25225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-44" unit="cm"
+           x="0" y="84.5" z="373.25225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-45" unit="cm"
+           x="0" y="252.5" z="373.25225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-46" unit="cm"
+           x="0" y="421.5" z="373.25225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-47" unit="cm"
+           x="0" y="589.5" z="373.25225"/>
+      </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper0" unit="cm"  x="-322.04" y="-676.3" z="0" />
+     <rotation name="rotFS0" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper1" unit="cm"  x="-316.04" y="-676.3" z="0" />
+     <rotation name="rotFS1" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper2" unit="cm"  x="-310.04" y="-676.3" z="0" />
+     <rotation name="rotFS2" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper3" unit="cm"  x="-304.04" y="-676.3" z="0" />
+     <rotation name="rotFS3" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper4" unit="cm"  x="-298.04" y="-676.3" z="0" />
+     <rotation name="rotFS4" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper5" unit="cm"  x="-292.04" y="-676.3" z="0" />
+     <rotation name="rotFS5" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper6" unit="cm"  x="-286.04" y="-676.3" z="0" />
+     <rotation name="rotFS6" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper7" unit="cm"  x="-280.04" y="-676.3" z="0" />
+     <rotation name="rotFS7" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper8" unit="cm"  x="-274.04" y="-676.3" z="0" />
+     <rotation name="rotFS8" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper9" unit="cm"  x="-268.04" y="-676.3" z="0" />
+     <rotation name="rotFS9" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper10" unit="cm"  x="-262.04" y="-676.3" z="0" />
+     <rotation name="rotFS10" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper11" unit="cm"  x="-256.04" y="-676.3" z="0" />
+     <rotation name="rotFS11" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper12" unit="cm"  x="-250.04" y="-676.3" z="0" />
+     <rotation name="rotFS12" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper13" unit="cm"  x="-244.04" y="-676.3" z="0" />
+     <rotation name="rotFS13" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper14" unit="cm"  x="-238.04" y="-676.3" z="0" />
+     <rotation name="rotFS14" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper15" unit="cm"  x="-232.04" y="-676.3" z="0" />
+     <rotation name="rotFS15" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper16" unit="cm"  x="-226.04" y="-676.3" z="0" />
+     <rotation name="rotFS16" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper17" unit="cm"  x="-220.04" y="-676.3" z="0" />
+     <rotation name="rotFS17" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper18" unit="cm"  x="-214.04" y="-676.3" z="0" />
+     <rotation name="rotFS18" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper19" unit="cm"  x="-208.04" y="-676.3" z="0" />
+     <rotation name="rotFS19" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper20" unit="cm"  x="-202.04" y="-676.3" z="0" />
+     <rotation name="rotFS20" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper21" unit="cm"  x="-196.04" y="-676.3" z="0" />
+     <rotation name="rotFS21" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper22" unit="cm"  x="-190.04" y="-676.3" z="0" />
+     <rotation name="rotFS22" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper23" unit="cm"  x="-184.04" y="-676.3" z="0" />
+     <rotation name="rotFS23" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper24" unit="cm"  x="-178.04" y="-676.3" z="0" />
+     <rotation name="rotFS24" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper25" unit="cm"  x="-172.04" y="-676.3" z="0" />
+     <rotation name="rotFS25" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper26" unit="cm"  x="-166.04" y="-676.3" z="0" />
+     <rotation name="rotFS26" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper27" unit="cm"  x="-160.04" y="-676.3" z="0" />
+     <rotation name="rotFS27" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper28" unit="cm"  x="-154.04" y="-676.3" z="0" />
+     <rotation name="rotFS28" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper29" unit="cm"  x="-148.04" y="-676.3" z="0" />
+     <rotation name="rotFS29" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper30" unit="cm"  x="-142.04" y="-676.3" z="0" />
+     <rotation name="rotFS30" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper31" unit="cm"  x="-136.04" y="-676.3" z="0" />
+     <rotation name="rotFS31" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper32" unit="cm"  x="-130.04" y="-676.3" z="0" />
+     <rotation name="rotFS32" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper33" unit="cm"  x="-124.04" y="-676.3" z="0" />
+     <rotation name="rotFS33" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper34" unit="cm"  x="-118.04" y="-676.3" z="0" />
+     <rotation name="rotFS34" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper35" unit="cm"  x="-112.04" y="-676.3" z="0" />
+     <rotation name="rotFS35" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper36" unit="cm"  x="-106.04" y="-676.3" z="0" />
+     <rotation name="rotFS36" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper37" unit="cm"  x="-100.04" y="-676.3" z="0" />
+     <rotation name="rotFS37" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper38" unit="cm"  x="-94.04" y="-676.3" z="0" />
+     <rotation name="rotFS38" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper39" unit="cm"  x="-88.04" y="-676.3" z="0" />
+     <rotation name="rotFS39" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper40" unit="cm"  x="-82.04" y="-676.3" z="0" />
+     <rotation name="rotFS40" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper41" unit="cm"  x="-76.04" y="-676.3" z="0" />
+     <rotation name="rotFS41" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper42" unit="cm"  x="-70.04" y="-676.3" z="0" />
+     <rotation name="rotFS42" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper43" unit="cm"  x="-64.04" y="-676.3" z="0" />
+     <rotation name="rotFS43" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper44" unit="cm"  x="-58.04" y="-676.3" z="0" />
+     <rotation name="rotFS44" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper45" unit="cm"  x="-52.04" y="-676.3" z="0" />
+     <rotation name="rotFS45" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper46" unit="cm"  x="-46.04" y="-676.3" z="0" />
+     <rotation name="rotFS46" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper47" unit="cm"  x="-40.04" y="-676.3" z="0" />
+     <rotation name="rotFS47" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper48" unit="cm"  x="-34.04" y="-676.3" z="0" />
+     <rotation name="rotFS48" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper49" unit="cm"  x="-28.04" y="-676.3" z="0" />
+     <rotation name="rotFS49" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper50" unit="cm"  x="-22.04" y="-676.3" z="0" />
+     <rotation name="rotFS50" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper51" unit="cm"  x="-16.04" y="-676.3" z="0" />
+     <rotation name="rotFS51" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper52" unit="cm"  x="-10.04" y="-676.3" z="0" />
+     <rotation name="rotFS52" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper53" unit="cm"  x="-4.04000000000001" y="-676.3" z="0" />
+     <rotation name="rotFS53" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper54" unit="cm"  x="1.95999999999999" y="-676.3" z="0" />
+     <rotation name="rotFS54" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper55" unit="cm"  x="7.95999999999999" y="-676.3" z="0" />
+     <rotation name="rotFS55" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper56" unit="cm"  x="13.96" y="-676.3" z="0" />
+     <rotation name="rotFS56" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper57" unit="cm"  x="19.96" y="-676.3" z="0" />
+     <rotation name="rotFS57" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper58" unit="cm"  x="25.96" y="-676.3" z="0" />
+     <rotation name="rotFS58" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper59" unit="cm"  x="31.96" y="-676.3" z="0" />
+     <rotation name="rotFS59" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper60" unit="cm"  x="37.96" y="-676.3" z="0" />
+     <rotation name="rotFS60" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper61" unit="cm"  x="43.96" y="-676.3" z="0" />
+     <rotation name="rotFS61" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper62" unit="cm"  x="49.96" y="-676.3" z="0" />
+     <rotation name="rotFS62" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper63" unit="cm"  x="55.96" y="-676.3" z="0" />
+     <rotation name="rotFS63" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper64" unit="cm"  x="61.96" y="-676.3" z="0" />
+     <rotation name="rotFS64" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper65" unit="cm"  x="67.96" y="-676.3" z="0" />
+     <rotation name="rotFS65" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper66" unit="cm"  x="73.96" y="-676.3" z="0" />
+     <rotation name="rotFS66" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper67" unit="cm"  x="79.96" y="-676.3" z="0" />
+     <rotation name="rotFS67" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper68" unit="cm"  x="85.96" y="-676.3" z="0" />
+     <rotation name="rotFS68" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper69" unit="cm"  x="91.96" y="-676.3" z="0" />
+     <rotation name="rotFS69" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper70" unit="cm"  x="97.96" y="-676.3" z="0" />
+     <rotation name="rotFS70" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper71" unit="cm"  x="103.96" y="-676.3" z="0" />
+     <rotation name="rotFS71" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper72" unit="cm"  x="109.96" y="-676.3" z="0" />
+     <rotation name="rotFS72" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper73" unit="cm"  x="115.96" y="-676.3" z="0" />
+     <rotation name="rotFS73" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper74" unit="cm"  x="121.96" y="-676.3" z="0" />
+     <rotation name="rotFS74" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper75" unit="cm"  x="127.96" y="-676.3" z="0" />
+     <rotation name="rotFS75" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper76" unit="cm"  x="133.96" y="-676.3" z="0" />
+     <rotation name="rotFS76" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper77" unit="cm"  x="139.96" y="-676.3" z="0" />
+     <rotation name="rotFS77" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper78" unit="cm"  x="145.96" y="-676.3" z="0" />
+     <rotation name="rotFS78" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper79" unit="cm"  x="151.96" y="-676.3" z="0" />
+     <rotation name="rotFS79" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper80" unit="cm"  x="157.96" y="-676.3" z="0" />
+     <rotation name="rotFS80" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper81" unit="cm"  x="163.96" y="-676.3" z="0" />
+     <rotation name="rotFS81" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper82" unit="cm"  x="169.96" y="-676.3" z="0" />
+     <rotation name="rotFS82" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper83" unit="cm"  x="175.96" y="-676.3" z="0" />
+     <rotation name="rotFS83" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper84" unit="cm"  x="181.96" y="-676.3" z="0" />
+     <rotation name="rotFS84" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper85" unit="cm"  x="187.96" y="-676.3" z="0" />
+     <rotation name="rotFS85" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper86" unit="cm"  x="193.96" y="-676.3" z="0" />
+     <rotation name="rotFS86" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper87" unit="cm"  x="199.96" y="-676.3" z="0" />
+     <rotation name="rotFS87" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper88" unit="cm"  x="205.96" y="-676.3" z="0" />
+     <rotation name="rotFS88" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper89" unit="cm"  x="211.96" y="-676.3" z="0" />
+     <rotation name="rotFS89" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper90" unit="cm"  x="217.96" y="-676.3" z="0" />
+     <rotation name="rotFS90" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper91" unit="cm"  x="223.96" y="-676.3" z="0" />
+     <rotation name="rotFS91" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper92" unit="cm"  x="229.96" y="-676.3" z="0" />
+     <rotation name="rotFS92" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper93" unit="cm"  x="235.96" y="-676.3" z="0" />
+     <rotation name="rotFS93" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper94" unit="cm"  x="241.96" y="-676.3" z="0" />
+     <rotation name="rotFS94" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper95" unit="cm"  x="247.96" y="-676.3" z="0" />
+     <rotation name="rotFS95" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper96" unit="cm"  x="253.96" y="-676.3" z="0" />
+     <rotation name="rotFS96" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper97" unit="cm"  x="259.96" y="-676.3" z="0" />
+     <rotation name="rotFS97" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper98" unit="cm"  x="265.96" y="-676.3" z="0" />
+     <rotation name="rotFS98" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper99" unit="cm"  x="271.96" y="-676.3" z="0" />
+     <rotation name="rotFS99" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper100" unit="cm"  x="277.96" y="-676.3" z="0" />
+     <rotation name="rotFS100" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper101" unit="cm"  x="283.96" y="-676.3" z="0" />
+     <rotation name="rotFS101" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper102" unit="cm"  x="289.96" y="-676.3" z="0" />
+     <rotation name="rotFS102" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper103" unit="cm"  x="295.96" y="-676.3" z="0" />
+     <rotation name="rotFS103" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper104" unit="cm"  x="301.96" y="-676.3" z="0" />
+     <rotation name="rotFS104" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper105" unit="cm"  x="307.96" y="-676.3" z="0" />
+     <rotation name="rotFS105" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper106" unit="cm"  x="313.96" y="-676.3" z="0" />
+     <rotation name="rotFS106" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper107" unit="cm"  x="319.96" y="-676.3" z="0" />
+     <rotation name="rotFS107" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-0" unit="cm" x="-328.04" y="-506" z="-299.3018"/>
+      </physvol>
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-1" unit="cm" x="-328.04" y="-170" z="-299.3018"/>
+      </physvol>
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-2" unit="cm" x="-328.04" y="166" z="-299.3018"/>
+      </physvol>
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-3" unit="cm" x="-328.04" y="502" z="-299.3018"/>
+      </physvol>
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-4" unit="cm" x="-328.04" y="-506" z="-1.50000000000006"/>
+      </physvol>
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-5" unit="cm" x="-328.04" y="-170" z="-1.50000000000006"/>
+      </physvol>
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-6" unit="cm" x="-328.04" y="166" z="-1.50000000000006"/>
+      </physvol>
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-7" unit="cm" x="-328.04" y="502" z="-1.50000000000006"/>
+      </physvol>
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-8" unit="cm" x="-328.04" y="-506" z="296.3018"/>
+      </physvol>
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-9" unit="cm" x="-328.04" y="-170" z="296.3018"/>
+      </physvol>
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-10" unit="cm" x="-328.04" y="166" z="296.3018"/>
+      </physvol>
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-11" unit="cm" x="-328.04" y="502" z="296.3018"/>
+      </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-0-0"/>
+       <position name="posArapucaDouble0-Frame-0-0" unit="cm" 
+         x="-328.04"
+	 y="-633.7" 
+	 z="-261.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-0"/>
+       <position name="posOpArapucaDouble0-Frame-0-0" unit="cm" 
+         x="-327.3"
+	 y="-633.7" 
+	 z="-261.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-0-1"/>
+       <position name="posArapucaDouble1-Frame-0-0" unit="cm" 
+         x="-328.04"
+	 y="-543" 
+	 z="-407.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-1"/>
+       <position name="posOpArapucaDouble1-Frame-0-0" unit="cm" 
+         x="-327.3"
+	 y="-543" 
+	 z="-407.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-0-2"/>
+       <position name="posArapucaDouble2-Frame-0-0" unit="cm" 
+         x="-328.04"
+	 y="-469" 
+	 z="-190.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-2"/>
+       <position name="posOpArapucaDouble2-Frame-0-0" unit="cm" 
+         x="-327.3"
+	 y="-469" 
+	 z="-190.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-0-3"/>
+       <position name="posArapucaDouble3-Frame-0-0" unit="cm" 
+         x="-328.04"
+	 y="-378.3" 
+	 z="-336.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-3"/>
+       <position name="posOpArapucaDouble3-Frame-0-0" unit="cm" 
+         x="-327.3"
+	 y="-378.3" 
+	 z="-336.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-1-0"/>
+       <position name="posArapucaDouble0-Frame-0-1" unit="cm" 
+         x="-328.04"
+	 y="-633.7" 
+	 z="35.9999999999999"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-0"/>
+       <position name="posOpArapucaDouble0-Frame-0-1" unit="cm" 
+         x="-327.3"
+	 y="-633.7" 
+	 z="35.9999999999999"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-1-1"/>
+       <position name="posArapucaDouble1-Frame-0-1" unit="cm" 
+         x="-328.04"
+	 y="-543" 
+	 z="-110"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-1"/>
+       <position name="posOpArapucaDouble1-Frame-0-1" unit="cm" 
+         x="-327.3"
+	 y="-543" 
+	 z="-110"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-1-2"/>
+       <position name="posArapucaDouble2-Frame-0-1" unit="cm" 
+         x="-328.04"
+	 y="-469" 
+	 z="107"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-2"/>
+       <position name="posOpArapucaDouble2-Frame-0-1" unit="cm" 
+         x="-327.3"
+	 y="-469" 
+	 z="107"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-1-3"/>
+       <position name="posArapucaDouble3-Frame-0-1" unit="cm" 
+         x="-328.04"
+	 y="-378.3" 
+	 z="-39.0000000000001"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-3"/>
+       <position name="posOpArapucaDouble3-Frame-0-1" unit="cm" 
+         x="-327.3"
+	 y="-378.3" 
+	 z="-39.0000000000001"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-2-0"/>
+       <position name="posArapucaDouble0-Frame-0-2" unit="cm" 
+         x="-328.04"
+	 y="-633.7" 
+	 z="333.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-0"/>
+       <position name="posOpArapucaDouble0-Frame-0-2" unit="cm" 
+         x="-327.3"
+	 y="-633.7" 
+	 z="333.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-2-1"/>
+       <position name="posArapucaDouble1-Frame-0-2" unit="cm" 
+         x="-328.04"
+	 y="-543" 
+	 z="187.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-1"/>
+       <position name="posOpArapucaDouble1-Frame-0-2" unit="cm" 
+         x="-327.3"
+	 y="-543" 
+	 z="187.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-2-2"/>
+       <position name="posArapucaDouble2-Frame-0-2" unit="cm" 
+         x="-328.04"
+	 y="-469" 
+	 z="404.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-2"/>
+       <position name="posOpArapucaDouble2-Frame-0-2" unit="cm" 
+         x="-327.3"
+	 y="-469" 
+	 z="404.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-2-3"/>
+       <position name="posArapucaDouble3-Frame-0-2" unit="cm" 
+         x="-328.04"
+	 y="-378.3" 
+	 z="258.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-3"/>
+       <position name="posOpArapucaDouble3-Frame-0-2" unit="cm" 
+         x="-327.3"
+	 y="-378.3" 
+	 z="258.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-0-0"/>
+       <position name="posArapucaDouble0-Frame-1-0" unit="cm" 
+         x="-328.04"
+	 y="-297.7" 
+	 z="-261.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-0"/>
+       <position name="posOpArapucaDouble0-Frame-1-0" unit="cm" 
+         x="-327.3"
+	 y="-297.7" 
+	 z="-261.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-0-1"/>
+       <position name="posArapucaDouble1-Frame-1-0" unit="cm" 
+         x="-328.04"
+	 y="-207" 
+	 z="-407.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-1"/>
+       <position name="posOpArapucaDouble1-Frame-1-0" unit="cm" 
+         x="-327.3"
+	 y="-207" 
+	 z="-407.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-0-2"/>
+       <position name="posArapucaDouble2-Frame-1-0" unit="cm" 
+         x="-328.04"
+	 y="-133" 
+	 z="-190.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-2"/>
+       <position name="posOpArapucaDouble2-Frame-1-0" unit="cm" 
+         x="-327.3"
+	 y="-133" 
+	 z="-190.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-0-3"/>
+       <position name="posArapucaDouble3-Frame-1-0" unit="cm" 
+         x="-328.04"
+	 y="-42.3" 
+	 z="-336.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-3"/>
+       <position name="posOpArapucaDouble3-Frame-1-0" unit="cm" 
+         x="-327.3"
+	 y="-42.3" 
+	 z="-336.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-1-0"/>
+       <position name="posArapucaDouble0-Frame-1-1" unit="cm" 
+         x="-328.04"
+	 y="-297.7" 
+	 z="35.9999999999999"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-0"/>
+       <position name="posOpArapucaDouble0-Frame-1-1" unit="cm" 
+         x="-327.3"
+	 y="-297.7" 
+	 z="35.9999999999999"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-1-1"/>
+       <position name="posArapucaDouble1-Frame-1-1" unit="cm" 
+         x="-328.04"
+	 y="-207" 
+	 z="-110"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-1"/>
+       <position name="posOpArapucaDouble1-Frame-1-1" unit="cm" 
+         x="-327.3"
+	 y="-207" 
+	 z="-110"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-1-2"/>
+       <position name="posArapucaDouble2-Frame-1-1" unit="cm" 
+         x="-328.04"
+	 y="-133" 
+	 z="107"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-2"/>
+       <position name="posOpArapucaDouble2-Frame-1-1" unit="cm" 
+         x="-327.3"
+	 y="-133" 
+	 z="107"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-1-3"/>
+       <position name="posArapucaDouble3-Frame-1-1" unit="cm" 
+         x="-328.04"
+	 y="-42.3" 
+	 z="-39.0000000000001"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-3"/>
+       <position name="posOpArapucaDouble3-Frame-1-1" unit="cm" 
+         x="-327.3"
+	 y="-42.3" 
+	 z="-39.0000000000001"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-2-0"/>
+       <position name="posArapucaDouble0-Frame-1-2" unit="cm" 
+         x="-328.04"
+	 y="-297.7" 
+	 z="333.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-0"/>
+       <position name="posOpArapucaDouble0-Frame-1-2" unit="cm" 
+         x="-327.3"
+	 y="-297.7" 
+	 z="333.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-2-1"/>
+       <position name="posArapucaDouble1-Frame-1-2" unit="cm" 
+         x="-328.04"
+	 y="-207" 
+	 z="187.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-1"/>
+       <position name="posOpArapucaDouble1-Frame-1-2" unit="cm" 
+         x="-327.3"
+	 y="-207" 
+	 z="187.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-2-2"/>
+       <position name="posArapucaDouble2-Frame-1-2" unit="cm" 
+         x="-328.04"
+	 y="-133" 
+	 z="404.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-2"/>
+       <position name="posOpArapucaDouble2-Frame-1-2" unit="cm" 
+         x="-327.3"
+	 y="-133" 
+	 z="404.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-2-3"/>
+       <position name="posArapucaDouble3-Frame-1-2" unit="cm" 
+         x="-328.04"
+	 y="-42.3" 
+	 z="258.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-3"/>
+       <position name="posOpArapucaDouble3-Frame-1-2" unit="cm" 
+         x="-327.3"
+	 y="-42.3" 
+	 z="258.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-0-0"/>
+       <position name="posArapucaDouble0-Frame-2-0" unit="cm" 
+         x="-328.04"
+	 y="38.3" 
+	 z="-261.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-0"/>
+       <position name="posOpArapucaDouble0-Frame-2-0" unit="cm" 
+         x="-327.3"
+	 y="38.3" 
+	 z="-261.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-0-1"/>
+       <position name="posArapucaDouble1-Frame-2-0" unit="cm" 
+         x="-328.04"
+	 y="129" 
+	 z="-407.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-1"/>
+       <position name="posOpArapucaDouble1-Frame-2-0" unit="cm" 
+         x="-327.3"
+	 y="129" 
+	 z="-407.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-0-2"/>
+       <position name="posArapucaDouble2-Frame-2-0" unit="cm" 
+         x="-328.04"
+	 y="203" 
+	 z="-190.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-2"/>
+       <position name="posOpArapucaDouble2-Frame-2-0" unit="cm" 
+         x="-327.3"
+	 y="203" 
+	 z="-190.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-0-3"/>
+       <position name="posArapucaDouble3-Frame-2-0" unit="cm" 
+         x="-328.04"
+	 y="293.7" 
+	 z="-336.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-3"/>
+       <position name="posOpArapucaDouble3-Frame-2-0" unit="cm" 
+         x="-327.3"
+	 y="293.7" 
+	 z="-336.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-1-0"/>
+       <position name="posArapucaDouble0-Frame-2-1" unit="cm" 
+         x="-328.04"
+	 y="38.3" 
+	 z="35.9999999999999"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-0"/>
+       <position name="posOpArapucaDouble0-Frame-2-1" unit="cm" 
+         x="-327.3"
+	 y="38.3" 
+	 z="35.9999999999999"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-1-1"/>
+       <position name="posArapucaDouble1-Frame-2-1" unit="cm" 
+         x="-328.04"
+	 y="129" 
+	 z="-110"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-1"/>
+       <position name="posOpArapucaDouble1-Frame-2-1" unit="cm" 
+         x="-327.3"
+	 y="129" 
+	 z="-110"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-1-2"/>
+       <position name="posArapucaDouble2-Frame-2-1" unit="cm" 
+         x="-328.04"
+	 y="203" 
+	 z="107"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-2"/>
+       <position name="posOpArapucaDouble2-Frame-2-1" unit="cm" 
+         x="-327.3"
+	 y="203" 
+	 z="107"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-1-3"/>
+       <position name="posArapucaDouble3-Frame-2-1" unit="cm" 
+         x="-328.04"
+	 y="293.7" 
+	 z="-39.0000000000001"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-3"/>
+       <position name="posOpArapucaDouble3-Frame-2-1" unit="cm" 
+         x="-327.3"
+	 y="293.7" 
+	 z="-39.0000000000001"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-2-0"/>
+       <position name="posArapucaDouble0-Frame-2-2" unit="cm" 
+         x="-328.04"
+	 y="38.3" 
+	 z="333.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-0"/>
+       <position name="posOpArapucaDouble0-Frame-2-2" unit="cm" 
+         x="-327.3"
+	 y="38.3" 
+	 z="333.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-2-1"/>
+       <position name="posArapucaDouble1-Frame-2-2" unit="cm" 
+         x="-328.04"
+	 y="129" 
+	 z="187.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-1"/>
+       <position name="posOpArapucaDouble1-Frame-2-2" unit="cm" 
+         x="-327.3"
+	 y="129" 
+	 z="187.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-2-2"/>
+       <position name="posArapucaDouble2-Frame-2-2" unit="cm" 
+         x="-328.04"
+	 y="203" 
+	 z="404.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-2"/>
+       <position name="posOpArapucaDouble2-Frame-2-2" unit="cm" 
+         x="-327.3"
+	 y="203" 
+	 z="404.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-2-3"/>
+       <position name="posArapucaDouble3-Frame-2-2" unit="cm" 
+         x="-328.04"
+	 y="293.7" 
+	 z="258.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-3"/>
+       <position name="posOpArapucaDouble3-Frame-2-2" unit="cm" 
+         x="-327.3"
+	 y="293.7" 
+	 z="258.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-0-0"/>
+       <position name="posArapucaDouble0-Frame-3-0" unit="cm" 
+         x="-328.04"
+	 y="374.3" 
+	 z="-261.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-0"/>
+       <position name="posOpArapucaDouble0-Frame-3-0" unit="cm" 
+         x="-327.3"
+	 y="374.3" 
+	 z="-261.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-0-1"/>
+       <position name="posArapucaDouble1-Frame-3-0" unit="cm" 
+         x="-328.04"
+	 y="465" 
+	 z="-407.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-1"/>
+       <position name="posOpArapucaDouble1-Frame-3-0" unit="cm" 
+         x="-327.3"
+	 y="465" 
+	 z="-407.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-0-2"/>
+       <position name="posArapucaDouble2-Frame-3-0" unit="cm" 
+         x="-328.04"
+	 y="539" 
+	 z="-190.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-2"/>
+       <position name="posOpArapucaDouble2-Frame-3-0" unit="cm" 
+         x="-327.3"
+	 y="539" 
+	 z="-190.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-0-3"/>
+       <position name="posArapucaDouble3-Frame-3-0" unit="cm" 
+         x="-328.04"
+	 y="629.7" 
+	 z="-336.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-3"/>
+       <position name="posOpArapucaDouble3-Frame-3-0" unit="cm" 
+         x="-327.3"
+	 y="629.7" 
+	 z="-336.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-1-0"/>
+       <position name="posArapucaDouble0-Frame-3-1" unit="cm" 
+         x="-328.04"
+	 y="374.3" 
+	 z="35.9999999999999"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-0"/>
+       <position name="posOpArapucaDouble0-Frame-3-1" unit="cm" 
+         x="-327.3"
+	 y="374.3" 
+	 z="35.9999999999999"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-1-1"/>
+       <position name="posArapucaDouble1-Frame-3-1" unit="cm" 
+         x="-328.04"
+	 y="465" 
+	 z="-110"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-1"/>
+       <position name="posOpArapucaDouble1-Frame-3-1" unit="cm" 
+         x="-327.3"
+	 y="465" 
+	 z="-110"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-1-2"/>
+       <position name="posArapucaDouble2-Frame-3-1" unit="cm" 
+         x="-328.04"
+	 y="539" 
+	 z="107"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-2"/>
+       <position name="posOpArapucaDouble2-Frame-3-1" unit="cm" 
+         x="-327.3"
+	 y="539" 
+	 z="107"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-1-3"/>
+       <position name="posArapucaDouble3-Frame-3-1" unit="cm" 
+         x="-328.04"
+	 y="629.7" 
+	 z="-39.0000000000001"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-3"/>
+       <position name="posOpArapucaDouble3-Frame-3-1" unit="cm" 
+         x="-327.3"
+	 y="629.7" 
+	 z="-39.0000000000001"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-2-0"/>
+       <position name="posArapucaDouble0-Frame-3-2" unit="cm" 
+         x="-328.04"
+	 y="374.3" 
+	 z="333.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-0"/>
+       <position name="posOpArapucaDouble0-Frame-3-2" unit="cm" 
+         x="-327.3"
+	 y="374.3" 
+	 z="333.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-2-1"/>
+       <position name="posArapucaDouble1-Frame-3-2" unit="cm" 
+         x="-328.04"
+	 y="465" 
+	 z="187.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-1"/>
+       <position name="posOpArapucaDouble1-Frame-3-2" unit="cm" 
+         x="-327.3"
+	 y="465" 
+	 z="187.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-2-2"/>
+       <position name="posArapucaDouble2-Frame-3-2" unit="cm" 
+         x="-328.04"
+	 y="539" 
+	 z="404.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-2"/>
+       <position name="posOpArapucaDouble2-Frame-3-2" unit="cm" 
+         x="-327.3"
+	 y="539" 
+	 z="404.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-2-3"/>
+       <position name="posArapucaDouble3-Frame-3-2" unit="cm" 
+         x="-328.04"
+	 y="629.7" 
+	 z="258.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-3"/>
+       <position name="posOpArapucaDouble3-Frame-3-2" unit="cm" 
+         x="-327.3"
+	 y="629.7" 
+	 z="258.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_0-0"/>
+       <position name="posArapuca0-Lat-0" unit="cm" 
+         x="285.03"
+	 y="-734" 
+	 z="-297.8018"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_0-0"/>
+       <position name="posOpArapuca0-Lat-0" unit="cm" 
+         x="285.03"
+	 y="-733.26" 
+	 z="-297.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_0-1"/>
+       <position name="posArapuca1-Lat-0" unit="cm" 
+         x="210.03"
+	 y="-734" 
+	 z="-297.8018"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_0-1"/>
+       <position name="posOpArapuca1-Lat-0" unit="cm" 
+         x="210.03"
+	 y="-733.26" 
+	 z="-297.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_0-2"/>
+       <position name="posArapuca2-Lat-0" unit="cm" 
+         x="135.03"
+	 y="-734" 
+	 z="-297.8018"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_0-2"/>
+       <position name="posOpArapuca2-Lat-0" unit="cm" 
+         x="135.03"
+	 y="-733.26" 
+	 z="-297.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_0-3"/>
+       <position name="posArapuca3-Lat-0" unit="cm" 
+         x="60.03"
+	 y="-734" 
+	 z="-297.8018"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_0-3"/>
+       <position name="posOpArapuca3-Lat-0" unit="cm" 
+         x="60.03"
+	 y="-733.26" 
+	 z="-297.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_0-4"/>
+       <position name="posArapuca4-Lat-0" unit="cm" 
+         x="285.03"
+	 y="734" 
+	 z="-297.8018"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_0-4"/>
+       <position name="posOpArapuca4-Lat-0" unit="cm" 
+         x="285.03"
+	 y="733.26" 
+	 z="-297.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_0-5"/>
+       <position name="posArapuca5-Lat-0" unit="cm" 
+         x="210.03"
+	 y="734" 
+	 z="-297.8018"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_0-5"/>
+       <position name="posOpArapuca5-Lat-0" unit="cm" 
+         x="210.03"
+	 y="733.26" 
+	 z="-297.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_0-6"/>
+       <position name="posArapuca6-Lat-0" unit="cm" 
+         x="135.03"
+	 y="734" 
+	 z="-297.8018"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_0-6"/>
+       <position name="posOpArapuca6-Lat-0" unit="cm" 
+         x="135.03"
+	 y="733.26" 
+	 z="-297.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_0-7"/>
+       <position name="posArapuca7-Lat-0" unit="cm" 
+         x="60.03"
+	 y="734" 
+	 z="-297.8018"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_0-7"/>
+       <position name="posOpArapuca7-Lat-0" unit="cm" 
+         x="60.03"
+	 y="733.26" 
+	 z="-297.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_1-0"/>
+       <position name="posArapuca0-Lat-1" unit="cm" 
+         x="285.03"
+	 y="-734" 
+	 z="2.8421709430404e-13"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_1-0"/>
+       <position name="posOpArapuca0-Lat-1" unit="cm" 
+         x="285.03"
+	 y="-733.26" 
+	 z="2.8421709430404e-13"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_1-1"/>
+       <position name="posArapuca1-Lat-1" unit="cm" 
+         x="210.03"
+	 y="-734" 
+	 z="2.8421709430404e-13"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_1-1"/>
+       <position name="posOpArapuca1-Lat-1" unit="cm" 
+         x="210.03"
+	 y="-733.26" 
+	 z="2.8421709430404e-13"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_1-2"/>
+       <position name="posArapuca2-Lat-1" unit="cm" 
+         x="135.03"
+	 y="-734" 
+	 z="2.8421709430404e-13"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_1-2"/>
+       <position name="posOpArapuca2-Lat-1" unit="cm" 
+         x="135.03"
+	 y="-733.26" 
+	 z="2.8421709430404e-13"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_1-3"/>
+       <position name="posArapuca3-Lat-1" unit="cm" 
+         x="60.03"
+	 y="-734" 
+	 z="2.8421709430404e-13"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_1-3"/>
+       <position name="posOpArapuca3-Lat-1" unit="cm" 
+         x="60.03"
+	 y="-733.26" 
+	 z="2.8421709430404e-13"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_1-4"/>
+       <position name="posArapuca4-Lat-1" unit="cm" 
+         x="285.03"
+	 y="734" 
+	 z="2.8421709430404e-13"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_1-4"/>
+       <position name="posOpArapuca4-Lat-1" unit="cm" 
+         x="285.03"
+	 y="733.26" 
+	 z="2.8421709430404e-13"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_1-5"/>
+       <position name="posArapuca5-Lat-1" unit="cm" 
+         x="210.03"
+	 y="734" 
+	 z="2.8421709430404e-13"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_1-5"/>
+       <position name="posOpArapuca5-Lat-1" unit="cm" 
+         x="210.03"
+	 y="733.26" 
+	 z="2.8421709430404e-13"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_1-6"/>
+       <position name="posArapuca6-Lat-1" unit="cm" 
+         x="135.03"
+	 y="734" 
+	 z="2.8421709430404e-13"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_1-6"/>
+       <position name="posOpArapuca6-Lat-1" unit="cm" 
+         x="135.03"
+	 y="733.26" 
+	 z="2.8421709430404e-13"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_1-7"/>
+       <position name="posArapuca7-Lat-1" unit="cm" 
+         x="60.03"
+	 y="734" 
+	 z="2.8421709430404e-13"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_1-7"/>
+       <position name="posOpArapuca7-Lat-1" unit="cm" 
+         x="60.03"
+	 y="733.26" 
+	 z="2.8421709430404e-13"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_2-0"/>
+       <position name="posArapuca0-Lat-2" unit="cm" 
+         x="285.03"
+	 y="-734" 
+	 z="297.8018"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_2-0"/>
+       <position name="posOpArapuca0-Lat-2" unit="cm" 
+         x="285.03"
+	 y="-733.26" 
+	 z="297.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_2-1"/>
+       <position name="posArapuca1-Lat-2" unit="cm" 
+         x="210.03"
+	 y="-734" 
+	 z="297.8018"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_2-1"/>
+       <position name="posOpArapuca1-Lat-2" unit="cm" 
+         x="210.03"
+	 y="-733.26" 
+	 z="297.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_2-2"/>
+       <position name="posArapuca2-Lat-2" unit="cm" 
+         x="135.03"
+	 y="-734" 
+	 z="297.8018"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_2-2"/>
+       <position name="posOpArapuca2-Lat-2" unit="cm" 
+         x="135.03"
+	 y="-733.26" 
+	 z="297.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_2-3"/>
+       <position name="posArapuca3-Lat-2" unit="cm" 
+         x="60.03"
+	 y="-734" 
+	 z="297.8018"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_2-3"/>
+       <position name="posOpArapuca3-Lat-2" unit="cm" 
+         x="60.03"
+	 y="-733.26" 
+	 z="297.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_2-4"/>
+       <position name="posArapuca4-Lat-2" unit="cm" 
+         x="285.03"
+	 y="734" 
+	 z="297.8018"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_2-4"/>
+       <position name="posOpArapuca4-Lat-2" unit="cm" 
+         x="285.03"
+	 y="733.26" 
+	 z="297.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_2-5"/>
+       <position name="posArapuca5-Lat-2" unit="cm" 
+         x="210.03"
+	 y="734" 
+	 z="297.8018"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_2-5"/>
+       <position name="posOpArapuca5-Lat-2" unit="cm" 
+         x="210.03"
+	 y="733.26" 
+	 z="297.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_2-6"/>
+       <position name="posArapuca6-Lat-2" unit="cm" 
+         x="135.03"
+	 y="734" 
+	 z="297.8018"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_2-6"/>
+       <position name="posOpArapuca6-Lat-2" unit="cm" 
+         x="135.03"
+	 y="733.26" 
+	 z="297.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_2-7"/>
+       <position name="posArapuca7-Lat-2" unit="cm" 
+         x="60.03"
+	 y="734" 
+	 z="297.8018"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_2-7"/>
+       <position name="posOpArapuca7-Lat-2" unit="cm" 
+         x="60.03"
+	 y="733.26" 
+	 z="297.8018"/>
+     </physvol>
+    </volume>
+
+    <volume name="volFoamPadding">
+      <materialref ref="fibrous_glass"/>
+      <solidref ref="FoamPadding"/>
+    </volume>
+
+    <volume name="volSteelSupport">
+      <materialref ref="AirSteelMixture"/>
+      <solidref ref="SteelSupport"/>
+    </volume>
+
+    <volume name="volDetEnclosure">
+      <materialref ref="Air"/>
+      <solidref ref="DetEnclosure"/>
+
+       <physvol>
+           <volumeref ref="volFoamPadding"/>
+           <positionref ref="posCryoInDetEnc"/>
+       </physvol>
+       <physvol>
+           <volumeref ref="volSteelSupport"/>
+           <positionref ref="posCryoInDetEnc"/>
+       </physvol>
+       <physvol>
+           <volumeref ref="volCryostat"/>
+           <positionref ref="posCryoInDetEnc"/>
+       </physvol>
+    </volume>
+
+    <volume name="volWorld" >
+      <materialref ref="DUSEL_Rock"/>
+      <solidref ref="World"/>
+
+      <physvol>
+        <volumeref ref="volDetEnclosure"/>
+	<position name="posDetEnclosure" unit="cm" x="50.04" y="-1.13686837721616e-13" z="448.2027"/>
+      </physvol>
+
+    </volume>
+</structure>
+  <setup name="Default" version="1.0">
+    <world ref="volWorld"/>
+  </setup>
+</gdml_simple_extension>

--- a/dunecore/Geometry/gdml/dunevd10kt_3view_v3_refactored_1x8x6ref_nowires.gdml
+++ b/dunecore/Geometry/gdml/dunevd10kt_3view_v3_refactored_1x8x6ref_nowires.gdml
@@ -1,0 +1,3345 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<gdml_simple_extension xmlns:gdml_simple_extension="http://www.example.org"
+                       xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"          
+                       xs:noNamespaceSchemaLocation="RefactoredGDMLSchema/SimpleExtension.xsd"> 
+<extension>
+   <color name="magenta"     R="0.0"  G="1.0"  B="0.0"  A="1.0" />
+   <color name="green"       R="0.0"  G="1.0"  B="0.0"  A="1.0" />
+   <color name="red"         R="1.0"  G="0.0"  B="0.0"  A="1.0" />
+   <color name="blue"        R="0.0"  G="0.0"  B="1.0"  A="1.0" />
+   <color name="yellow"      R="1.0"  G="1.0"  B="0.0"  A="1.0" />    
+</extension>
+<define>
+
+<!--
+
+
+
+-->
+
+   <position name="posCryoInDetEnc"     unit="cm" x="-50.0000000000001" y="0" z="0"/>
+   <position name="posCenter"           unit="cm" x="0" y="0" z="0"/>
+   <rotation name="rUWireAboutX"        unit="deg" x="131.63" y="0" z="0"/>
+   <rotation name="rPlus90AboutX"       unit="deg" x="90" y="0" z="0"/>
+   <rotation name="rPlus90AboutY"       unit="deg" x="0" y="90" z="0"/>
+   <rotation name="rPlus90AboutXPlus90AboutY" unit="deg" x="90" y="90" z="0"/>
+   <rotation name="rMinus90AboutX"      unit="deg" x="270" y="0" z="0"/>
+   <rotation name="rMinus90AboutY"      unit="deg" x="0" y="270" z="0"/>
+   <rotation name="rMinus90AboutYMinus90AboutX"       unit="deg" x="270" y="270" z="0"/>
+   <rotation name="rPlus180AboutX"	unit="deg" x="180" y="0"   z="0"/>
+   <rotation name="rPlus180AboutY"	unit="deg" x="0" y="180"   z="0"/>
+   <rotation name="rPlus180AboutXPlus180AboutY"	unit="deg" x="180" y="180"   z="0"/>
+   <rotation name="rIdentity"		unit="deg" x="0" y="0"   z="0"/>
+</define>
+<materials>
+  <element name="videRef" formula="VACUUM" Z="1">  <atom value="1"/> </element>
+  <element name="copper" formula="Cu" Z="29">  <atom value="63.546"/>  </element>
+  <element name="beryllium" formula="Be" Z="4">  <atom value="9.0121831"/>  </element>
+  <element name="bromine" formula="Br" Z="35"> <atom value="79.904"/> </element>
+  <element name="hydrogen" formula="H" Z="1">  <atom value="1.0079"/> </element>
+  <element name="nitrogen" formula="N" Z="7">  <atom value="14.0067"/> </element>
+  <element name="oxygen" formula="O" Z="8">  <atom value="15.999"/> </element>
+  <element name="aluminum" formula="Al" Z="13"> <atom value="26.9815"/>  </element>
+  <element name="silicon" formula="Si" Z="14"> <atom value="28.0855"/>  </element>
+  <element name="carbon" formula="C" Z="6">  <atom value="12.0107"/>  </element>
+  <element name="potassium" formula="K" Z="19"> <atom value="39.0983"/>  </element>
+  <element name="chromium" formula="Cr" Z="24"> <atom value="51.9961"/>  </element>
+  <element name="iron" formula="Fe" Z="26"> <atom value="55.8450"/>  </element>
+  <element name="nickel" formula="Ni" Z="28"> <atom value="58.6934"/>  </element>
+  <element name="calcium" formula="Ca" Z="20"> <atom value="40.078"/>   </element>
+  <element name="magnesium" formula="Mg" Z="12"> <atom value="24.305"/>   </element>
+  <element name="sodium" formula="Na" Z="11"> <atom value="22.99"/>    </element>
+  <element name="titanium" formula="Ti" Z="22"> <atom value="47.867"/>   </element>
+  <element name="argon" formula="Ar" Z="18"> <atom value="39.9480"/>  </element>
+  <element name="sulphur" formula="S" Z="16"> <atom value="32.065"/>  </element>
+  <element name="phosphorus" formula="P" Z="15"> <atom value="30.973"/>  </element>
+
+  <material name="Vacuum" formula="Vacuum">
+   <D value="1.e-25" unit="g/cm3"/>
+   <fraction n="1.0" ref="videRef"/>
+  </material>
+
+  <material name="ALUMINUM_Al" formula="ALUMINUM_Al">
+   <D value="2.6990" unit="g/cm3"/>
+   <fraction n="1.0000" ref="aluminum"/>
+  </material>
+
+  <material name="SILICON_Si" formula="SILICON_Si">
+   <D value="2.3300" unit="g/cm3"/>
+   <fraction n="1.0000" ref="silicon"/>
+  </material>
+
+  <material name="epoxy_resin" formula="C38H40O6Br4">
+   <D value="1.1250" unit="g/cm3"/>
+   <composite n="38" ref="carbon"/>
+   <composite n="40" ref="hydrogen"/>
+   <composite n="6" ref="oxygen"/>
+   <composite n="4" ref="bromine"/>
+  </material>
+
+  <material name="SiO2" formula="SiO2">
+   <D value="2.2" unit="g/cm3"/>
+   <composite n="1" ref="silicon"/>
+   <composite n="2" ref="oxygen"/>
+  </material>
+
+  <material name="Al2O3" formula="Al2O3">
+   <D value="3.97" unit="g/cm3"/>
+   <composite n="2" ref="aluminum"/>
+   <composite n="3" ref="oxygen"/>
+  </material>
+
+  <material name="Fe2O3" formula="Fe2O3">
+   <D value="5.24" unit="g/cm3"/>
+   <composite n="2" ref="iron"/>
+   <composite n="3" ref="oxygen"/>
+  </material>
+
+  <material name="CaO" formula="CaO">
+   <D value="3.35" unit="g/cm3"/>
+   <composite n="1" ref="calcium"/>
+   <composite n="1" ref="oxygen"/>
+  </material>
+
+  <material name="Delrin" formula="CH2O">
+    <D value="1.41" unit="g/cm3"/>
+    <composite n="1" ref="carbon"/>
+    <composite n="2" ref="hydrogen"/>
+    <composite n="1" ref="oxygen"/>
+  </material>
+
+  <material name="MgO" formula="MgO">
+   <D value="3.58" unit="g/cm3"/>
+   <composite n="1" ref="magnesium"/>
+   <composite n="1" ref="oxygen"/>
+  </material>
+
+  <material name="Na2O" formula="Na2O">
+   <D value="2.27" unit="g/cm3"/>
+   <composite n="2" ref="sodium"/>
+   <composite n="1" ref="oxygen"/>
+  </material>
+
+  <material name="TiO2" formula="TiO2">
+   <D value="4.23" unit="g/cm3"/>
+   <composite n="1" ref="titanium"/>
+   <composite n="2" ref="oxygen"/>
+  </material>
+
+  <material name="FeO" formula="FeO">
+   <D value="5.745" unit="g/cm3"/>
+   <composite n="1" ref="iron"/>
+   <composite n="1" ref="oxygen"/>
+  </material>
+
+  <material name="CO2" formula="CO2">
+   <D value="1.562" unit="g/cm3"/>
+   <composite n="1" ref="iron"/>
+   <composite n="2" ref="oxygen"/>
+  </material>
+
+  <material name="P2O5" formula="P2O5">
+   <D value="1.562" unit="g/cm3"/>
+   <composite n="2" ref="phosphorus"/>
+   <composite n="5" ref="oxygen"/>
+  </material>
+
+  <material formula=" " name="DUSEL_Rock">
+    <D value="2.82" unit="g/cm3"/>
+    <fraction n="0.5267" ref="SiO2"/>
+    <fraction n="0.1174" ref="FeO"/>
+    <fraction n="0.1025" ref="Al2O3"/>
+    <fraction n="0.0473" ref="MgO"/>
+    <fraction n="0.0422" ref="CO2"/>
+    <fraction n="0.0382" ref="CaO"/>
+    <fraction n="0.0240" ref="carbon"/>
+    <fraction n="0.0186" ref="sulphur"/>
+    <fraction n="0.0053" ref="Na2O"/>
+    <fraction n="0.00070" ref="P2O5"/>
+    <fraction n="0.0771" ref="oxygen"/>
+  </material> 
+
+  <material formula="Air" name="Air">
+   <D value="0.001205" unit="g/cm3"/>
+   <fraction n="0.781154" ref="nitrogen"/>
+   <fraction n="0.209476" ref="oxygen"/>
+   <fraction n="0.00934" ref="argon"/>
+  </material>
+
+  <material name="fibrous_glass">
+   <D value="2.74351" unit="g/cm3"/>
+   <fraction n="0.600" ref="SiO2"/>
+   <fraction n="0.118" ref="Al2O3"/>
+   <fraction n="0.001" ref="Fe2O3"/>
+   <fraction n="0.224" ref="CaO"/>
+   <fraction n="0.034" ref="MgO"/>
+   <fraction n="0.010" ref="Na2O"/>
+   <fraction n="0.013" ref="TiO2"/>
+  </material>
+
+  <!-- density referenced from EHN1-Cold Cryostats Technical Requirements:
+       https://edms.cern.ch/document/1543254 -->
+  <material name="FD_foam">
+   <D value="0.09" unit="g/cm3"/>
+   <fraction n="0.95" ref="Air"/>
+   <fraction n="0.05" ref="fibrous_glass"/>
+  </material>
+
+  <!-- Foam density is 70 kg / m^3 for the 3x1x1 -->
+  <material name="foam_3x1x1dp">
+   <D value="0.07" unit="g/cm3"/>
+   <fraction n="0.95" ref="Air"/>
+   <fraction n="0.05" ref="fibrous_glass"/>
+  </material>
+
+  <!-- Copied from protodune_v4.gdml -->
+  <material name="foam_protoDUNEdp">
+   <D value="0.135" unit="g/cm3"/>
+   <composite n="17" ref="carbon"/>
+   <composite n="16" ref="hydrogen"/>
+   <composite n="2" ref="nitrogen"/>
+   <composite n="4" ref="oxygen"/>
+  </material>
+
+  <material name="FR4">
+   <D value="1.98281" unit="g/cm3"/>
+   <fraction n="0.47" ref="epoxy_resin"/>
+   <fraction n="0.53" ref="fibrous_glass"/>
+  </material>
+
+  <material name="STEEL_STAINLESS_Fe7Cr2Ni" formula="STEEL_STAINLESS_Fe7Cr2Ni">
+   <D value="7.9300" unit="g/cm3"/>
+   <fraction n="0.0010" ref="carbon"/>
+   <fraction n="0.1792" ref="chromium"/>
+   <fraction n="0.7298" ref="iron"/>
+   <fraction n="0.0900" ref="nickel"/>
+  </material>
+
+  <material name="Copper_Beryllium_alloy25" formula="Copper_Beryllium_alloy25">
+   <D value="8.26" unit="g/cm3"/>
+   <fraction n="0.981" ref="copper"/>
+   <fraction n="0.019" ref="beryllium"/>
+  </material>
+
+  <material name="LAr" formula="LAr">
+   <D value="1.40" unit="g/cm3"/>
+   <fraction n="1.0000" ref="argon"/>
+  </material>
+
+  <material name="ArGas" formula="ArGas">
+   <D value="0.00166" unit="g/cm3"/>
+   <fraction n="1.0" ref="argon"/>
+  </material>
+
+  <material formula=" " name="G10">
+   <D value="1.7" unit="g/cm3"/>
+   <fraction n="0.2805" ref="silicon"/>
+   <fraction n="0.3954" ref="oxygen"/>
+   <fraction n="0.2990" ref="carbon"/>
+   <fraction n="0.0251" ref="hydrogen"/>
+  </material>
+
+  <material formula=" " name="Granite">
+   <D value="2.7" unit="g/cm3"/>
+   <fraction n="0.438" ref="oxygen"/>
+   <fraction n="0.257" ref="silicon"/>
+   <fraction n="0.222" ref="sodium"/>
+   <fraction n="0.049" ref="aluminum"/>
+   <fraction n="0.019" ref="iron"/>
+   <fraction n="0.015" ref="potassium"/>
+  </material>
+
+  <material formula=" " name="ShotRock">
+   <D value="1.62" unit="g/cm3"/>
+   <fraction n="0.438" ref="oxygen"/>
+   <fraction n="0.257" ref="silicon"/>
+   <fraction n="0.222" ref="sodium"/>
+   <fraction n="0.049" ref="aluminum"/>
+   <fraction n="0.019" ref="iron"/>
+   <fraction n="0.015" ref="potassium"/>
+  </material>
+
+  <material formula=" " name="Dirt">
+   <D value="1.7" unit="g/cm3"/>
+   <fraction n="0.438" ref="oxygen"/>
+   <fraction n="0.257" ref="silicon"/>
+   <fraction n="0.222" ref="sodium"/>
+   <fraction n="0.049" ref="aluminum"/>
+   <fraction n="0.019" ref="iron"/>
+   <fraction n="0.015" ref="potassium"/>
+  </material>
+
+  <material formula=" " name="Concrete">
+   <D value="2.3" unit="g/cm3"/>
+   <fraction n="0.530" ref="oxygen"/>
+   <fraction n="0.335" ref="silicon"/>
+   <fraction n="0.060" ref="calcium"/>
+   <fraction n="0.015" ref="sodium"/>
+   <fraction n="0.020" ref="iron"/>
+   <fraction n="0.040" ref="aluminum"/>
+  </material>
+
+  <material formula="H2O" name="Water">
+   <D value="1.0" unit="g/cm3"/>
+   <fraction n="0.1119" ref="hydrogen"/>
+   <fraction n="0.8881" ref="oxygen"/>
+  </material>
+
+  <material formula="Ti" name="Titanium">
+   <D value="4.506" unit="g/cm3"/>
+   <fraction n="1." ref="titanium"/>
+  </material>
+
+  <material name="TPB" formula="TPB">
+   <D value="1.40" unit="g/cm3"/>
+   <fraction n="1.0000" ref="argon"/>
+  </material>
+
+  <material name="Glass">
+   <D value="2.74351" unit="g/cm3"/>
+   <fraction n="0.600" ref="SiO2"/>
+   <fraction n="0.118" ref="Al2O3"/>
+   <fraction n="0.001" ref="Fe2O3"/>
+   <fraction n="0.224" ref="CaO"/>
+   <fraction n="0.034" ref="MgO"/>
+   <fraction n="0.010" ref="Na2O"/>
+   <fraction n="0.013" ref="TiO2"/>
+  </material>
+
+  <material name="Acrylic">
+   <D value="1.19" unit="g/cm3"/>
+   <fraction n="0.600" ref="carbon"/>
+   <fraction n="0.320" ref="oxygen"/>
+   <fraction n="0.080" ref="hydrogen"/>
+  </material>
+
+  <material name="NiGas1atm80K">
+   <D value="0.0039" unit="g/cm3"/>
+   <fraction n="1.000" ref="nitrogen"/>
+  </material>
+
+  <material name="NiGas">
+   <D value="0.001165" unit="g/cm3"/>
+   <fraction n="1.000" ref="nitrogen"/>
+  </material>
+
+  <material name="PolyurethaneFoam">
+   <D value="0.088" unit="g/cm3"/>
+   <composite n="17" ref="carbon"/>
+   <composite n="16" ref="hydrogen"/>
+   <composite n="2" ref="nitrogen"/>
+   <composite n="4" ref="oxygen"/>
+  </material>
+
+  <material name="ProtoDUNEFoam">
+   <D value="0.135" unit="g/cm3"/>
+   <composite n="17" ref="carbon"/>
+   <composite n="16" ref="hydrogen"/>
+   <composite n="2" ref="nitrogen"/>
+   <composite n="4" ref="oxygen"/>
+  </material>
+
+  <material name="LightPolyurethaneFoam">
+   <D value="0.009" unit="g/cm3"/>
+   <composite n="17" ref="carbon"/>
+   <composite n="16" ref="hydrogen"/>
+   <composite n="2" ref="nitrogen"/>
+   <composite n="4" ref="oxygen"/>
+  </material>
+
+  <material name="ProtoDUNEBWFoam">
+   <D value="0.021" unit="g/cm3"/>
+   <composite n="17" ref="carbon"/>
+   <composite n="16" ref="hydrogen"/>
+   <composite n="2" ref="nitrogen"/>
+   <composite n="4" ref="oxygen"/>
+  </material>
+
+  <material name="GlassWool">
+   <D value="0.035" unit="g/cm3"/>
+   <fraction n="0.65" ref="SiO2"/>
+   <fraction n="0.09" ref="Al2O3"/>
+   <fraction n="0.07" ref="CaO"/>
+   <fraction n="0.03" ref="MgO"/>
+   <fraction n="0.16" ref="Na2O"/>
+  </material>
+
+  <material name="Polystyrene">
+   <D value="1.06" unit="g/cm3"/>
+   <composite n="8" ref="carbon"/>
+   <composite n="8" ref="hydrogen"/>
+  </material>
+
+
+
+  <!-- preliminary values -->
+  <material name="AirSteelMixture" formula="AirSteelMixture">
+   <D value=" 0.001205*(1-0.5) + 7.9300*0.5 " unit="g/cm3"/>
+   <fraction n="0.5" ref="STEEL_STAINLESS_Fe7Cr2Ni"/>
+   <fraction n="0.5"   ref="Air"/>
+  </material>
+  <material name="vm2000" formula="vm2000">
+    <D value="1.2" unit="g/cm3"/>
+    <composite n="2" ref="carbon"/>
+    <composite n="4" ref="hydrogen"/>
+  </material>
+
+</materials>
+<solids>
+     <torus name="FieldShaperCorner" rmin="0.5" rmax="2.285" rtor="2.3" deltaphi="90" startphi="0" aunit="deg" lunit="cm"/>
+     <tube name="FieldShaperLongtube" rmin="0.5" rmax="2.285" z="896.4054" deltaphi="360" startphi="0" aunit="deg" lunit="cm"/>
+     <tube name="FieldShaperLongtubeSlim" rmin="0.5" rmax="0.75" z="896.4054" deltaphi="360" startphi="0" aunit="deg" lunit="cm"/>
+     <tube name="FieldShaperShorttube" rmin="0.5" rmax="2.285" z="1348" deltaphi="360" startphi="0" aunit="deg" lunit="cm"/>
+
+    <union name="FSunion1">
+      <first ref="FieldShaperLongtube"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos1" unit="cm" x="-2.3" y="0" z="448.2027"/>
+		<rotation name="rot1" unit="deg" x="90" y="0" z="0" />
+    </union>
+
+    <union name="FSunion2">
+      <first ref="FSunion1"/>
+      <second ref="FieldShaperShorttube"/>
+   		<position name="esquinapos2" unit="cm" x="-676.3" y="0" z="450.5027"/>
+   		<rotation name="rot2" unit="deg" x="0" y="90" z="0" />
+    </union>
+
+    <union name="FSunion3">
+      <first ref="FSunion2"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos3" unit="cm" x="-1350.3" y="0" z="448.2027"/>
+		<rotation name="rot3" unit="deg" x="90" y="270" z="0" />
+    </union>
+
+    <union name="FSunion4">
+      <first ref="FSunion3"/>
+      <second ref="FieldShaperLongtube"/>
+   		<position name="esquinapos4" unit="cm" x="-1352.6" y="0" z="0"/>
+    </union>
+
+    <union name="FSunion5">
+      <first ref="FSunion4"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos5" unit="cm" x="-1350.3" y="0" z="-448.2027"/>
+		<rotation name="rot5" unit="deg" x="90" y="180" z="0" />
+    </union>
+
+    <union name="FSunion6">
+      <first ref="FSunion5"/>
+      <second ref="FieldShaperShorttube"/>
+   		<position name="esquinapos6" unit="cm" x="-676.3" y="0" z="-450.5027"/>
+		<rotation name="rot6" unit="deg" x="0" y="90" z="0" />
+    </union>
+
+    <union name="FieldShaperSolid">
+      <first ref="FSunion6"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos7" unit="cm" x="-2.3" y="0" z="-448.2027"/>
+		<rotation name="rot7" unit="deg" x="90" y="90" z="0" />
+    </union>
+    
+    <union name="FSunionSlim1">
+      <first ref="FieldShaperLongtubeSlim"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos1" unit="cm" x="-2.3" y="0" z="448.2027"/>
+		<rotation name="rot1" unit="deg" x="90" y="0" z="0" />
+    </union>
+
+    <union name="FSunionSlim2">
+      <first ref="FSunionSlim1"/>
+      <second ref="FieldShaperShorttube"/>
+   		<position name="esquinapos2" unit="cm" x="-676.3" y="0" z="450.5027"/>
+   		<rotation name="rot2" unit="deg" x="0" y="90" z="0" />
+    </union>
+
+    <union name="FSunionSlim3">
+      <first ref="FSunionSlim2"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos3" unit="cm" x="-1350.3" y="0" z="448.2027"/>
+		<rotation name="rot3" unit="deg" x="90" y="270" z="0" />
+    </union>
+
+    <union name="FSunionSlim4">
+      <first ref="FSunionSlim3"/>
+      <second ref="FieldShaperLongtubeSlim"/>
+   		<position name="esquinapos4" unit="cm" x="-1352.6" y="0" z="0"/>
+    </union>
+
+    <union name="FSunionSlim5">
+      <first ref="FSunionSlim4"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos5" unit="cm" x="-1350.3" y="0" z="-448.2027"/>
+		<rotation name="rot5" unit="deg" x="90" y="180" z="0" />
+    </union>
+
+    <union name="FSunionSlim6">
+      <first ref="FSunionSlim5"/>
+      <second ref="FieldShaperShorttube"/>
+   		<position name="esquinapos6" unit="cm" x="-676.3" y="0" z="-450.5027"/>
+		<rotation name="rot6" unit="deg" x="0" y="90" z="0" />
+    </union>
+
+    <union name="FieldShaperSolidSlim">
+      <first ref="FSunionSlim6"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos7" unit="cm" x="-2.3" y="0" z="-448.2027"/>
+		<rotation name="rot7" unit="deg" x="90" y="90" z="0" />
+    </union>
+    
+
+   <box name="CRM"
+      x="650.08" 
+      y="168" 
+      z="148.9009"
+      lunit="cm"/>
+   <box name="CRMUPlane" 
+      x="0.02" 
+      y="168" 
+      z="148.9009"
+      lunit="cm"/>
+   <box name="CRMYPlane" 
+      x="0.02" 
+      y="168" 
+      z="148.9009"
+      lunit="cm"/>
+   <box name="CRMZPlane" 
+      x="0.02"
+      y="168"
+      z="148.9009"
+      lunit="cm"/>
+   <box name="CRMActive" 
+      x="650"
+      y="168"
+      z="148.9009"
+      lunit="cm"/>
+
+    <box name="ArapucaOut" lunit="cm"
+      x="65"
+      y="2.5"
+      z="65"/>
+
+    <box name="ArapucaIn" lunit="cm"
+      x="60"
+      y="2.5"
+      z="60"/>
+
+     <subtraction name="ArapucaWalls">
+      <first  ref="ArapucaOut"/>
+      <second ref="ArapucaIn"/>
+      <position name="posArapucaSub" x="0" y="1.25" z="0." unit="cm"/>
+      </subtraction>
+
+    <box name="ArapucaAcceptanceWindow" lunit="cm"
+      x="60"
+      y="1"
+      z="60"/>
+
+    <box name="ArapucaDoubleIn" lunit="cm"
+      x="60"
+      y="3.5"
+      z="60"/>
+
+     <subtraction name="ArapucaDoubleWalls">
+      <first  ref="ArapucaOut"/>
+      <second ref="ArapucaDoubleIn"/>
+      <position name="posArapucaDoubleSub" x="0" y="0" z="0" unit="cm"/>
+      </subtraction>
+
+    <box name="ArapucaDoubleAcceptanceWindow" lunit="cm"
+      x="2.48"
+      y="60"
+      z="60"/>
+
+    <box name="ArapucaCathodeAcceptanceWindow" lunit="cm"
+      x="1"
+      y="60"
+      z="60"/>
+
+
+    <box name="Cryostat" lunit="cm" 
+      x="850.32" 
+      y="1548.24" 
+      z="1096.6454"/>
+
+    <box name="ArgonInterior" lunit="cm" 
+      x="850.08"
+      y="1548"
+      z="1096.4054"/>
+
+    <box name="GaseousArgon" lunit="cm" 
+      x="100"
+      y="1548"
+      z="1096.4054"/>
+
+    <box name="ExternalAuxOut" lunit="cm" 
+      x="850.08 - 100"
+      y="1548 - 2*2.5 - 2*40"
+      z="1096.4054"/>
+
+    <box name="ExternalAuxIn" lunit="cm" 
+      x="850.08"
+      y="1359.17"
+      z="1096.4054 + 1"/>
+
+   <subtraction name="ExternalActive">
+      <first ref="ExternalAuxOut"/>
+      <second ref="ExternalAuxIn"/>
+    </subtraction>
+
+    <subtraction name="SteelShell">
+      <first ref="Cryostat"/>
+      <second ref="ArgonInterior"/>
+    </subtraction>
+
+
+
+    <box name="CathodeBlock" lunit="cm"
+      x="4"
+      y="336"
+      z="297.8018" />
+
+    <box name="CathodeVoid" lunit="cm"
+      x="5"
+      y="76.35"
+      z="67" />
+
+    <subtraction name="Cathode1">
+      <first ref="CathodeBlock"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub1" x="0" y="-122.525" z="-108.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode2">
+      <first ref="Cathode1"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub2" x="0" y="-122.525" z="-37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode3">
+      <first ref="Cathode2"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub3" x="0" y="-122.525" z="37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode4">
+      <first ref="Cathode3"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub4" x="0" y="-122.525" z="108.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode5">
+      <first ref="Cathode4"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub5" x="0" y="-42.175" z="-108.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode6">
+      <first ref="Cathode5"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub6" x="0" y="-42.175" z="-37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode7">
+      <first ref="Cathode6"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub7" x="0" y="-42.175" z="37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode8">
+      <first ref="Cathode7"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub8" x="0" y="-42.175" z="108.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode9">
+      <first ref="Cathode8"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub9" x="0" y="42.175" z="-108.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode10">
+      <first ref="Cathode9"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub10" x="0" y="42.175" z="-37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode11">
+      <first ref="Cathode10"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub11" x="0" y="42.175" z="37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode12">
+      <first ref="Cathode11"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub12" x="0" y="42.175" z="108.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode13">
+      <first ref="Cathode12"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub13" x="0" y="122.525" z="-108.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode14">
+      <first ref="Cathode13"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub14" x="0" y="122.525" z="-37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode15">
+      <first ref="Cathode14"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub15" x="0" y="122.525" z="37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="CathodeGrid">
+      <first ref="Cathode15"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub16" x="0" y="122.525" z="108.5" unit="cm"/>
+    </subtraction>
+
+    <box name="FoamPadBlock" lunit="cm"
+      x="1010.32"
+      y="1708.24"
+      z="1256.6454" />
+
+    <subtraction name="FoamPadding">
+      <first ref="FoamPadBlock"/>
+      <second ref="Cryostat"/>
+      <positionref ref="posCenter"/>
+    </subtraction>
+
+    <box name="SteelSupportBlock" lunit="cm"
+      x="1210.32"
+      y="1908.24"
+      z="1456.6454" />
+
+    <subtraction name="SteelSupport">
+      <first ref="SteelSupportBlock"/>
+      <second ref="FoamPadBlock"/>
+      <positionref ref="posCenter"/>
+    </subtraction>
+
+    <box name="DetEnclosure" lunit="cm" 
+      x="1310.32"
+      y="2108.24"
+      z="1656.6454"/>
+
+
+    <box name="World" lunit="cm" 
+      x="9310.32" 
+      y="10108.24" 
+      z="9656.6454"/>
+</solids>
+<structure>
+<volume name="volFieldShaper">
+  <materialref ref="Al2O3"/>
+  <solidref ref="FieldShaperSolid"/>
+</volume>
+<volume name="volFieldShaperSlim">
+  <materialref ref="Al2O3"/>
+  <solidref ref="FieldShaperSolidSlim"/>
+</volume>
+
+
+    <volume name="volTPCActive">
+      <materialref ref="LAr"/>
+      <solidref ref="CRMActive"/>
+      <auxiliary auxtype="SensDet" auxvalue="SimEnergyDeposit"/>
+      <auxiliary auxtype="StepLimit" auxunit="cm" auxvalue="0.5208*cm"/>
+      <auxiliary auxtype="Efield" auxunit="V/cm" auxvalue="500*V/cm"/>
+      <colorref ref="blue"/>
+    </volume>
+   <volume name="volTPCPlaneU">
+     <materialref ref="LAr"/>
+     <solidref ref="CRMUPlane"/>
+   </volume>
+  <volume name="volTPCPlaneY">
+    <materialref ref="LAr"/>
+    <solidref ref="CRMYPlane"/>
+  </volume>
+  <volume name="volTPCPlaneZ">
+    <materialref ref="LAr"/>
+    <solidref ref="CRMZPlane"/>
+  </volume>
+   <volume name="volTPC">
+     <materialref ref="LAr"/>
+       <solidref ref="CRM"/>
+       <physvol>
+       <volumeref ref="volTPCPlaneU"/>
+       <position name="posPlaneU" unit="cm" 
+         x="324.99" y="0" z="0"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCPlaneY"/>
+       <position name="posPlaneY" unit="cm" 
+         x="325.01" y="0" z="0"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCPlaneZ"/>
+       <position name="posPlaneZ" unit="cm" 
+         x="325.03" y="0" z="0"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCActive"/>
+       <position name="posActive" unit="cm" 
+        x="-0.04" y="" z="0"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+   </volume>
+ 
+    <volume name="volSteelShell">
+      <materialref ref="STEEL_STAINLESS_Fe7Cr2Ni" />
+      <solidref ref="SteelShell" />
+    </volume>
+    <volume name="volGroundGrid">
+      <materialref ref="STEEL_STAINLESS_Fe7Cr2Ni" />
+      <solidref ref="CathodeGrid" />
+    </volume>    
+    <volume name="volGaseousArgon">
+      <materialref ref="ArGas"/>
+      <solidref ref="GaseousArgon"/>
+    </volume>
+    <volume name="volExternalActive">
+      <materialref ref="LAr"/>
+      <solidref ref="ExternalActive"/>
+      <auxiliary auxtype="SensDet" auxvalue="SimEnergyDeposit"/>
+      <auxiliary auxtype="StepLimit" auxunit="cm" auxvalue="0.5208*cm"/>
+      <auxiliary auxtype="Efield" auxunit="V/cm" auxvalue="0*V/cm"/>
+      <colorref ref="green"/>
+    </volume>
+    <volume name="volArapucaDouble_0-0-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-0-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-0-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-0-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-0-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-0-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-0-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-0-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-1-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-1-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-1-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-1-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-1-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-1-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-1-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-1-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-2-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-2-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-2-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-2-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-2-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-2-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-2-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-2-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-0-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-0-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-0-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-0-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-0-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-0-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-0-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-0-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-1-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-1-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-1-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-1-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-1-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-1-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-1-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-1-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-2-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-2-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-2-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-2-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-2-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-2-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-2-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-2-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-0-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-0-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-0-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-0-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-0-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-0-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-0-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-0-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-1-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-1-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-1-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-1-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-1-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-1-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-1-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-1-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-2-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-2-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-2-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-2-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-2-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-2-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-2-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-2-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-0-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-0-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-0-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-0-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-0-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-0-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-0-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-0-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-1-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-1-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-1-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-1-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-1-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-1-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-1-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-1-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-2-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-2-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-2-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-2-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-2-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-2-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-2-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-2-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_0-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_0-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_0-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_0-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_0-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_0-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_0-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_0-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_0-4">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_0-4">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_0-5">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_0-5">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_0-6">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_0-6">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_0-7">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_0-7">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_1-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_1-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_1-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_1-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_1-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_1-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_1-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_1-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_1-4">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_1-4">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_1-5">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_1-5">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_1-6">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_1-6">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_1-7">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_1-7">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_2-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_2-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_2-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_2-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_2-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_2-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_2-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_2-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_2-4">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_2-4">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_2-5">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_2-5">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_2-6">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_2-6">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_2-7">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_2-7">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+
+    <volume name="volCryostat">
+      <materialref ref="LAr" />
+      <solidref ref="Cryostat" />
+      <physvol>
+        <volumeref ref="volGaseousArgon"/>
+        <position name="posGaseousArgon" unit="cm" x="375.04" y="0" z="0"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volSteelShell"/>
+        <position name="posSteelShell" unit="cm" x="0" y="0" z="0"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volExternalActive"/>
+        <position name="posExternalActive" unit="cm" x="-100/2" y="0" z="0"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-0" unit="cm"
+           x="0" y="-589.5" z="-373.25225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-1" unit="cm"
+           x="0" y="-421.5" z="-373.25225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-2" unit="cm"
+           x="0" y="-252.5" z="-373.25225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-3" unit="cm"
+           x="0" y="-84.5" z="-373.25225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-4" unit="cm"
+           x="0" y="84.5" z="-373.25225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-5" unit="cm"
+           x="0" y="252.5" z="-373.25225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-6" unit="cm"
+           x="0" y="421.5" z="-373.25225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-7" unit="cm"
+           x="0" y="589.5" z="-373.25225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-8" unit="cm"
+           x="0" y="-589.5" z="-224.35135"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-9" unit="cm"
+           x="0" y="-421.5" z="-224.35135"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-10" unit="cm"
+           x="0" y="-252.5" z="-224.35135"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-11" unit="cm"
+           x="0" y="-84.5" z="-224.35135"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-12" unit="cm"
+           x="0" y="84.5" z="-224.35135"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-13" unit="cm"
+           x="0" y="252.5" z="-224.35135"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-14" unit="cm"
+           x="0" y="421.5" z="-224.35135"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-15" unit="cm"
+           x="0" y="589.5" z="-224.35135"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-16" unit="cm"
+           x="0" y="-589.5" z="-74.45045"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-17" unit="cm"
+           x="0" y="-421.5" z="-74.45045"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-18" unit="cm"
+           x="0" y="-252.5" z="-74.45045"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-19" unit="cm"
+           x="0" y="-84.5" z="-74.45045"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-20" unit="cm"
+           x="0" y="84.5" z="-74.45045"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-21" unit="cm"
+           x="0" y="252.5" z="-74.45045"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-22" unit="cm"
+           x="0" y="421.5" z="-74.45045"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-23" unit="cm"
+           x="0" y="589.5" z="-74.45045"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-24" unit="cm"
+           x="0" y="-589.5" z="74.45045"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-25" unit="cm"
+           x="0" y="-421.5" z="74.45045"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-26" unit="cm"
+           x="0" y="-252.5" z="74.45045"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-27" unit="cm"
+           x="0" y="-84.5" z="74.45045"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-28" unit="cm"
+           x="0" y="84.5" z="74.45045"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-29" unit="cm"
+           x="0" y="252.5" z="74.45045"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-30" unit="cm"
+           x="0" y="421.5" z="74.45045"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-31" unit="cm"
+           x="0" y="589.5" z="74.45045"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-32" unit="cm"
+           x="0" y="-589.5" z="224.35135"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-33" unit="cm"
+           x="0" y="-421.5" z="224.35135"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-34" unit="cm"
+           x="0" y="-252.5" z="224.35135"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-35" unit="cm"
+           x="0" y="-84.5" z="224.35135"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-36" unit="cm"
+           x="0" y="84.5" z="224.35135"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-37" unit="cm"
+           x="0" y="252.5" z="224.35135"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-38" unit="cm"
+           x="0" y="421.5" z="224.35135"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-39" unit="cm"
+           x="0" y="589.5" z="224.35135"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-40" unit="cm"
+           x="0" y="-589.5" z="373.25225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-41" unit="cm"
+           x="0" y="-421.5" z="373.25225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-42" unit="cm"
+           x="0" y="-252.5" z="373.25225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-43" unit="cm"
+           x="0" y="-84.5" z="373.25225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-44" unit="cm"
+           x="0" y="84.5" z="373.25225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-45" unit="cm"
+           x="0" y="252.5" z="373.25225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-46" unit="cm"
+           x="0" y="421.5" z="373.25225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-47" unit="cm"
+           x="0" y="589.5" z="373.25225"/>
+      </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper0" unit="cm"  x="-322.04" y="-676.3" z="0" />
+     <rotation name="rotFS0" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper1" unit="cm"  x="-316.04" y="-676.3" z="0" />
+     <rotation name="rotFS1" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper2" unit="cm"  x="-310.04" y="-676.3" z="0" />
+     <rotation name="rotFS2" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper3" unit="cm"  x="-304.04" y="-676.3" z="0" />
+     <rotation name="rotFS3" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper4" unit="cm"  x="-298.04" y="-676.3" z="0" />
+     <rotation name="rotFS4" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper5" unit="cm"  x="-292.04" y="-676.3" z="0" />
+     <rotation name="rotFS5" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper6" unit="cm"  x="-286.04" y="-676.3" z="0" />
+     <rotation name="rotFS6" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper7" unit="cm"  x="-280.04" y="-676.3" z="0" />
+     <rotation name="rotFS7" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper8" unit="cm"  x="-274.04" y="-676.3" z="0" />
+     <rotation name="rotFS8" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper9" unit="cm"  x="-268.04" y="-676.3" z="0" />
+     <rotation name="rotFS9" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper10" unit="cm"  x="-262.04" y="-676.3" z="0" />
+     <rotation name="rotFS10" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper11" unit="cm"  x="-256.04" y="-676.3" z="0" />
+     <rotation name="rotFS11" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper12" unit="cm"  x="-250.04" y="-676.3" z="0" />
+     <rotation name="rotFS12" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper13" unit="cm"  x="-244.04" y="-676.3" z="0" />
+     <rotation name="rotFS13" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper14" unit="cm"  x="-238.04" y="-676.3" z="0" />
+     <rotation name="rotFS14" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper15" unit="cm"  x="-232.04" y="-676.3" z="0" />
+     <rotation name="rotFS15" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper16" unit="cm"  x="-226.04" y="-676.3" z="0" />
+     <rotation name="rotFS16" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper17" unit="cm"  x="-220.04" y="-676.3" z="0" />
+     <rotation name="rotFS17" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper18" unit="cm"  x="-214.04" y="-676.3" z="0" />
+     <rotation name="rotFS18" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper19" unit="cm"  x="-208.04" y="-676.3" z="0" />
+     <rotation name="rotFS19" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper20" unit="cm"  x="-202.04" y="-676.3" z="0" />
+     <rotation name="rotFS20" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper21" unit="cm"  x="-196.04" y="-676.3" z="0" />
+     <rotation name="rotFS21" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper22" unit="cm"  x="-190.04" y="-676.3" z="0" />
+     <rotation name="rotFS22" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper23" unit="cm"  x="-184.04" y="-676.3" z="0" />
+     <rotation name="rotFS23" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper24" unit="cm"  x="-178.04" y="-676.3" z="0" />
+     <rotation name="rotFS24" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper25" unit="cm"  x="-172.04" y="-676.3" z="0" />
+     <rotation name="rotFS25" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper26" unit="cm"  x="-166.04" y="-676.3" z="0" />
+     <rotation name="rotFS26" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper27" unit="cm"  x="-160.04" y="-676.3" z="0" />
+     <rotation name="rotFS27" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper28" unit="cm"  x="-154.04" y="-676.3" z="0" />
+     <rotation name="rotFS28" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper29" unit="cm"  x="-148.04" y="-676.3" z="0" />
+     <rotation name="rotFS29" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper30" unit="cm"  x="-142.04" y="-676.3" z="0" />
+     <rotation name="rotFS30" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper31" unit="cm"  x="-136.04" y="-676.3" z="0" />
+     <rotation name="rotFS31" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper32" unit="cm"  x="-130.04" y="-676.3" z="0" />
+     <rotation name="rotFS32" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper33" unit="cm"  x="-124.04" y="-676.3" z="0" />
+     <rotation name="rotFS33" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper34" unit="cm"  x="-118.04" y="-676.3" z="0" />
+     <rotation name="rotFS34" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper35" unit="cm"  x="-112.04" y="-676.3" z="0" />
+     <rotation name="rotFS35" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper36" unit="cm"  x="-106.04" y="-676.3" z="0" />
+     <rotation name="rotFS36" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper37" unit="cm"  x="-100.04" y="-676.3" z="0" />
+     <rotation name="rotFS37" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper38" unit="cm"  x="-94.04" y="-676.3" z="0" />
+     <rotation name="rotFS38" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper39" unit="cm"  x="-88.04" y="-676.3" z="0" />
+     <rotation name="rotFS39" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper40" unit="cm"  x="-82.04" y="-676.3" z="0" />
+     <rotation name="rotFS40" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper41" unit="cm"  x="-76.04" y="-676.3" z="0" />
+     <rotation name="rotFS41" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper42" unit="cm"  x="-70.04" y="-676.3" z="0" />
+     <rotation name="rotFS42" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper43" unit="cm"  x="-64.04" y="-676.3" z="0" />
+     <rotation name="rotFS43" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper44" unit="cm"  x="-58.04" y="-676.3" z="0" />
+     <rotation name="rotFS44" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper45" unit="cm"  x="-52.04" y="-676.3" z="0" />
+     <rotation name="rotFS45" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper46" unit="cm"  x="-46.04" y="-676.3" z="0" />
+     <rotation name="rotFS46" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper47" unit="cm"  x="-40.04" y="-676.3" z="0" />
+     <rotation name="rotFS47" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper48" unit="cm"  x="-34.04" y="-676.3" z="0" />
+     <rotation name="rotFS48" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper49" unit="cm"  x="-28.04" y="-676.3" z="0" />
+     <rotation name="rotFS49" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper50" unit="cm"  x="-22.04" y="-676.3" z="0" />
+     <rotation name="rotFS50" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper51" unit="cm"  x="-16.04" y="-676.3" z="0" />
+     <rotation name="rotFS51" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper52" unit="cm"  x="-10.04" y="-676.3" z="0" />
+     <rotation name="rotFS52" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper53" unit="cm"  x="-4.04000000000001" y="-676.3" z="0" />
+     <rotation name="rotFS53" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper54" unit="cm"  x="1.95999999999999" y="-676.3" z="0" />
+     <rotation name="rotFS54" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper55" unit="cm"  x="7.95999999999999" y="-676.3" z="0" />
+     <rotation name="rotFS55" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper56" unit="cm"  x="13.96" y="-676.3" z="0" />
+     <rotation name="rotFS56" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper57" unit="cm"  x="19.96" y="-676.3" z="0" />
+     <rotation name="rotFS57" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper58" unit="cm"  x="25.96" y="-676.3" z="0" />
+     <rotation name="rotFS58" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper59" unit="cm"  x="31.96" y="-676.3" z="0" />
+     <rotation name="rotFS59" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper60" unit="cm"  x="37.96" y="-676.3" z="0" />
+     <rotation name="rotFS60" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper61" unit="cm"  x="43.96" y="-676.3" z="0" />
+     <rotation name="rotFS61" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper62" unit="cm"  x="49.96" y="-676.3" z="0" />
+     <rotation name="rotFS62" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper63" unit="cm"  x="55.96" y="-676.3" z="0" />
+     <rotation name="rotFS63" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper64" unit="cm"  x="61.96" y="-676.3" z="0" />
+     <rotation name="rotFS64" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper65" unit="cm"  x="67.96" y="-676.3" z="0" />
+     <rotation name="rotFS65" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper66" unit="cm"  x="73.96" y="-676.3" z="0" />
+     <rotation name="rotFS66" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper67" unit="cm"  x="79.96" y="-676.3" z="0" />
+     <rotation name="rotFS67" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper68" unit="cm"  x="85.96" y="-676.3" z="0" />
+     <rotation name="rotFS68" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper69" unit="cm"  x="91.96" y="-676.3" z="0" />
+     <rotation name="rotFS69" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper70" unit="cm"  x="97.96" y="-676.3" z="0" />
+     <rotation name="rotFS70" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper71" unit="cm"  x="103.96" y="-676.3" z="0" />
+     <rotation name="rotFS71" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper72" unit="cm"  x="109.96" y="-676.3" z="0" />
+     <rotation name="rotFS72" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper73" unit="cm"  x="115.96" y="-676.3" z="0" />
+     <rotation name="rotFS73" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper74" unit="cm"  x="121.96" y="-676.3" z="0" />
+     <rotation name="rotFS74" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper75" unit="cm"  x="127.96" y="-676.3" z="0" />
+     <rotation name="rotFS75" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper76" unit="cm"  x="133.96" y="-676.3" z="0" />
+     <rotation name="rotFS76" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper77" unit="cm"  x="139.96" y="-676.3" z="0" />
+     <rotation name="rotFS77" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper78" unit="cm"  x="145.96" y="-676.3" z="0" />
+     <rotation name="rotFS78" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper79" unit="cm"  x="151.96" y="-676.3" z="0" />
+     <rotation name="rotFS79" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper80" unit="cm"  x="157.96" y="-676.3" z="0" />
+     <rotation name="rotFS80" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper81" unit="cm"  x="163.96" y="-676.3" z="0" />
+     <rotation name="rotFS81" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper82" unit="cm"  x="169.96" y="-676.3" z="0" />
+     <rotation name="rotFS82" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper83" unit="cm"  x="175.96" y="-676.3" z="0" />
+     <rotation name="rotFS83" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper84" unit="cm"  x="181.96" y="-676.3" z="0" />
+     <rotation name="rotFS84" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper85" unit="cm"  x="187.96" y="-676.3" z="0" />
+     <rotation name="rotFS85" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper86" unit="cm"  x="193.96" y="-676.3" z="0" />
+     <rotation name="rotFS86" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper87" unit="cm"  x="199.96" y="-676.3" z="0" />
+     <rotation name="rotFS87" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper88" unit="cm"  x="205.96" y="-676.3" z="0" />
+     <rotation name="rotFS88" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper89" unit="cm"  x="211.96" y="-676.3" z="0" />
+     <rotation name="rotFS89" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper90" unit="cm"  x="217.96" y="-676.3" z="0" />
+     <rotation name="rotFS90" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper91" unit="cm"  x="223.96" y="-676.3" z="0" />
+     <rotation name="rotFS91" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper92" unit="cm"  x="229.96" y="-676.3" z="0" />
+     <rotation name="rotFS92" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper93" unit="cm"  x="235.96" y="-676.3" z="0" />
+     <rotation name="rotFS93" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper94" unit="cm"  x="241.96" y="-676.3" z="0" />
+     <rotation name="rotFS94" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper95" unit="cm"  x="247.96" y="-676.3" z="0" />
+     <rotation name="rotFS95" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper96" unit="cm"  x="253.96" y="-676.3" z="0" />
+     <rotation name="rotFS96" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper97" unit="cm"  x="259.96" y="-676.3" z="0" />
+     <rotation name="rotFS97" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper98" unit="cm"  x="265.96" y="-676.3" z="0" />
+     <rotation name="rotFS98" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper99" unit="cm"  x="271.96" y="-676.3" z="0" />
+     <rotation name="rotFS99" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper100" unit="cm"  x="277.96" y="-676.3" z="0" />
+     <rotation name="rotFS100" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper101" unit="cm"  x="283.96" y="-676.3" z="0" />
+     <rotation name="rotFS101" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper102" unit="cm"  x="289.96" y="-676.3" z="0" />
+     <rotation name="rotFS102" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper103" unit="cm"  x="295.96" y="-676.3" z="0" />
+     <rotation name="rotFS103" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper104" unit="cm"  x="301.96" y="-676.3" z="0" />
+     <rotation name="rotFS104" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper105" unit="cm"  x="307.96" y="-676.3" z="0" />
+     <rotation name="rotFS105" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper106" unit="cm"  x="313.96" y="-676.3" z="0" />
+     <rotation name="rotFS106" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper107" unit="cm"  x="319.96" y="-676.3" z="0" />
+     <rotation name="rotFS107" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-0" unit="cm" x="-328.04" y="-506" z="-299.3018"/>
+      </physvol>
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-1" unit="cm" x="-328.04" y="-170" z="-299.3018"/>
+      </physvol>
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-2" unit="cm" x="-328.04" y="166" z="-299.3018"/>
+      </physvol>
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-3" unit="cm" x="-328.04" y="502" z="-299.3018"/>
+      </physvol>
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-4" unit="cm" x="-328.04" y="-506" z="-1.50000000000006"/>
+      </physvol>
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-5" unit="cm" x="-328.04" y="-170" z="-1.50000000000006"/>
+      </physvol>
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-6" unit="cm" x="-328.04" y="166" z="-1.50000000000006"/>
+      </physvol>
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-7" unit="cm" x="-328.04" y="502" z="-1.50000000000006"/>
+      </physvol>
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-8" unit="cm" x="-328.04" y="-506" z="296.3018"/>
+      </physvol>
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-9" unit="cm" x="-328.04" y="-170" z="296.3018"/>
+      </physvol>
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-10" unit="cm" x="-328.04" y="166" z="296.3018"/>
+      </physvol>
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-11" unit="cm" x="-328.04" y="502" z="296.3018"/>
+      </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-0-0"/>
+       <position name="posArapucaDouble0-Frame-0-0" unit="cm" 
+         x="-328.04"
+	 y="-633.7" 
+	 z="-261.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-0"/>
+       <position name="posOpArapucaDouble0-Frame-0-0" unit="cm" 
+         x="-327.3"
+	 y="-633.7" 
+	 z="-261.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-0-1"/>
+       <position name="posArapucaDouble1-Frame-0-0" unit="cm" 
+         x="-328.04"
+	 y="-543" 
+	 z="-407.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-1"/>
+       <position name="posOpArapucaDouble1-Frame-0-0" unit="cm" 
+         x="-327.3"
+	 y="-543" 
+	 z="-407.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-0-2"/>
+       <position name="posArapucaDouble2-Frame-0-0" unit="cm" 
+         x="-328.04"
+	 y="-469" 
+	 z="-190.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-2"/>
+       <position name="posOpArapucaDouble2-Frame-0-0" unit="cm" 
+         x="-327.3"
+	 y="-469" 
+	 z="-190.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-0-3"/>
+       <position name="posArapucaDouble3-Frame-0-0" unit="cm" 
+         x="-328.04"
+	 y="-378.3" 
+	 z="-336.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-3"/>
+       <position name="posOpArapucaDouble3-Frame-0-0" unit="cm" 
+         x="-327.3"
+	 y="-378.3" 
+	 z="-336.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-1-0"/>
+       <position name="posArapucaDouble0-Frame-0-1" unit="cm" 
+         x="-328.04"
+	 y="-633.7" 
+	 z="35.9999999999999"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-0"/>
+       <position name="posOpArapucaDouble0-Frame-0-1" unit="cm" 
+         x="-327.3"
+	 y="-633.7" 
+	 z="35.9999999999999"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-1-1"/>
+       <position name="posArapucaDouble1-Frame-0-1" unit="cm" 
+         x="-328.04"
+	 y="-543" 
+	 z="-110"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-1"/>
+       <position name="posOpArapucaDouble1-Frame-0-1" unit="cm" 
+         x="-327.3"
+	 y="-543" 
+	 z="-110"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-1-2"/>
+       <position name="posArapucaDouble2-Frame-0-1" unit="cm" 
+         x="-328.04"
+	 y="-469" 
+	 z="107"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-2"/>
+       <position name="posOpArapucaDouble2-Frame-0-1" unit="cm" 
+         x="-327.3"
+	 y="-469" 
+	 z="107"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-1-3"/>
+       <position name="posArapucaDouble3-Frame-0-1" unit="cm" 
+         x="-328.04"
+	 y="-378.3" 
+	 z="-39.0000000000001"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-3"/>
+       <position name="posOpArapucaDouble3-Frame-0-1" unit="cm" 
+         x="-327.3"
+	 y="-378.3" 
+	 z="-39.0000000000001"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-2-0"/>
+       <position name="posArapucaDouble0-Frame-0-2" unit="cm" 
+         x="-328.04"
+	 y="-633.7" 
+	 z="333.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-0"/>
+       <position name="posOpArapucaDouble0-Frame-0-2" unit="cm" 
+         x="-327.3"
+	 y="-633.7" 
+	 z="333.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-2-1"/>
+       <position name="posArapucaDouble1-Frame-0-2" unit="cm" 
+         x="-328.04"
+	 y="-543" 
+	 z="187.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-1"/>
+       <position name="posOpArapucaDouble1-Frame-0-2" unit="cm" 
+         x="-327.3"
+	 y="-543" 
+	 z="187.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-2-2"/>
+       <position name="posArapucaDouble2-Frame-0-2" unit="cm" 
+         x="-328.04"
+	 y="-469" 
+	 z="404.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-2"/>
+       <position name="posOpArapucaDouble2-Frame-0-2" unit="cm" 
+         x="-327.3"
+	 y="-469" 
+	 z="404.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-2-3"/>
+       <position name="posArapucaDouble3-Frame-0-2" unit="cm" 
+         x="-328.04"
+	 y="-378.3" 
+	 z="258.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-3"/>
+       <position name="posOpArapucaDouble3-Frame-0-2" unit="cm" 
+         x="-327.3"
+	 y="-378.3" 
+	 z="258.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-0-0"/>
+       <position name="posArapucaDouble0-Frame-1-0" unit="cm" 
+         x="-328.04"
+	 y="-297.7" 
+	 z="-261.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-0"/>
+       <position name="posOpArapucaDouble0-Frame-1-0" unit="cm" 
+         x="-327.3"
+	 y="-297.7" 
+	 z="-261.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-0-1"/>
+       <position name="posArapucaDouble1-Frame-1-0" unit="cm" 
+         x="-328.04"
+	 y="-207" 
+	 z="-407.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-1"/>
+       <position name="posOpArapucaDouble1-Frame-1-0" unit="cm" 
+         x="-327.3"
+	 y="-207" 
+	 z="-407.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-0-2"/>
+       <position name="posArapucaDouble2-Frame-1-0" unit="cm" 
+         x="-328.04"
+	 y="-133" 
+	 z="-190.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-2"/>
+       <position name="posOpArapucaDouble2-Frame-1-0" unit="cm" 
+         x="-327.3"
+	 y="-133" 
+	 z="-190.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-0-3"/>
+       <position name="posArapucaDouble3-Frame-1-0" unit="cm" 
+         x="-328.04"
+	 y="-42.3" 
+	 z="-336.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-3"/>
+       <position name="posOpArapucaDouble3-Frame-1-0" unit="cm" 
+         x="-327.3"
+	 y="-42.3" 
+	 z="-336.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-1-0"/>
+       <position name="posArapucaDouble0-Frame-1-1" unit="cm" 
+         x="-328.04"
+	 y="-297.7" 
+	 z="35.9999999999999"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-0"/>
+       <position name="posOpArapucaDouble0-Frame-1-1" unit="cm" 
+         x="-327.3"
+	 y="-297.7" 
+	 z="35.9999999999999"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-1-1"/>
+       <position name="posArapucaDouble1-Frame-1-1" unit="cm" 
+         x="-328.04"
+	 y="-207" 
+	 z="-110"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-1"/>
+       <position name="posOpArapucaDouble1-Frame-1-1" unit="cm" 
+         x="-327.3"
+	 y="-207" 
+	 z="-110"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-1-2"/>
+       <position name="posArapucaDouble2-Frame-1-1" unit="cm" 
+         x="-328.04"
+	 y="-133" 
+	 z="107"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-2"/>
+       <position name="posOpArapucaDouble2-Frame-1-1" unit="cm" 
+         x="-327.3"
+	 y="-133" 
+	 z="107"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-1-3"/>
+       <position name="posArapucaDouble3-Frame-1-1" unit="cm" 
+         x="-328.04"
+	 y="-42.3" 
+	 z="-39.0000000000001"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-3"/>
+       <position name="posOpArapucaDouble3-Frame-1-1" unit="cm" 
+         x="-327.3"
+	 y="-42.3" 
+	 z="-39.0000000000001"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-2-0"/>
+       <position name="posArapucaDouble0-Frame-1-2" unit="cm" 
+         x="-328.04"
+	 y="-297.7" 
+	 z="333.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-0"/>
+       <position name="posOpArapucaDouble0-Frame-1-2" unit="cm" 
+         x="-327.3"
+	 y="-297.7" 
+	 z="333.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-2-1"/>
+       <position name="posArapucaDouble1-Frame-1-2" unit="cm" 
+         x="-328.04"
+	 y="-207" 
+	 z="187.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-1"/>
+       <position name="posOpArapucaDouble1-Frame-1-2" unit="cm" 
+         x="-327.3"
+	 y="-207" 
+	 z="187.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-2-2"/>
+       <position name="posArapucaDouble2-Frame-1-2" unit="cm" 
+         x="-328.04"
+	 y="-133" 
+	 z="404.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-2"/>
+       <position name="posOpArapucaDouble2-Frame-1-2" unit="cm" 
+         x="-327.3"
+	 y="-133" 
+	 z="404.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-2-3"/>
+       <position name="posArapucaDouble3-Frame-1-2" unit="cm" 
+         x="-328.04"
+	 y="-42.3" 
+	 z="258.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-3"/>
+       <position name="posOpArapucaDouble3-Frame-1-2" unit="cm" 
+         x="-327.3"
+	 y="-42.3" 
+	 z="258.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-0-0"/>
+       <position name="posArapucaDouble0-Frame-2-0" unit="cm" 
+         x="-328.04"
+	 y="38.3" 
+	 z="-261.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-0"/>
+       <position name="posOpArapucaDouble0-Frame-2-0" unit="cm" 
+         x="-327.3"
+	 y="38.3" 
+	 z="-261.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-0-1"/>
+       <position name="posArapucaDouble1-Frame-2-0" unit="cm" 
+         x="-328.04"
+	 y="129" 
+	 z="-407.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-1"/>
+       <position name="posOpArapucaDouble1-Frame-2-0" unit="cm" 
+         x="-327.3"
+	 y="129" 
+	 z="-407.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-0-2"/>
+       <position name="posArapucaDouble2-Frame-2-0" unit="cm" 
+         x="-328.04"
+	 y="203" 
+	 z="-190.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-2"/>
+       <position name="posOpArapucaDouble2-Frame-2-0" unit="cm" 
+         x="-327.3"
+	 y="203" 
+	 z="-190.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-0-3"/>
+       <position name="posArapucaDouble3-Frame-2-0" unit="cm" 
+         x="-328.04"
+	 y="293.7" 
+	 z="-336.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-3"/>
+       <position name="posOpArapucaDouble3-Frame-2-0" unit="cm" 
+         x="-327.3"
+	 y="293.7" 
+	 z="-336.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-1-0"/>
+       <position name="posArapucaDouble0-Frame-2-1" unit="cm" 
+         x="-328.04"
+	 y="38.3" 
+	 z="35.9999999999999"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-0"/>
+       <position name="posOpArapucaDouble0-Frame-2-1" unit="cm" 
+         x="-327.3"
+	 y="38.3" 
+	 z="35.9999999999999"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-1-1"/>
+       <position name="posArapucaDouble1-Frame-2-1" unit="cm" 
+         x="-328.04"
+	 y="129" 
+	 z="-110"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-1"/>
+       <position name="posOpArapucaDouble1-Frame-2-1" unit="cm" 
+         x="-327.3"
+	 y="129" 
+	 z="-110"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-1-2"/>
+       <position name="posArapucaDouble2-Frame-2-1" unit="cm" 
+         x="-328.04"
+	 y="203" 
+	 z="107"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-2"/>
+       <position name="posOpArapucaDouble2-Frame-2-1" unit="cm" 
+         x="-327.3"
+	 y="203" 
+	 z="107"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-1-3"/>
+       <position name="posArapucaDouble3-Frame-2-1" unit="cm" 
+         x="-328.04"
+	 y="293.7" 
+	 z="-39.0000000000001"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-3"/>
+       <position name="posOpArapucaDouble3-Frame-2-1" unit="cm" 
+         x="-327.3"
+	 y="293.7" 
+	 z="-39.0000000000001"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-2-0"/>
+       <position name="posArapucaDouble0-Frame-2-2" unit="cm" 
+         x="-328.04"
+	 y="38.3" 
+	 z="333.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-0"/>
+       <position name="posOpArapucaDouble0-Frame-2-2" unit="cm" 
+         x="-327.3"
+	 y="38.3" 
+	 z="333.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-2-1"/>
+       <position name="posArapucaDouble1-Frame-2-2" unit="cm" 
+         x="-328.04"
+	 y="129" 
+	 z="187.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-1"/>
+       <position name="posOpArapucaDouble1-Frame-2-2" unit="cm" 
+         x="-327.3"
+	 y="129" 
+	 z="187.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-2-2"/>
+       <position name="posArapucaDouble2-Frame-2-2" unit="cm" 
+         x="-328.04"
+	 y="203" 
+	 z="404.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-2"/>
+       <position name="posOpArapucaDouble2-Frame-2-2" unit="cm" 
+         x="-327.3"
+	 y="203" 
+	 z="404.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-2-3"/>
+       <position name="posArapucaDouble3-Frame-2-2" unit="cm" 
+         x="-328.04"
+	 y="293.7" 
+	 z="258.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-3"/>
+       <position name="posOpArapucaDouble3-Frame-2-2" unit="cm" 
+         x="-327.3"
+	 y="293.7" 
+	 z="258.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-0-0"/>
+       <position name="posArapucaDouble0-Frame-3-0" unit="cm" 
+         x="-328.04"
+	 y="374.3" 
+	 z="-261.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-0"/>
+       <position name="posOpArapucaDouble0-Frame-3-0" unit="cm" 
+         x="-327.3"
+	 y="374.3" 
+	 z="-261.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-0-1"/>
+       <position name="posArapucaDouble1-Frame-3-0" unit="cm" 
+         x="-328.04"
+	 y="465" 
+	 z="-407.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-1"/>
+       <position name="posOpArapucaDouble1-Frame-3-0" unit="cm" 
+         x="-327.3"
+	 y="465" 
+	 z="-407.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-0-2"/>
+       <position name="posArapucaDouble2-Frame-3-0" unit="cm" 
+         x="-328.04"
+	 y="539" 
+	 z="-190.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-2"/>
+       <position name="posOpArapucaDouble2-Frame-3-0" unit="cm" 
+         x="-327.3"
+	 y="539" 
+	 z="-190.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-0-3"/>
+       <position name="posArapucaDouble3-Frame-3-0" unit="cm" 
+         x="-328.04"
+	 y="629.7" 
+	 z="-336.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-3"/>
+       <position name="posOpArapucaDouble3-Frame-3-0" unit="cm" 
+         x="-327.3"
+	 y="629.7" 
+	 z="-336.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-1-0"/>
+       <position name="posArapucaDouble0-Frame-3-1" unit="cm" 
+         x="-328.04"
+	 y="374.3" 
+	 z="35.9999999999999"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-0"/>
+       <position name="posOpArapucaDouble0-Frame-3-1" unit="cm" 
+         x="-327.3"
+	 y="374.3" 
+	 z="35.9999999999999"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-1-1"/>
+       <position name="posArapucaDouble1-Frame-3-1" unit="cm" 
+         x="-328.04"
+	 y="465" 
+	 z="-110"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-1"/>
+       <position name="posOpArapucaDouble1-Frame-3-1" unit="cm" 
+         x="-327.3"
+	 y="465" 
+	 z="-110"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-1-2"/>
+       <position name="posArapucaDouble2-Frame-3-1" unit="cm" 
+         x="-328.04"
+	 y="539" 
+	 z="107"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-2"/>
+       <position name="posOpArapucaDouble2-Frame-3-1" unit="cm" 
+         x="-327.3"
+	 y="539" 
+	 z="107"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-1-3"/>
+       <position name="posArapucaDouble3-Frame-3-1" unit="cm" 
+         x="-328.04"
+	 y="629.7" 
+	 z="-39.0000000000001"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-3"/>
+       <position name="posOpArapucaDouble3-Frame-3-1" unit="cm" 
+         x="-327.3"
+	 y="629.7" 
+	 z="-39.0000000000001"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-2-0"/>
+       <position name="posArapucaDouble0-Frame-3-2" unit="cm" 
+         x="-328.04"
+	 y="374.3" 
+	 z="333.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-0"/>
+       <position name="posOpArapucaDouble0-Frame-3-2" unit="cm" 
+         x="-327.3"
+	 y="374.3" 
+	 z="333.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-2-1"/>
+       <position name="posArapucaDouble1-Frame-3-2" unit="cm" 
+         x="-328.04"
+	 y="465" 
+	 z="187.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-1"/>
+       <position name="posOpArapucaDouble1-Frame-3-2" unit="cm" 
+         x="-327.3"
+	 y="465" 
+	 z="187.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-2-2"/>
+       <position name="posArapucaDouble2-Frame-3-2" unit="cm" 
+         x="-328.04"
+	 y="539" 
+	 z="404.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-2"/>
+       <position name="posOpArapucaDouble2-Frame-3-2" unit="cm" 
+         x="-327.3"
+	 y="539" 
+	 z="404.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-2-3"/>
+       <position name="posArapucaDouble3-Frame-3-2" unit="cm" 
+         x="-328.04"
+	 y="629.7" 
+	 z="258.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-3"/>
+       <position name="posOpArapucaDouble3-Frame-3-2" unit="cm" 
+         x="-327.3"
+	 y="629.7" 
+	 z="258.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_0-0"/>
+       <position name="posArapuca0-Lat-0" unit="cm" 
+         x="285.03"
+	 y="-734" 
+	 z="-297.8018"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_0-0"/>
+       <position name="posOpArapuca0-Lat-0" unit="cm" 
+         x="285.03"
+	 y="-733.26" 
+	 z="-297.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_0-1"/>
+       <position name="posArapuca1-Lat-0" unit="cm" 
+         x="210.03"
+	 y="-734" 
+	 z="-297.8018"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_0-1"/>
+       <position name="posOpArapuca1-Lat-0" unit="cm" 
+         x="210.03"
+	 y="-733.26" 
+	 z="-297.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_0-2"/>
+       <position name="posArapuca2-Lat-0" unit="cm" 
+         x="135.03"
+	 y="-734" 
+	 z="-297.8018"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_0-2"/>
+       <position name="posOpArapuca2-Lat-0" unit="cm" 
+         x="135.03"
+	 y="-733.26" 
+	 z="-297.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_0-3"/>
+       <position name="posArapuca3-Lat-0" unit="cm" 
+         x="60.03"
+	 y="-734" 
+	 z="-297.8018"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_0-3"/>
+       <position name="posOpArapuca3-Lat-0" unit="cm" 
+         x="60.03"
+	 y="-733.26" 
+	 z="-297.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_0-4"/>
+       <position name="posArapuca4-Lat-0" unit="cm" 
+         x="285.03"
+	 y="734" 
+	 z="-297.8018"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_0-4"/>
+       <position name="posOpArapuca4-Lat-0" unit="cm" 
+         x="285.03"
+	 y="733.26" 
+	 z="-297.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_0-5"/>
+       <position name="posArapuca5-Lat-0" unit="cm" 
+         x="210.03"
+	 y="734" 
+	 z="-297.8018"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_0-5"/>
+       <position name="posOpArapuca5-Lat-0" unit="cm" 
+         x="210.03"
+	 y="733.26" 
+	 z="-297.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_0-6"/>
+       <position name="posArapuca6-Lat-0" unit="cm" 
+         x="135.03"
+	 y="734" 
+	 z="-297.8018"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_0-6"/>
+       <position name="posOpArapuca6-Lat-0" unit="cm" 
+         x="135.03"
+	 y="733.26" 
+	 z="-297.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_0-7"/>
+       <position name="posArapuca7-Lat-0" unit="cm" 
+         x="60.03"
+	 y="734" 
+	 z="-297.8018"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_0-7"/>
+       <position name="posOpArapuca7-Lat-0" unit="cm" 
+         x="60.03"
+	 y="733.26" 
+	 z="-297.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_1-0"/>
+       <position name="posArapuca0-Lat-1" unit="cm" 
+         x="285.03"
+	 y="-734" 
+	 z="2.8421709430404e-13"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_1-0"/>
+       <position name="posOpArapuca0-Lat-1" unit="cm" 
+         x="285.03"
+	 y="-733.26" 
+	 z="2.8421709430404e-13"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_1-1"/>
+       <position name="posArapuca1-Lat-1" unit="cm" 
+         x="210.03"
+	 y="-734" 
+	 z="2.8421709430404e-13"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_1-1"/>
+       <position name="posOpArapuca1-Lat-1" unit="cm" 
+         x="210.03"
+	 y="-733.26" 
+	 z="2.8421709430404e-13"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_1-2"/>
+       <position name="posArapuca2-Lat-1" unit="cm" 
+         x="135.03"
+	 y="-734" 
+	 z="2.8421709430404e-13"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_1-2"/>
+       <position name="posOpArapuca2-Lat-1" unit="cm" 
+         x="135.03"
+	 y="-733.26" 
+	 z="2.8421709430404e-13"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_1-3"/>
+       <position name="posArapuca3-Lat-1" unit="cm" 
+         x="60.03"
+	 y="-734" 
+	 z="2.8421709430404e-13"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_1-3"/>
+       <position name="posOpArapuca3-Lat-1" unit="cm" 
+         x="60.03"
+	 y="-733.26" 
+	 z="2.8421709430404e-13"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_1-4"/>
+       <position name="posArapuca4-Lat-1" unit="cm" 
+         x="285.03"
+	 y="734" 
+	 z="2.8421709430404e-13"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_1-4"/>
+       <position name="posOpArapuca4-Lat-1" unit="cm" 
+         x="285.03"
+	 y="733.26" 
+	 z="2.8421709430404e-13"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_1-5"/>
+       <position name="posArapuca5-Lat-1" unit="cm" 
+         x="210.03"
+	 y="734" 
+	 z="2.8421709430404e-13"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_1-5"/>
+       <position name="posOpArapuca5-Lat-1" unit="cm" 
+         x="210.03"
+	 y="733.26" 
+	 z="2.8421709430404e-13"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_1-6"/>
+       <position name="posArapuca6-Lat-1" unit="cm" 
+         x="135.03"
+	 y="734" 
+	 z="2.8421709430404e-13"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_1-6"/>
+       <position name="posOpArapuca6-Lat-1" unit="cm" 
+         x="135.03"
+	 y="733.26" 
+	 z="2.8421709430404e-13"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_1-7"/>
+       <position name="posArapuca7-Lat-1" unit="cm" 
+         x="60.03"
+	 y="734" 
+	 z="2.8421709430404e-13"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_1-7"/>
+       <position name="posOpArapuca7-Lat-1" unit="cm" 
+         x="60.03"
+	 y="733.26" 
+	 z="2.8421709430404e-13"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_2-0"/>
+       <position name="posArapuca0-Lat-2" unit="cm" 
+         x="285.03"
+	 y="-734" 
+	 z="297.8018"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_2-0"/>
+       <position name="posOpArapuca0-Lat-2" unit="cm" 
+         x="285.03"
+	 y="-733.26" 
+	 z="297.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_2-1"/>
+       <position name="posArapuca1-Lat-2" unit="cm" 
+         x="210.03"
+	 y="-734" 
+	 z="297.8018"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_2-1"/>
+       <position name="posOpArapuca1-Lat-2" unit="cm" 
+         x="210.03"
+	 y="-733.26" 
+	 z="297.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_2-2"/>
+       <position name="posArapuca2-Lat-2" unit="cm" 
+         x="135.03"
+	 y="-734" 
+	 z="297.8018"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_2-2"/>
+       <position name="posOpArapuca2-Lat-2" unit="cm" 
+         x="135.03"
+	 y="-733.26" 
+	 z="297.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_2-3"/>
+       <position name="posArapuca3-Lat-2" unit="cm" 
+         x="60.03"
+	 y="-734" 
+	 z="297.8018"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_2-3"/>
+       <position name="posOpArapuca3-Lat-2" unit="cm" 
+         x="60.03"
+	 y="-733.26" 
+	 z="297.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_2-4"/>
+       <position name="posArapuca4-Lat-2" unit="cm" 
+         x="285.03"
+	 y="734" 
+	 z="297.8018"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_2-4"/>
+       <position name="posOpArapuca4-Lat-2" unit="cm" 
+         x="285.03"
+	 y="733.26" 
+	 z="297.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_2-5"/>
+       <position name="posArapuca5-Lat-2" unit="cm" 
+         x="210.03"
+	 y="734" 
+	 z="297.8018"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_2-5"/>
+       <position name="posOpArapuca5-Lat-2" unit="cm" 
+         x="210.03"
+	 y="733.26" 
+	 z="297.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_2-6"/>
+       <position name="posArapuca6-Lat-2" unit="cm" 
+         x="135.03"
+	 y="734" 
+	 z="297.8018"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_2-6"/>
+       <position name="posOpArapuca6-Lat-2" unit="cm" 
+         x="135.03"
+	 y="733.26" 
+	 z="297.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_2-7"/>
+       <position name="posArapuca7-Lat-2" unit="cm" 
+         x="60.03"
+	 y="734" 
+	 z="297.8018"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_2-7"/>
+       <position name="posOpArapuca7-Lat-2" unit="cm" 
+         x="60.03"
+	 y="733.26" 
+	 z="297.8018"/>
+     </physvol>
+    </volume>
+
+    <volume name="volFoamPadding">
+      <materialref ref="fibrous_glass"/>
+      <solidref ref="FoamPadding"/>
+    </volume>
+
+    <volume name="volSteelSupport">
+      <materialref ref="AirSteelMixture"/>
+      <solidref ref="SteelSupport"/>
+    </volume>
+
+    <volume name="volDetEnclosure">
+      <materialref ref="Air"/>
+      <solidref ref="DetEnclosure"/>
+
+       <physvol>
+           <volumeref ref="volFoamPadding"/>
+           <positionref ref="posCryoInDetEnc"/>
+       </physvol>
+       <physvol>
+           <volumeref ref="volSteelSupport"/>
+           <positionref ref="posCryoInDetEnc"/>
+       </physvol>
+       <physvol>
+           <volumeref ref="volCryostat"/>
+           <positionref ref="posCryoInDetEnc"/>
+       </physvol>
+    </volume>
+
+    <volume name="volWorld" >
+      <materialref ref="DUSEL_Rock"/>
+      <solidref ref="World"/>
+
+      <physvol>
+        <volumeref ref="volDetEnclosure"/>
+	<position name="posDetEnclosure" unit="cm" x="50.04" y="-1.13686837721616e-13" z="448.2027"/>
+      </physvol>
+
+    </volume>
+</structure>
+  <setup name="Default" version="1.0">
+    <world ref="volWorld"/>
+  </setup>
+</gdml_simple_extension>

--- a/dunecore/Geometry/gdml/dunevd10kt_3view_v4_refactored_1x8x14ref.gdml
+++ b/dunecore/Geometry/gdml/dunevd10kt_3view_v4_refactored_1x8x14ref.gdml
@@ -1,0 +1,12757 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<gdml_simple_extension xmlns:gdml_simple_extension="http://www.example.org"
+                       xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"          
+                       xs:noNamespaceSchemaLocation="RefactoredGDMLSchema/SimpleExtension.xsd"> 
+<extension>
+   <color name="magenta"     R="0.0"  G="1.0"  B="0.0"  A="1.0" />
+   <color name="green"       R="0.0"  G="1.0"  B="0.0"  A="1.0" />
+   <color name="red"         R="1.0"  G="0.0"  B="0.0"  A="1.0" />
+   <color name="blue"        R="0.0"  G="0.0"  B="1.0"  A="1.0" />
+   <color name="yellow"      R="1.0"  G="1.0"  B="0.0"  A="1.0" />    
+</extension>
+<define>
+
+<!--
+
+
+
+-->
+
+   <position name="posCryoInDetEnc"     unit="cm" x="-50.0000000000001" y="0" z="0"/>
+   <position name="posCenter"           unit="cm" x="0" y="0" z="0"/>
+   <rotation name="rUWireAboutX"        unit="deg" x="131.63" y="0" z="0"/>
+   <rotation name="rPlus90AboutX"       unit="deg" x="90" y="0" z="0"/>
+   <rotation name="rPlus90AboutY"       unit="deg" x="0" y="90" z="0"/>
+   <rotation name="rPlus90AboutXPlus90AboutY" unit="deg" x="90" y="90" z="0"/>
+   <rotation name="rMinus90AboutX"      unit="deg" x="270" y="0" z="0"/>
+   <rotation name="rMinus90AboutY"      unit="deg" x="0" y="270" z="0"/>
+   <rotation name="rMinus90AboutYMinus90AboutX"       unit="deg" x="270" y="270" z="0"/>
+   <rotation name="rPlus180AboutX"	unit="deg" x="180" y="0"   z="0"/>
+   <rotation name="rPlus180AboutY"	unit="deg" x="0" y="180"   z="0"/>
+   <rotation name="rPlus180AboutXPlus180AboutY"	unit="deg" x="180" y="180"   z="0"/>
+   <rotation name="rIdentity"		unit="deg" x="0" y="0"   z="0"/>
+</define>
+<materials>
+  <element name="videRef" formula="VACUUM" Z="1">  <atom value="1"/> </element>
+  <element name="copper" formula="Cu" Z="29">  <atom value="63.546"/>  </element>
+  <element name="beryllium" formula="Be" Z="4">  <atom value="9.0121831"/>  </element>
+  <element name="bromine" formula="Br" Z="35"> <atom value="79.904"/> </element>
+  <element name="hydrogen" formula="H" Z="1">  <atom value="1.0079"/> </element>
+  <element name="nitrogen" formula="N" Z="7">  <atom value="14.0067"/> </element>
+  <element name="oxygen" formula="O" Z="8">  <atom value="15.999"/> </element>
+  <element name="aluminum" formula="Al" Z="13"> <atom value="26.9815"/>  </element>
+  <element name="silicon" formula="Si" Z="14"> <atom value="28.0855"/>  </element>
+  <element name="carbon" formula="C" Z="6">  <atom value="12.0107"/>  </element>
+  <element name="potassium" formula="K" Z="19"> <atom value="39.0983"/>  </element>
+  <element name="chromium" formula="Cr" Z="24"> <atom value="51.9961"/>  </element>
+  <element name="iron" formula="Fe" Z="26"> <atom value="55.8450"/>  </element>
+  <element name="nickel" formula="Ni" Z="28"> <atom value="58.6934"/>  </element>
+  <element name="calcium" formula="Ca" Z="20"> <atom value="40.078"/>   </element>
+  <element name="magnesium" formula="Mg" Z="12"> <atom value="24.305"/>   </element>
+  <element name="sodium" formula="Na" Z="11"> <atom value="22.99"/>    </element>
+  <element name="titanium" formula="Ti" Z="22"> <atom value="47.867"/>   </element>
+  <element name="argon" formula="Ar" Z="18"> <atom value="39.9480"/>  </element>
+  <element name="sulphur" formula="S" Z="16"> <atom value="32.065"/>  </element>
+  <element name="phosphorus" formula="P" Z="15"> <atom value="30.973"/>  </element>
+
+  <material name="Vacuum" formula="Vacuum">
+   <D value="1.e-25" unit="g/cm3"/>
+   <fraction n="1.0" ref="videRef"/>
+  </material>
+
+  <material name="ALUMINUM_Al" formula="ALUMINUM_Al">
+   <D value="2.6990" unit="g/cm3"/>
+   <fraction n="1.0000" ref="aluminum"/>
+  </material>
+
+  <material name="SILICON_Si" formula="SILICON_Si">
+   <D value="2.3300" unit="g/cm3"/>
+   <fraction n="1.0000" ref="silicon"/>
+  </material>
+
+  <material name="epoxy_resin" formula="C38H40O6Br4">
+   <D value="1.1250" unit="g/cm3"/>
+   <composite n="38" ref="carbon"/>
+   <composite n="40" ref="hydrogen"/>
+   <composite n="6" ref="oxygen"/>
+   <composite n="4" ref="bromine"/>
+  </material>
+
+  <material name="SiO2" formula="SiO2">
+   <D value="2.2" unit="g/cm3"/>
+   <composite n="1" ref="silicon"/>
+   <composite n="2" ref="oxygen"/>
+  </material>
+
+  <material name="Al2O3" formula="Al2O3">
+   <D value="3.97" unit="g/cm3"/>
+   <composite n="2" ref="aluminum"/>
+   <composite n="3" ref="oxygen"/>
+  </material>
+
+  <material name="Fe2O3" formula="Fe2O3">
+   <D value="5.24" unit="g/cm3"/>
+   <composite n="2" ref="iron"/>
+   <composite n="3" ref="oxygen"/>
+  </material>
+
+  <material name="CaO" formula="CaO">
+   <D value="3.35" unit="g/cm3"/>
+   <composite n="1" ref="calcium"/>
+   <composite n="1" ref="oxygen"/>
+  </material>
+
+  <material name="Delrin" formula="CH2O">
+    <D value="1.41" unit="g/cm3"/>
+    <composite n="1" ref="carbon"/>
+    <composite n="2" ref="hydrogen"/>
+    <composite n="1" ref="oxygen"/>
+  </material>
+
+  <material name="MgO" formula="MgO">
+   <D value="3.58" unit="g/cm3"/>
+   <composite n="1" ref="magnesium"/>
+   <composite n="1" ref="oxygen"/>
+  </material>
+
+  <material name="Na2O" formula="Na2O">
+   <D value="2.27" unit="g/cm3"/>
+   <composite n="2" ref="sodium"/>
+   <composite n="1" ref="oxygen"/>
+  </material>
+
+  <material name="TiO2" formula="TiO2">
+   <D value="4.23" unit="g/cm3"/>
+   <composite n="1" ref="titanium"/>
+   <composite n="2" ref="oxygen"/>
+  </material>
+
+  <material name="FeO" formula="FeO">
+   <D value="5.745" unit="g/cm3"/>
+   <composite n="1" ref="iron"/>
+   <composite n="1" ref="oxygen"/>
+  </material>
+
+  <material name="CO2" formula="CO2">
+   <D value="1.562" unit="g/cm3"/>
+   <composite n="1" ref="iron"/>
+   <composite n="2" ref="oxygen"/>
+  </material>
+
+  <material name="P2O5" formula="P2O5">
+   <D value="1.562" unit="g/cm3"/>
+   <composite n="2" ref="phosphorus"/>
+   <composite n="5" ref="oxygen"/>
+  </material>
+
+  <material formula=" " name="DUSEL_Rock">
+    <D value="2.82" unit="g/cm3"/>
+    <fraction n="0.5267" ref="SiO2"/>
+    <fraction n="0.1174" ref="FeO"/>
+    <fraction n="0.1025" ref="Al2O3"/>
+    <fraction n="0.0473" ref="MgO"/>
+    <fraction n="0.0422" ref="CO2"/>
+    <fraction n="0.0382" ref="CaO"/>
+    <fraction n="0.0240" ref="carbon"/>
+    <fraction n="0.0186" ref="sulphur"/>
+    <fraction n="0.0053" ref="Na2O"/>
+    <fraction n="0.00070" ref="P2O5"/>
+    <fraction n="0.0771" ref="oxygen"/>
+  </material> 
+
+  <material formula="Air" name="Air">
+   <D value="0.001205" unit="g/cm3"/>
+   <fraction n="0.781154" ref="nitrogen"/>
+   <fraction n="0.209476" ref="oxygen"/>
+   <fraction n="0.00934" ref="argon"/>
+  </material>
+
+  <material name="fibrous_glass">
+   <D value="2.74351" unit="g/cm3"/>
+   <fraction n="0.600" ref="SiO2"/>
+   <fraction n="0.118" ref="Al2O3"/>
+   <fraction n="0.001" ref="Fe2O3"/>
+   <fraction n="0.224" ref="CaO"/>
+   <fraction n="0.034" ref="MgO"/>
+   <fraction n="0.010" ref="Na2O"/>
+   <fraction n="0.013" ref="TiO2"/>
+  </material>
+
+  <!-- density referenced from EHN1-Cold Cryostats Technical Requirements:
+       https://edms.cern.ch/document/1543254 -->
+  <material name="FD_foam">
+   <D value="0.09" unit="g/cm3"/>
+   <fraction n="0.95" ref="Air"/>
+   <fraction n="0.05" ref="fibrous_glass"/>
+  </material>
+
+  <!-- Foam density is 70 kg / m^3 for the 3x1x1 -->
+  <material name="foam_3x1x1dp">
+   <D value="0.07" unit="g/cm3"/>
+   <fraction n="0.95" ref="Air"/>
+   <fraction n="0.05" ref="fibrous_glass"/>
+  </material>
+
+  <!-- Copied from protodune_v4.gdml -->
+  <material name="foam_protoDUNEdp">
+   <D value="0.135" unit="g/cm3"/>
+   <composite n="17" ref="carbon"/>
+   <composite n="16" ref="hydrogen"/>
+   <composite n="2" ref="nitrogen"/>
+   <composite n="4" ref="oxygen"/>
+  </material>
+
+  <material name="FR4">
+   <D value="1.98281" unit="g/cm3"/>
+   <fraction n="0.47" ref="epoxy_resin"/>
+   <fraction n="0.53" ref="fibrous_glass"/>
+  </material>
+
+  <material name="STEEL_STAINLESS_Fe7Cr2Ni" formula="STEEL_STAINLESS_Fe7Cr2Ni">
+   <D value="7.9300" unit="g/cm3"/>
+   <fraction n="0.0010" ref="carbon"/>
+   <fraction n="0.1792" ref="chromium"/>
+   <fraction n="0.7298" ref="iron"/>
+   <fraction n="0.0900" ref="nickel"/>
+  </material>
+
+  <material name="Copper_Beryllium_alloy25" formula="Copper_Beryllium_alloy25">
+   <D value="8.26" unit="g/cm3"/>
+   <fraction n="0.981" ref="copper"/>
+   <fraction n="0.019" ref="beryllium"/>
+  </material>
+
+  <material name="LAr" formula="LAr">
+   <D value="1.40" unit="g/cm3"/>
+   <fraction n="1.0000" ref="argon"/>
+  </material>
+
+  <material name="ArGas" formula="ArGas">
+   <D value="0.00166" unit="g/cm3"/>
+   <fraction n="1.0" ref="argon"/>
+  </material>
+
+  <material formula=" " name="G10">
+   <D value="1.7" unit="g/cm3"/>
+   <fraction n="0.2805" ref="silicon"/>
+   <fraction n="0.3954" ref="oxygen"/>
+   <fraction n="0.2990" ref="carbon"/>
+   <fraction n="0.0251" ref="hydrogen"/>
+  </material>
+
+  <material formula=" " name="Granite">
+   <D value="2.7" unit="g/cm3"/>
+   <fraction n="0.438" ref="oxygen"/>
+   <fraction n="0.257" ref="silicon"/>
+   <fraction n="0.222" ref="sodium"/>
+   <fraction n="0.049" ref="aluminum"/>
+   <fraction n="0.019" ref="iron"/>
+   <fraction n="0.015" ref="potassium"/>
+  </material>
+
+  <material formula=" " name="ShotRock">
+   <D value="1.62" unit="g/cm3"/>
+   <fraction n="0.438" ref="oxygen"/>
+   <fraction n="0.257" ref="silicon"/>
+   <fraction n="0.222" ref="sodium"/>
+   <fraction n="0.049" ref="aluminum"/>
+   <fraction n="0.019" ref="iron"/>
+   <fraction n="0.015" ref="potassium"/>
+  </material>
+
+  <material formula=" " name="Dirt">
+   <D value="1.7" unit="g/cm3"/>
+   <fraction n="0.438" ref="oxygen"/>
+   <fraction n="0.257" ref="silicon"/>
+   <fraction n="0.222" ref="sodium"/>
+   <fraction n="0.049" ref="aluminum"/>
+   <fraction n="0.019" ref="iron"/>
+   <fraction n="0.015" ref="potassium"/>
+  </material>
+
+  <material formula=" " name="Concrete">
+   <D value="2.3" unit="g/cm3"/>
+   <fraction n="0.530" ref="oxygen"/>
+   <fraction n="0.335" ref="silicon"/>
+   <fraction n="0.060" ref="calcium"/>
+   <fraction n="0.015" ref="sodium"/>
+   <fraction n="0.020" ref="iron"/>
+   <fraction n="0.040" ref="aluminum"/>
+  </material>
+
+  <material formula="H2O" name="Water">
+   <D value="1.0" unit="g/cm3"/>
+   <fraction n="0.1119" ref="hydrogen"/>
+   <fraction n="0.8881" ref="oxygen"/>
+  </material>
+
+  <material formula="Ti" name="Titanium">
+   <D value="4.506" unit="g/cm3"/>
+   <fraction n="1." ref="titanium"/>
+  </material>
+
+  <material name="TPB" formula="TPB">
+   <D value="1.40" unit="g/cm3"/>
+   <fraction n="1.0000" ref="argon"/>
+  </material>
+
+  <material name="Glass">
+   <D value="2.74351" unit="g/cm3"/>
+   <fraction n="0.600" ref="SiO2"/>
+   <fraction n="0.118" ref="Al2O3"/>
+   <fraction n="0.001" ref="Fe2O3"/>
+   <fraction n="0.224" ref="CaO"/>
+   <fraction n="0.034" ref="MgO"/>
+   <fraction n="0.010" ref="Na2O"/>
+   <fraction n="0.013" ref="TiO2"/>
+  </material>
+
+  <material name="Acrylic">
+   <D value="1.19" unit="g/cm3"/>
+   <fraction n="0.600" ref="carbon"/>
+   <fraction n="0.320" ref="oxygen"/>
+   <fraction n="0.080" ref="hydrogen"/>
+  </material>
+
+  <material name="NiGas1atm80K">
+   <D value="0.0039" unit="g/cm3"/>
+   <fraction n="1.000" ref="nitrogen"/>
+  </material>
+
+  <material name="NiGas">
+   <D value="0.001165" unit="g/cm3"/>
+   <fraction n="1.000" ref="nitrogen"/>
+  </material>
+
+  <material name="PolyurethaneFoam">
+   <D value="0.088" unit="g/cm3"/>
+   <composite n="17" ref="carbon"/>
+   <composite n="16" ref="hydrogen"/>
+   <composite n="2" ref="nitrogen"/>
+   <composite n="4" ref="oxygen"/>
+  </material>
+
+  <material name="ProtoDUNEFoam">
+   <D value="0.135" unit="g/cm3"/>
+   <composite n="17" ref="carbon"/>
+   <composite n="16" ref="hydrogen"/>
+   <composite n="2" ref="nitrogen"/>
+   <composite n="4" ref="oxygen"/>
+  </material>
+
+  <material name="LightPolyurethaneFoam">
+   <D value="0.009" unit="g/cm3"/>
+   <composite n="17" ref="carbon"/>
+   <composite n="16" ref="hydrogen"/>
+   <composite n="2" ref="nitrogen"/>
+   <composite n="4" ref="oxygen"/>
+  </material>
+
+  <material name="ProtoDUNEBWFoam">
+   <D value="0.021" unit="g/cm3"/>
+   <composite n="17" ref="carbon"/>
+   <composite n="16" ref="hydrogen"/>
+   <composite n="2" ref="nitrogen"/>
+   <composite n="4" ref="oxygen"/>
+  </material>
+
+  <material name="GlassWool">
+   <D value="0.035" unit="g/cm3"/>
+   <fraction n="0.65" ref="SiO2"/>
+   <fraction n="0.09" ref="Al2O3"/>
+   <fraction n="0.07" ref="CaO"/>
+   <fraction n="0.03" ref="MgO"/>
+   <fraction n="0.16" ref="Na2O"/>
+  </material>
+
+  <material name="Polystyrene">
+   <D value="1.06" unit="g/cm3"/>
+   <composite n="8" ref="carbon"/>
+   <composite n="8" ref="hydrogen"/>
+  </material>
+
+
+
+  <!-- preliminary values -->
+  <material name="AirSteelMixture" formula="AirSteelMixture">
+   <D value=" 0.001205*(1-0.5) + 7.9300*0.5 " unit="g/cm3"/>
+   <fraction n="0.5" ref="STEEL_STAINLESS_Fe7Cr2Ni"/>
+   <fraction n="0.5"   ref="Air"/>
+  </material>
+  <material name="vm2000" formula="vm2000">
+    <D value="1.2" unit="g/cm3"/>
+    <composite n="2" ref="carbon"/>
+    <composite n="4" ref="hydrogen"/>
+  </material>
+
+</materials>
+<solids>
+     <torus name="FieldShaperCorner" rmin="0.5" rmax="2.285" rtor="2.3" deltaphi="90" startphi="0" aunit="deg" lunit="cm"/>
+     <tube name="FieldShaperLongtube" rmin="0.5" rmax="2.285" z="2091.6126" deltaphi="360" startphi="0" aunit="deg" lunit="cm"/>
+     <tube name="FieldShaperLongtubeSlim" rmin="0.5" rmax="0.75" z="2091.6126" deltaphi="360" startphi="0" aunit="deg" lunit="cm"/>
+     <tube name="FieldShaperShorttube" rmin="0.5" rmax="2.285" z="1348" deltaphi="360" startphi="0" aunit="deg" lunit="cm"/>
+
+    <union name="FSunion1">
+      <first ref="FieldShaperLongtube"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos1" unit="cm" x="-2.3" y="0" z="1045.8063"/>
+		<rotation name="rot1" unit="deg" x="90" y="0" z="0" />
+    </union>
+
+    <union name="FSunion2">
+      <first ref="FSunion1"/>
+      <second ref="FieldShaperShorttube"/>
+   		<position name="esquinapos2" unit="cm" x="-676.3" y="0" z="1048.1063"/>
+   		<rotation name="rot2" unit="deg" x="0" y="90" z="0" />
+    </union>
+
+    <union name="FSunion3">
+      <first ref="FSunion2"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos3" unit="cm" x="-1350.3" y="0" z="1045.8063"/>
+		<rotation name="rot3" unit="deg" x="90" y="270" z="0" />
+    </union>
+
+    <union name="FSunion4">
+      <first ref="FSunion3"/>
+      <second ref="FieldShaperLongtube"/>
+   		<position name="esquinapos4" unit="cm" x="-1352.6" y="0" z="0"/>
+    </union>
+
+    <union name="FSunion5">
+      <first ref="FSunion4"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos5" unit="cm" x="-1350.3" y="0" z="-1045.8063"/>
+		<rotation name="rot5" unit="deg" x="90" y="180" z="0" />
+    </union>
+
+    <union name="FSunion6">
+      <first ref="FSunion5"/>
+      <second ref="FieldShaperShorttube"/>
+   		<position name="esquinapos6" unit="cm" x="-676.3" y="0" z="-1048.1063"/>
+		<rotation name="rot6" unit="deg" x="0" y="90" z="0" />
+    </union>
+
+    <union name="FieldShaperSolid">
+      <first ref="FSunion6"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos7" unit="cm" x="-2.3" y="0" z="-1045.8063"/>
+		<rotation name="rot7" unit="deg" x="90" y="90" z="0" />
+    </union>
+    
+    <union name="FSunionSlim1">
+      <first ref="FieldShaperLongtubeSlim"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos1" unit="cm" x="-2.3" y="0" z="1045.8063"/>
+		<rotation name="rot1" unit="deg" x="90" y="0" z="0" />
+    </union>
+
+    <union name="FSunionSlim2">
+      <first ref="FSunionSlim1"/>
+      <second ref="FieldShaperShorttube"/>
+   		<position name="esquinapos2" unit="cm" x="-676.3" y="0" z="1048.1063"/>
+   		<rotation name="rot2" unit="deg" x="0" y="90" z="0" />
+    </union>
+
+    <union name="FSunionSlim3">
+      <first ref="FSunionSlim2"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos3" unit="cm" x="-1350.3" y="0" z="1045.8063"/>
+		<rotation name="rot3" unit="deg" x="90" y="270" z="0" />
+    </union>
+
+    <union name="FSunionSlim4">
+      <first ref="FSunionSlim3"/>
+      <second ref="FieldShaperLongtubeSlim"/>
+   		<position name="esquinapos4" unit="cm" x="-1352.6" y="0" z="0"/>
+    </union>
+
+    <union name="FSunionSlim5">
+      <first ref="FSunionSlim4"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos5" unit="cm" x="-1350.3" y="0" z="-1045.8063"/>
+		<rotation name="rot5" unit="deg" x="90" y="180" z="0" />
+    </union>
+
+    <union name="FSunionSlim6">
+      <first ref="FSunionSlim5"/>
+      <second ref="FieldShaperShorttube"/>
+   		<position name="esquinapos6" unit="cm" x="-676.3" y="0" z="-1048.1063"/>
+		<rotation name="rot6" unit="deg" x="0" y="90" z="0" />
+    </union>
+
+    <union name="FieldShaperSolidSlim">
+      <first ref="FSunionSlim6"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos7" unit="cm" x="-2.3" y="0" z="-1045.8063"/>
+		<rotation name="rot7" unit="deg" x="90" y="90" z="0" />
+    </union>
+    
+
+   <box name="CRM"
+      x="650.08" 
+      y="168" 
+      z="148.9009"
+      lunit="cm"/>
+   <box name="CRMUPlane" 
+      x="0.02" 
+      y="168" 
+      z="148.9009"
+      lunit="cm"/>
+   <box name="CRMYPlane" 
+      x="0.02" 
+      y="168" 
+      z="148.9009"
+      lunit="cm"/>
+   <box name="CRMZPlane" 
+      x="0.02"
+      y="168"
+      z="148.9009"
+      lunit="cm"/>
+   <box name="CRMActive" 
+      x="650"
+      y="168"
+      z="148.9009"
+      lunit="cm"/>
+   <tube name="CRMWireU0"
+      rmax="0.5*0.02"
+      z="0.875550971308563"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU1"
+      rmax="0.5*0.02"
+      z="2.62665291392569"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU2"
+      rmax="0.5*0.02"
+      z="4.37775485654281"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU3"
+      rmax="0.5*0.02"
+      z="6.12885679915994"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU4"
+      rmax="0.5*0.02"
+      z="7.87995874177706"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU5"
+      rmax="0.5*0.02"
+      z="9.63106068439417"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU6"
+      rmax="0.5*0.02"
+      z="11.3821626270113"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU7"
+      rmax="0.5*0.02"
+      z="13.1332645696284"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU8"
+      rmax="0.5*0.02"
+      z="14.8843665122456"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU9"
+      rmax="0.5*0.02"
+      z="16.6354684548627"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU10"
+      rmax="0.5*0.02"
+      z="18.3865703974798"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU11"
+      rmax="0.5*0.02"
+      z="20.1376723400969"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU12"
+      rmax="0.5*0.02"
+      z="21.8887742827141"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU13"
+      rmax="0.5*0.02"
+      z="23.6398762253312"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU14"
+      rmax="0.5*0.02"
+      z="25.3909781679483"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU15"
+      rmax="0.5*0.02"
+      z="27.1420801105654"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU16"
+      rmax="0.5*0.02"
+      z="28.8931820531826"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU17"
+      rmax="0.5*0.02"
+      z="30.6442839957997"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU18"
+      rmax="0.5*0.02"
+      z="32.3953859384168"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU19"
+      rmax="0.5*0.02"
+      z="34.1464878810339"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU20"
+      rmax="0.5*0.02"
+      z="35.897589823651"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU21"
+      rmax="0.5*0.02"
+      z="37.6486917662682"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU22"
+      rmax="0.5*0.02"
+      z="39.3997937088853"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU23"
+      rmax="0.5*0.02"
+      z="41.1508956515024"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU24"
+      rmax="0.5*0.02"
+      z="42.9019975941195"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU25"
+      rmax="0.5*0.02"
+      z="44.6530995367366"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU26"
+      rmax="0.5*0.02"
+      z="46.4042014793538"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU27"
+      rmax="0.5*0.02"
+      z="48.1553034219709"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU28"
+      rmax="0.5*0.02"
+      z="49.906405364588"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU29"
+      rmax="0.5*0.02"
+      z="51.6575073072051"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU30"
+      rmax="0.5*0.02"
+      z="53.4086092498223"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU31"
+      rmax="0.5*0.02"
+      z="55.1597111924394"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU32"
+      rmax="0.5*0.02"
+      z="56.9108131350565"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU33"
+      rmax="0.5*0.02"
+      z="58.6619150776736"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU34"
+      rmax="0.5*0.02"
+      z="60.4130170202907"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU35"
+      rmax="0.5*0.02"
+      z="62.1641189629079"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU36"
+      rmax="0.5*0.02"
+      z="63.915220905525"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU37"
+      rmax="0.5*0.02"
+      z="65.6663228481421"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU38"
+      rmax="0.5*0.02"
+      z="67.4174247907592"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU39"
+      rmax="0.5*0.02"
+      z="69.1685267333764"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU40"
+      rmax="0.5*0.02"
+      z="70.9196286759935"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU41"
+      rmax="0.5*0.02"
+      z="72.6707306186106"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU42"
+      rmax="0.5*0.02"
+      z="74.4218325612277"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU43"
+      rmax="0.5*0.02"
+      z="76.1729345038449"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU44"
+      rmax="0.5*0.02"
+      z="77.924036446462"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU45"
+      rmax="0.5*0.02"
+      z="79.6751383890791"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU46"
+      rmax="0.5*0.02"
+      z="81.4262403316963"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU47"
+      rmax="0.5*0.02"
+      z="83.1773422743134"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU48"
+      rmax="0.5*0.02"
+      z="84.9284442169305"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU49"
+      rmax="0.5*0.02"
+      z="86.6795461595477"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU50"
+      rmax="0.5*0.02"
+      z="88.4306481021648"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU51"
+      rmax="0.5*0.02"
+      z="90.1817500447819"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU52"
+      rmax="0.5*0.02"
+      z="91.932851987399"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU53"
+      rmax="0.5*0.02"
+      z="93.6839539300162"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU54"
+      rmax="0.5*0.02"
+      z="95.4350558726333"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU55"
+      rmax="0.5*0.02"
+      z="97.1861578152504"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU56"
+      rmax="0.5*0.02"
+      z="98.9372597578676"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU57"
+      rmax="0.5*0.02"
+      z="100.688361700485"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU58"
+      rmax="0.5*0.02"
+      z="102.439463643102"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU59"
+      rmax="0.5*0.02"
+      z="104.190565585719"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU60"
+      rmax="0.5*0.02"
+      z="105.941667528336"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU61"
+      rmax="0.5*0.02"
+      z="107.692769470953"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU62"
+      rmax="0.5*0.02"
+      z="109.44387141357"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU63"
+      rmax="0.5*0.02"
+      z="111.194973356187"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU64"
+      rmax="0.5*0.02"
+      z="112.946075298805"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU65"
+      rmax="0.5*0.02"
+      z="114.697177241422"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU66"
+      rmax="0.5*0.02"
+      z="116.448279184039"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU67"
+      rmax="0.5*0.02"
+      z="118.199381126656"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU68"
+      rmax="0.5*0.02"
+      z="119.950483069273"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU69"
+      rmax="0.5*0.02"
+      z="121.70158501189"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU70"
+      rmax="0.5*0.02"
+      z="123.452686954507"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU71"
+      rmax="0.5*0.02"
+      z="125.203788897124"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU72"
+      rmax="0.5*0.02"
+      z="126.954890839742"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU73"
+      rmax="0.5*0.02"
+      z="128.705992782359"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU74"
+      rmax="0.5*0.02"
+      z="130.457094724976"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU75"
+      rmax="0.5*0.02"
+      z="132.208196667593"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU76"
+      rmax="0.5*0.02"
+      z="133.95929861021"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU77"
+      rmax="0.5*0.02"
+      z="135.710400552827"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU78"
+      rmax="0.5*0.02"
+      z="137.461502495444"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU79"
+      rmax="0.5*0.02"
+      z="139.212604438061"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU80"
+      rmax="0.5*0.02"
+      z="140.963706380679"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU81"
+      rmax="0.5*0.02"
+      z="142.714808323296"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU82"
+      rmax="0.5*0.02"
+      z="144.465910265913"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU83"
+      rmax="0.5*0.02"
+      z="146.21701220853"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU84"
+      rmax="0.5*0.02"
+      z="147.968114151147"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU85"
+      rmax="0.5*0.02"
+      z="149.719216093764"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU86"
+      rmax="0.5*0.02"
+      z="151.470318036381"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU87"
+      rmax="0.5*0.02"
+      z="153.221419978999"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU88"
+      rmax="0.5*0.02"
+      z="154.972521921616"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU89"
+      rmax="0.5*0.02"
+      z="156.723623864233"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU90"
+      rmax="0.5*0.02"
+      z="158.47472580685"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU91"
+      rmax="0.5*0.02"
+      z="160.225827749467"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU92"
+      rmax="0.5*0.02"
+      z="161.976929692084"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU93"
+      rmax="0.5*0.02"
+      z="163.728031634701"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU94"
+      rmax="0.5*0.02"
+      z="165.479133577318"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU95"
+      rmax="0.5*0.02"
+      z="167.230235519936"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU96"
+      rmax="0.5*0.02"
+      z="168.981337462553"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU97"
+      rmax="0.5*0.02"
+      z="170.73243940517"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU98"
+      rmax="0.5*0.02"
+      z="172.483541347787"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU99"
+      rmax="0.5*0.02"
+      z="174.234643290404"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU100"
+      rmax="0.5*0.02"
+      z="175.985745233021"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU101"
+      rmax="0.5*0.02"
+      z="177.736847175638"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU102"
+      rmax="0.5*0.02"
+      z="179.487949118255"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU103"
+      rmax="0.5*0.02"
+      z="181.239051060873"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU104"
+      rmax="0.5*0.02"
+      z="182.99015300349"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU105"
+      rmax="0.5*0.02"
+      z="184.741254946107"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU106"
+      rmax="0.5*0.02"
+      z="186.492356888724"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU107"
+      rmax="0.5*0.02"
+      z="188.243458831341"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU108"
+      rmax="0.5*0.02"
+      z="189.994560773958"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU109"
+      rmax="0.5*0.02"
+      z="191.745662716575"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU110"
+      rmax="0.5*0.02"
+      z="193.496764659192"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU111"
+      rmax="0.5*0.02"
+      z="195.24786660181"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU112"
+      rmax="0.5*0.02"
+      z="196.998968544427"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU113"
+      rmax="0.5*0.02"
+      z="198.750070487044"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU114"
+      rmax="0.5*0.02"
+      z="200.501172429661"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU115"
+      rmax="0.5*0.02"
+      z="202.252274372278"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU116"
+      rmax="0.5*0.02"
+      z="204.003376314895"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU117"
+      rmax="0.5*0.02"
+      z="205.754478257512"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU118"
+      rmax="0.5*0.02"
+      z="207.505580200129"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU119"
+      rmax="0.5*0.02"
+      z="209.256682142747"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU120"
+      rmax="0.5*0.02"
+      z="211.007784085364"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU121"
+      rmax="0.5*0.02"
+      z="212.758886027981"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU122"
+      rmax="0.5*0.02"
+      z="214.509987970598"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU123"
+      rmax="0.5*0.02"
+      z="216.261089913215"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU124"
+      rmax="0.5*0.02"
+      z="218.012191855832"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU125"
+      rmax="0.5*0.02"
+      z="219.763293798449"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU126"
+      rmax="0.5*0.02"
+      z="221.514395741067"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU127"
+      rmax="0.5*0.02"
+      z="223.265497683684"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU128"
+      rmax="0.5*0.02"
+      z="223.265497683683"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU129"
+      rmax="0.5*0.02"
+      z="221.514395741066"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU130"
+      rmax="0.5*0.02"
+      z="219.763293798449"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU131"
+      rmax="0.5*0.02"
+      z="218.012191855832"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU132"
+      rmax="0.5*0.02"
+      z="216.261089913215"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU133"
+      rmax="0.5*0.02"
+      z="214.509987970597"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU134"
+      rmax="0.5*0.02"
+      z="212.75888602798"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU135"
+      rmax="0.5*0.02"
+      z="211.007784085363"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU136"
+      rmax="0.5*0.02"
+      z="209.256682142746"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU137"
+      rmax="0.5*0.02"
+      z="207.505580200129"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU138"
+      rmax="0.5*0.02"
+      z="205.754478257512"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU139"
+      rmax="0.5*0.02"
+      z="204.003376314895"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU140"
+      rmax="0.5*0.02"
+      z="202.252274372277"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU141"
+      rmax="0.5*0.02"
+      z="200.50117242966"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU142"
+      rmax="0.5*0.02"
+      z="198.750070487043"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU143"
+      rmax="0.5*0.02"
+      z="196.998968544426"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU144"
+      rmax="0.5*0.02"
+      z="195.247866601809"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU145"
+      rmax="0.5*0.02"
+      z="193.496764659192"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU146"
+      rmax="0.5*0.02"
+      z="191.745662716575"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU147"
+      rmax="0.5*0.02"
+      z="189.994560773958"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU148"
+      rmax="0.5*0.02"
+      z="188.243458831341"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU149"
+      rmax="0.5*0.02"
+      z="186.492356888723"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU150"
+      rmax="0.5*0.02"
+      z="184.741254946106"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU151"
+      rmax="0.5*0.02"
+      z="182.990153003489"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU152"
+      rmax="0.5*0.02"
+      z="181.239051060872"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU153"
+      rmax="0.5*0.02"
+      z="179.487949118255"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU154"
+      rmax="0.5*0.02"
+      z="177.736847175638"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU155"
+      rmax="0.5*0.02"
+      z="175.985745233021"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU156"
+      rmax="0.5*0.02"
+      z="174.234643290404"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU157"
+      rmax="0.5*0.02"
+      z="172.483541347787"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU158"
+      rmax="0.5*0.02"
+      z="170.73243940517"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU159"
+      rmax="0.5*0.02"
+      z="168.981337462552"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU160"
+      rmax="0.5*0.02"
+      z="167.230235519935"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU161"
+      rmax="0.5*0.02"
+      z="165.479133577318"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU162"
+      rmax="0.5*0.02"
+      z="163.728031634701"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU163"
+      rmax="0.5*0.02"
+      z="161.976929692084"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU164"
+      rmax="0.5*0.02"
+      z="160.225827749467"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU165"
+      rmax="0.5*0.02"
+      z="158.47472580685"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU166"
+      rmax="0.5*0.02"
+      z="156.723623864233"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU167"
+      rmax="0.5*0.02"
+      z="154.972521921616"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU168"
+      rmax="0.5*0.02"
+      z="153.221419978999"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU169"
+      rmax="0.5*0.02"
+      z="151.470318036381"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU170"
+      rmax="0.5*0.02"
+      z="149.719216093764"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU171"
+      rmax="0.5*0.02"
+      z="147.968114151147"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU172"
+      rmax="0.5*0.02"
+      z="146.21701220853"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU173"
+      rmax="0.5*0.02"
+      z="144.465910265913"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU174"
+      rmax="0.5*0.02"
+      z="142.714808323296"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU175"
+      rmax="0.5*0.02"
+      z="140.963706380679"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU176"
+      rmax="0.5*0.02"
+      z="139.212604438062"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU177"
+      rmax="0.5*0.02"
+      z="137.461502495445"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU178"
+      rmax="0.5*0.02"
+      z="135.710400552828"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU179"
+      rmax="0.5*0.02"
+      z="133.95929861021"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU180"
+      rmax="0.5*0.02"
+      z="132.208196667593"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU181"
+      rmax="0.5*0.02"
+      z="130.457094724976"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU182"
+      rmax="0.5*0.02"
+      z="128.705992782359"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU183"
+      rmax="0.5*0.02"
+      z="126.954890839742"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU184"
+      rmax="0.5*0.02"
+      z="125.203788897125"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU185"
+      rmax="0.5*0.02"
+      z="123.452686954508"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU186"
+      rmax="0.5*0.02"
+      z="121.701585011891"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU187"
+      rmax="0.5*0.02"
+      z="119.950483069274"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU188"
+      rmax="0.5*0.02"
+      z="118.199381126657"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU189"
+      rmax="0.5*0.02"
+      z="116.448279184039"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU190"
+      rmax="0.5*0.02"
+      z="114.697177241422"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU191"
+      rmax="0.5*0.02"
+      z="112.946075298805"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU192"
+      rmax="0.5*0.02"
+      z="111.194973356188"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU193"
+      rmax="0.5*0.02"
+      z="109.443871413571"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU194"
+      rmax="0.5*0.02"
+      z="107.692769470954"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU195"
+      rmax="0.5*0.02"
+      z="105.941667528337"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU196"
+      rmax="0.5*0.02"
+      z="104.19056558572"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU197"
+      rmax="0.5*0.02"
+      z="102.439463643103"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU198"
+      rmax="0.5*0.02"
+      z="100.688361700486"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU199"
+      rmax="0.5*0.02"
+      z="98.9372597578684"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU200"
+      rmax="0.5*0.02"
+      z="97.1861578152513"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU201"
+      rmax="0.5*0.02"
+      z="95.4350558726343"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU202"
+      rmax="0.5*0.02"
+      z="93.6839539300172"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU203"
+      rmax="0.5*0.02"
+      z="91.9328519874001"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU204"
+      rmax="0.5*0.02"
+      z="90.181750044783"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU205"
+      rmax="0.5*0.02"
+      z="88.4306481021658"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU206"
+      rmax="0.5*0.02"
+      z="86.6795461595488"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU207"
+      rmax="0.5*0.02"
+      z="84.9284442169317"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU208"
+      rmax="0.5*0.02"
+      z="83.1773422743145"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU209"
+      rmax="0.5*0.02"
+      z="81.4262403316975"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU210"
+      rmax="0.5*0.02"
+      z="79.6751383890803"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU211"
+      rmax="0.5*0.02"
+      z="77.9240364464633"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU212"
+      rmax="0.5*0.02"
+      z="76.1729345038461"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU213"
+      rmax="0.5*0.02"
+      z="74.4218325612291"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU214"
+      rmax="0.5*0.02"
+      z="72.670730618612"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU215"
+      rmax="0.5*0.02"
+      z="70.9196286759948"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU216"
+      rmax="0.5*0.02"
+      z="69.1685267333778"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU217"
+      rmax="0.5*0.02"
+      z="67.4174247907606"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU218"
+      rmax="0.5*0.02"
+      z="65.6663228481435"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU219"
+      rmax="0.5*0.02"
+      z="63.9152209055265"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU220"
+      rmax="0.5*0.02"
+      z="62.1641189629093"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU221"
+      rmax="0.5*0.02"
+      z="60.4130170202923"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU222"
+      rmax="0.5*0.02"
+      z="58.6619150776752"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU223"
+      rmax="0.5*0.02"
+      z="56.910813135058"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU224"
+      rmax="0.5*0.02"
+      z="55.159711192441"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU225"
+      rmax="0.5*0.02"
+      z="53.4086092498239"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU226"
+      rmax="0.5*0.02"
+      z="51.6575073072067"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU227"
+      rmax="0.5*0.02"
+      z="49.9064053645897"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU228"
+      rmax="0.5*0.02"
+      z="48.1553034219725"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU229"
+      rmax="0.5*0.02"
+      z="46.4042014793555"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU230"
+      rmax="0.5*0.02"
+      z="44.6530995367384"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU231"
+      rmax="0.5*0.02"
+      z="42.9019975941212"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU232"
+      rmax="0.5*0.02"
+      z="41.1508956515042"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU233"
+      rmax="0.5*0.02"
+      z="39.399793708887"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU234"
+      rmax="0.5*0.02"
+      z="37.64869176627"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU235"
+      rmax="0.5*0.02"
+      z="35.8975898236529"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU236"
+      rmax="0.5*0.02"
+      z="34.1464878810357"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU237"
+      rmax="0.5*0.02"
+      z="32.3953859384187"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU238"
+      rmax="0.5*0.02"
+      z="30.6442839958015"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU239"
+      rmax="0.5*0.02"
+      z="28.8931820531845"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU240"
+      rmax="0.5*0.02"
+      z="27.1420801105674"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU241"
+      rmax="0.5*0.02"
+      z="25.3909781679502"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU242"
+      rmax="0.5*0.02"
+      z="23.6398762253332"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU243"
+      rmax="0.5*0.02"
+      z="21.888774282716"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU244"
+      rmax="0.5*0.02"
+      z="20.1376723400989"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU245"
+      rmax="0.5*0.02"
+      z="18.3865703974819"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU246"
+      rmax="0.5*0.02"
+      z="16.6354684548648"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU247"
+      rmax="0.5*0.02"
+      z="14.8843665122477"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU248"
+      rmax="0.5*0.02"
+      z="13.1332645696306"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU249"
+      rmax="0.5*0.02"
+      z="11.3821626270135"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU250"
+      rmax="0.5*0.02"
+      z="9.63106068439639"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU251"
+      rmax="0.5*0.02"
+      z="7.87995874177926"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU252"
+      rmax="0.5*0.02"
+      z="6.12885679916218"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU253"
+      rmax="0.5*0.02"
+      z="4.37775485654507"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU254"
+      rmax="0.5*0.02"
+      z="2.62665291392794"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU255"
+      rmax="0.5*0.02"
+      z="0.875550971310878"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireY"
+      rmax="0.5*0.02"
+      z="148.9009"               
+      deltaphi="360" 
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireZ"
+      rmax="0.5*0.02"
+      z="168"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+
+    <box name="ArapucaOut" lunit="cm"
+      x="65"
+      y="2.5"
+      z="65"/>
+
+    <box name="ArapucaIn" lunit="cm"
+      x="60"
+      y="2.5"
+      z="60"/>
+
+     <subtraction name="ArapucaWalls">
+      <first  ref="ArapucaOut"/>
+      <second ref="ArapucaIn"/>
+      <position name="posArapucaSub" x="0" y="1.25" z="0." unit="cm"/>
+      </subtraction>
+
+    <box name="ArapucaAcceptanceWindow" lunit="cm"
+      x="60"
+      y="1"
+      z="60"/>
+
+    <box name="ArapucaDoubleIn" lunit="cm"
+      x="60"
+      y="3.5"
+      z="60"/>
+
+     <subtraction name="ArapucaDoubleWalls">
+      <first  ref="ArapucaOut"/>
+      <second ref="ArapucaDoubleIn"/>
+      <position name="posArapucaDoubleSub" x="0" y="0" z="0" unit="cm"/>
+      </subtraction>
+
+    <box name="ArapucaDoubleAcceptanceWindow" lunit="cm"
+      x="2.48"
+      y="60"
+      z="60"/>
+
+    <box name="ArapucaCathodeAcceptanceWindow" lunit="cm"
+      x="1"
+      y="60"
+      z="60"/>
+
+
+    <box name="Cryostat" lunit="cm" 
+      x="850.32" 
+      y="1548.24" 
+      z="2291.8526"/>
+
+    <box name="ArgonInterior" lunit="cm" 
+      x="850.08"
+      y="1548"
+      z="2291.6126"/>
+
+    <box name="GaseousArgon" lunit="cm" 
+      x="100 - 0.01"
+      y="1548"
+      z="2291.6126"/>
+
+    <box name="ExternalAuxOut" lunit="cm" 
+      x="850.08 - 100"
+      y="1548 - 2*2.5 - 2*40"
+      z="2291.6126"/>
+
+    <box name="ExternalAuxIn" lunit="cm" 
+      x="850.08"
+      y="1359.17"
+      z="2291.6126 + 1"/>
+
+   <subtraction name="ExternalActive">
+      <first ref="ExternalAuxOut"/>
+      <second ref="ExternalAuxIn"/>
+    </subtraction>
+
+    <subtraction name="SteelShell">
+      <first ref="Cryostat"/>
+      <second ref="ArgonInterior"/>
+    </subtraction>
+
+
+
+    <box name="CathodeBlock" lunit="cm"
+      x="4"
+      y="336"
+      z="297.8018" />
+
+    <box name="CathodeVoid" lunit="cm"
+      x="5"
+      y="76.35"
+      z="67" />
+
+    <subtraction name="Cathode1">
+      <first ref="CathodeBlock"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub1" x="0" y="-122.525" z="-108.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode2">
+      <first ref="Cathode1"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub2" x="0" y="-122.525" z="-37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode3">
+      <first ref="Cathode2"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub3" x="0" y="-122.525" z="37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode4">
+      <first ref="Cathode3"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub4" x="0" y="-122.525" z="108.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode5">
+      <first ref="Cathode4"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub5" x="0" y="-42.175" z="-108.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode6">
+      <first ref="Cathode5"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub6" x="0" y="-42.175" z="-37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode7">
+      <first ref="Cathode6"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub7" x="0" y="-42.175" z="37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode8">
+      <first ref="Cathode7"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub8" x="0" y="-42.175" z="108.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode9">
+      <first ref="Cathode8"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub9" x="0" y="42.175" z="-108.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode10">
+      <first ref="Cathode9"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub10" x="0" y="42.175" z="-37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode11">
+      <first ref="Cathode10"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub11" x="0" y="42.175" z="37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode12">
+      <first ref="Cathode11"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub12" x="0" y="42.175" z="108.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode13">
+      <first ref="Cathode12"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub13" x="0" y="122.525" z="-108.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode14">
+      <first ref="Cathode13"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub14" x="0" y="122.525" z="-37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode15">
+      <first ref="Cathode14"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub15" x="0" y="122.525" z="37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="CathodeGrid">
+      <first ref="Cathode15"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub16" x="0" y="122.525" z="108.5" unit="cm"/>
+    </subtraction>
+
+   <box name="AnodePlate" 
+      x="0.01"
+      y="336"
+      z="297.8018"
+      lunit="cm"/>
+
+    <box name="FoamPadBlock" lunit="cm"
+      x="1010.32"
+      y="1708.24"
+      z="2451.8526" />
+
+    <subtraction name="FoamPadding">
+      <first ref="FoamPadBlock"/>
+      <second ref="Cryostat"/>
+      <positionref ref="posCenter"/>
+    </subtraction>
+
+    <box name="SteelSupportBlock" lunit="cm"
+      x="1210.32"
+      y="1908.24"
+      z="2651.8526" />
+
+    <subtraction name="SteelSupport">
+      <first ref="SteelSupportBlock"/>
+      <second ref="FoamPadBlock"/>
+      <positionref ref="posCenter"/>
+    </subtraction>
+
+    <box name="DetEnclosure" lunit="cm" 
+      x="1310.32"
+      y="2108.24"
+      z="2851.8526"/>
+
+
+    <box name="World" lunit="cm" 
+      x="9310.32" 
+      y="10108.24" 
+      z="10851.8526"/>
+</solids>
+<structure>
+<volume name="volFieldShaper">
+  <materialref ref="Al2O3"/>
+  <solidref ref="FieldShaperSolid"/>
+</volume>
+<volume name="volFieldShaperSlim">
+  <materialref ref="Al2O3"/>
+  <solidref ref="FieldShaperSolidSlim"/>
+</volume>
+
+
+    <volume name="volTPCActive">
+      <materialref ref="LAr"/>
+      <solidref ref="CRMActive"/>
+      <auxiliary auxtype="SensDet" auxvalue="SimEnergyDeposit"/>
+      <auxiliary auxtype="StepLimit" auxunit="cm" auxvalue="0.5208*cm"/>
+      <auxiliary auxtype="Efield" auxunit="V/cm" auxvalue="500*V/cm"/>
+      <colorref ref="blue"/>
+    </volume>
+    <volume name="volTPCWireU0">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU0"/>
+    </volume>
+    <volume name="volTPCWireU1">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU1"/>
+    </volume>
+    <volume name="volTPCWireU2">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU2"/>
+    </volume>
+    <volume name="volTPCWireU3">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU3"/>
+    </volume>
+    <volume name="volTPCWireU4">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU4"/>
+    </volume>
+    <volume name="volTPCWireU5">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU5"/>
+    </volume>
+    <volume name="volTPCWireU6">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU6"/>
+    </volume>
+    <volume name="volTPCWireU7">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU7"/>
+    </volume>
+    <volume name="volTPCWireU8">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU8"/>
+    </volume>
+    <volume name="volTPCWireU9">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU9"/>
+    </volume>
+    <volume name="volTPCWireU10">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU10"/>
+    </volume>
+    <volume name="volTPCWireU11">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU11"/>
+    </volume>
+    <volume name="volTPCWireU12">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU12"/>
+    </volume>
+    <volume name="volTPCWireU13">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU13"/>
+    </volume>
+    <volume name="volTPCWireU14">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU14"/>
+    </volume>
+    <volume name="volTPCWireU15">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU15"/>
+    </volume>
+    <volume name="volTPCWireU16">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU16"/>
+    </volume>
+    <volume name="volTPCWireU17">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU17"/>
+    </volume>
+    <volume name="volTPCWireU18">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU18"/>
+    </volume>
+    <volume name="volTPCWireU19">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU19"/>
+    </volume>
+    <volume name="volTPCWireU20">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU20"/>
+    </volume>
+    <volume name="volTPCWireU21">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU21"/>
+    </volume>
+    <volume name="volTPCWireU22">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU22"/>
+    </volume>
+    <volume name="volTPCWireU23">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU23"/>
+    </volume>
+    <volume name="volTPCWireU24">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU24"/>
+    </volume>
+    <volume name="volTPCWireU25">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU25"/>
+    </volume>
+    <volume name="volTPCWireU26">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU26"/>
+    </volume>
+    <volume name="volTPCWireU27">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU27"/>
+    </volume>
+    <volume name="volTPCWireU28">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU28"/>
+    </volume>
+    <volume name="volTPCWireU29">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU29"/>
+    </volume>
+    <volume name="volTPCWireU30">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU30"/>
+    </volume>
+    <volume name="volTPCWireU31">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU31"/>
+    </volume>
+    <volume name="volTPCWireU32">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU32"/>
+    </volume>
+    <volume name="volTPCWireU33">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU33"/>
+    </volume>
+    <volume name="volTPCWireU34">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU34"/>
+    </volume>
+    <volume name="volTPCWireU35">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU35"/>
+    </volume>
+    <volume name="volTPCWireU36">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU36"/>
+    </volume>
+    <volume name="volTPCWireU37">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU37"/>
+    </volume>
+    <volume name="volTPCWireU38">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU38"/>
+    </volume>
+    <volume name="volTPCWireU39">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU39"/>
+    </volume>
+    <volume name="volTPCWireU40">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU40"/>
+    </volume>
+    <volume name="volTPCWireU41">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU41"/>
+    </volume>
+    <volume name="volTPCWireU42">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU42"/>
+    </volume>
+    <volume name="volTPCWireU43">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU43"/>
+    </volume>
+    <volume name="volTPCWireU44">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU44"/>
+    </volume>
+    <volume name="volTPCWireU45">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU45"/>
+    </volume>
+    <volume name="volTPCWireU46">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU46"/>
+    </volume>
+    <volume name="volTPCWireU47">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU47"/>
+    </volume>
+    <volume name="volTPCWireU48">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU48"/>
+    </volume>
+    <volume name="volTPCWireU49">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU49"/>
+    </volume>
+    <volume name="volTPCWireU50">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU50"/>
+    </volume>
+    <volume name="volTPCWireU51">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU51"/>
+    </volume>
+    <volume name="volTPCWireU52">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU52"/>
+    </volume>
+    <volume name="volTPCWireU53">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU53"/>
+    </volume>
+    <volume name="volTPCWireU54">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU54"/>
+    </volume>
+    <volume name="volTPCWireU55">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU55"/>
+    </volume>
+    <volume name="volTPCWireU56">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU56"/>
+    </volume>
+    <volume name="volTPCWireU57">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU57"/>
+    </volume>
+    <volume name="volTPCWireU58">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU58"/>
+    </volume>
+    <volume name="volTPCWireU59">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU59"/>
+    </volume>
+    <volume name="volTPCWireU60">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU60"/>
+    </volume>
+    <volume name="volTPCWireU61">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU61"/>
+    </volume>
+    <volume name="volTPCWireU62">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU62"/>
+    </volume>
+    <volume name="volTPCWireU63">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU63"/>
+    </volume>
+    <volume name="volTPCWireU64">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU64"/>
+    </volume>
+    <volume name="volTPCWireU65">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU65"/>
+    </volume>
+    <volume name="volTPCWireU66">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU66"/>
+    </volume>
+    <volume name="volTPCWireU67">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU67"/>
+    </volume>
+    <volume name="volTPCWireU68">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU68"/>
+    </volume>
+    <volume name="volTPCWireU69">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU69"/>
+    </volume>
+    <volume name="volTPCWireU70">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU70"/>
+    </volume>
+    <volume name="volTPCWireU71">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU71"/>
+    </volume>
+    <volume name="volTPCWireU72">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU72"/>
+    </volume>
+    <volume name="volTPCWireU73">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU73"/>
+    </volume>
+    <volume name="volTPCWireU74">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU74"/>
+    </volume>
+    <volume name="volTPCWireU75">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU75"/>
+    </volume>
+    <volume name="volTPCWireU76">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU76"/>
+    </volume>
+    <volume name="volTPCWireU77">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU77"/>
+    </volume>
+    <volume name="volTPCWireU78">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU78"/>
+    </volume>
+    <volume name="volTPCWireU79">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU79"/>
+    </volume>
+    <volume name="volTPCWireU80">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU80"/>
+    </volume>
+    <volume name="volTPCWireU81">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU81"/>
+    </volume>
+    <volume name="volTPCWireU82">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU82"/>
+    </volume>
+    <volume name="volTPCWireU83">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU83"/>
+    </volume>
+    <volume name="volTPCWireU84">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU84"/>
+    </volume>
+    <volume name="volTPCWireU85">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU85"/>
+    </volume>
+    <volume name="volTPCWireU86">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU86"/>
+    </volume>
+    <volume name="volTPCWireU87">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU87"/>
+    </volume>
+    <volume name="volTPCWireU88">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU88"/>
+    </volume>
+    <volume name="volTPCWireU89">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU89"/>
+    </volume>
+    <volume name="volTPCWireU90">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU90"/>
+    </volume>
+    <volume name="volTPCWireU91">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU91"/>
+    </volume>
+    <volume name="volTPCWireU92">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU92"/>
+    </volume>
+    <volume name="volTPCWireU93">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU93"/>
+    </volume>
+    <volume name="volTPCWireU94">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU94"/>
+    </volume>
+    <volume name="volTPCWireU95">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU95"/>
+    </volume>
+    <volume name="volTPCWireU96">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU96"/>
+    </volume>
+    <volume name="volTPCWireU97">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU97"/>
+    </volume>
+    <volume name="volTPCWireU98">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU98"/>
+    </volume>
+    <volume name="volTPCWireU99">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU99"/>
+    </volume>
+    <volume name="volTPCWireU100">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU100"/>
+    </volume>
+    <volume name="volTPCWireU101">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU101"/>
+    </volume>
+    <volume name="volTPCWireU102">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU102"/>
+    </volume>
+    <volume name="volTPCWireU103">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU103"/>
+    </volume>
+    <volume name="volTPCWireU104">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU104"/>
+    </volume>
+    <volume name="volTPCWireU105">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU105"/>
+    </volume>
+    <volume name="volTPCWireU106">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU106"/>
+    </volume>
+    <volume name="volTPCWireU107">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU107"/>
+    </volume>
+    <volume name="volTPCWireU108">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU108"/>
+    </volume>
+    <volume name="volTPCWireU109">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU109"/>
+    </volume>
+    <volume name="volTPCWireU110">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU110"/>
+    </volume>
+    <volume name="volTPCWireU111">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU111"/>
+    </volume>
+    <volume name="volTPCWireU112">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU112"/>
+    </volume>
+    <volume name="volTPCWireU113">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU113"/>
+    </volume>
+    <volume name="volTPCWireU114">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU114"/>
+    </volume>
+    <volume name="volTPCWireU115">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU115"/>
+    </volume>
+    <volume name="volTPCWireU116">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU116"/>
+    </volume>
+    <volume name="volTPCWireU117">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU117"/>
+    </volume>
+    <volume name="volTPCWireU118">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU118"/>
+    </volume>
+    <volume name="volTPCWireU119">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU119"/>
+    </volume>
+    <volume name="volTPCWireU120">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU120"/>
+    </volume>
+    <volume name="volTPCWireU121">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU121"/>
+    </volume>
+    <volume name="volTPCWireU122">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU122"/>
+    </volume>
+    <volume name="volTPCWireU123">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU123"/>
+    </volume>
+    <volume name="volTPCWireU124">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU124"/>
+    </volume>
+    <volume name="volTPCWireU125">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU125"/>
+    </volume>
+    <volume name="volTPCWireU126">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU126"/>
+    </volume>
+    <volume name="volTPCWireU127">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU127"/>
+    </volume>
+    <volume name="volTPCWireU128">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU128"/>
+    </volume>
+    <volume name="volTPCWireU129">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU129"/>
+    </volume>
+    <volume name="volTPCWireU130">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU130"/>
+    </volume>
+    <volume name="volTPCWireU131">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU131"/>
+    </volume>
+    <volume name="volTPCWireU132">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU132"/>
+    </volume>
+    <volume name="volTPCWireU133">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU133"/>
+    </volume>
+    <volume name="volTPCWireU134">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU134"/>
+    </volume>
+    <volume name="volTPCWireU135">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU135"/>
+    </volume>
+    <volume name="volTPCWireU136">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU136"/>
+    </volume>
+    <volume name="volTPCWireU137">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU137"/>
+    </volume>
+    <volume name="volTPCWireU138">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU138"/>
+    </volume>
+    <volume name="volTPCWireU139">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU139"/>
+    </volume>
+    <volume name="volTPCWireU140">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU140"/>
+    </volume>
+    <volume name="volTPCWireU141">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU141"/>
+    </volume>
+    <volume name="volTPCWireU142">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU142"/>
+    </volume>
+    <volume name="volTPCWireU143">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU143"/>
+    </volume>
+    <volume name="volTPCWireU144">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU144"/>
+    </volume>
+    <volume name="volTPCWireU145">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU145"/>
+    </volume>
+    <volume name="volTPCWireU146">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU146"/>
+    </volume>
+    <volume name="volTPCWireU147">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU147"/>
+    </volume>
+    <volume name="volTPCWireU148">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU148"/>
+    </volume>
+    <volume name="volTPCWireU149">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU149"/>
+    </volume>
+    <volume name="volTPCWireU150">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU150"/>
+    </volume>
+    <volume name="volTPCWireU151">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU151"/>
+    </volume>
+    <volume name="volTPCWireU152">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU152"/>
+    </volume>
+    <volume name="volTPCWireU153">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU153"/>
+    </volume>
+    <volume name="volTPCWireU154">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU154"/>
+    </volume>
+    <volume name="volTPCWireU155">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU155"/>
+    </volume>
+    <volume name="volTPCWireU156">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU156"/>
+    </volume>
+    <volume name="volTPCWireU157">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU157"/>
+    </volume>
+    <volume name="volTPCWireU158">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU158"/>
+    </volume>
+    <volume name="volTPCWireU159">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU159"/>
+    </volume>
+    <volume name="volTPCWireU160">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU160"/>
+    </volume>
+    <volume name="volTPCWireU161">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU161"/>
+    </volume>
+    <volume name="volTPCWireU162">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU162"/>
+    </volume>
+    <volume name="volTPCWireU163">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU163"/>
+    </volume>
+    <volume name="volTPCWireU164">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU164"/>
+    </volume>
+    <volume name="volTPCWireU165">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU165"/>
+    </volume>
+    <volume name="volTPCWireU166">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU166"/>
+    </volume>
+    <volume name="volTPCWireU167">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU167"/>
+    </volume>
+    <volume name="volTPCWireU168">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU168"/>
+    </volume>
+    <volume name="volTPCWireU169">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU169"/>
+    </volume>
+    <volume name="volTPCWireU170">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU170"/>
+    </volume>
+    <volume name="volTPCWireU171">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU171"/>
+    </volume>
+    <volume name="volTPCWireU172">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU172"/>
+    </volume>
+    <volume name="volTPCWireU173">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU173"/>
+    </volume>
+    <volume name="volTPCWireU174">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU174"/>
+    </volume>
+    <volume name="volTPCWireU175">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU175"/>
+    </volume>
+    <volume name="volTPCWireU176">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU176"/>
+    </volume>
+    <volume name="volTPCWireU177">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU177"/>
+    </volume>
+    <volume name="volTPCWireU178">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU178"/>
+    </volume>
+    <volume name="volTPCWireU179">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU179"/>
+    </volume>
+    <volume name="volTPCWireU180">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU180"/>
+    </volume>
+    <volume name="volTPCWireU181">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU181"/>
+    </volume>
+    <volume name="volTPCWireU182">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU182"/>
+    </volume>
+    <volume name="volTPCWireU183">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU183"/>
+    </volume>
+    <volume name="volTPCWireU184">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU184"/>
+    </volume>
+    <volume name="volTPCWireU185">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU185"/>
+    </volume>
+    <volume name="volTPCWireU186">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU186"/>
+    </volume>
+    <volume name="volTPCWireU187">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU187"/>
+    </volume>
+    <volume name="volTPCWireU188">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU188"/>
+    </volume>
+    <volume name="volTPCWireU189">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU189"/>
+    </volume>
+    <volume name="volTPCWireU190">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU190"/>
+    </volume>
+    <volume name="volTPCWireU191">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU191"/>
+    </volume>
+    <volume name="volTPCWireU192">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU192"/>
+    </volume>
+    <volume name="volTPCWireU193">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU193"/>
+    </volume>
+    <volume name="volTPCWireU194">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU194"/>
+    </volume>
+    <volume name="volTPCWireU195">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU195"/>
+    </volume>
+    <volume name="volTPCWireU196">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU196"/>
+    </volume>
+    <volume name="volTPCWireU197">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU197"/>
+    </volume>
+    <volume name="volTPCWireU198">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU198"/>
+    </volume>
+    <volume name="volTPCWireU199">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU199"/>
+    </volume>
+    <volume name="volTPCWireU200">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU200"/>
+    </volume>
+    <volume name="volTPCWireU201">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU201"/>
+    </volume>
+    <volume name="volTPCWireU202">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU202"/>
+    </volume>
+    <volume name="volTPCWireU203">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU203"/>
+    </volume>
+    <volume name="volTPCWireU204">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU204"/>
+    </volume>
+    <volume name="volTPCWireU205">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU205"/>
+    </volume>
+    <volume name="volTPCWireU206">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU206"/>
+    </volume>
+    <volume name="volTPCWireU207">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU207"/>
+    </volume>
+    <volume name="volTPCWireU208">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU208"/>
+    </volume>
+    <volume name="volTPCWireU209">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU209"/>
+    </volume>
+    <volume name="volTPCWireU210">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU210"/>
+    </volume>
+    <volume name="volTPCWireU211">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU211"/>
+    </volume>
+    <volume name="volTPCWireU212">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU212"/>
+    </volume>
+    <volume name="volTPCWireU213">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU213"/>
+    </volume>
+    <volume name="volTPCWireU214">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU214"/>
+    </volume>
+    <volume name="volTPCWireU215">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU215"/>
+    </volume>
+    <volume name="volTPCWireU216">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU216"/>
+    </volume>
+    <volume name="volTPCWireU217">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU217"/>
+    </volume>
+    <volume name="volTPCWireU218">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU218"/>
+    </volume>
+    <volume name="volTPCWireU219">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU219"/>
+    </volume>
+    <volume name="volTPCWireU220">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU220"/>
+    </volume>
+    <volume name="volTPCWireU221">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU221"/>
+    </volume>
+    <volume name="volTPCWireU222">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU222"/>
+    </volume>
+    <volume name="volTPCWireU223">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU223"/>
+    </volume>
+    <volume name="volTPCWireU224">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU224"/>
+    </volume>
+    <volume name="volTPCWireU225">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU225"/>
+    </volume>
+    <volume name="volTPCWireU226">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU226"/>
+    </volume>
+    <volume name="volTPCWireU227">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU227"/>
+    </volume>
+    <volume name="volTPCWireU228">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU228"/>
+    </volume>
+    <volume name="volTPCWireU229">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU229"/>
+    </volume>
+    <volume name="volTPCWireU230">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU230"/>
+    </volume>
+    <volume name="volTPCWireU231">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU231"/>
+    </volume>
+    <volume name="volTPCWireU232">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU232"/>
+    </volume>
+    <volume name="volTPCWireU233">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU233"/>
+    </volume>
+    <volume name="volTPCWireU234">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU234"/>
+    </volume>
+    <volume name="volTPCWireU235">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU235"/>
+    </volume>
+    <volume name="volTPCWireU236">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU236"/>
+    </volume>
+    <volume name="volTPCWireU237">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU237"/>
+    </volume>
+    <volume name="volTPCWireU238">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU238"/>
+    </volume>
+    <volume name="volTPCWireU239">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU239"/>
+    </volume>
+    <volume name="volTPCWireU240">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU240"/>
+    </volume>
+    <volume name="volTPCWireU241">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU241"/>
+    </volume>
+    <volume name="volTPCWireU242">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU242"/>
+    </volume>
+    <volume name="volTPCWireU243">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU243"/>
+    </volume>
+    <volume name="volTPCWireU244">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU244"/>
+    </volume>
+    <volume name="volTPCWireU245">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU245"/>
+    </volume>
+    <volume name="volTPCWireU246">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU246"/>
+    </volume>
+    <volume name="volTPCWireU247">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU247"/>
+    </volume>
+    <volume name="volTPCWireU248">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU248"/>
+    </volume>
+    <volume name="volTPCWireU249">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU249"/>
+    </volume>
+    <volume name="volTPCWireU250">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU250"/>
+    </volume>
+    <volume name="volTPCWireU251">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU251"/>
+    </volume>
+    <volume name="volTPCWireU252">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU252"/>
+    </volume>
+    <volume name="volTPCWireU253">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU253"/>
+    </volume>
+    <volume name="volTPCWireU254">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU254"/>
+    </volume>
+    <volume name="volTPCWireU255">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU255"/>
+    </volume>
+    <volume name="volTPCWireY">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireY"/>
+    </volume>
+    <volume name="volTPCWireZ">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireZ"/>
+    </volume>
+   <volume name="volTPCPlaneU">
+     <materialref ref="LAr"/>
+     <solidref ref="CRMUPlane"/>
+     <physvol>
+       <volumeref ref="volTPCWireU0"/> 
+       <position name="posWireU0" unit="cm" x="0" y="-83.4399379809595" z="-74.1596073595279"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU1"/> 
+       <position name="posWireU1" unit="cm" x="0" y="-82.7855070948343" z="-73.5779633802374"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU2"/> 
+       <position name="posWireU2" unit="cm" x="0" y="-82.1310762087091" z="-72.996319400947"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU3"/> 
+       <position name="posWireU3" unit="cm" x="0" y="-81.476645322584" z="-72.4146754216566"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU4"/> 
+       <position name="posWireU4" unit="cm" x="0" y="-80.8222144364588" z="-71.8330314423662"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU5"/> 
+       <position name="posWireU5" unit="cm" x="0" y="-80.1677835503336" z="-71.2513874630758"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU6"/> 
+       <position name="posWireU6" unit="cm" x="0" y="-79.5133526642084" z="-70.6697434837854"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU7"/> 
+       <position name="posWireU7" unit="cm" x="0" y="-78.8589217780833" z="-70.0880995044949"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU8"/> 
+       <position name="posWireU8" unit="cm" x="0" y="-78.2044908919581" z="-69.5064555252045"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU9"/> 
+       <position name="posWireU9" unit="cm" x="0" y="-77.5500600058329" z="-68.9248115459141"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU10"/> 
+       <position name="posWireU10" unit="cm" x="0" y="-76.8956291197078" z="-68.3431675666237"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU11"/> 
+       <position name="posWireU11" unit="cm" x="0" y="-76.2411982335826" z="-67.7615235873333"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU12"/> 
+       <position name="posWireU12" unit="cm" x="0" y="-75.5867673474574" z="-67.1798796080429"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU13"/> 
+       <position name="posWireU13" unit="cm" x="0" y="-74.9323364613322" z="-66.5982356287525"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU14"/> 
+       <position name="posWireU14" unit="cm" x="0" y="-74.2779055752071" z="-66.016591649462"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU15"/> 
+       <position name="posWireU15" unit="cm" x="0" y="-73.6234746890819" z="-65.4349476701716"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU16"/> 
+       <position name="posWireU16" unit="cm" x="0" y="-72.9690438029567" z="-64.8533036908812"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU17"/> 
+       <position name="posWireU17" unit="cm" x="0" y="-72.3146129168315" z="-64.2716597115908"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU18"/> 
+       <position name="posWireU18" unit="cm" x="0" y="-71.6601820307064" z="-63.6900157323004"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU19"/> 
+       <position name="posWireU19" unit="cm" x="0" y="-71.0057511445812" z="-63.10837175301"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU20"/> 
+       <position name="posWireU20" unit="cm" x="0" y="-70.351320258456" z="-62.5267277737196"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU21"/> 
+       <position name="posWireU21" unit="cm" x="0" y="-69.6968893723309" z="-61.9450837944292"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU22"/> 
+       <position name="posWireU22" unit="cm" x="0" y="-69.0424584862057" z="-61.3634398151387"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU23"/> 
+       <position name="posWireU23" unit="cm" x="0" y="-68.3880276000805" z="-60.7817958358483"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU24"/> 
+       <position name="posWireU24" unit="cm" x="0" y="-67.7335967139554" z="-60.2001518565579"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU25"/> 
+       <position name="posWireU25" unit="cm" x="0" y="-67.0791658278302" z="-59.6185078772675"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU26"/> 
+       <position name="posWireU26" unit="cm" x="0" y="-66.424734941705" z="-59.0368638979771"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU27"/> 
+       <position name="posWireU27" unit="cm" x="0" y="-65.7703040555798" z="-58.4552199186867"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU28"/> 
+       <position name="posWireU28" unit="cm" x="0" y="-65.1158731694547" z="-57.8735759393963"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU29"/> 
+       <position name="posWireU29" unit="cm" x="0" y="-64.4614422833295" z="-57.2919319601058"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU30"/> 
+       <position name="posWireU30" unit="cm" x="0" y="-63.8070113972043" z="-56.7102879808154"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU31"/> 
+       <position name="posWireU31" unit="cm" x="0" y="-63.1525805110792" z="-56.128644001525"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU32"/> 
+       <position name="posWireU32" unit="cm" x="0" y="-62.498149624954" z="-55.5470000222346"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU33"/> 
+       <position name="posWireU33" unit="cm" x="0" y="-61.8437187388288" z="-54.9653560429442"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU34"/> 
+       <position name="posWireU34" unit="cm" x="0" y="-61.1892878527036" z="-54.3837120636538"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU35"/> 
+       <position name="posWireU35" unit="cm" x="0" y="-60.5348569665785" z="-53.8020680843634"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU36"/> 
+       <position name="posWireU36" unit="cm" x="0" y="-59.8804260804533" z="-53.220424105073"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU37"/> 
+       <position name="posWireU37" unit="cm" x="0" y="-59.2259951943281" z="-52.6387801257825"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU38"/> 
+       <position name="posWireU38" unit="cm" x="0" y="-58.571564308203" z="-52.0571361464921"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU39"/> 
+       <position name="posWireU39" unit="cm" x="0" y="-57.9171334220778" z="-51.4754921672017"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU40"/> 
+       <position name="posWireU40" unit="cm" x="0" y="-57.2627025359526" z="-50.8938481879113"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU41"/> 
+       <position name="posWireU41" unit="cm" x="0" y="-56.6082716498274" z="-50.3122042086209"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU42"/> 
+       <position name="posWireU42" unit="cm" x="0" y="-55.9538407637023" z="-49.7305602293305"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU43"/> 
+       <position name="posWireU43" unit="cm" x="0" y="-55.2994098775771" z="-49.14891625004"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU44"/> 
+       <position name="posWireU44" unit="cm" x="0" y="-54.6449789914519" z="-48.5672722707496"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU45"/> 
+       <position name="posWireU45" unit="cm" x="0" y="-53.9905481053267" z="-47.9856282914592"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU46"/> 
+       <position name="posWireU46" unit="cm" x="0" y="-53.3361172192016" z="-47.4039843121688"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU47"/> 
+       <position name="posWireU47" unit="cm" x="0" y="-52.6816863330764" z="-46.8223403328784"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU48"/> 
+       <position name="posWireU48" unit="cm" x="0" y="-52.0272554469512" z="-46.240696353588"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU49"/> 
+       <position name="posWireU49" unit="cm" x="0" y="-51.372824560826" z="-45.6590523742975"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU50"/> 
+       <position name="posWireU50" unit="cm" x="0" y="-50.7183936747009" z="-45.0774083950071"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU51"/> 
+       <position name="posWireU51" unit="cm" x="0" y="-50.0639627885757" z="-44.4957644157167"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU52"/> 
+       <position name="posWireU52" unit="cm" x="0" y="-49.4095319024505" z="-43.9141204364263"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU53"/> 
+       <position name="posWireU53" unit="cm" x="0" y="-48.7551010163253" z="-43.3324764571359"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU54"/> 
+       <position name="posWireU54" unit="cm" x="0" y="-48.1006701302002" z="-42.7508324778455"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU55"/> 
+       <position name="posWireU55" unit="cm" x="0" y="-47.446239244075" z="-42.1691884985551"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU56"/> 
+       <position name="posWireU56" unit="cm" x="0" y="-46.7918083579498" z="-41.5875445192646"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU57"/> 
+       <position name="posWireU57" unit="cm" x="0" y="-46.1373774718246" z="-41.0059005399742"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU58"/> 
+       <position name="posWireU58" unit="cm" x="0" y="-45.4829465856995" z="-40.4242565606838"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU59"/> 
+       <position name="posWireU59" unit="cm" x="0" y="-44.8285156995743" z="-39.8426125813934"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU60"/> 
+       <position name="posWireU60" unit="cm" x="0" y="-44.1740848134491" z="-39.260968602103"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU61"/> 
+       <position name="posWireU61" unit="cm" x="0" y="-43.5196539273239" z="-38.6793246228126"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU62"/> 
+       <position name="posWireU62" unit="cm" x="0" y="-42.8652230411988" z="-38.0976806435221"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU63"/> 
+       <position name="posWireU63" unit="cm" x="0" y="-42.2107921550736" z="-37.5160366642317"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU64"/> 
+       <position name="posWireU64" unit="cm" x="0" y="-41.5563612689484" z="-36.9343926849413"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU65"/> 
+       <position name="posWireU65" unit="cm" x="0" y="-40.9019303828233" z="-36.3527487056509"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU66"/> 
+       <position name="posWireU66" unit="cm" x="0" y="-40.2474994966981" z="-35.7711047263605"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU67"/> 
+       <position name="posWireU67" unit="cm" x="0" y="-39.5930686105729" z="-35.1894607470701"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU68"/> 
+       <position name="posWireU68" unit="cm" x="0" y="-38.9386377244477" z="-34.6078167677796"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU69"/> 
+       <position name="posWireU69" unit="cm" x="0" y="-38.2842068383226" z="-34.0261727884892"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU70"/> 
+       <position name="posWireU70" unit="cm" x="0" y="-37.6297759521974" z="-33.4445288091988"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU71"/> 
+       <position name="posWireU71" unit="cm" x="0" y="-36.9753450660722" z="-32.8628848299084"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU72"/> 
+       <position name="posWireU72" unit="cm" x="0" y="-36.320914179947" z="-32.281240850618"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU73"/> 
+       <position name="posWireU73" unit="cm" x="0" y="-35.6664832938219" z="-31.6995968713276"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU74"/> 
+       <position name="posWireU74" unit="cm" x="0" y="-35.0120524076967" z="-31.1179528920372"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU75"/> 
+       <position name="posWireU75" unit="cm" x="0" y="-34.3576215215715" z="-30.5363089127467"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU76"/> 
+       <position name="posWireU76" unit="cm" x="0" y="-33.7031906354463" z="-29.9546649334563"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU77"/> 
+       <position name="posWireU77" unit="cm" x="0" y="-33.0487597493212" z="-29.3730209541659"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU78"/> 
+       <position name="posWireU78" unit="cm" x="0" y="-32.394328863196" z="-28.7913769748755"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU79"/> 
+       <position name="posWireU79" unit="cm" x="0" y="-31.7398979770708" z="-28.2097329955851"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU80"/> 
+       <position name="posWireU80" unit="cm" x="0" y="-31.0854670909456" z="-27.6280890162947"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU81"/> 
+       <position name="posWireU81" unit="cm" x="0" y="-30.4310362048205" z="-27.0464450370042"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU82"/> 
+       <position name="posWireU82" unit="cm" x="0" y="-29.7766053186953" z="-26.4648010577138"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU83"/> 
+       <position name="posWireU83" unit="cm" x="0" y="-29.1221744325701" z="-25.8831570784234"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU84"/> 
+       <position name="posWireU84" unit="cm" x="0" y="-28.467743546445" z="-25.301513099133"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU85"/> 
+       <position name="posWireU85" unit="cm" x="0" y="-27.8133126603198" z="-24.7198691198426"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU86"/> 
+       <position name="posWireU86" unit="cm" x="0" y="-27.1588817741946" z="-24.1382251405522"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU87"/> 
+       <position name="posWireU87" unit="cm" x="0" y="-26.5044508880694" z="-23.5565811612617"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU88"/> 
+       <position name="posWireU88" unit="cm" x="0" y="-25.8500200019443" z="-22.9749371819713"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU89"/> 
+       <position name="posWireU89" unit="cm" x="0" y="-25.1955891158191" z="-22.3932932026809"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU90"/> 
+       <position name="posWireU90" unit="cm" x="0" y="-24.5411582296939" z="-21.8116492233905"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU91"/> 
+       <position name="posWireU91" unit="cm" x="0" y="-23.8867273435687" z="-21.2300052441001"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU92"/> 
+       <position name="posWireU92" unit="cm" x="0" y="-23.2322964574436" z="-20.6483612648097"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU93"/> 
+       <position name="posWireU93" unit="cm" x="0" y="-22.5778655713184" z="-20.0667172855192"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU94"/> 
+       <position name="posWireU94" unit="cm" x="0" y="-21.9234346851932" z="-19.4850733062288"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU95"/> 
+       <position name="posWireU95" unit="cm" x="0" y="-21.269003799068" z="-18.9034293269384"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU96"/> 
+       <position name="posWireU96" unit="cm" x="0" y="-20.6145729129429" z="-18.321785347648"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU97"/> 
+       <position name="posWireU97" unit="cm" x="0" y="-19.9601420268177" z="-17.7401413683576"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU98"/> 
+       <position name="posWireU98" unit="cm" x="0" y="-19.3057111406925" z="-17.1584973890672"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU99"/> 
+       <position name="posWireU99" unit="cm" x="0" y="-18.6512802545673" z="-16.5768534097767"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU100"/> 
+       <position name="posWireU100" unit="cm" x="0" y="-17.9968493684422" z="-15.9952094304863"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU101"/> 
+       <position name="posWireU101" unit="cm" x="0" y="-17.342418482317" z="-15.4135654511959"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU102"/> 
+       <position name="posWireU102" unit="cm" x="0" y="-16.6879875961918" z="-14.8319214719055"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU103"/> 
+       <position name="posWireU103" unit="cm" x="0" y="-16.0335567100666" z="-14.2502774926151"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU104"/> 
+       <position name="posWireU104" unit="cm" x="0" y="-15.3791258239415" z="-13.6686335133247"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU105"/> 
+       <position name="posWireU105" unit="cm" x="0" y="-14.7246949378163" z="-13.0869895340343"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU106"/> 
+       <position name="posWireU106" unit="cm" x="0" y="-14.0702640516911" z="-12.5053455547438"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU107"/> 
+       <position name="posWireU107" unit="cm" x="0" y="-13.415833165566" z="-11.9237015754534"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU108"/> 
+       <position name="posWireU108" unit="cm" x="0" y="-12.7614022794408" z="-11.342057596163"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU109"/> 
+       <position name="posWireU109" unit="cm" x="0" y="-12.1069713933156" z="-10.7604136168726"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU110"/> 
+       <position name="posWireU110" unit="cm" x="0" y="-11.4525405071904" z="-10.1787696375822"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU111"/> 
+       <position name="posWireU111" unit="cm" x="0" y="-10.7981096210653" z="-9.59712565829176"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU112"/> 
+       <position name="posWireU112" unit="cm" x="0" y="-10.1436787349401" z="-9.01548167900135"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU113"/> 
+       <position name="posWireU113" unit="cm" x="0" y="-9.4892478488149" z="-8.43383769971093"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU114"/> 
+       <position name="posWireU114" unit="cm" x="0" y="-8.83481696268973" z="-7.85219372042052"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU115"/> 
+       <position name="posWireU115" unit="cm" x="0" y="-8.18038607656456" z="-7.2705497411301"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU116"/> 
+       <position name="posWireU116" unit="cm" x="0" y="-7.52595519043939" z="-6.68890576183968"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU117"/> 
+       <position name="posWireU117" unit="cm" x="0" y="-6.87152430431422" z="-6.10726178254927"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU118"/> 
+       <position name="posWireU118" unit="cm" x="0" y="-6.21709341818904" z="-5.52561780325885"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU119"/> 
+       <position name="posWireU119" unit="cm" x="0" y="-5.56266253206387" z="-4.94397382396843"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU120"/> 
+       <position name="posWireU120" unit="cm" x="0" y="-4.90823164593868" z="-4.36232984467803"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU121"/> 
+       <position name="posWireU121" unit="cm" x="0" y="-4.25380075981352" z="-3.78068586538761"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU122"/> 
+       <position name="posWireU122" unit="cm" x="0" y="-3.59936987368835" z="-3.19904188609719"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU123"/> 
+       <position name="posWireU123" unit="cm" x="0" y="-2.94493898756318" z="-2.61739790680677"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU124"/> 
+       <position name="posWireU124" unit="cm" x="0" y="-2.29050810143798" z="-2.03575392751635"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU125"/> 
+       <position name="posWireU125" unit="cm" x="0" y="-1.63607721531281" z="-1.45410994822593"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU126"/> 
+       <position name="posWireU126" unit="cm" x="0" y="-0.98164632918764" z="-0.872465968935515"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU127"/> 
+       <position name="posWireU127" unit="cm" x="0" y="-0.327215443062471" z="-0.290821989645096"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU128"/> 
+       <position name="posWireU128" unit="cm" x="0" y="0.327215443062705" z="0.290821989645316"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU129"/> 
+       <position name="posWireU129" unit="cm" x="0" y="0.981646329187875" z="0.872465968935728"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU130"/> 
+       <position name="posWireU130" unit="cm" x="0" y="1.63607721531305" z="1.45410994822615"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU131"/> 
+       <position name="posWireU131" unit="cm" x="0" y="2.29050810143823" z="2.03575392751656"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU132"/> 
+       <position name="posWireU132" unit="cm" x="0" y="2.9449389875634" z="2.61739790680698"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU133"/> 
+       <position name="posWireU133" unit="cm" x="0" y="3.59936987368857" z="3.19904188609739"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU134"/> 
+       <position name="posWireU134" unit="cm" x="0" y="4.25380075981374" z="3.7806858653878"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU135"/> 
+       <position name="posWireU135" unit="cm" x="0" y="4.90823164593891" z="4.36232984467821"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU136"/> 
+       <position name="posWireU136" unit="cm" x="0" y="5.56266253206409" z="4.94397382396863"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU137"/> 
+       <position name="posWireU137" unit="cm" x="0" y="6.21709341818926" z="5.52561780325905"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU138"/> 
+       <position name="posWireU138" unit="cm" x="0" y="6.87152430431443" z="6.10726178254946"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU139"/> 
+       <position name="posWireU139" unit="cm" x="0" y="7.5259551904396" z="6.68890576183988"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU140"/> 
+       <position name="posWireU140" unit="cm" x="0" y="8.18038607656479" z="7.2705497411303"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU141"/> 
+       <position name="posWireU141" unit="cm" x="0" y="8.83481696268996" z="7.85219372042071"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU142"/> 
+       <position name="posWireU142" unit="cm" x="0" y="9.48924784881513" z="8.43383769971113"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU143"/> 
+       <position name="posWireU143" unit="cm" x="0" y="10.1436787349403" z="9.01548167900155"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU144"/> 
+       <position name="posWireU144" unit="cm" x="0" y="10.7981096210655" z="9.59712565829196"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU145"/> 
+       <position name="posWireU145" unit="cm" x="0" y="11.4525405071907" z="10.1787696375824"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU146"/> 
+       <position name="posWireU146" unit="cm" x="0" y="12.1069713933158" z="10.7604136168728"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU147"/> 
+       <position name="posWireU147" unit="cm" x="0" y="12.761402279441" z="11.3420575961632"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU148"/> 
+       <position name="posWireU148" unit="cm" x="0" y="13.4158331655662" z="11.9237015754536"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU149"/> 
+       <position name="posWireU149" unit="cm" x="0" y="14.0702640516913" z="12.505345554744"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU150"/> 
+       <position name="posWireU150" unit="cm" x="0" y="14.7246949378165" z="13.0869895340344"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU151"/> 
+       <position name="posWireU151" unit="cm" x="0" y="15.3791258239416" z="13.6686335133248"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU152"/> 
+       <position name="posWireU152" unit="cm" x="0" y="16.0335567100668" z="14.2502774926152"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU153"/> 
+       <position name="posWireU153" unit="cm" x="0" y="16.687987596192" z="14.8319214719056"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU154"/> 
+       <position name="posWireU154" unit="cm" x="0" y="17.3424184823171" z="15.413565451196"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU155"/> 
+       <position name="posWireU155" unit="cm" x="0" y="17.9968493684423" z="15.9952094304864"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU156"/> 
+       <position name="posWireU156" unit="cm" x="0" y="18.6512802545675" z="16.5768534097769"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU157"/> 
+       <position name="posWireU157" unit="cm" x="0" y="19.3057111406926" z="17.1584973890673"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU158"/> 
+       <position name="posWireU158" unit="cm" x="0" y="19.9601420268178" z="17.7401413683577"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU159"/> 
+       <position name="posWireU159" unit="cm" x="0" y="20.614572912943" z="18.3217853476481"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU160"/> 
+       <position name="posWireU160" unit="cm" x="0" y="21.2690037990681" z="18.9034293269385"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU161"/> 
+       <position name="posWireU161" unit="cm" x="0" y="21.9234346851933" z="19.4850733062289"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU162"/> 
+       <position name="posWireU162" unit="cm" x="0" y="22.5778655713184" z="20.0667172855193"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU163"/> 
+       <position name="posWireU163" unit="cm" x="0" y="23.2322964574436" z="20.6483612648097"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU164"/> 
+       <position name="posWireU164" unit="cm" x="0" y="23.8867273435688" z="21.2300052441001"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU165"/> 
+       <position name="posWireU165" unit="cm" x="0" y="24.5411582296939" z="21.8116492233905"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU166"/> 
+       <position name="posWireU166" unit="cm" x="0" y="25.1955891158191" z="22.3932932026809"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU167"/> 
+       <position name="posWireU167" unit="cm" x="0" y="25.8500200019443" z="22.9749371819713"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU168"/> 
+       <position name="posWireU168" unit="cm" x="0" y="26.5044508880694" z="23.5565811612617"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU169"/> 
+       <position name="posWireU169" unit="cm" x="0" y="27.1588817741946" z="24.1382251405521"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU170"/> 
+       <position name="posWireU170" unit="cm" x="0" y="27.8133126603198" z="24.7198691198426"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU171"/> 
+       <position name="posWireU171" unit="cm" x="0" y="28.4677435464449" z="25.301513099133"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU172"/> 
+       <position name="posWireU172" unit="cm" x="0" y="29.1221744325701" z="25.8831570784234"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU173"/> 
+       <position name="posWireU173" unit="cm" x="0" y="29.7766053186952" z="26.4648010577138"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU174"/> 
+       <position name="posWireU174" unit="cm" x="0" y="30.4310362048204" z="27.0464450370042"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU175"/> 
+       <position name="posWireU175" unit="cm" x="0" y="31.0854670909456" z="27.6280890162946"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU176"/> 
+       <position name="posWireU176" unit="cm" x="0" y="31.7398979770707" z="28.209732995585"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU177"/> 
+       <position name="posWireU177" unit="cm" x="0" y="32.3943288631959" z="28.7913769748754"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU178"/> 
+       <position name="posWireU178" unit="cm" x="0" y="33.0487597493211" z="29.3730209541658"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU179"/> 
+       <position name="posWireU179" unit="cm" x="0" y="33.7031906354462" z="29.9546649334562"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU180"/> 
+       <position name="posWireU180" unit="cm" x="0" y="34.3576215215714" z="30.5363089127466"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU181"/> 
+       <position name="posWireU181" unit="cm" x="0" y="35.0120524076965" z="31.117952892037"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU182"/> 
+       <position name="posWireU182" unit="cm" x="0" y="35.6664832938217" z="31.6995968713274"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU183"/> 
+       <position name="posWireU183" unit="cm" x="0" y="36.3209141799469" z="32.2812408506178"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU184"/> 
+       <position name="posWireU184" unit="cm" x="0" y="36.975345066072" z="32.8628848299082"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU185"/> 
+       <position name="posWireU185" unit="cm" x="0" y="37.6297759521972" z="33.4445288091987"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU186"/> 
+       <position name="posWireU186" unit="cm" x="0" y="38.2842068383224" z="34.026172788489"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU187"/> 
+       <position name="posWireU187" unit="cm" x="0" y="38.9386377244475" z="34.6078167677795"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU188"/> 
+       <position name="posWireU188" unit="cm" x="0" y="39.5930686105727" z="35.1894607470699"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU189"/> 
+       <position name="posWireU189" unit="cm" x="0" y="40.2474994966978" z="35.7711047263603"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU190"/> 
+       <position name="posWireU190" unit="cm" x="0" y="40.901930382823" z="36.3527487056507"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU191"/> 
+       <position name="posWireU191" unit="cm" x="0" y="41.5563612689482" z="36.9343926849411"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU192"/> 
+       <position name="posWireU192" unit="cm" x="0" y="42.2107921550733" z="37.5160366642315"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU193"/> 
+       <position name="posWireU193" unit="cm" x="0" y="42.8652230411985" z="38.0976806435219"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU194"/> 
+       <position name="posWireU194" unit="cm" x="0" y="43.5196539273237" z="38.6793246228123"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU195"/> 
+       <position name="posWireU195" unit="cm" x="0" y="44.1740848134488" z="39.2609686021027"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU196"/> 
+       <position name="posWireU196" unit="cm" x="0" y="44.828515699574" z="39.8426125813931"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU197"/> 
+       <position name="posWireU197" unit="cm" x="0" y="45.4829465856992" z="40.4242565606835"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU198"/> 
+       <position name="posWireU198" unit="cm" x="0" y="46.1373774718243" z="41.0059005399739"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU199"/> 
+       <position name="posWireU199" unit="cm" x="0" y="46.7918083579495" z="41.5875445192643"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU200"/> 
+       <position name="posWireU200" unit="cm" x="0" y="47.4462392440746" z="42.1691884985547"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU201"/> 
+       <position name="posWireU201" unit="cm" x="0" y="48.1006701301998" z="42.7508324778452"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU202"/> 
+       <position name="posWireU202" unit="cm" x="0" y="48.755101016325" z="43.3324764571356"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU203"/> 
+       <position name="posWireU203" unit="cm" x="0" y="49.4095319024501" z="43.9141204364259"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU204"/> 
+       <position name="posWireU204" unit="cm" x="0" y="50.0639627885753" z="44.4957644157164"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU205"/> 
+       <position name="posWireU205" unit="cm" x="0" y="50.7183936747005" z="45.0774083950068"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU206"/> 
+       <position name="posWireU206" unit="cm" x="0" y="51.3728245608256" z="45.6590523742972"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU207"/> 
+       <position name="posWireU207" unit="cm" x="0" y="52.0272554469508" z="46.2406963535876"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU208"/> 
+       <position name="posWireU208" unit="cm" x="0" y="52.681686333076" z="46.822340332878"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU209"/> 
+       <position name="posWireU209" unit="cm" x="0" y="53.3361172192011" z="47.4039843121684"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU210"/> 
+       <position name="posWireU210" unit="cm" x="0" y="53.9905481053263" z="47.9856282914588"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU211"/> 
+       <position name="posWireU211" unit="cm" x="0" y="54.6449789914514" z="48.5672722707492"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU212"/> 
+       <position name="posWireU212" unit="cm" x="0" y="55.2994098775766" z="49.1489162500396"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU213"/> 
+       <position name="posWireU213" unit="cm" x="0" y="55.9538407637018" z="49.73056022933"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU214"/> 
+       <position name="posWireU214" unit="cm" x="0" y="56.6082716498269" z="50.3122042086204"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU215"/> 
+       <position name="posWireU215" unit="cm" x="0" y="57.2627025359521" z="50.8938481879108"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU216"/> 
+       <position name="posWireU216" unit="cm" x="0" y="57.9171334220772" z="51.4754921672012"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU217"/> 
+       <position name="posWireU217" unit="cm" x="0" y="58.5715643082024" z="52.0571361464917"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU218"/> 
+       <position name="posWireU218" unit="cm" x="0" y="59.2259951943276" z="52.6387801257821"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU219"/> 
+       <position name="posWireU219" unit="cm" x="0" y="59.8804260804527" z="53.2204241050725"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU220"/> 
+       <position name="posWireU220" unit="cm" x="0" y="60.5348569665779" z="53.8020680843629"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU221"/> 
+       <position name="posWireU221" unit="cm" x="0" y="61.1892878527031" z="54.3837120636533"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU222"/> 
+       <position name="posWireU222" unit="cm" x="0" y="61.8437187388282" z="54.9653560429437"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU223"/> 
+       <position name="posWireU223" unit="cm" x="0" y="62.4981496249534" z="55.5470000222341"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU224"/> 
+       <position name="posWireU224" unit="cm" x="0" y="63.1525805110786" z="56.1286440015245"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU225"/> 
+       <position name="posWireU225" unit="cm" x="0" y="63.8070113972037" z="56.7102879808149"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU226"/> 
+       <position name="posWireU226" unit="cm" x="0" y="64.4614422833289" z="57.2919319601053"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU227"/> 
+       <position name="posWireU227" unit="cm" x="0" y="65.115873169454" z="57.8735759393957"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU228"/> 
+       <position name="posWireU228" unit="cm" x="0" y="65.7703040555792" z="58.4552199186861"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU229"/> 
+       <position name="posWireU229" unit="cm" x="0" y="66.4247349417044" z="59.0368638979765"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU230"/> 
+       <position name="posWireU230" unit="cm" x="0" y="67.0791658278295" z="59.6185078772669"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU231"/> 
+       <position name="posWireU231" unit="cm" x="0" y="67.7335967139547" z="60.2001518565573"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU232"/> 
+       <position name="posWireU232" unit="cm" x="0" y="68.3880276000799" z="60.7817958358477"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU233"/> 
+       <position name="posWireU233" unit="cm" x="0" y="69.042458486205" z="61.3634398151382"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU234"/> 
+       <position name="posWireU234" unit="cm" x="0" y="69.6968893723302" z="61.9450837944285"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU235"/> 
+       <position name="posWireU235" unit="cm" x="0" y="70.3513202584554" z="62.526727773719"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU236"/> 
+       <position name="posWireU236" unit="cm" x="0" y="71.0057511445805" z="63.1083717530094"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU237"/> 
+       <position name="posWireU237" unit="cm" x="0" y="71.6601820307057" z="63.6900157322998"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU238"/> 
+       <position name="posWireU238" unit="cm" x="0" y="72.3146129168309" z="64.2716597115902"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU239"/> 
+       <position name="posWireU239" unit="cm" x="0" y="72.969043802956" z="64.8533036908806"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU240"/> 
+       <position name="posWireU240" unit="cm" x="0" y="73.6234746890812" z="65.434947670171"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU241"/> 
+       <position name="posWireU241" unit="cm" x="0" y="74.2779055752063" z="66.0165916494614"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU242"/> 
+       <position name="posWireU242" unit="cm" x="0" y="74.9323364613315" z="66.5982356287518"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU243"/> 
+       <position name="posWireU243" unit="cm" x="0" y="75.5867673474567" z="67.1798796080422"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU244"/> 
+       <position name="posWireU244" unit="cm" x="0" y="76.2411982335818" z="67.7615235873326"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU245"/> 
+       <position name="posWireU245" unit="cm" x="0" y="76.895629119707" z="68.343167566623"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU246"/> 
+       <position name="posWireU246" unit="cm" x="0" y="77.5500600058322" z="68.9248115459134"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU247"/> 
+       <position name="posWireU247" unit="cm" x="0" y="78.2044908919573" z="69.5064555252038"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU248"/> 
+       <position name="posWireU248" unit="cm" x="0" y="78.8589217780825" z="70.0880995044943"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU249"/> 
+       <position name="posWireU249" unit="cm" x="0" y="79.5133526642076" z="70.6697434837847"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU250"/> 
+       <position name="posWireU250" unit="cm" x="0" y="80.1677835503328" z="71.251387463075"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU251"/> 
+       <position name="posWireU251" unit="cm" x="0" y="80.822214436458" z="71.8330314423655"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU252"/> 
+       <position name="posWireU252" unit="cm" x="0" y="81.4766453225831" z="72.4146754216559"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU253"/> 
+       <position name="posWireU253" unit="cm" x="0" y="82.1310762087083" z="72.9963194009463"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU254"/> 
+       <position name="posWireU254" unit="cm" x="0" y="82.7855070948335" z="73.5779633802367"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU255"/> 
+       <position name="posWireU255" unit="cm" x="0" y="83.4399379809586" z="74.1596073595271"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+   </volume>
+  <volume name="volTPCPlaneY">
+    <materialref ref="LAr"/>
+    <solidref ref="CRMYPlane"/>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY0" unit="cm" x="0" y="-83.7375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY1" unit="cm" x="0" y="-83.2125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY2" unit="cm" x="0" y="-82.6875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY3" unit="cm" x="0" y="-82.1625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY4" unit="cm" x="0" y="-81.6375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY5" unit="cm" x="0" y="-81.1125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY6" unit="cm" x="0" y="-80.5875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY7" unit="cm" x="0" y="-80.0625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY8" unit="cm" x="0" y="-79.5375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY9" unit="cm" x="0" y="-79.0125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY10" unit="cm" x="0" y="-78.4875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY11" unit="cm" x="0" y="-77.9625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY12" unit="cm" x="0" y="-77.4375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY13" unit="cm" x="0" y="-76.9125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY14" unit="cm" x="0" y="-76.3875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY15" unit="cm" x="0" y="-75.8625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY16" unit="cm" x="0" y="-75.3375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY17" unit="cm" x="0" y="-74.8125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY18" unit="cm" x="0" y="-74.2875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY19" unit="cm" x="0" y="-73.7625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY20" unit="cm" x="0" y="-73.2375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY21" unit="cm" x="0" y="-72.7125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY22" unit="cm" x="0" y="-72.1875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY23" unit="cm" x="0" y="-71.6625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY24" unit="cm" x="0" y="-71.1375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY25" unit="cm" x="0" y="-70.6125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY26" unit="cm" x="0" y="-70.0875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY27" unit="cm" x="0" y="-69.5625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY28" unit="cm" x="0" y="-69.0375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY29" unit="cm" x="0" y="-68.5125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY30" unit="cm" x="0" y="-67.9875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY31" unit="cm" x="0" y="-67.4625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY32" unit="cm" x="0" y="-66.9375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY33" unit="cm" x="0" y="-66.4125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY34" unit="cm" x="0" y="-65.8875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY35" unit="cm" x="0" y="-65.3625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY36" unit="cm" x="0" y="-64.8375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY37" unit="cm" x="0" y="-64.3125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY38" unit="cm" x="0" y="-63.7875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY39" unit="cm" x="0" y="-63.2625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY40" unit="cm" x="0" y="-62.7375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY41" unit="cm" x="0" y="-62.2125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY42" unit="cm" x="0" y="-61.6875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY43" unit="cm" x="0" y="-61.1625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY44" unit="cm" x="0" y="-60.6375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY45" unit="cm" x="0" y="-60.1125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY46" unit="cm" x="0" y="-59.5875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY47" unit="cm" x="0" y="-59.0625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY48" unit="cm" x="0" y="-58.5375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY49" unit="cm" x="0" y="-58.0125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY50" unit="cm" x="0" y="-57.4875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY51" unit="cm" x="0" y="-56.9625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY52" unit="cm" x="0" y="-56.4375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY53" unit="cm" x="0" y="-55.9125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY54" unit="cm" x="0" y="-55.3875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY55" unit="cm" x="0" y="-54.8625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY56" unit="cm" x="0" y="-54.3375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY57" unit="cm" x="0" y="-53.8125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY58" unit="cm" x="0" y="-53.2875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY59" unit="cm" x="0" y="-52.7625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY60" unit="cm" x="0" y="-52.2375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY61" unit="cm" x="0" y="-51.7125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY62" unit="cm" x="0" y="-51.1875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY63" unit="cm" x="0" y="-50.6625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY64" unit="cm" x="0" y="-50.1375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY65" unit="cm" x="0" y="-49.6125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY66" unit="cm" x="0" y="-49.0875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY67" unit="cm" x="0" y="-48.5625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY68" unit="cm" x="0" y="-48.0375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY69" unit="cm" x="0" y="-47.5125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY70" unit="cm" x="0" y="-46.9875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY71" unit="cm" x="0" y="-46.4625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY72" unit="cm" x="0" y="-45.9375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY73" unit="cm" x="0" y="-45.4125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY74" unit="cm" x="0" y="-44.8875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY75" unit="cm" x="0" y="-44.3625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY76" unit="cm" x="0" y="-43.8375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY77" unit="cm" x="0" y="-43.3125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY78" unit="cm" x="0" y="-42.7875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY79" unit="cm" x="0" y="-42.2625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY80" unit="cm" x="0" y="-41.7375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY81" unit="cm" x="0" y="-41.2125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY82" unit="cm" x="0" y="-40.6875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY83" unit="cm" x="0" y="-40.1625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY84" unit="cm" x="0" y="-39.6375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY85" unit="cm" x="0" y="-39.1125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY86" unit="cm" x="0" y="-38.5875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY87" unit="cm" x="0" y="-38.0625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY88" unit="cm" x="0" y="-37.5375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY89" unit="cm" x="0" y="-37.0125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY90" unit="cm" x="0" y="-36.4875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY91" unit="cm" x="0" y="-35.9625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY92" unit="cm" x="0" y="-35.4375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY93" unit="cm" x="0" y="-34.9125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY94" unit="cm" x="0" y="-34.3875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY95" unit="cm" x="0" y="-33.8625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY96" unit="cm" x="0" y="-33.3375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY97" unit="cm" x="0" y="-32.8125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY98" unit="cm" x="0" y="-32.2875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY99" unit="cm" x="0" y="-31.7625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY100" unit="cm" x="0" y="-31.2375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY101" unit="cm" x="0" y="-30.7125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY102" unit="cm" x="0" y="-30.1875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY103" unit="cm" x="0" y="-29.6625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY104" unit="cm" x="0" y="-29.1375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY105" unit="cm" x="0" y="-28.6125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY106" unit="cm" x="0" y="-28.0875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY107" unit="cm" x="0" y="-27.5625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY108" unit="cm" x="0" y="-27.0375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY109" unit="cm" x="0" y="-26.5125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY110" unit="cm" x="0" y="-25.9875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY111" unit="cm" x="0" y="-25.4625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY112" unit="cm" x="0" y="-24.9375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY113" unit="cm" x="0" y="-24.4125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY114" unit="cm" x="0" y="-23.8875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY115" unit="cm" x="0" y="-23.3625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY116" unit="cm" x="0" y="-22.8375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY117" unit="cm" x="0" y="-22.3125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY118" unit="cm" x="0" y="-21.7875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY119" unit="cm" x="0" y="-21.2625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY120" unit="cm" x="0" y="-20.7375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY121" unit="cm" x="0" y="-20.2125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY122" unit="cm" x="0" y="-19.6875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY123" unit="cm" x="0" y="-19.1625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY124" unit="cm" x="0" y="-18.6375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY125" unit="cm" x="0" y="-18.1125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY126" unit="cm" x="0" y="-17.5875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY127" unit="cm" x="0" y="-17.0625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY128" unit="cm" x="0" y="-16.5375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY129" unit="cm" x="0" y="-16.0125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY130" unit="cm" x="0" y="-15.4875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY131" unit="cm" x="0" y="-14.9625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY132" unit="cm" x="0" y="-14.4375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY133" unit="cm" x="0" y="-13.9125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY134" unit="cm" x="0" y="-13.3875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY135" unit="cm" x="0" y="-12.8625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY136" unit="cm" x="0" y="-12.3375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY137" unit="cm" x="0" y="-11.8125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY138" unit="cm" x="0" y="-11.2875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY139" unit="cm" x="0" y="-10.7625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY140" unit="cm" x="0" y="-10.2375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY141" unit="cm" x="0" y="-9.7125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY142" unit="cm" x="0" y="-9.1875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY143" unit="cm" x="0" y="-8.6625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY144" unit="cm" x="0" y="-8.1375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY145" unit="cm" x="0" y="-7.6125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY146" unit="cm" x="0" y="-7.0875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY147" unit="cm" x="0" y="-6.5625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY148" unit="cm" x="0" y="-6.0375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY149" unit="cm" x="0" y="-5.5125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY150" unit="cm" x="0" y="-4.9875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY151" unit="cm" x="0" y="-4.4625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY152" unit="cm" x="0" y="-3.9375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY153" unit="cm" x="0" y="-3.4125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY154" unit="cm" x="0" y="-2.8875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY155" unit="cm" x="0" y="-2.3625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY156" unit="cm" x="0" y="-1.8375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY157" unit="cm" x="0" y="-1.3125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY158" unit="cm" x="0" y="-0.7875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY159" unit="cm" x="0" y="-0.2625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY160" unit="cm" x="0" y="0.2625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY161" unit="cm" x="0" y="0.7875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY162" unit="cm" x="0" y="1.3125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY163" unit="cm" x="0" y="1.8375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY164" unit="cm" x="0" y="2.3625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY165" unit="cm" x="0" y="2.8875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY166" unit="cm" x="0" y="3.4125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY167" unit="cm" x="0" y="3.9375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY168" unit="cm" x="0" y="4.4625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY169" unit="cm" x="0" y="4.9875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY170" unit="cm" x="0" y="5.5125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY171" unit="cm" x="0" y="6.0375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY172" unit="cm" x="0" y="6.5625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY173" unit="cm" x="0" y="7.0875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY174" unit="cm" x="0" y="7.6125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY175" unit="cm" x="0" y="8.1375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY176" unit="cm" x="0" y="8.6625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY177" unit="cm" x="0" y="9.1875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY178" unit="cm" x="0" y="9.7125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY179" unit="cm" x="0" y="10.2375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY180" unit="cm" x="0" y="10.7625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY181" unit="cm" x="0" y="11.2875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY182" unit="cm" x="0" y="11.8125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY183" unit="cm" x="0" y="12.3375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY184" unit="cm" x="0" y="12.8625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY185" unit="cm" x="0" y="13.3875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY186" unit="cm" x="0" y="13.9125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY187" unit="cm" x="0" y="14.4375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY188" unit="cm" x="0" y="14.9625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY189" unit="cm" x="0" y="15.4875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY190" unit="cm" x="0" y="16.0125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY191" unit="cm" x="0" y="16.5375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY192" unit="cm" x="0" y="17.0625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY193" unit="cm" x="0" y="17.5875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY194" unit="cm" x="0" y="18.1125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY195" unit="cm" x="0" y="18.6375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY196" unit="cm" x="0" y="19.1625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY197" unit="cm" x="0" y="19.6875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY198" unit="cm" x="0" y="20.2125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY199" unit="cm" x="0" y="20.7375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY200" unit="cm" x="0" y="21.2625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY201" unit="cm" x="0" y="21.7875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY202" unit="cm" x="0" y="22.3125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY203" unit="cm" x="0" y="22.8375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY204" unit="cm" x="0" y="23.3625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY205" unit="cm" x="0" y="23.8875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY206" unit="cm" x="0" y="24.4125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY207" unit="cm" x="0" y="24.9375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY208" unit="cm" x="0" y="25.4625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY209" unit="cm" x="0" y="25.9875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY210" unit="cm" x="0" y="26.5125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY211" unit="cm" x="0" y="27.0375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY212" unit="cm" x="0" y="27.5625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY213" unit="cm" x="0" y="28.0875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY214" unit="cm" x="0" y="28.6125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY215" unit="cm" x="0" y="29.1375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY216" unit="cm" x="0" y="29.6625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY217" unit="cm" x="0" y="30.1875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY218" unit="cm" x="0" y="30.7125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY219" unit="cm" x="0" y="31.2375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY220" unit="cm" x="0" y="31.7625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY221" unit="cm" x="0" y="32.2875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY222" unit="cm" x="0" y="32.8125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY223" unit="cm" x="0" y="33.3375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY224" unit="cm" x="0" y="33.8625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY225" unit="cm" x="0" y="34.3875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY226" unit="cm" x="0" y="34.9125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY227" unit="cm" x="0" y="35.4375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY228" unit="cm" x="0" y="35.9625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY229" unit="cm" x="0" y="36.4875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY230" unit="cm" x="0" y="37.0125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY231" unit="cm" x="0" y="37.5375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY232" unit="cm" x="0" y="38.0625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY233" unit="cm" x="0" y="38.5875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY234" unit="cm" x="0" y="39.1125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY235" unit="cm" x="0" y="39.6375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY236" unit="cm" x="0" y="40.1625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY237" unit="cm" x="0" y="40.6875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY238" unit="cm" x="0" y="41.2125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY239" unit="cm" x="0" y="41.7375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY240" unit="cm" x="0" y="42.2625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY241" unit="cm" x="0" y="42.7875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY242" unit="cm" x="0" y="43.3125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY243" unit="cm" x="0" y="43.8375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY244" unit="cm" x="0" y="44.3625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY245" unit="cm" x="0" y="44.8875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY246" unit="cm" x="0" y="45.4125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY247" unit="cm" x="0" y="45.9375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY248" unit="cm" x="0" y="46.4625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY249" unit="cm" x="0" y="46.9875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY250" unit="cm" x="0" y="47.5125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY251" unit="cm" x="0" y="48.0375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY252" unit="cm" x="0" y="48.5625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY253" unit="cm" x="0" y="49.0875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY254" unit="cm" x="0" y="49.6125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY255" unit="cm" x="0" y="50.1375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY256" unit="cm" x="0" y="50.6625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY257" unit="cm" x="0" y="51.1875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY258" unit="cm" x="0" y="51.7125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY259" unit="cm" x="0" y="52.2375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY260" unit="cm" x="0" y="52.7625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY261" unit="cm" x="0" y="53.2875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY262" unit="cm" x="0" y="53.8125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY263" unit="cm" x="0" y="54.3375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY264" unit="cm" x="0" y="54.8625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY265" unit="cm" x="0" y="55.3875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY266" unit="cm" x="0" y="55.9125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY267" unit="cm" x="0" y="56.4375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY268" unit="cm" x="0" y="56.9625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY269" unit="cm" x="0" y="57.4875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY270" unit="cm" x="0" y="58.0125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY271" unit="cm" x="0" y="58.5375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY272" unit="cm" x="0" y="59.0625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY273" unit="cm" x="0" y="59.5875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY274" unit="cm" x="0" y="60.1125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY275" unit="cm" x="0" y="60.6375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY276" unit="cm" x="0" y="61.1625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY277" unit="cm" x="0" y="61.6875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY278" unit="cm" x="0" y="62.2125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY279" unit="cm" x="0" y="62.7375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY280" unit="cm" x="0" y="63.2625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY281" unit="cm" x="0" y="63.7875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY282" unit="cm" x="0" y="64.3125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY283" unit="cm" x="0" y="64.8375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY284" unit="cm" x="0" y="65.3625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY285" unit="cm" x="0" y="65.8875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY286" unit="cm" x="0" y="66.4125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY287" unit="cm" x="0" y="66.9375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY288" unit="cm" x="0" y="67.4625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY289" unit="cm" x="0" y="67.9875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY290" unit="cm" x="0" y="68.5125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY291" unit="cm" x="0" y="69.0375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY292" unit="cm" x="0" y="69.5625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY293" unit="cm" x="0" y="70.0875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY294" unit="cm" x="0" y="70.6125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY295" unit="cm" x="0" y="71.1375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY296" unit="cm" x="0" y="71.6625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY297" unit="cm" x="0" y="72.1875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY298" unit="cm" x="0" y="72.7125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY299" unit="cm" x="0" y="73.2375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY300" unit="cm" x="0" y="73.7625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY301" unit="cm" x="0" y="74.2875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY302" unit="cm" x="0" y="74.8125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY303" unit="cm" x="0" y="75.3375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY304" unit="cm" x="0" y="75.8625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY305" unit="cm" x="0" y="76.3875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY306" unit="cm" x="0" y="76.9125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY307" unit="cm" x="0" y="77.4375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY308" unit="cm" x="0" y="77.9625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY309" unit="cm" x="0" y="78.4875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY310" unit="cm" x="0" y="79.0125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY311" unit="cm" x="0" y="79.5375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY312" unit="cm" x="0" y="80.0625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY313" unit="cm" x="0" y="80.5875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY314" unit="cm" x="0" y="81.1125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY315" unit="cm" x="0" y="81.6375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY316" unit="cm" x="0" y="82.1625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY317" unit="cm" x="0" y="82.6875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY318" unit="cm" x="0" y="83.2125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY319" unit="cm" x="0" y="83.7375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+  </volume>
+  <volume name="volTPCPlaneZ">
+    <materialref ref="LAr"/>
+    <solidref ref="CRMZPlane"/>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ0" unit="cm" x="0" y="0" z="-74.1895"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ1" unit="cm" x="0" y="0" z="-73.6725"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ2" unit="cm" x="0" y="0" z="-73.1555"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ3" unit="cm" x="0" y="0" z="-72.6385"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ4" unit="cm" x="0" y="0" z="-72.1215"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ5" unit="cm" x="0" y="0" z="-71.6045"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ6" unit="cm" x="0" y="0" z="-71.0875"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ7" unit="cm" x="0" y="0" z="-70.5705"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ8" unit="cm" x="0" y="0" z="-70.0535"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ9" unit="cm" x="0" y="0" z="-69.5365"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ10" unit="cm" x="0" y="0" z="-69.0195"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ11" unit="cm" x="0" y="0" z="-68.5025"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ12" unit="cm" x="0" y="0" z="-67.9855"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ13" unit="cm" x="0" y="0" z="-67.4685"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ14" unit="cm" x="0" y="0" z="-66.9515"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ15" unit="cm" x="0" y="0" z="-66.4345"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ16" unit="cm" x="0" y="0" z="-65.9175"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ17" unit="cm" x="0" y="0" z="-65.4005"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ18" unit="cm" x="0" y="0" z="-64.8835"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ19" unit="cm" x="0" y="0" z="-64.3665"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ20" unit="cm" x="0" y="0" z="-63.8495"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ21" unit="cm" x="0" y="0" z="-63.3325"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ22" unit="cm" x="0" y="0" z="-62.8155"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ23" unit="cm" x="0" y="0" z="-62.2985"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ24" unit="cm" x="0" y="0" z="-61.7815"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ25" unit="cm" x="0" y="0" z="-61.2645"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ26" unit="cm" x="0" y="0" z="-60.7475"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ27" unit="cm" x="0" y="0" z="-60.2305"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ28" unit="cm" x="0" y="0" z="-59.7135"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ29" unit="cm" x="0" y="0" z="-59.1965"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ30" unit="cm" x="0" y="0" z="-58.6795"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ31" unit="cm" x="0" y="0" z="-58.1625"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ32" unit="cm" x="0" y="0" z="-57.6455"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ33" unit="cm" x="0" y="0" z="-57.1285"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ34" unit="cm" x="0" y="0" z="-56.6115"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ35" unit="cm" x="0" y="0" z="-56.0945"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ36" unit="cm" x="0" y="0" z="-55.5775"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ37" unit="cm" x="0" y="0" z="-55.0605"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ38" unit="cm" x="0" y="0" z="-54.5435"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ39" unit="cm" x="0" y="0" z="-54.0265"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ40" unit="cm" x="0" y="0" z="-53.5095"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ41" unit="cm" x="0" y="0" z="-52.9925"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ42" unit="cm" x="0" y="0" z="-52.4755"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ43" unit="cm" x="0" y="0" z="-51.9585"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ44" unit="cm" x="0" y="0" z="-51.4415"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ45" unit="cm" x="0" y="0" z="-50.9245"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ46" unit="cm" x="0" y="0" z="-50.4075"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ47" unit="cm" x="0" y="0" z="-49.8905"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ48" unit="cm" x="0" y="0" z="-49.3735"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ49" unit="cm" x="0" y="0" z="-48.8565"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ50" unit="cm" x="0" y="0" z="-48.3395"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ51" unit="cm" x="0" y="0" z="-47.8225"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ52" unit="cm" x="0" y="0" z="-47.3055"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ53" unit="cm" x="0" y="0" z="-46.7885"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ54" unit="cm" x="0" y="0" z="-46.2715"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ55" unit="cm" x="0" y="0" z="-45.7545"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ56" unit="cm" x="0" y="0" z="-45.2375"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ57" unit="cm" x="0" y="0" z="-44.7205"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ58" unit="cm" x="0" y="0" z="-44.2035"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ59" unit="cm" x="0" y="0" z="-43.6865"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ60" unit="cm" x="0" y="0" z="-43.1695"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ61" unit="cm" x="0" y="0" z="-42.6525"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ62" unit="cm" x="0" y="0" z="-42.1355"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ63" unit="cm" x="0" y="0" z="-41.6185"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ64" unit="cm" x="0" y="0" z="-41.1015"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ65" unit="cm" x="0" y="0" z="-40.5845"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ66" unit="cm" x="0" y="0" z="-40.0675"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ67" unit="cm" x="0" y="0" z="-39.5505"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ68" unit="cm" x="0" y="0" z="-39.0335"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ69" unit="cm" x="0" y="0" z="-38.5165"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ70" unit="cm" x="0" y="0" z="-37.9995"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ71" unit="cm" x="0" y="0" z="-37.4825"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ72" unit="cm" x="0" y="0" z="-36.9655"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ73" unit="cm" x="0" y="0" z="-36.4485"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ74" unit="cm" x="0" y="0" z="-35.9315"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ75" unit="cm" x="0" y="0" z="-35.4145"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ76" unit="cm" x="0" y="0" z="-34.8975"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ77" unit="cm" x="0" y="0" z="-34.3805"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ78" unit="cm" x="0" y="0" z="-33.8635"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ79" unit="cm" x="0" y="0" z="-33.3465"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ80" unit="cm" x="0" y="0" z="-32.8295"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ81" unit="cm" x="0" y="0" z="-32.3125"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ82" unit="cm" x="0" y="0" z="-31.7955"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ83" unit="cm" x="0" y="0" z="-31.2785"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ84" unit="cm" x="0" y="0" z="-30.7615"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ85" unit="cm" x="0" y="0" z="-30.2445"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ86" unit="cm" x="0" y="0" z="-29.7275"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ87" unit="cm" x="0" y="0" z="-29.2105"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ88" unit="cm" x="0" y="0" z="-28.6935"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ89" unit="cm" x="0" y="0" z="-28.1765"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ90" unit="cm" x="0" y="0" z="-27.6595"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ91" unit="cm" x="0" y="0" z="-27.1425"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ92" unit="cm" x="0" y="0" z="-26.6255"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ93" unit="cm" x="0" y="0" z="-26.1085"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ94" unit="cm" x="0" y="0" z="-25.5915"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ95" unit="cm" x="0" y="0" z="-25.0745"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ96" unit="cm" x="0" y="0" z="-24.5575"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ97" unit="cm" x="0" y="0" z="-24.0405"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ98" unit="cm" x="0" y="0" z="-23.5235"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ99" unit="cm" x="0" y="0" z="-23.0065"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ100" unit="cm" x="0" y="0" z="-22.4895"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ101" unit="cm" x="0" y="0" z="-21.9725"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ102" unit="cm" x="0" y="0" z="-21.4555"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ103" unit="cm" x="0" y="0" z="-20.9385"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ104" unit="cm" x="0" y="0" z="-20.4215"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ105" unit="cm" x="0" y="0" z="-19.9045"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ106" unit="cm" x="0" y="0" z="-19.3875"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ107" unit="cm" x="0" y="0" z="-18.8705"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ108" unit="cm" x="0" y="0" z="-18.3535"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ109" unit="cm" x="0" y="0" z="-17.8365"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ110" unit="cm" x="0" y="0" z="-17.3195"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ111" unit="cm" x="0" y="0" z="-16.8025"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ112" unit="cm" x="0" y="0" z="-16.2855"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ113" unit="cm" x="0" y="0" z="-15.7685"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ114" unit="cm" x="0" y="0" z="-15.2515"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ115" unit="cm" x="0" y="0" z="-14.7345"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ116" unit="cm" x="0" y="0" z="-14.2175"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ117" unit="cm" x="0" y="0" z="-13.7005"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ118" unit="cm" x="0" y="0" z="-13.1835"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ119" unit="cm" x="0" y="0" z="-12.6665"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ120" unit="cm" x="0" y="0" z="-12.1495"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ121" unit="cm" x="0" y="0" z="-11.6325"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ122" unit="cm" x="0" y="0" z="-11.1155"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ123" unit="cm" x="0" y="0" z="-10.5985"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ124" unit="cm" x="0" y="0" z="-10.0815"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ125" unit="cm" x="0" y="0" z="-9.5645"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ126" unit="cm" x="0" y="0" z="-9.0475"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ127" unit="cm" x="0" y="0" z="-8.5305"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ128" unit="cm" x="0" y="0" z="-8.0135"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ129" unit="cm" x="0" y="0" z="-7.4965"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ130" unit="cm" x="0" y="0" z="-6.9795"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ131" unit="cm" x="0" y="0" z="-6.4625"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ132" unit="cm" x="0" y="0" z="-5.9455"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ133" unit="cm" x="0" y="0" z="-5.4285"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ134" unit="cm" x="0" y="0" z="-4.9115"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ135" unit="cm" x="0" y="0" z="-4.3945"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ136" unit="cm" x="0" y="0" z="-3.8775"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ137" unit="cm" x="0" y="0" z="-3.3605"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ138" unit="cm" x="0" y="0" z="-2.8435"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ139" unit="cm" x="0" y="0" z="-2.3265"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ140" unit="cm" x="0" y="0" z="-1.8095"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ141" unit="cm" x="0" y="0" z="-1.2925"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ142" unit="cm" x="0" y="0" z="-0.7755"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ143" unit="cm" x="0" y="0" z="-0.2585"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ144" unit="cm" x="0" y="0" z="0.2585"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ145" unit="cm" x="0" y="0" z="0.7755"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ146" unit="cm" x="0" y="0" z="1.2925"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ147" unit="cm" x="0" y="0" z="1.8095"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ148" unit="cm" x="0" y="0" z="2.3265"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ149" unit="cm" x="0" y="0" z="2.8435"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ150" unit="cm" x="0" y="0" z="3.3605"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ151" unit="cm" x="0" y="0" z="3.8775"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ152" unit="cm" x="0" y="0" z="4.3945"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ153" unit="cm" x="0" y="0" z="4.9115"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ154" unit="cm" x="0" y="0" z="5.4285"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ155" unit="cm" x="0" y="0" z="5.9455"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ156" unit="cm" x="0" y="0" z="6.4625"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ157" unit="cm" x="0" y="0" z="6.9795"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ158" unit="cm" x="0" y="0" z="7.4965"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ159" unit="cm" x="0" y="0" z="8.0135"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ160" unit="cm" x="0" y="0" z="8.5305"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ161" unit="cm" x="0" y="0" z="9.0475"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ162" unit="cm" x="0" y="0" z="9.5645"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ163" unit="cm" x="0" y="0" z="10.0815"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ164" unit="cm" x="0" y="0" z="10.5985"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ165" unit="cm" x="0" y="0" z="11.1155"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ166" unit="cm" x="0" y="0" z="11.6325"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ167" unit="cm" x="0" y="0" z="12.1495"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ168" unit="cm" x="0" y="0" z="12.6665"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ169" unit="cm" x="0" y="0" z="13.1835"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ170" unit="cm" x="0" y="0" z="13.7005"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ171" unit="cm" x="0" y="0" z="14.2175"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ172" unit="cm" x="0" y="0" z="14.7345"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ173" unit="cm" x="0" y="0" z="15.2515"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ174" unit="cm" x="0" y="0" z="15.7685"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ175" unit="cm" x="0" y="0" z="16.2855"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ176" unit="cm" x="0" y="0" z="16.8025"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ177" unit="cm" x="0" y="0" z="17.3195"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ178" unit="cm" x="0" y="0" z="17.8365"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ179" unit="cm" x="0" y="0" z="18.3535"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ180" unit="cm" x="0" y="0" z="18.8705"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ181" unit="cm" x="0" y="0" z="19.3875"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ182" unit="cm" x="0" y="0" z="19.9045"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ183" unit="cm" x="0" y="0" z="20.4215"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ184" unit="cm" x="0" y="0" z="20.9385"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ185" unit="cm" x="0" y="0" z="21.4555"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ186" unit="cm" x="0" y="0" z="21.9725"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ187" unit="cm" x="0" y="0" z="22.4895"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ188" unit="cm" x="0" y="0" z="23.0065"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ189" unit="cm" x="0" y="0" z="23.5235"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ190" unit="cm" x="0" y="0" z="24.0405"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ191" unit="cm" x="0" y="0" z="24.5575"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ192" unit="cm" x="0" y="0" z="25.0745"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ193" unit="cm" x="0" y="0" z="25.5915"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ194" unit="cm" x="0" y="0" z="26.1085"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ195" unit="cm" x="0" y="0" z="26.6255"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ196" unit="cm" x="0" y="0" z="27.1425"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ197" unit="cm" x="0" y="0" z="27.6595"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ198" unit="cm" x="0" y="0" z="28.1765"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ199" unit="cm" x="0" y="0" z="28.6935"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ200" unit="cm" x="0" y="0" z="29.2105"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ201" unit="cm" x="0" y="0" z="29.7275"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ202" unit="cm" x="0" y="0" z="30.2445"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ203" unit="cm" x="0" y="0" z="30.7615"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ204" unit="cm" x="0" y="0" z="31.2785"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ205" unit="cm" x="0" y="0" z="31.7955"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ206" unit="cm" x="0" y="0" z="32.3125"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ207" unit="cm" x="0" y="0" z="32.8295"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ208" unit="cm" x="0" y="0" z="33.3465"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ209" unit="cm" x="0" y="0" z="33.8635"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ210" unit="cm" x="0" y="0" z="34.3805"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ211" unit="cm" x="0" y="0" z="34.8975"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ212" unit="cm" x="0" y="0" z="35.4145"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ213" unit="cm" x="0" y="0" z="35.9315"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ214" unit="cm" x="0" y="0" z="36.4485"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ215" unit="cm" x="0" y="0" z="36.9655"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ216" unit="cm" x="0" y="0" z="37.4825"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ217" unit="cm" x="0" y="0" z="37.9995"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ218" unit="cm" x="0" y="0" z="38.5165"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ219" unit="cm" x="0" y="0" z="39.0335"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ220" unit="cm" x="0" y="0" z="39.5505"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ221" unit="cm" x="0" y="0" z="40.0675"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ222" unit="cm" x="0" y="0" z="40.5845"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ223" unit="cm" x="0" y="0" z="41.1015"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ224" unit="cm" x="0" y="0" z="41.6185"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ225" unit="cm" x="0" y="0" z="42.1355"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ226" unit="cm" x="0" y="0" z="42.6525"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ227" unit="cm" x="0" y="0" z="43.1695"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ228" unit="cm" x="0" y="0" z="43.6865"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ229" unit="cm" x="0" y="0" z="44.2035"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ230" unit="cm" x="0" y="0" z="44.7205"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ231" unit="cm" x="0" y="0" z="45.2375"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ232" unit="cm" x="0" y="0" z="45.7545"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ233" unit="cm" x="0" y="0" z="46.2715"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ234" unit="cm" x="0" y="0" z="46.7885"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ235" unit="cm" x="0" y="0" z="47.3055"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ236" unit="cm" x="0" y="0" z="47.8225"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ237" unit="cm" x="0" y="0" z="48.3395"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ238" unit="cm" x="0" y="0" z="48.8565"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ239" unit="cm" x="0" y="0" z="49.3735"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ240" unit="cm" x="0" y="0" z="49.8905"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ241" unit="cm" x="0" y="0" z="50.4075"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ242" unit="cm" x="0" y="0" z="50.9245"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ243" unit="cm" x="0" y="0" z="51.4415"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ244" unit="cm" x="0" y="0" z="51.9585"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ245" unit="cm" x="0" y="0" z="52.4755"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ246" unit="cm" x="0" y="0" z="52.9925"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ247" unit="cm" x="0" y="0" z="53.5095"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ248" unit="cm" x="0" y="0" z="54.0265"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ249" unit="cm" x="0" y="0" z="54.5435"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ250" unit="cm" x="0" y="0" z="55.0605"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ251" unit="cm" x="0" y="0" z="55.5775"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ252" unit="cm" x="0" y="0" z="56.0945"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ253" unit="cm" x="0" y="0" z="56.6115"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ254" unit="cm" x="0" y="0" z="57.1285"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ255" unit="cm" x="0" y="0" z="57.6455"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ256" unit="cm" x="0" y="0" z="58.1625"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ257" unit="cm" x="0" y="0" z="58.6795"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ258" unit="cm" x="0" y="0" z="59.1965"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ259" unit="cm" x="0" y="0" z="59.7135"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ260" unit="cm" x="0" y="0" z="60.2305"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ261" unit="cm" x="0" y="0" z="60.7475"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ262" unit="cm" x="0" y="0" z="61.2645"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ263" unit="cm" x="0" y="0" z="61.7815"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ264" unit="cm" x="0" y="0" z="62.2985"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ265" unit="cm" x="0" y="0" z="62.8155"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ266" unit="cm" x="0" y="0" z="63.3325"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ267" unit="cm" x="0" y="0" z="63.8495"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ268" unit="cm" x="0" y="0" z="64.3665"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ269" unit="cm" x="0" y="0" z="64.8835"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ270" unit="cm" x="0" y="0" z="65.4005"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ271" unit="cm" x="0" y="0" z="65.9175"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ272" unit="cm" x="0" y="0" z="66.4345"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ273" unit="cm" x="0" y="0" z="66.9515"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ274" unit="cm" x="0" y="0" z="67.4685"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ275" unit="cm" x="0" y="0" z="67.9855"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ276" unit="cm" x="0" y="0" z="68.5025"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ277" unit="cm" x="0" y="0" z="69.0195"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ278" unit="cm" x="0" y="0" z="69.5365"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ279" unit="cm" x="0" y="0" z="70.0535"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ280" unit="cm" x="0" y="0" z="70.5705"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ281" unit="cm" x="0" y="0" z="71.0875"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ282" unit="cm" x="0" y="0" z="71.6045"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ283" unit="cm" x="0" y="0" z="72.1215"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ284" unit="cm" x="0" y="0" z="72.6385"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ285" unit="cm" x="0" y="0" z="73.1555"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ286" unit="cm" x="0" y="0" z="73.6725"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ287" unit="cm" x="0" y="0" z="74.1895"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+  </volume>
+   <volume name="volTPC">
+     <materialref ref="LAr"/>
+       <solidref ref="CRM"/>
+       <physvol>
+       <volumeref ref="volTPCPlaneU"/>
+       <position name="posPlaneU" unit="cm" 
+         x="324.99" y="0" z="0"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCPlaneY"/>
+       <position name="posPlaneY" unit="cm" 
+         x="325.01" y="0" z="0"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCPlaneZ"/>
+       <position name="posPlaneZ" unit="cm" 
+         x="325.03" y="0" z="0"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCActive"/>
+       <position name="posActive" unit="cm" 
+        x="-0.04" y="" z="0"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+   </volume>
+ 
+    <volume name="volSteelShell">
+      <materialref ref="STEEL_STAINLESS_Fe7Cr2Ni" />
+      <solidref ref="SteelShell" />
+    </volume>
+    <volume name="volGroundGrid">
+      <materialref ref="STEEL_STAINLESS_Fe7Cr2Ni" />
+      <solidref ref="CathodeGrid" />
+    </volume>    
+    <volume name="volAnodePlate">
+     <materialref ref="vm2000"/>
+     <solidref ref="AnodePlate"/>
+    </volume>
+    <volume name="volGaseousArgon">
+      <materialref ref="ArGas"/>
+      <solidref ref="GaseousArgon"/>
+    </volume>
+    <volume name="volExternalActive">
+      <materialref ref="LAr"/>
+      <solidref ref="ExternalActive"/>
+      <auxiliary auxtype="SensDet" auxvalue="SimEnergyDeposit"/>
+      <auxiliary auxtype="StepLimit" auxunit="cm" auxvalue="0.5208*cm"/>
+      <auxiliary auxtype="Efield" auxunit="V/cm" auxvalue="0*V/cm"/>
+      <colorref ref="green"/>
+    </volume>
+    <volume name="volArapucaDouble_0-0-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-0-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-0-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-0-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-0-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-0-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-0-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-0-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-1-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-1-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-1-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-1-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-1-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-1-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-1-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-1-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-2-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-2-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-2-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-2-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-2-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-2-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-2-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-2-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-3-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-3-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-3-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-3-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-3-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-3-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-3-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-3-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-4-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-4-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-4-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-4-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-4-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-4-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-4-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-4-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-5-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-5-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-5-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-5-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-5-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-5-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-5-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-5-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-6-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-6-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-6-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-6-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-6-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-6-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-6-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-6-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-0-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-0-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-0-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-0-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-0-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-0-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-0-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-0-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-1-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-1-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-1-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-1-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-1-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-1-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-1-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-1-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-2-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-2-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-2-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-2-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-2-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-2-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-2-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-2-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-3-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-3-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-3-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-3-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-3-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-3-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-3-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-3-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-4-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-4-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-4-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-4-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-4-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-4-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-4-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-4-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-5-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-5-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-5-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-5-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-5-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-5-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-5-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-5-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-6-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-6-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-6-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-6-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-6-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-6-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-6-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-6-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-0-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-0-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-0-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-0-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-0-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-0-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-0-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-0-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-1-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-1-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-1-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-1-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-1-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-1-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-1-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-1-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-2-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-2-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-2-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-2-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-2-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-2-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-2-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-2-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-3-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-3-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-3-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-3-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-3-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-3-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-3-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-3-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-4-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-4-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-4-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-4-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-4-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-4-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-4-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-4-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-5-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-5-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-5-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-5-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-5-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-5-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-5-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-5-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-6-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-6-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-6-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-6-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-6-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-6-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-6-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-6-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-0-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-0-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-0-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-0-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-0-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-0-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-0-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-0-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-1-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-1-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-1-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-1-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-1-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-1-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-1-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-1-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-2-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-2-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-2-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-2-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-2-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-2-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-2-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-2-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-3-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-3-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-3-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-3-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-3-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-3-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-3-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-3-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-4-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-4-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-4-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-4-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-4-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-4-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-4-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-4-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-5-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-5-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-5-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-5-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-5-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-5-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-5-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-5-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-6-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-6-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-6-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-6-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-6-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-6-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-6-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-6-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_0-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_0-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_0-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_0-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_0-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_0-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_0-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_0-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_0-4">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_0-4">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_0-5">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_0-5">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_0-6">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_0-6">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_0-7">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_0-7">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_1-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_1-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_1-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_1-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_1-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_1-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_1-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_1-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_1-4">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_1-4">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_1-5">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_1-5">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_1-6">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_1-6">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_1-7">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_1-7">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_2-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_2-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_2-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_2-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_2-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_2-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_2-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_2-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_2-4">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_2-4">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_2-5">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_2-5">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_2-6">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_2-6">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_2-7">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_2-7">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_3-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_3-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_3-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_3-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_3-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_3-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_3-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_3-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_3-4">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_3-4">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_3-5">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_3-5">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_3-6">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_3-6">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_3-7">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_3-7">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_4-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_4-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_4-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_4-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_4-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_4-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_4-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_4-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_4-4">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_4-4">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_4-5">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_4-5">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_4-6">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_4-6">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_4-7">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_4-7">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_5-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_5-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_5-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_5-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_5-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_5-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_5-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_5-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_5-4">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_5-4">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_5-5">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_5-5">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_5-6">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_5-6">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_5-7">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_5-7">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_6-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_6-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_6-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_6-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_6-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_6-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_6-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_6-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_6-4">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_6-4">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_6-5">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_6-5">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_6-6">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_6-6">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_6-7">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_6-7">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+
+    <volume name="volCryostat">
+      <materialref ref="LAr" />
+      <solidref ref="Cryostat" />
+      <physvol>
+        <volumeref ref="volGaseousArgon"/>
+        <position name="posGaseousArgon" unit="cm" x="375.045" y="0" z="0"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volSteelShell"/>
+        <position name="posSteelShell" unit="cm" x="0" y="0" z="0"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volExternalActive"/>
+        <position name="posExternalActive" unit="cm" x="-100/2" y="0" z="0"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-0" unit="cm"
+           x="0" y="-589.5" z="-970.85585"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-1" unit="cm"
+           x="0" y="-421.5" z="-970.85585"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-2" unit="cm"
+           x="0" y="-252.5" z="-970.85585"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-3" unit="cm"
+           x="0" y="-84.5" z="-970.85585"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-4" unit="cm"
+           x="0" y="84.5" z="-970.85585"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-5" unit="cm"
+           x="0" y="252.5" z="-970.85585"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-6" unit="cm"
+           x="0" y="421.5" z="-970.85585"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-7" unit="cm"
+           x="0" y="589.5" z="-970.85585"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-8" unit="cm"
+           x="0" y="-589.5" z="-821.95495"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-9" unit="cm"
+           x="0" y="-421.5" z="-821.95495"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-10" unit="cm"
+           x="0" y="-252.5" z="-821.95495"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-11" unit="cm"
+           x="0" y="-84.5" z="-821.95495"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-12" unit="cm"
+           x="0" y="84.5" z="-821.95495"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-13" unit="cm"
+           x="0" y="252.5" z="-821.95495"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-14" unit="cm"
+           x="0" y="421.5" z="-821.95495"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-15" unit="cm"
+           x="0" y="589.5" z="-821.95495"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-16" unit="cm"
+           x="0" y="-589.5" z="-672.05405"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-17" unit="cm"
+           x="0" y="-421.5" z="-672.05405"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-18" unit="cm"
+           x="0" y="-252.5" z="-672.05405"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-19" unit="cm"
+           x="0" y="-84.5" z="-672.05405"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-20" unit="cm"
+           x="0" y="84.5" z="-672.05405"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-21" unit="cm"
+           x="0" y="252.5" z="-672.05405"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-22" unit="cm"
+           x="0" y="421.5" z="-672.05405"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-23" unit="cm"
+           x="0" y="589.5" z="-672.05405"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-24" unit="cm"
+           x="0" y="-589.5" z="-523.15315"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-25" unit="cm"
+           x="0" y="-421.5" z="-523.15315"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-26" unit="cm"
+           x="0" y="-252.5" z="-523.15315"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-27" unit="cm"
+           x="0" y="-84.5" z="-523.15315"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-28" unit="cm"
+           x="0" y="84.5" z="-523.15315"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-29" unit="cm"
+           x="0" y="252.5" z="-523.15315"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-30" unit="cm"
+           x="0" y="421.5" z="-523.15315"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-31" unit="cm"
+           x="0" y="589.5" z="-523.15315"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-32" unit="cm"
+           x="0" y="-589.5" z="-373.25225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-33" unit="cm"
+           x="0" y="-421.5" z="-373.25225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-34" unit="cm"
+           x="0" y="-252.5" z="-373.25225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-35" unit="cm"
+           x="0" y="-84.5" z="-373.25225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-36" unit="cm"
+           x="0" y="84.5" z="-373.25225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-37" unit="cm"
+           x="0" y="252.5" z="-373.25225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-38" unit="cm"
+           x="0" y="421.5" z="-373.25225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-39" unit="cm"
+           x="0" y="589.5" z="-373.25225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-40" unit="cm"
+           x="0" y="-589.5" z="-224.35135"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-41" unit="cm"
+           x="0" y="-421.5" z="-224.35135"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-42" unit="cm"
+           x="0" y="-252.5" z="-224.35135"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-43" unit="cm"
+           x="0" y="-84.5" z="-224.35135"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-44" unit="cm"
+           x="0" y="84.5" z="-224.35135"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-45" unit="cm"
+           x="0" y="252.5" z="-224.35135"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-46" unit="cm"
+           x="0" y="421.5" z="-224.35135"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-47" unit="cm"
+           x="0" y="589.5" z="-224.35135"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-48" unit="cm"
+           x="0" y="-589.5" z="-74.45045"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-49" unit="cm"
+           x="0" y="-421.5" z="-74.45045"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-50" unit="cm"
+           x="0" y="-252.5" z="-74.45045"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-51" unit="cm"
+           x="0" y="-84.5" z="-74.45045"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-52" unit="cm"
+           x="0" y="84.5" z="-74.45045"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-53" unit="cm"
+           x="0" y="252.5" z="-74.45045"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-54" unit="cm"
+           x="0" y="421.5" z="-74.45045"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-55" unit="cm"
+           x="0" y="589.5" z="-74.45045"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-56" unit="cm"
+           x="0" y="-589.5" z="74.45045"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-57" unit="cm"
+           x="0" y="-421.5" z="74.45045"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-58" unit="cm"
+           x="0" y="-252.5" z="74.45045"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-59" unit="cm"
+           x="0" y="-84.5" z="74.45045"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-60" unit="cm"
+           x="0" y="84.5" z="74.45045"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-61" unit="cm"
+           x="0" y="252.5" z="74.45045"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-62" unit="cm"
+           x="0" y="421.5" z="74.45045"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-63" unit="cm"
+           x="0" y="589.5" z="74.45045"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-64" unit="cm"
+           x="0" y="-589.5" z="224.35135"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-65" unit="cm"
+           x="0" y="-421.5" z="224.35135"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-66" unit="cm"
+           x="0" y="-252.5" z="224.35135"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-67" unit="cm"
+           x="0" y="-84.5" z="224.35135"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-68" unit="cm"
+           x="0" y="84.5" z="224.35135"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-69" unit="cm"
+           x="0" y="252.5" z="224.35135"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-70" unit="cm"
+           x="0" y="421.5" z="224.35135"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-71" unit="cm"
+           x="0" y="589.5" z="224.35135"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-72" unit="cm"
+           x="0" y="-589.5" z="373.25225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-73" unit="cm"
+           x="0" y="-421.5" z="373.25225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-74" unit="cm"
+           x="0" y="-252.5" z="373.25225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-75" unit="cm"
+           x="0" y="-84.5" z="373.25225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-76" unit="cm"
+           x="0" y="84.5" z="373.25225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-77" unit="cm"
+           x="0" y="252.5" z="373.25225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-78" unit="cm"
+           x="0" y="421.5" z="373.25225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-79" unit="cm"
+           x="0" y="589.5" z="373.25225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-80" unit="cm"
+           x="0" y="-589.5" z="523.15315"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-81" unit="cm"
+           x="0" y="-421.5" z="523.15315"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-82" unit="cm"
+           x="0" y="-252.5" z="523.15315"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-83" unit="cm"
+           x="0" y="-84.5" z="523.15315"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-84" unit="cm"
+           x="0" y="84.5" z="523.15315"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-85" unit="cm"
+           x="0" y="252.5" z="523.15315"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-86" unit="cm"
+           x="0" y="421.5" z="523.15315"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-87" unit="cm"
+           x="0" y="589.5" z="523.15315"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-88" unit="cm"
+           x="0" y="-589.5" z="672.05405"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-89" unit="cm"
+           x="0" y="-421.5" z="672.05405"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-90" unit="cm"
+           x="0" y="-252.5" z="672.05405"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-91" unit="cm"
+           x="0" y="-84.5" z="672.05405"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-92" unit="cm"
+           x="0" y="84.5" z="672.05405"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-93" unit="cm"
+           x="0" y="252.5" z="672.05405"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-94" unit="cm"
+           x="0" y="421.5" z="672.05405"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-95" unit="cm"
+           x="0" y="589.5" z="672.05405"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-96" unit="cm"
+           x="0" y="-589.5" z="821.95495"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-97" unit="cm"
+           x="0" y="-421.5" z="821.95495"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-98" unit="cm"
+           x="0" y="-252.5" z="821.95495"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-99" unit="cm"
+           x="0" y="-84.5" z="821.95495"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-100" unit="cm"
+           x="0" y="84.5" z="821.95495"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-101" unit="cm"
+           x="0" y="252.5" z="821.95495"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-102" unit="cm"
+           x="0" y="421.5" z="821.95495"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-103" unit="cm"
+           x="0" y="589.5" z="821.95495"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-104" unit="cm"
+           x="0" y="-589.5" z="970.85585"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-105" unit="cm"
+           x="0" y="-421.5" z="970.85585"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-106" unit="cm"
+           x="0" y="-252.5" z="970.85585"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-107" unit="cm"
+           x="0" y="-84.5" z="970.85585"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-108" unit="cm"
+           x="0" y="84.5" z="970.85585"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-109" unit="cm"
+           x="0" y="252.5" z="970.85585"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-110" unit="cm"
+           x="0" y="421.5" z="970.85585"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-111" unit="cm"
+           x="0" y="589.5" z="970.85585"/>
+      </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper0" unit="cm"  x="-322.04" y="-676.3" z="0" />
+     <rotation name="rotFS0" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper1" unit="cm"  x="-316.04" y="-676.3" z="0" />
+     <rotation name="rotFS1" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper2" unit="cm"  x="-310.04" y="-676.3" z="0" />
+     <rotation name="rotFS2" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper3" unit="cm"  x="-304.04" y="-676.3" z="0" />
+     <rotation name="rotFS3" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper4" unit="cm"  x="-298.04" y="-676.3" z="0" />
+     <rotation name="rotFS4" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper5" unit="cm"  x="-292.04" y="-676.3" z="0" />
+     <rotation name="rotFS5" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper6" unit="cm"  x="-286.04" y="-676.3" z="0" />
+     <rotation name="rotFS6" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper7" unit="cm"  x="-280.04" y="-676.3" z="0" />
+     <rotation name="rotFS7" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper8" unit="cm"  x="-274.04" y="-676.3" z="0" />
+     <rotation name="rotFS8" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper9" unit="cm"  x="-268.04" y="-676.3" z="0" />
+     <rotation name="rotFS9" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper10" unit="cm"  x="-262.04" y="-676.3" z="0" />
+     <rotation name="rotFS10" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper11" unit="cm"  x="-256.04" y="-676.3" z="0" />
+     <rotation name="rotFS11" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper12" unit="cm"  x="-250.04" y="-676.3" z="0" />
+     <rotation name="rotFS12" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper13" unit="cm"  x="-244.04" y="-676.3" z="0" />
+     <rotation name="rotFS13" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper14" unit="cm"  x="-238.04" y="-676.3" z="0" />
+     <rotation name="rotFS14" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper15" unit="cm"  x="-232.04" y="-676.3" z="0" />
+     <rotation name="rotFS15" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper16" unit="cm"  x="-226.04" y="-676.3" z="0" />
+     <rotation name="rotFS16" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper17" unit="cm"  x="-220.04" y="-676.3" z="0" />
+     <rotation name="rotFS17" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper18" unit="cm"  x="-214.04" y="-676.3" z="0" />
+     <rotation name="rotFS18" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper19" unit="cm"  x="-208.04" y="-676.3" z="0" />
+     <rotation name="rotFS19" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper20" unit="cm"  x="-202.04" y="-676.3" z="0" />
+     <rotation name="rotFS20" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper21" unit="cm"  x="-196.04" y="-676.3" z="0" />
+     <rotation name="rotFS21" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper22" unit="cm"  x="-190.04" y="-676.3" z="0" />
+     <rotation name="rotFS22" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper23" unit="cm"  x="-184.04" y="-676.3" z="0" />
+     <rotation name="rotFS23" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper24" unit="cm"  x="-178.04" y="-676.3" z="0" />
+     <rotation name="rotFS24" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper25" unit="cm"  x="-172.04" y="-676.3" z="0" />
+     <rotation name="rotFS25" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper26" unit="cm"  x="-166.04" y="-676.3" z="0" />
+     <rotation name="rotFS26" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper27" unit="cm"  x="-160.04" y="-676.3" z="0" />
+     <rotation name="rotFS27" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper28" unit="cm"  x="-154.04" y="-676.3" z="0" />
+     <rotation name="rotFS28" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper29" unit="cm"  x="-148.04" y="-676.3" z="0" />
+     <rotation name="rotFS29" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper30" unit="cm"  x="-142.04" y="-676.3" z="0" />
+     <rotation name="rotFS30" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper31" unit="cm"  x="-136.04" y="-676.3" z="0" />
+     <rotation name="rotFS31" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper32" unit="cm"  x="-130.04" y="-676.3" z="0" />
+     <rotation name="rotFS32" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper33" unit="cm"  x="-124.04" y="-676.3" z="0" />
+     <rotation name="rotFS33" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper34" unit="cm"  x="-118.04" y="-676.3" z="0" />
+     <rotation name="rotFS34" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper35" unit="cm"  x="-112.04" y="-676.3" z="0" />
+     <rotation name="rotFS35" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper36" unit="cm"  x="-106.04" y="-676.3" z="0" />
+     <rotation name="rotFS36" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper37" unit="cm"  x="-100.04" y="-676.3" z="0" />
+     <rotation name="rotFS37" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper38" unit="cm"  x="-94.04" y="-676.3" z="0" />
+     <rotation name="rotFS38" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper39" unit="cm"  x="-88.04" y="-676.3" z="0" />
+     <rotation name="rotFS39" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper40" unit="cm"  x="-82.04" y="-676.3" z="0" />
+     <rotation name="rotFS40" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper41" unit="cm"  x="-76.04" y="-676.3" z="0" />
+     <rotation name="rotFS41" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper42" unit="cm"  x="-70.04" y="-676.3" z="0" />
+     <rotation name="rotFS42" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper43" unit="cm"  x="-64.04" y="-676.3" z="0" />
+     <rotation name="rotFS43" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper44" unit="cm"  x="-58.04" y="-676.3" z="0" />
+     <rotation name="rotFS44" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper45" unit="cm"  x="-52.04" y="-676.3" z="0" />
+     <rotation name="rotFS45" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper46" unit="cm"  x="-46.04" y="-676.3" z="0" />
+     <rotation name="rotFS46" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper47" unit="cm"  x="-40.04" y="-676.3" z="0" />
+     <rotation name="rotFS47" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper48" unit="cm"  x="-34.04" y="-676.3" z="0" />
+     <rotation name="rotFS48" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper49" unit="cm"  x="-28.04" y="-676.3" z="0" />
+     <rotation name="rotFS49" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper50" unit="cm"  x="-22.04" y="-676.3" z="0" />
+     <rotation name="rotFS50" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper51" unit="cm"  x="-16.04" y="-676.3" z="0" />
+     <rotation name="rotFS51" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper52" unit="cm"  x="-10.04" y="-676.3" z="0" />
+     <rotation name="rotFS52" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper53" unit="cm"  x="-4.04000000000001" y="-676.3" z="0" />
+     <rotation name="rotFS53" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper54" unit="cm"  x="1.95999999999999" y="-676.3" z="0" />
+     <rotation name="rotFS54" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper55" unit="cm"  x="7.95999999999999" y="-676.3" z="0" />
+     <rotation name="rotFS55" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper56" unit="cm"  x="13.96" y="-676.3" z="0" />
+     <rotation name="rotFS56" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper57" unit="cm"  x="19.96" y="-676.3" z="0" />
+     <rotation name="rotFS57" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper58" unit="cm"  x="25.96" y="-676.3" z="0" />
+     <rotation name="rotFS58" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper59" unit="cm"  x="31.96" y="-676.3" z="0" />
+     <rotation name="rotFS59" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper60" unit="cm"  x="37.96" y="-676.3" z="0" />
+     <rotation name="rotFS60" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper61" unit="cm"  x="43.96" y="-676.3" z="0" />
+     <rotation name="rotFS61" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper62" unit="cm"  x="49.96" y="-676.3" z="0" />
+     <rotation name="rotFS62" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper63" unit="cm"  x="55.96" y="-676.3" z="0" />
+     <rotation name="rotFS63" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper64" unit="cm"  x="61.96" y="-676.3" z="0" />
+     <rotation name="rotFS64" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper65" unit="cm"  x="67.96" y="-676.3" z="0" />
+     <rotation name="rotFS65" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper66" unit="cm"  x="73.96" y="-676.3" z="0" />
+     <rotation name="rotFS66" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper67" unit="cm"  x="79.96" y="-676.3" z="0" />
+     <rotation name="rotFS67" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper68" unit="cm"  x="85.96" y="-676.3" z="0" />
+     <rotation name="rotFS68" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper69" unit="cm"  x="91.96" y="-676.3" z="0" />
+     <rotation name="rotFS69" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper70" unit="cm"  x="97.96" y="-676.3" z="0" />
+     <rotation name="rotFS70" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper71" unit="cm"  x="103.96" y="-676.3" z="0" />
+     <rotation name="rotFS71" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper72" unit="cm"  x="109.96" y="-676.3" z="0" />
+     <rotation name="rotFS72" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper73" unit="cm"  x="115.96" y="-676.3" z="0" />
+     <rotation name="rotFS73" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper74" unit="cm"  x="121.96" y="-676.3" z="0" />
+     <rotation name="rotFS74" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper75" unit="cm"  x="127.96" y="-676.3" z="0" />
+     <rotation name="rotFS75" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper76" unit="cm"  x="133.96" y="-676.3" z="0" />
+     <rotation name="rotFS76" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper77" unit="cm"  x="139.96" y="-676.3" z="0" />
+     <rotation name="rotFS77" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper78" unit="cm"  x="145.96" y="-676.3" z="0" />
+     <rotation name="rotFS78" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper79" unit="cm"  x="151.96" y="-676.3" z="0" />
+     <rotation name="rotFS79" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper80" unit="cm"  x="157.96" y="-676.3" z="0" />
+     <rotation name="rotFS80" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper81" unit="cm"  x="163.96" y="-676.3" z="0" />
+     <rotation name="rotFS81" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper82" unit="cm"  x="169.96" y="-676.3" z="0" />
+     <rotation name="rotFS82" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper83" unit="cm"  x="175.96" y="-676.3" z="0" />
+     <rotation name="rotFS83" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper84" unit="cm"  x="181.96" y="-676.3" z="0" />
+     <rotation name="rotFS84" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper85" unit="cm"  x="187.96" y="-676.3" z="0" />
+     <rotation name="rotFS85" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper86" unit="cm"  x="193.96" y="-676.3" z="0" />
+     <rotation name="rotFS86" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper87" unit="cm"  x="199.96" y="-676.3" z="0" />
+     <rotation name="rotFS87" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper88" unit="cm"  x="205.96" y="-676.3" z="0" />
+     <rotation name="rotFS88" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper89" unit="cm"  x="211.96" y="-676.3" z="0" />
+     <rotation name="rotFS89" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper90" unit="cm"  x="217.96" y="-676.3" z="0" />
+     <rotation name="rotFS90" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper91" unit="cm"  x="223.96" y="-676.3" z="0" />
+     <rotation name="rotFS91" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper92" unit="cm"  x="229.96" y="-676.3" z="0" />
+     <rotation name="rotFS92" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper93" unit="cm"  x="235.96" y="-676.3" z="0" />
+     <rotation name="rotFS93" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper94" unit="cm"  x="241.96" y="-676.3" z="0" />
+     <rotation name="rotFS94" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper95" unit="cm"  x="247.96" y="-676.3" z="0" />
+     <rotation name="rotFS95" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper96" unit="cm"  x="253.96" y="-676.3" z="0" />
+     <rotation name="rotFS96" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper97" unit="cm"  x="259.96" y="-676.3" z="0" />
+     <rotation name="rotFS97" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper98" unit="cm"  x="265.96" y="-676.3" z="0" />
+     <rotation name="rotFS98" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper99" unit="cm"  x="271.96" y="-676.3" z="0" />
+     <rotation name="rotFS99" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper100" unit="cm"  x="277.96" y="-676.3" z="0" />
+     <rotation name="rotFS100" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper101" unit="cm"  x="283.96" y="-676.3" z="0" />
+     <rotation name="rotFS101" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper102" unit="cm"  x="289.96" y="-676.3" z="0" />
+     <rotation name="rotFS102" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper103" unit="cm"  x="295.96" y="-676.3" z="0" />
+     <rotation name="rotFS103" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper104" unit="cm"  x="301.96" y="-676.3" z="0" />
+     <rotation name="rotFS104" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper105" unit="cm"  x="307.96" y="-676.3" z="0" />
+     <rotation name="rotFS105" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper106" unit="cm"  x="313.96" y="-676.3" z="0" />
+     <rotation name="rotFS106" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper107" unit="cm"  x="319.96" y="-676.3" z="0" />
+     <rotation name="rotFS107" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-0" unit="cm" x="-328.04" y="-506" z="-896.9054"/>
+      </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-0" unit="cm" 
+         x="325.045" y="-506" z="-896.9054"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-1" unit="cm" x="-328.04" y="-170" z="-896.9054"/>
+      </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-1" unit="cm" 
+         x="325.045" y="-170" z="-896.9054"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-2" unit="cm" x="-328.04" y="166" z="-896.9054"/>
+      </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-2" unit="cm" 
+         x="325.045" y="166" z="-896.9054"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-3" unit="cm" x="-328.04" y="502" z="-896.9054"/>
+      </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-3" unit="cm" 
+         x="325.045" y="502" z="-896.9054"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-4" unit="cm" x="-328.04" y="-506" z="-599.1036"/>
+      </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-4" unit="cm" 
+         x="325.045" y="-506" z="-599.1036"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-5" unit="cm" x="-328.04" y="-170" z="-599.1036"/>
+      </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-5" unit="cm" 
+         x="325.045" y="-170" z="-599.1036"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-6" unit="cm" x="-328.04" y="166" z="-599.1036"/>
+      </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-6" unit="cm" 
+         x="325.045" y="166" z="-599.1036"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-7" unit="cm" x="-328.04" y="502" z="-599.1036"/>
+      </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-7" unit="cm" 
+         x="325.045" y="502" z="-599.1036"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-8" unit="cm" x="-328.04" y="-506" z="-301.3018"/>
+      </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-8" unit="cm" 
+         x="325.045" y="-506" z="-301.3018"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-9" unit="cm" x="-328.04" y="-170" z="-301.3018"/>
+      </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-9" unit="cm" 
+         x="325.045" y="-170" z="-301.3018"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-10" unit="cm" x="-328.04" y="166" z="-301.3018"/>
+      </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-10" unit="cm" 
+         x="325.045" y="166" z="-301.3018"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-11" unit="cm" x="-328.04" y="502" z="-301.3018"/>
+      </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-11" unit="cm" 
+         x="325.045" y="502" z="-301.3018"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-12" unit="cm" x="-328.04" y="-506" z="-3.49999999999989"/>
+      </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-12" unit="cm" 
+         x="325.045" y="-506" z="-3.49999999999989"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-13" unit="cm" x="-328.04" y="-170" z="-3.49999999999989"/>
+      </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-13" unit="cm" 
+         x="325.045" y="-170" z="-3.49999999999989"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-14" unit="cm" x="-328.04" y="166" z="-3.49999999999989"/>
+      </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-14" unit="cm" 
+         x="325.045" y="166" z="-3.49999999999989"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-15" unit="cm" x="-328.04" y="502" z="-3.49999999999989"/>
+      </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-15" unit="cm" 
+         x="325.045" y="502" z="-3.49999999999989"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-16" unit="cm" x="-328.04" y="-506" z="294.3018"/>
+      </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-16" unit="cm" 
+         x="325.045" y="-506" z="294.3018"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-17" unit="cm" x="-328.04" y="-170" z="294.3018"/>
+      </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-17" unit="cm" 
+         x="325.045" y="-170" z="294.3018"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-18" unit="cm" x="-328.04" y="166" z="294.3018"/>
+      </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-18" unit="cm" 
+         x="325.045" y="166" z="294.3018"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-19" unit="cm" x="-328.04" y="502" z="294.3018"/>
+      </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-19" unit="cm" 
+         x="325.045" y="502" z="294.3018"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-20" unit="cm" x="-328.04" y="-506" z="592.1036"/>
+      </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-20" unit="cm" 
+         x="325.045" y="-506" z="592.1036"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-21" unit="cm" x="-328.04" y="-170" z="592.1036"/>
+      </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-21" unit="cm" 
+         x="325.045" y="-170" z="592.1036"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-22" unit="cm" x="-328.04" y="166" z="592.1036"/>
+      </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-22" unit="cm" 
+         x="325.045" y="166" z="592.1036"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-23" unit="cm" x="-328.04" y="502" z="592.1036"/>
+      </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-23" unit="cm" 
+         x="325.045" y="502" z="592.1036"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-24" unit="cm" x="-328.04" y="-506" z="889.9054"/>
+      </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-24" unit="cm" 
+         x="325.045" y="-506" z="889.9054"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-25" unit="cm" x="-328.04" y="-170" z="889.9054"/>
+      </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-25" unit="cm" 
+         x="325.045" y="-170" z="889.9054"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-26" unit="cm" x="-328.04" y="166" z="889.9054"/>
+      </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-26" unit="cm" 
+         x="325.045" y="166" z="889.9054"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-27" unit="cm" x="-328.04" y="502" z="889.9054"/>
+      </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-27" unit="cm" 
+         x="325.045" y="502" z="889.9054"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-0-0"/>
+       <position name="posArapucaDouble0-Frame-0-0" unit="cm" 
+         x="-328.04"
+	 y="-633.7" 
+	 z="-859.4054"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-0"/>
+       <position name="posOpArapucaDouble0-Frame-0-0" unit="cm" 
+         x="-327.3"
+	 y="-633.7" 
+	 z="-859.4054"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-0-1"/>
+       <position name="posArapucaDouble1-Frame-0-0" unit="cm" 
+         x="-328.04"
+	 y="-543" 
+	 z="-1005.4054"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-1"/>
+       <position name="posOpArapucaDouble1-Frame-0-0" unit="cm" 
+         x="-327.3"
+	 y="-543" 
+	 z="-1005.4054"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-0-2"/>
+       <position name="posArapucaDouble2-Frame-0-0" unit="cm" 
+         x="-328.04"
+	 y="-469" 
+	 z="-788.4054"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-2"/>
+       <position name="posOpArapucaDouble2-Frame-0-0" unit="cm" 
+         x="-327.3"
+	 y="-469" 
+	 z="-788.4054"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-0-3"/>
+       <position name="posArapucaDouble3-Frame-0-0" unit="cm" 
+         x="-328.04"
+	 y="-378.3" 
+	 z="-934.4054"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-3"/>
+       <position name="posOpArapucaDouble3-Frame-0-0" unit="cm" 
+         x="-327.3"
+	 y="-378.3" 
+	 z="-934.4054"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-1-0"/>
+       <position name="posArapucaDouble0-Frame-0-1" unit="cm" 
+         x="-328.04"
+	 y="-633.7" 
+	 z="-561.6036"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-0"/>
+       <position name="posOpArapucaDouble0-Frame-0-1" unit="cm" 
+         x="-327.3"
+	 y="-633.7" 
+	 z="-561.6036"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-1-1"/>
+       <position name="posArapucaDouble1-Frame-0-1" unit="cm" 
+         x="-328.04"
+	 y="-543" 
+	 z="-707.6036"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-1"/>
+       <position name="posOpArapucaDouble1-Frame-0-1" unit="cm" 
+         x="-327.3"
+	 y="-543" 
+	 z="-707.6036"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-1-2"/>
+       <position name="posArapucaDouble2-Frame-0-1" unit="cm" 
+         x="-328.04"
+	 y="-469" 
+	 z="-490.6036"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-2"/>
+       <position name="posOpArapucaDouble2-Frame-0-1" unit="cm" 
+         x="-327.3"
+	 y="-469" 
+	 z="-490.6036"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-1-3"/>
+       <position name="posArapucaDouble3-Frame-0-1" unit="cm" 
+         x="-328.04"
+	 y="-378.3" 
+	 z="-636.6036"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-3"/>
+       <position name="posOpArapucaDouble3-Frame-0-1" unit="cm" 
+         x="-327.3"
+	 y="-378.3" 
+	 z="-636.6036"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-2-0"/>
+       <position name="posArapucaDouble0-Frame-0-2" unit="cm" 
+         x="-328.04"
+	 y="-633.7" 
+	 z="-263.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-0"/>
+       <position name="posOpArapucaDouble0-Frame-0-2" unit="cm" 
+         x="-327.3"
+	 y="-633.7" 
+	 z="-263.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-2-1"/>
+       <position name="posArapucaDouble1-Frame-0-2" unit="cm" 
+         x="-328.04"
+	 y="-543" 
+	 z="-409.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-1"/>
+       <position name="posOpArapucaDouble1-Frame-0-2" unit="cm" 
+         x="-327.3"
+	 y="-543" 
+	 z="-409.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-2-2"/>
+       <position name="posArapucaDouble2-Frame-0-2" unit="cm" 
+         x="-328.04"
+	 y="-469" 
+	 z="-192.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-2"/>
+       <position name="posOpArapucaDouble2-Frame-0-2" unit="cm" 
+         x="-327.3"
+	 y="-469" 
+	 z="-192.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-2-3"/>
+       <position name="posArapucaDouble3-Frame-0-2" unit="cm" 
+         x="-328.04"
+	 y="-378.3" 
+	 z="-338.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-3"/>
+       <position name="posOpArapucaDouble3-Frame-0-2" unit="cm" 
+         x="-327.3"
+	 y="-378.3" 
+	 z="-338.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-3-0"/>
+       <position name="posArapucaDouble0-Frame-0-3" unit="cm" 
+         x="-328.04"
+	 y="-633.7" 
+	 z="34.0000000000001"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-3-0"/>
+       <position name="posOpArapucaDouble0-Frame-0-3" unit="cm" 
+         x="-327.3"
+	 y="-633.7" 
+	 z="34.0000000000001"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-3-1"/>
+       <position name="posArapucaDouble1-Frame-0-3" unit="cm" 
+         x="-328.04"
+	 y="-543" 
+	 z="-112"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-3-1"/>
+       <position name="posOpArapucaDouble1-Frame-0-3" unit="cm" 
+         x="-327.3"
+	 y="-543" 
+	 z="-112"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-3-2"/>
+       <position name="posArapucaDouble2-Frame-0-3" unit="cm" 
+         x="-328.04"
+	 y="-469" 
+	 z="105"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-3-2"/>
+       <position name="posOpArapucaDouble2-Frame-0-3" unit="cm" 
+         x="-327.3"
+	 y="-469" 
+	 z="105"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-3-3"/>
+       <position name="posArapucaDouble3-Frame-0-3" unit="cm" 
+         x="-328.04"
+	 y="-378.3" 
+	 z="-40.9999999999999"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-3-3"/>
+       <position name="posOpArapucaDouble3-Frame-0-3" unit="cm" 
+         x="-327.3"
+	 y="-378.3" 
+	 z="-40.9999999999999"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-4-0"/>
+       <position name="posArapucaDouble0-Frame-0-4" unit="cm" 
+         x="-328.04"
+	 y="-633.7" 
+	 z="331.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-4-0"/>
+       <position name="posOpArapucaDouble0-Frame-0-4" unit="cm" 
+         x="-327.3"
+	 y="-633.7" 
+	 z="331.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-4-1"/>
+       <position name="posArapucaDouble1-Frame-0-4" unit="cm" 
+         x="-328.04"
+	 y="-543" 
+	 z="185.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-4-1"/>
+       <position name="posOpArapucaDouble1-Frame-0-4" unit="cm" 
+         x="-327.3"
+	 y="-543" 
+	 z="185.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-4-2"/>
+       <position name="posArapucaDouble2-Frame-0-4" unit="cm" 
+         x="-328.04"
+	 y="-469" 
+	 z="402.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-4-2"/>
+       <position name="posOpArapucaDouble2-Frame-0-4" unit="cm" 
+         x="-327.3"
+	 y="-469" 
+	 z="402.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-4-3"/>
+       <position name="posArapucaDouble3-Frame-0-4" unit="cm" 
+         x="-328.04"
+	 y="-378.3" 
+	 z="256.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-4-3"/>
+       <position name="posOpArapucaDouble3-Frame-0-4" unit="cm" 
+         x="-327.3"
+	 y="-378.3" 
+	 z="256.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-5-0"/>
+       <position name="posArapucaDouble0-Frame-0-5" unit="cm" 
+         x="-328.04"
+	 y="-633.7" 
+	 z="629.6036"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-5-0"/>
+       <position name="posOpArapucaDouble0-Frame-0-5" unit="cm" 
+         x="-327.3"
+	 y="-633.7" 
+	 z="629.6036"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-5-1"/>
+       <position name="posArapucaDouble1-Frame-0-5" unit="cm" 
+         x="-328.04"
+	 y="-543" 
+	 z="483.6036"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-5-1"/>
+       <position name="posOpArapucaDouble1-Frame-0-5" unit="cm" 
+         x="-327.3"
+	 y="-543" 
+	 z="483.6036"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-5-2"/>
+       <position name="posArapucaDouble2-Frame-0-5" unit="cm" 
+         x="-328.04"
+	 y="-469" 
+	 z="700.6036"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-5-2"/>
+       <position name="posOpArapucaDouble2-Frame-0-5" unit="cm" 
+         x="-327.3"
+	 y="-469" 
+	 z="700.6036"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-5-3"/>
+       <position name="posArapucaDouble3-Frame-0-5" unit="cm" 
+         x="-328.04"
+	 y="-378.3" 
+	 z="554.6036"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-5-3"/>
+       <position name="posOpArapucaDouble3-Frame-0-5" unit="cm" 
+         x="-327.3"
+	 y="-378.3" 
+	 z="554.6036"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-6-0"/>
+       <position name="posArapucaDouble0-Frame-0-6" unit="cm" 
+         x="-328.04"
+	 y="-633.7" 
+	 z="927.4054"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-6-0"/>
+       <position name="posOpArapucaDouble0-Frame-0-6" unit="cm" 
+         x="-327.3"
+	 y="-633.7" 
+	 z="927.4054"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-6-1"/>
+       <position name="posArapucaDouble1-Frame-0-6" unit="cm" 
+         x="-328.04"
+	 y="-543" 
+	 z="781.4054"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-6-1"/>
+       <position name="posOpArapucaDouble1-Frame-0-6" unit="cm" 
+         x="-327.3"
+	 y="-543" 
+	 z="781.4054"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-6-2"/>
+       <position name="posArapucaDouble2-Frame-0-6" unit="cm" 
+         x="-328.04"
+	 y="-469" 
+	 z="998.4054"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-6-2"/>
+       <position name="posOpArapucaDouble2-Frame-0-6" unit="cm" 
+         x="-327.3"
+	 y="-469" 
+	 z="998.4054"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-6-3"/>
+       <position name="posArapucaDouble3-Frame-0-6" unit="cm" 
+         x="-328.04"
+	 y="-378.3" 
+	 z="852.4054"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-6-3"/>
+       <position name="posOpArapucaDouble3-Frame-0-6" unit="cm" 
+         x="-327.3"
+	 y="-378.3" 
+	 z="852.4054"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-0-0"/>
+       <position name="posArapucaDouble0-Frame-1-0" unit="cm" 
+         x="-328.04"
+	 y="-297.7" 
+	 z="-859.4054"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-0"/>
+       <position name="posOpArapucaDouble0-Frame-1-0" unit="cm" 
+         x="-327.3"
+	 y="-297.7" 
+	 z="-859.4054"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-0-1"/>
+       <position name="posArapucaDouble1-Frame-1-0" unit="cm" 
+         x="-328.04"
+	 y="-207" 
+	 z="-1005.4054"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-1"/>
+       <position name="posOpArapucaDouble1-Frame-1-0" unit="cm" 
+         x="-327.3"
+	 y="-207" 
+	 z="-1005.4054"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-0-2"/>
+       <position name="posArapucaDouble2-Frame-1-0" unit="cm" 
+         x="-328.04"
+	 y="-133" 
+	 z="-788.4054"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-2"/>
+       <position name="posOpArapucaDouble2-Frame-1-0" unit="cm" 
+         x="-327.3"
+	 y="-133" 
+	 z="-788.4054"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-0-3"/>
+       <position name="posArapucaDouble3-Frame-1-0" unit="cm" 
+         x="-328.04"
+	 y="-42.3" 
+	 z="-934.4054"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-3"/>
+       <position name="posOpArapucaDouble3-Frame-1-0" unit="cm" 
+         x="-327.3"
+	 y="-42.3" 
+	 z="-934.4054"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-1-0"/>
+       <position name="posArapucaDouble0-Frame-1-1" unit="cm" 
+         x="-328.04"
+	 y="-297.7" 
+	 z="-561.6036"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-0"/>
+       <position name="posOpArapucaDouble0-Frame-1-1" unit="cm" 
+         x="-327.3"
+	 y="-297.7" 
+	 z="-561.6036"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-1-1"/>
+       <position name="posArapucaDouble1-Frame-1-1" unit="cm" 
+         x="-328.04"
+	 y="-207" 
+	 z="-707.6036"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-1"/>
+       <position name="posOpArapucaDouble1-Frame-1-1" unit="cm" 
+         x="-327.3"
+	 y="-207" 
+	 z="-707.6036"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-1-2"/>
+       <position name="posArapucaDouble2-Frame-1-1" unit="cm" 
+         x="-328.04"
+	 y="-133" 
+	 z="-490.6036"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-2"/>
+       <position name="posOpArapucaDouble2-Frame-1-1" unit="cm" 
+         x="-327.3"
+	 y="-133" 
+	 z="-490.6036"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-1-3"/>
+       <position name="posArapucaDouble3-Frame-1-1" unit="cm" 
+         x="-328.04"
+	 y="-42.3" 
+	 z="-636.6036"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-3"/>
+       <position name="posOpArapucaDouble3-Frame-1-1" unit="cm" 
+         x="-327.3"
+	 y="-42.3" 
+	 z="-636.6036"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-2-0"/>
+       <position name="posArapucaDouble0-Frame-1-2" unit="cm" 
+         x="-328.04"
+	 y="-297.7" 
+	 z="-263.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-0"/>
+       <position name="posOpArapucaDouble0-Frame-1-2" unit="cm" 
+         x="-327.3"
+	 y="-297.7" 
+	 z="-263.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-2-1"/>
+       <position name="posArapucaDouble1-Frame-1-2" unit="cm" 
+         x="-328.04"
+	 y="-207" 
+	 z="-409.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-1"/>
+       <position name="posOpArapucaDouble1-Frame-1-2" unit="cm" 
+         x="-327.3"
+	 y="-207" 
+	 z="-409.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-2-2"/>
+       <position name="posArapucaDouble2-Frame-1-2" unit="cm" 
+         x="-328.04"
+	 y="-133" 
+	 z="-192.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-2"/>
+       <position name="posOpArapucaDouble2-Frame-1-2" unit="cm" 
+         x="-327.3"
+	 y="-133" 
+	 z="-192.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-2-3"/>
+       <position name="posArapucaDouble3-Frame-1-2" unit="cm" 
+         x="-328.04"
+	 y="-42.3" 
+	 z="-338.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-3"/>
+       <position name="posOpArapucaDouble3-Frame-1-2" unit="cm" 
+         x="-327.3"
+	 y="-42.3" 
+	 z="-338.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-3-0"/>
+       <position name="posArapucaDouble0-Frame-1-3" unit="cm" 
+         x="-328.04"
+	 y="-297.7" 
+	 z="34.0000000000001"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-3-0"/>
+       <position name="posOpArapucaDouble0-Frame-1-3" unit="cm" 
+         x="-327.3"
+	 y="-297.7" 
+	 z="34.0000000000001"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-3-1"/>
+       <position name="posArapucaDouble1-Frame-1-3" unit="cm" 
+         x="-328.04"
+	 y="-207" 
+	 z="-112"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-3-1"/>
+       <position name="posOpArapucaDouble1-Frame-1-3" unit="cm" 
+         x="-327.3"
+	 y="-207" 
+	 z="-112"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-3-2"/>
+       <position name="posArapucaDouble2-Frame-1-3" unit="cm" 
+         x="-328.04"
+	 y="-133" 
+	 z="105"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-3-2"/>
+       <position name="posOpArapucaDouble2-Frame-1-3" unit="cm" 
+         x="-327.3"
+	 y="-133" 
+	 z="105"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-3-3"/>
+       <position name="posArapucaDouble3-Frame-1-3" unit="cm" 
+         x="-328.04"
+	 y="-42.3" 
+	 z="-40.9999999999999"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-3-3"/>
+       <position name="posOpArapucaDouble3-Frame-1-3" unit="cm" 
+         x="-327.3"
+	 y="-42.3" 
+	 z="-40.9999999999999"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-4-0"/>
+       <position name="posArapucaDouble0-Frame-1-4" unit="cm" 
+         x="-328.04"
+	 y="-297.7" 
+	 z="331.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-4-0"/>
+       <position name="posOpArapucaDouble0-Frame-1-4" unit="cm" 
+         x="-327.3"
+	 y="-297.7" 
+	 z="331.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-4-1"/>
+       <position name="posArapucaDouble1-Frame-1-4" unit="cm" 
+         x="-328.04"
+	 y="-207" 
+	 z="185.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-4-1"/>
+       <position name="posOpArapucaDouble1-Frame-1-4" unit="cm" 
+         x="-327.3"
+	 y="-207" 
+	 z="185.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-4-2"/>
+       <position name="posArapucaDouble2-Frame-1-4" unit="cm" 
+         x="-328.04"
+	 y="-133" 
+	 z="402.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-4-2"/>
+       <position name="posOpArapucaDouble2-Frame-1-4" unit="cm" 
+         x="-327.3"
+	 y="-133" 
+	 z="402.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-4-3"/>
+       <position name="posArapucaDouble3-Frame-1-4" unit="cm" 
+         x="-328.04"
+	 y="-42.3" 
+	 z="256.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-4-3"/>
+       <position name="posOpArapucaDouble3-Frame-1-4" unit="cm" 
+         x="-327.3"
+	 y="-42.3" 
+	 z="256.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-5-0"/>
+       <position name="posArapucaDouble0-Frame-1-5" unit="cm" 
+         x="-328.04"
+	 y="-297.7" 
+	 z="629.6036"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-5-0"/>
+       <position name="posOpArapucaDouble0-Frame-1-5" unit="cm" 
+         x="-327.3"
+	 y="-297.7" 
+	 z="629.6036"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-5-1"/>
+       <position name="posArapucaDouble1-Frame-1-5" unit="cm" 
+         x="-328.04"
+	 y="-207" 
+	 z="483.6036"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-5-1"/>
+       <position name="posOpArapucaDouble1-Frame-1-5" unit="cm" 
+         x="-327.3"
+	 y="-207" 
+	 z="483.6036"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-5-2"/>
+       <position name="posArapucaDouble2-Frame-1-5" unit="cm" 
+         x="-328.04"
+	 y="-133" 
+	 z="700.6036"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-5-2"/>
+       <position name="posOpArapucaDouble2-Frame-1-5" unit="cm" 
+         x="-327.3"
+	 y="-133" 
+	 z="700.6036"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-5-3"/>
+       <position name="posArapucaDouble3-Frame-1-5" unit="cm" 
+         x="-328.04"
+	 y="-42.3" 
+	 z="554.6036"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-5-3"/>
+       <position name="posOpArapucaDouble3-Frame-1-5" unit="cm" 
+         x="-327.3"
+	 y="-42.3" 
+	 z="554.6036"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-6-0"/>
+       <position name="posArapucaDouble0-Frame-1-6" unit="cm" 
+         x="-328.04"
+	 y="-297.7" 
+	 z="927.4054"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-6-0"/>
+       <position name="posOpArapucaDouble0-Frame-1-6" unit="cm" 
+         x="-327.3"
+	 y="-297.7" 
+	 z="927.4054"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-6-1"/>
+       <position name="posArapucaDouble1-Frame-1-6" unit="cm" 
+         x="-328.04"
+	 y="-207" 
+	 z="781.4054"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-6-1"/>
+       <position name="posOpArapucaDouble1-Frame-1-6" unit="cm" 
+         x="-327.3"
+	 y="-207" 
+	 z="781.4054"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-6-2"/>
+       <position name="posArapucaDouble2-Frame-1-6" unit="cm" 
+         x="-328.04"
+	 y="-133" 
+	 z="998.4054"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-6-2"/>
+       <position name="posOpArapucaDouble2-Frame-1-6" unit="cm" 
+         x="-327.3"
+	 y="-133" 
+	 z="998.4054"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-6-3"/>
+       <position name="posArapucaDouble3-Frame-1-6" unit="cm" 
+         x="-328.04"
+	 y="-42.3" 
+	 z="852.4054"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-6-3"/>
+       <position name="posOpArapucaDouble3-Frame-1-6" unit="cm" 
+         x="-327.3"
+	 y="-42.3" 
+	 z="852.4054"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-0-0"/>
+       <position name="posArapucaDouble0-Frame-2-0" unit="cm" 
+         x="-328.04"
+	 y="38.3" 
+	 z="-859.4054"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-0"/>
+       <position name="posOpArapucaDouble0-Frame-2-0" unit="cm" 
+         x="-327.3"
+	 y="38.3" 
+	 z="-859.4054"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-0-1"/>
+       <position name="posArapucaDouble1-Frame-2-0" unit="cm" 
+         x="-328.04"
+	 y="129" 
+	 z="-1005.4054"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-1"/>
+       <position name="posOpArapucaDouble1-Frame-2-0" unit="cm" 
+         x="-327.3"
+	 y="129" 
+	 z="-1005.4054"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-0-2"/>
+       <position name="posArapucaDouble2-Frame-2-0" unit="cm" 
+         x="-328.04"
+	 y="203" 
+	 z="-788.4054"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-2"/>
+       <position name="posOpArapucaDouble2-Frame-2-0" unit="cm" 
+         x="-327.3"
+	 y="203" 
+	 z="-788.4054"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-0-3"/>
+       <position name="posArapucaDouble3-Frame-2-0" unit="cm" 
+         x="-328.04"
+	 y="293.7" 
+	 z="-934.4054"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-3"/>
+       <position name="posOpArapucaDouble3-Frame-2-0" unit="cm" 
+         x="-327.3"
+	 y="293.7" 
+	 z="-934.4054"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-1-0"/>
+       <position name="posArapucaDouble0-Frame-2-1" unit="cm" 
+         x="-328.04"
+	 y="38.3" 
+	 z="-561.6036"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-0"/>
+       <position name="posOpArapucaDouble0-Frame-2-1" unit="cm" 
+         x="-327.3"
+	 y="38.3" 
+	 z="-561.6036"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-1-1"/>
+       <position name="posArapucaDouble1-Frame-2-1" unit="cm" 
+         x="-328.04"
+	 y="129" 
+	 z="-707.6036"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-1"/>
+       <position name="posOpArapucaDouble1-Frame-2-1" unit="cm" 
+         x="-327.3"
+	 y="129" 
+	 z="-707.6036"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-1-2"/>
+       <position name="posArapucaDouble2-Frame-2-1" unit="cm" 
+         x="-328.04"
+	 y="203" 
+	 z="-490.6036"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-2"/>
+       <position name="posOpArapucaDouble2-Frame-2-1" unit="cm" 
+         x="-327.3"
+	 y="203" 
+	 z="-490.6036"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-1-3"/>
+       <position name="posArapucaDouble3-Frame-2-1" unit="cm" 
+         x="-328.04"
+	 y="293.7" 
+	 z="-636.6036"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-3"/>
+       <position name="posOpArapucaDouble3-Frame-2-1" unit="cm" 
+         x="-327.3"
+	 y="293.7" 
+	 z="-636.6036"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-2-0"/>
+       <position name="posArapucaDouble0-Frame-2-2" unit="cm" 
+         x="-328.04"
+	 y="38.3" 
+	 z="-263.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-0"/>
+       <position name="posOpArapucaDouble0-Frame-2-2" unit="cm" 
+         x="-327.3"
+	 y="38.3" 
+	 z="-263.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-2-1"/>
+       <position name="posArapucaDouble1-Frame-2-2" unit="cm" 
+         x="-328.04"
+	 y="129" 
+	 z="-409.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-1"/>
+       <position name="posOpArapucaDouble1-Frame-2-2" unit="cm" 
+         x="-327.3"
+	 y="129" 
+	 z="-409.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-2-2"/>
+       <position name="posArapucaDouble2-Frame-2-2" unit="cm" 
+         x="-328.04"
+	 y="203" 
+	 z="-192.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-2"/>
+       <position name="posOpArapucaDouble2-Frame-2-2" unit="cm" 
+         x="-327.3"
+	 y="203" 
+	 z="-192.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-2-3"/>
+       <position name="posArapucaDouble3-Frame-2-2" unit="cm" 
+         x="-328.04"
+	 y="293.7" 
+	 z="-338.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-3"/>
+       <position name="posOpArapucaDouble3-Frame-2-2" unit="cm" 
+         x="-327.3"
+	 y="293.7" 
+	 z="-338.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-3-0"/>
+       <position name="posArapucaDouble0-Frame-2-3" unit="cm" 
+         x="-328.04"
+	 y="38.3" 
+	 z="34.0000000000001"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-3-0"/>
+       <position name="posOpArapucaDouble0-Frame-2-3" unit="cm" 
+         x="-327.3"
+	 y="38.3" 
+	 z="34.0000000000001"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-3-1"/>
+       <position name="posArapucaDouble1-Frame-2-3" unit="cm" 
+         x="-328.04"
+	 y="129" 
+	 z="-112"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-3-1"/>
+       <position name="posOpArapucaDouble1-Frame-2-3" unit="cm" 
+         x="-327.3"
+	 y="129" 
+	 z="-112"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-3-2"/>
+       <position name="posArapucaDouble2-Frame-2-3" unit="cm" 
+         x="-328.04"
+	 y="203" 
+	 z="105"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-3-2"/>
+       <position name="posOpArapucaDouble2-Frame-2-3" unit="cm" 
+         x="-327.3"
+	 y="203" 
+	 z="105"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-3-3"/>
+       <position name="posArapucaDouble3-Frame-2-3" unit="cm" 
+         x="-328.04"
+	 y="293.7" 
+	 z="-40.9999999999999"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-3-3"/>
+       <position name="posOpArapucaDouble3-Frame-2-3" unit="cm" 
+         x="-327.3"
+	 y="293.7" 
+	 z="-40.9999999999999"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-4-0"/>
+       <position name="posArapucaDouble0-Frame-2-4" unit="cm" 
+         x="-328.04"
+	 y="38.3" 
+	 z="331.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-4-0"/>
+       <position name="posOpArapucaDouble0-Frame-2-4" unit="cm" 
+         x="-327.3"
+	 y="38.3" 
+	 z="331.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-4-1"/>
+       <position name="posArapucaDouble1-Frame-2-4" unit="cm" 
+         x="-328.04"
+	 y="129" 
+	 z="185.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-4-1"/>
+       <position name="posOpArapucaDouble1-Frame-2-4" unit="cm" 
+         x="-327.3"
+	 y="129" 
+	 z="185.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-4-2"/>
+       <position name="posArapucaDouble2-Frame-2-4" unit="cm" 
+         x="-328.04"
+	 y="203" 
+	 z="402.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-4-2"/>
+       <position name="posOpArapucaDouble2-Frame-2-4" unit="cm" 
+         x="-327.3"
+	 y="203" 
+	 z="402.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-4-3"/>
+       <position name="posArapucaDouble3-Frame-2-4" unit="cm" 
+         x="-328.04"
+	 y="293.7" 
+	 z="256.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-4-3"/>
+       <position name="posOpArapucaDouble3-Frame-2-4" unit="cm" 
+         x="-327.3"
+	 y="293.7" 
+	 z="256.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-5-0"/>
+       <position name="posArapucaDouble0-Frame-2-5" unit="cm" 
+         x="-328.04"
+	 y="38.3" 
+	 z="629.6036"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-5-0"/>
+       <position name="posOpArapucaDouble0-Frame-2-5" unit="cm" 
+         x="-327.3"
+	 y="38.3" 
+	 z="629.6036"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-5-1"/>
+       <position name="posArapucaDouble1-Frame-2-5" unit="cm" 
+         x="-328.04"
+	 y="129" 
+	 z="483.6036"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-5-1"/>
+       <position name="posOpArapucaDouble1-Frame-2-5" unit="cm" 
+         x="-327.3"
+	 y="129" 
+	 z="483.6036"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-5-2"/>
+       <position name="posArapucaDouble2-Frame-2-5" unit="cm" 
+         x="-328.04"
+	 y="203" 
+	 z="700.6036"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-5-2"/>
+       <position name="posOpArapucaDouble2-Frame-2-5" unit="cm" 
+         x="-327.3"
+	 y="203" 
+	 z="700.6036"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-5-3"/>
+       <position name="posArapucaDouble3-Frame-2-5" unit="cm" 
+         x="-328.04"
+	 y="293.7" 
+	 z="554.6036"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-5-3"/>
+       <position name="posOpArapucaDouble3-Frame-2-5" unit="cm" 
+         x="-327.3"
+	 y="293.7" 
+	 z="554.6036"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-6-0"/>
+       <position name="posArapucaDouble0-Frame-2-6" unit="cm" 
+         x="-328.04"
+	 y="38.3" 
+	 z="927.4054"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-6-0"/>
+       <position name="posOpArapucaDouble0-Frame-2-6" unit="cm" 
+         x="-327.3"
+	 y="38.3" 
+	 z="927.4054"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-6-1"/>
+       <position name="posArapucaDouble1-Frame-2-6" unit="cm" 
+         x="-328.04"
+	 y="129" 
+	 z="781.4054"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-6-1"/>
+       <position name="posOpArapucaDouble1-Frame-2-6" unit="cm" 
+         x="-327.3"
+	 y="129" 
+	 z="781.4054"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-6-2"/>
+       <position name="posArapucaDouble2-Frame-2-6" unit="cm" 
+         x="-328.04"
+	 y="203" 
+	 z="998.4054"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-6-2"/>
+       <position name="posOpArapucaDouble2-Frame-2-6" unit="cm" 
+         x="-327.3"
+	 y="203" 
+	 z="998.4054"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-6-3"/>
+       <position name="posArapucaDouble3-Frame-2-6" unit="cm" 
+         x="-328.04"
+	 y="293.7" 
+	 z="852.4054"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-6-3"/>
+       <position name="posOpArapucaDouble3-Frame-2-6" unit="cm" 
+         x="-327.3"
+	 y="293.7" 
+	 z="852.4054"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-0-0"/>
+       <position name="posArapucaDouble0-Frame-3-0" unit="cm" 
+         x="-328.04"
+	 y="374.3" 
+	 z="-859.4054"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-0"/>
+       <position name="posOpArapucaDouble0-Frame-3-0" unit="cm" 
+         x="-327.3"
+	 y="374.3" 
+	 z="-859.4054"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-0-1"/>
+       <position name="posArapucaDouble1-Frame-3-0" unit="cm" 
+         x="-328.04"
+	 y="465" 
+	 z="-1005.4054"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-1"/>
+       <position name="posOpArapucaDouble1-Frame-3-0" unit="cm" 
+         x="-327.3"
+	 y="465" 
+	 z="-1005.4054"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-0-2"/>
+       <position name="posArapucaDouble2-Frame-3-0" unit="cm" 
+         x="-328.04"
+	 y="539" 
+	 z="-788.4054"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-2"/>
+       <position name="posOpArapucaDouble2-Frame-3-0" unit="cm" 
+         x="-327.3"
+	 y="539" 
+	 z="-788.4054"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-0-3"/>
+       <position name="posArapucaDouble3-Frame-3-0" unit="cm" 
+         x="-328.04"
+	 y="629.7" 
+	 z="-934.4054"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-3"/>
+       <position name="posOpArapucaDouble3-Frame-3-0" unit="cm" 
+         x="-327.3"
+	 y="629.7" 
+	 z="-934.4054"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-1-0"/>
+       <position name="posArapucaDouble0-Frame-3-1" unit="cm" 
+         x="-328.04"
+	 y="374.3" 
+	 z="-561.6036"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-0"/>
+       <position name="posOpArapucaDouble0-Frame-3-1" unit="cm" 
+         x="-327.3"
+	 y="374.3" 
+	 z="-561.6036"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-1-1"/>
+       <position name="posArapucaDouble1-Frame-3-1" unit="cm" 
+         x="-328.04"
+	 y="465" 
+	 z="-707.6036"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-1"/>
+       <position name="posOpArapucaDouble1-Frame-3-1" unit="cm" 
+         x="-327.3"
+	 y="465" 
+	 z="-707.6036"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-1-2"/>
+       <position name="posArapucaDouble2-Frame-3-1" unit="cm" 
+         x="-328.04"
+	 y="539" 
+	 z="-490.6036"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-2"/>
+       <position name="posOpArapucaDouble2-Frame-3-1" unit="cm" 
+         x="-327.3"
+	 y="539" 
+	 z="-490.6036"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-1-3"/>
+       <position name="posArapucaDouble3-Frame-3-1" unit="cm" 
+         x="-328.04"
+	 y="629.7" 
+	 z="-636.6036"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-3"/>
+       <position name="posOpArapucaDouble3-Frame-3-1" unit="cm" 
+         x="-327.3"
+	 y="629.7" 
+	 z="-636.6036"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-2-0"/>
+       <position name="posArapucaDouble0-Frame-3-2" unit="cm" 
+         x="-328.04"
+	 y="374.3" 
+	 z="-263.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-0"/>
+       <position name="posOpArapucaDouble0-Frame-3-2" unit="cm" 
+         x="-327.3"
+	 y="374.3" 
+	 z="-263.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-2-1"/>
+       <position name="posArapucaDouble1-Frame-3-2" unit="cm" 
+         x="-328.04"
+	 y="465" 
+	 z="-409.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-1"/>
+       <position name="posOpArapucaDouble1-Frame-3-2" unit="cm" 
+         x="-327.3"
+	 y="465" 
+	 z="-409.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-2-2"/>
+       <position name="posArapucaDouble2-Frame-3-2" unit="cm" 
+         x="-328.04"
+	 y="539" 
+	 z="-192.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-2"/>
+       <position name="posOpArapucaDouble2-Frame-3-2" unit="cm" 
+         x="-327.3"
+	 y="539" 
+	 z="-192.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-2-3"/>
+       <position name="posArapucaDouble3-Frame-3-2" unit="cm" 
+         x="-328.04"
+	 y="629.7" 
+	 z="-338.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-3"/>
+       <position name="posOpArapucaDouble3-Frame-3-2" unit="cm" 
+         x="-327.3"
+	 y="629.7" 
+	 z="-338.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-3-0"/>
+       <position name="posArapucaDouble0-Frame-3-3" unit="cm" 
+         x="-328.04"
+	 y="374.3" 
+	 z="34.0000000000001"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-3-0"/>
+       <position name="posOpArapucaDouble0-Frame-3-3" unit="cm" 
+         x="-327.3"
+	 y="374.3" 
+	 z="34.0000000000001"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-3-1"/>
+       <position name="posArapucaDouble1-Frame-3-3" unit="cm" 
+         x="-328.04"
+	 y="465" 
+	 z="-112"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-3-1"/>
+       <position name="posOpArapucaDouble1-Frame-3-3" unit="cm" 
+         x="-327.3"
+	 y="465" 
+	 z="-112"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-3-2"/>
+       <position name="posArapucaDouble2-Frame-3-3" unit="cm" 
+         x="-328.04"
+	 y="539" 
+	 z="105"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-3-2"/>
+       <position name="posOpArapucaDouble2-Frame-3-3" unit="cm" 
+         x="-327.3"
+	 y="539" 
+	 z="105"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-3-3"/>
+       <position name="posArapucaDouble3-Frame-3-3" unit="cm" 
+         x="-328.04"
+	 y="629.7" 
+	 z="-40.9999999999999"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-3-3"/>
+       <position name="posOpArapucaDouble3-Frame-3-3" unit="cm" 
+         x="-327.3"
+	 y="629.7" 
+	 z="-40.9999999999999"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-4-0"/>
+       <position name="posArapucaDouble0-Frame-3-4" unit="cm" 
+         x="-328.04"
+	 y="374.3" 
+	 z="331.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-4-0"/>
+       <position name="posOpArapucaDouble0-Frame-3-4" unit="cm" 
+         x="-327.3"
+	 y="374.3" 
+	 z="331.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-4-1"/>
+       <position name="posArapucaDouble1-Frame-3-4" unit="cm" 
+         x="-328.04"
+	 y="465" 
+	 z="185.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-4-1"/>
+       <position name="posOpArapucaDouble1-Frame-3-4" unit="cm" 
+         x="-327.3"
+	 y="465" 
+	 z="185.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-4-2"/>
+       <position name="posArapucaDouble2-Frame-3-4" unit="cm" 
+         x="-328.04"
+	 y="539" 
+	 z="402.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-4-2"/>
+       <position name="posOpArapucaDouble2-Frame-3-4" unit="cm" 
+         x="-327.3"
+	 y="539" 
+	 z="402.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-4-3"/>
+       <position name="posArapucaDouble3-Frame-3-4" unit="cm" 
+         x="-328.04"
+	 y="629.7" 
+	 z="256.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-4-3"/>
+       <position name="posOpArapucaDouble3-Frame-3-4" unit="cm" 
+         x="-327.3"
+	 y="629.7" 
+	 z="256.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-5-0"/>
+       <position name="posArapucaDouble0-Frame-3-5" unit="cm" 
+         x="-328.04"
+	 y="374.3" 
+	 z="629.6036"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-5-0"/>
+       <position name="posOpArapucaDouble0-Frame-3-5" unit="cm" 
+         x="-327.3"
+	 y="374.3" 
+	 z="629.6036"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-5-1"/>
+       <position name="posArapucaDouble1-Frame-3-5" unit="cm" 
+         x="-328.04"
+	 y="465" 
+	 z="483.6036"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-5-1"/>
+       <position name="posOpArapucaDouble1-Frame-3-5" unit="cm" 
+         x="-327.3"
+	 y="465" 
+	 z="483.6036"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-5-2"/>
+       <position name="posArapucaDouble2-Frame-3-5" unit="cm" 
+         x="-328.04"
+	 y="539" 
+	 z="700.6036"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-5-2"/>
+       <position name="posOpArapucaDouble2-Frame-3-5" unit="cm" 
+         x="-327.3"
+	 y="539" 
+	 z="700.6036"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-5-3"/>
+       <position name="posArapucaDouble3-Frame-3-5" unit="cm" 
+         x="-328.04"
+	 y="629.7" 
+	 z="554.6036"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-5-3"/>
+       <position name="posOpArapucaDouble3-Frame-3-5" unit="cm" 
+         x="-327.3"
+	 y="629.7" 
+	 z="554.6036"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-6-0"/>
+       <position name="posArapucaDouble0-Frame-3-6" unit="cm" 
+         x="-328.04"
+	 y="374.3" 
+	 z="927.4054"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-6-0"/>
+       <position name="posOpArapucaDouble0-Frame-3-6" unit="cm" 
+         x="-327.3"
+	 y="374.3" 
+	 z="927.4054"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-6-1"/>
+       <position name="posArapucaDouble1-Frame-3-6" unit="cm" 
+         x="-328.04"
+	 y="465" 
+	 z="781.4054"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-6-1"/>
+       <position name="posOpArapucaDouble1-Frame-3-6" unit="cm" 
+         x="-327.3"
+	 y="465" 
+	 z="781.4054"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-6-2"/>
+       <position name="posArapucaDouble2-Frame-3-6" unit="cm" 
+         x="-328.04"
+	 y="539" 
+	 z="998.4054"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-6-2"/>
+       <position name="posOpArapucaDouble2-Frame-3-6" unit="cm" 
+         x="-327.3"
+	 y="539" 
+	 z="998.4054"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-6-3"/>
+       <position name="posArapucaDouble3-Frame-3-6" unit="cm" 
+         x="-328.04"
+	 y="629.7" 
+	 z="852.4054"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-6-3"/>
+       <position name="posOpArapucaDouble3-Frame-3-6" unit="cm" 
+         x="-327.3"
+	 y="629.7" 
+	 z="852.4054"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_0-0"/>
+       <position name="posArapuca0-Lat-0" unit="cm" 
+         x="285.03"
+	 y="-734" 
+	 z="-893.4054"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_0-0"/>
+       <position name="posOpArapuca0-Lat-0" unit="cm" 
+         x="285.03"
+	 y="-733.26" 
+	 z="-893.4054"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_0-1"/>
+       <position name="posArapuca1-Lat-0" unit="cm" 
+         x="210.03"
+	 y="-734" 
+	 z="-893.4054"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_0-1"/>
+       <position name="posOpArapuca1-Lat-0" unit="cm" 
+         x="210.03"
+	 y="-733.26" 
+	 z="-893.4054"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_0-2"/>
+       <position name="posArapuca2-Lat-0" unit="cm" 
+         x="135.03"
+	 y="-734" 
+	 z="-893.4054"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_0-2"/>
+       <position name="posOpArapuca2-Lat-0" unit="cm" 
+         x="135.03"
+	 y="-733.26" 
+	 z="-893.4054"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_0-3"/>
+       <position name="posArapuca3-Lat-0" unit="cm" 
+         x="60.03"
+	 y="-734" 
+	 z="-893.4054"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_0-3"/>
+       <position name="posOpArapuca3-Lat-0" unit="cm" 
+         x="60.03"
+	 y="-733.26" 
+	 z="-893.4054"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_0-4"/>
+       <position name="posArapuca4-Lat-0" unit="cm" 
+         x="285.03"
+	 y="734" 
+	 z="-893.4054"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_0-4"/>
+       <position name="posOpArapuca4-Lat-0" unit="cm" 
+         x="285.03"
+	 y="733.26" 
+	 z="-893.4054"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_0-5"/>
+       <position name="posArapuca5-Lat-0" unit="cm" 
+         x="210.03"
+	 y="734" 
+	 z="-893.4054"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_0-5"/>
+       <position name="posOpArapuca5-Lat-0" unit="cm" 
+         x="210.03"
+	 y="733.26" 
+	 z="-893.4054"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_0-6"/>
+       <position name="posArapuca6-Lat-0" unit="cm" 
+         x="135.03"
+	 y="734" 
+	 z="-893.4054"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_0-6"/>
+       <position name="posOpArapuca6-Lat-0" unit="cm" 
+         x="135.03"
+	 y="733.26" 
+	 z="-893.4054"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_0-7"/>
+       <position name="posArapuca7-Lat-0" unit="cm" 
+         x="60.03"
+	 y="734" 
+	 z="-893.4054"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_0-7"/>
+       <position name="posOpArapuca7-Lat-0" unit="cm" 
+         x="60.03"
+	 y="733.26" 
+	 z="-893.4054"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_1-0"/>
+       <position name="posArapuca0-Lat-1" unit="cm" 
+         x="285.03"
+	 y="-734" 
+	 z="-595.6036"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_1-0"/>
+       <position name="posOpArapuca0-Lat-1" unit="cm" 
+         x="285.03"
+	 y="-733.26" 
+	 z="-595.6036"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_1-1"/>
+       <position name="posArapuca1-Lat-1" unit="cm" 
+         x="210.03"
+	 y="-734" 
+	 z="-595.6036"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_1-1"/>
+       <position name="posOpArapuca1-Lat-1" unit="cm" 
+         x="210.03"
+	 y="-733.26" 
+	 z="-595.6036"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_1-2"/>
+       <position name="posArapuca2-Lat-1" unit="cm" 
+         x="135.03"
+	 y="-734" 
+	 z="-595.6036"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_1-2"/>
+       <position name="posOpArapuca2-Lat-1" unit="cm" 
+         x="135.03"
+	 y="-733.26" 
+	 z="-595.6036"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_1-3"/>
+       <position name="posArapuca3-Lat-1" unit="cm" 
+         x="60.03"
+	 y="-734" 
+	 z="-595.6036"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_1-3"/>
+       <position name="posOpArapuca3-Lat-1" unit="cm" 
+         x="60.03"
+	 y="-733.26" 
+	 z="-595.6036"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_1-4"/>
+       <position name="posArapuca4-Lat-1" unit="cm" 
+         x="285.03"
+	 y="734" 
+	 z="-595.6036"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_1-4"/>
+       <position name="posOpArapuca4-Lat-1" unit="cm" 
+         x="285.03"
+	 y="733.26" 
+	 z="-595.6036"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_1-5"/>
+       <position name="posArapuca5-Lat-1" unit="cm" 
+         x="210.03"
+	 y="734" 
+	 z="-595.6036"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_1-5"/>
+       <position name="posOpArapuca5-Lat-1" unit="cm" 
+         x="210.03"
+	 y="733.26" 
+	 z="-595.6036"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_1-6"/>
+       <position name="posArapuca6-Lat-1" unit="cm" 
+         x="135.03"
+	 y="734" 
+	 z="-595.6036"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_1-6"/>
+       <position name="posOpArapuca6-Lat-1" unit="cm" 
+         x="135.03"
+	 y="733.26" 
+	 z="-595.6036"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_1-7"/>
+       <position name="posArapuca7-Lat-1" unit="cm" 
+         x="60.03"
+	 y="734" 
+	 z="-595.6036"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_1-7"/>
+       <position name="posOpArapuca7-Lat-1" unit="cm" 
+         x="60.03"
+	 y="733.26" 
+	 z="-595.6036"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_2-0"/>
+       <position name="posArapuca0-Lat-2" unit="cm" 
+         x="285.03"
+	 y="-734" 
+	 z="-297.8018"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_2-0"/>
+       <position name="posOpArapuca0-Lat-2" unit="cm" 
+         x="285.03"
+	 y="-733.26" 
+	 z="-297.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_2-1"/>
+       <position name="posArapuca1-Lat-2" unit="cm" 
+         x="210.03"
+	 y="-734" 
+	 z="-297.8018"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_2-1"/>
+       <position name="posOpArapuca1-Lat-2" unit="cm" 
+         x="210.03"
+	 y="-733.26" 
+	 z="-297.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_2-2"/>
+       <position name="posArapuca2-Lat-2" unit="cm" 
+         x="135.03"
+	 y="-734" 
+	 z="-297.8018"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_2-2"/>
+       <position name="posOpArapuca2-Lat-2" unit="cm" 
+         x="135.03"
+	 y="-733.26" 
+	 z="-297.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_2-3"/>
+       <position name="posArapuca3-Lat-2" unit="cm" 
+         x="60.03"
+	 y="-734" 
+	 z="-297.8018"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_2-3"/>
+       <position name="posOpArapuca3-Lat-2" unit="cm" 
+         x="60.03"
+	 y="-733.26" 
+	 z="-297.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_2-4"/>
+       <position name="posArapuca4-Lat-2" unit="cm" 
+         x="285.03"
+	 y="734" 
+	 z="-297.8018"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_2-4"/>
+       <position name="posOpArapuca4-Lat-2" unit="cm" 
+         x="285.03"
+	 y="733.26" 
+	 z="-297.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_2-5"/>
+       <position name="posArapuca5-Lat-2" unit="cm" 
+         x="210.03"
+	 y="734" 
+	 z="-297.8018"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_2-5"/>
+       <position name="posOpArapuca5-Lat-2" unit="cm" 
+         x="210.03"
+	 y="733.26" 
+	 z="-297.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_2-6"/>
+       <position name="posArapuca6-Lat-2" unit="cm" 
+         x="135.03"
+	 y="734" 
+	 z="-297.8018"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_2-6"/>
+       <position name="posOpArapuca6-Lat-2" unit="cm" 
+         x="135.03"
+	 y="733.26" 
+	 z="-297.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_2-7"/>
+       <position name="posArapuca7-Lat-2" unit="cm" 
+         x="60.03"
+	 y="734" 
+	 z="-297.8018"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_2-7"/>
+       <position name="posOpArapuca7-Lat-2" unit="cm" 
+         x="60.03"
+	 y="733.26" 
+	 z="-297.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_3-0"/>
+       <position name="posArapuca0-Lat-3" unit="cm" 
+         x="285.03"
+	 y="-734" 
+	 z="1.13686837721616e-13"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_3-0"/>
+       <position name="posOpArapuca0-Lat-3" unit="cm" 
+         x="285.03"
+	 y="-733.26" 
+	 z="1.13686837721616e-13"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_3-1"/>
+       <position name="posArapuca1-Lat-3" unit="cm" 
+         x="210.03"
+	 y="-734" 
+	 z="1.13686837721616e-13"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_3-1"/>
+       <position name="posOpArapuca1-Lat-3" unit="cm" 
+         x="210.03"
+	 y="-733.26" 
+	 z="1.13686837721616e-13"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_3-2"/>
+       <position name="posArapuca2-Lat-3" unit="cm" 
+         x="135.03"
+	 y="-734" 
+	 z="1.13686837721616e-13"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_3-2"/>
+       <position name="posOpArapuca2-Lat-3" unit="cm" 
+         x="135.03"
+	 y="-733.26" 
+	 z="1.13686837721616e-13"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_3-3"/>
+       <position name="posArapuca3-Lat-3" unit="cm" 
+         x="60.03"
+	 y="-734" 
+	 z="1.13686837721616e-13"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_3-3"/>
+       <position name="posOpArapuca3-Lat-3" unit="cm" 
+         x="60.03"
+	 y="-733.26" 
+	 z="1.13686837721616e-13"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_3-4"/>
+       <position name="posArapuca4-Lat-3" unit="cm" 
+         x="285.03"
+	 y="734" 
+	 z="1.13686837721616e-13"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_3-4"/>
+       <position name="posOpArapuca4-Lat-3" unit="cm" 
+         x="285.03"
+	 y="733.26" 
+	 z="1.13686837721616e-13"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_3-5"/>
+       <position name="posArapuca5-Lat-3" unit="cm" 
+         x="210.03"
+	 y="734" 
+	 z="1.13686837721616e-13"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_3-5"/>
+       <position name="posOpArapuca5-Lat-3" unit="cm" 
+         x="210.03"
+	 y="733.26" 
+	 z="1.13686837721616e-13"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_3-6"/>
+       <position name="posArapuca6-Lat-3" unit="cm" 
+         x="135.03"
+	 y="734" 
+	 z="1.13686837721616e-13"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_3-6"/>
+       <position name="posOpArapuca6-Lat-3" unit="cm" 
+         x="135.03"
+	 y="733.26" 
+	 z="1.13686837721616e-13"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_3-7"/>
+       <position name="posArapuca7-Lat-3" unit="cm" 
+         x="60.03"
+	 y="734" 
+	 z="1.13686837721616e-13"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_3-7"/>
+       <position name="posOpArapuca7-Lat-3" unit="cm" 
+         x="60.03"
+	 y="733.26" 
+	 z="1.13686837721616e-13"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_4-0"/>
+       <position name="posArapuca0-Lat-4" unit="cm" 
+         x="285.03"
+	 y="-734" 
+	 z="297.8018"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_4-0"/>
+       <position name="posOpArapuca0-Lat-4" unit="cm" 
+         x="285.03"
+	 y="-733.26" 
+	 z="297.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_4-1"/>
+       <position name="posArapuca1-Lat-4" unit="cm" 
+         x="210.03"
+	 y="-734" 
+	 z="297.8018"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_4-1"/>
+       <position name="posOpArapuca1-Lat-4" unit="cm" 
+         x="210.03"
+	 y="-733.26" 
+	 z="297.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_4-2"/>
+       <position name="posArapuca2-Lat-4" unit="cm" 
+         x="135.03"
+	 y="-734" 
+	 z="297.8018"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_4-2"/>
+       <position name="posOpArapuca2-Lat-4" unit="cm" 
+         x="135.03"
+	 y="-733.26" 
+	 z="297.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_4-3"/>
+       <position name="posArapuca3-Lat-4" unit="cm" 
+         x="60.03"
+	 y="-734" 
+	 z="297.8018"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_4-3"/>
+       <position name="posOpArapuca3-Lat-4" unit="cm" 
+         x="60.03"
+	 y="-733.26" 
+	 z="297.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_4-4"/>
+       <position name="posArapuca4-Lat-4" unit="cm" 
+         x="285.03"
+	 y="734" 
+	 z="297.8018"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_4-4"/>
+       <position name="posOpArapuca4-Lat-4" unit="cm" 
+         x="285.03"
+	 y="733.26" 
+	 z="297.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_4-5"/>
+       <position name="posArapuca5-Lat-4" unit="cm" 
+         x="210.03"
+	 y="734" 
+	 z="297.8018"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_4-5"/>
+       <position name="posOpArapuca5-Lat-4" unit="cm" 
+         x="210.03"
+	 y="733.26" 
+	 z="297.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_4-6"/>
+       <position name="posArapuca6-Lat-4" unit="cm" 
+         x="135.03"
+	 y="734" 
+	 z="297.8018"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_4-6"/>
+       <position name="posOpArapuca6-Lat-4" unit="cm" 
+         x="135.03"
+	 y="733.26" 
+	 z="297.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_4-7"/>
+       <position name="posArapuca7-Lat-4" unit="cm" 
+         x="60.03"
+	 y="734" 
+	 z="297.8018"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_4-7"/>
+       <position name="posOpArapuca7-Lat-4" unit="cm" 
+         x="60.03"
+	 y="733.26" 
+	 z="297.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_5-0"/>
+       <position name="posArapuca0-Lat-5" unit="cm" 
+         x="285.03"
+	 y="-734" 
+	 z="595.6036"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_5-0"/>
+       <position name="posOpArapuca0-Lat-5" unit="cm" 
+         x="285.03"
+	 y="-733.26" 
+	 z="595.6036"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_5-1"/>
+       <position name="posArapuca1-Lat-5" unit="cm" 
+         x="210.03"
+	 y="-734" 
+	 z="595.6036"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_5-1"/>
+       <position name="posOpArapuca1-Lat-5" unit="cm" 
+         x="210.03"
+	 y="-733.26" 
+	 z="595.6036"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_5-2"/>
+       <position name="posArapuca2-Lat-5" unit="cm" 
+         x="135.03"
+	 y="-734" 
+	 z="595.6036"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_5-2"/>
+       <position name="posOpArapuca2-Lat-5" unit="cm" 
+         x="135.03"
+	 y="-733.26" 
+	 z="595.6036"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_5-3"/>
+       <position name="posArapuca3-Lat-5" unit="cm" 
+         x="60.03"
+	 y="-734" 
+	 z="595.6036"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_5-3"/>
+       <position name="posOpArapuca3-Lat-5" unit="cm" 
+         x="60.03"
+	 y="-733.26" 
+	 z="595.6036"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_5-4"/>
+       <position name="posArapuca4-Lat-5" unit="cm" 
+         x="285.03"
+	 y="734" 
+	 z="595.6036"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_5-4"/>
+       <position name="posOpArapuca4-Lat-5" unit="cm" 
+         x="285.03"
+	 y="733.26" 
+	 z="595.6036"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_5-5"/>
+       <position name="posArapuca5-Lat-5" unit="cm" 
+         x="210.03"
+	 y="734" 
+	 z="595.6036"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_5-5"/>
+       <position name="posOpArapuca5-Lat-5" unit="cm" 
+         x="210.03"
+	 y="733.26" 
+	 z="595.6036"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_5-6"/>
+       <position name="posArapuca6-Lat-5" unit="cm" 
+         x="135.03"
+	 y="734" 
+	 z="595.6036"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_5-6"/>
+       <position name="posOpArapuca6-Lat-5" unit="cm" 
+         x="135.03"
+	 y="733.26" 
+	 z="595.6036"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_5-7"/>
+       <position name="posArapuca7-Lat-5" unit="cm" 
+         x="60.03"
+	 y="734" 
+	 z="595.6036"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_5-7"/>
+       <position name="posOpArapuca7-Lat-5" unit="cm" 
+         x="60.03"
+	 y="733.26" 
+	 z="595.6036"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_6-0"/>
+       <position name="posArapuca0-Lat-6" unit="cm" 
+         x="285.03"
+	 y="-734" 
+	 z="893.4054"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_6-0"/>
+       <position name="posOpArapuca0-Lat-6" unit="cm" 
+         x="285.03"
+	 y="-733.26" 
+	 z="893.4054"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_6-1"/>
+       <position name="posArapuca1-Lat-6" unit="cm" 
+         x="210.03"
+	 y="-734" 
+	 z="893.4054"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_6-1"/>
+       <position name="posOpArapuca1-Lat-6" unit="cm" 
+         x="210.03"
+	 y="-733.26" 
+	 z="893.4054"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_6-2"/>
+       <position name="posArapuca2-Lat-6" unit="cm" 
+         x="135.03"
+	 y="-734" 
+	 z="893.4054"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_6-2"/>
+       <position name="posOpArapuca2-Lat-6" unit="cm" 
+         x="135.03"
+	 y="-733.26" 
+	 z="893.4054"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_6-3"/>
+       <position name="posArapuca3-Lat-6" unit="cm" 
+         x="60.03"
+	 y="-734" 
+	 z="893.4054"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_6-3"/>
+       <position name="posOpArapuca3-Lat-6" unit="cm" 
+         x="60.03"
+	 y="-733.26" 
+	 z="893.4054"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_6-4"/>
+       <position name="posArapuca4-Lat-6" unit="cm" 
+         x="285.03"
+	 y="734" 
+	 z="893.4054"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_6-4"/>
+       <position name="posOpArapuca4-Lat-6" unit="cm" 
+         x="285.03"
+	 y="733.26" 
+	 z="893.4054"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_6-5"/>
+       <position name="posArapuca5-Lat-6" unit="cm" 
+         x="210.03"
+	 y="734" 
+	 z="893.4054"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_6-5"/>
+       <position name="posOpArapuca5-Lat-6" unit="cm" 
+         x="210.03"
+	 y="733.26" 
+	 z="893.4054"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_6-6"/>
+       <position name="posArapuca6-Lat-6" unit="cm" 
+         x="135.03"
+	 y="734" 
+	 z="893.4054"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_6-6"/>
+       <position name="posOpArapuca6-Lat-6" unit="cm" 
+         x="135.03"
+	 y="733.26" 
+	 z="893.4054"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_6-7"/>
+       <position name="posArapuca7-Lat-6" unit="cm" 
+         x="60.03"
+	 y="734" 
+	 z="893.4054"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_6-7"/>
+       <position name="posOpArapuca7-Lat-6" unit="cm" 
+         x="60.03"
+	 y="733.26" 
+	 z="893.4054"/>
+     </physvol>
+    </volume>
+
+    <volume name="volFoamPadding">
+      <materialref ref="fibrous_glass"/>
+      <solidref ref="FoamPadding"/>
+    </volume>
+
+    <volume name="volSteelSupport">
+      <materialref ref="AirSteelMixture"/>
+      <solidref ref="SteelSupport"/>
+    </volume>
+
+    <volume name="volDetEnclosure">
+      <materialref ref="Air"/>
+      <solidref ref="DetEnclosure"/>
+
+       <physvol>
+           <volumeref ref="volFoamPadding"/>
+           <positionref ref="posCryoInDetEnc"/>
+       </physvol>
+       <physvol>
+           <volumeref ref="volSteelSupport"/>
+           <positionref ref="posCryoInDetEnc"/>
+       </physvol>
+       <physvol>
+           <volumeref ref="volCryostat"/>
+           <positionref ref="posCryoInDetEnc"/>
+       </physvol>
+    </volume>
+
+    <volume name="volWorld" >
+      <materialref ref="DUSEL_Rock"/>
+      <solidref ref="World"/>
+
+      <physvol>
+        <volumeref ref="volDetEnclosure"/>
+	<position name="posDetEnclosure" unit="cm" x="50.04" y="-1.13686837721616e-13" z="1045.8063"/>
+      </physvol>
+
+    </volume>
+</structure>
+  <setup name="Default" version="1.0">
+    <world ref="volWorld"/>
+  </setup>
+</gdml_simple_extension>

--- a/dunecore/Geometry/gdml/dunevd10kt_3view_v4_refactored_1x8x14ref_nowires.gdml
+++ b/dunecore/Geometry/gdml/dunevd10kt_3view_v4_refactored_1x8x14ref_nowires.gdml
@@ -1,0 +1,6115 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<gdml_simple_extension xmlns:gdml_simple_extension="http://www.example.org"
+                       xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"          
+                       xs:noNamespaceSchemaLocation="RefactoredGDMLSchema/SimpleExtension.xsd"> 
+<extension>
+   <color name="magenta"     R="0.0"  G="1.0"  B="0.0"  A="1.0" />
+   <color name="green"       R="0.0"  G="1.0"  B="0.0"  A="1.0" />
+   <color name="red"         R="1.0"  G="0.0"  B="0.0"  A="1.0" />
+   <color name="blue"        R="0.0"  G="0.0"  B="1.0"  A="1.0" />
+   <color name="yellow"      R="1.0"  G="1.0"  B="0.0"  A="1.0" />    
+</extension>
+<define>
+
+<!--
+
+
+
+-->
+
+   <position name="posCryoInDetEnc"     unit="cm" x="-50.0000000000001" y="0" z="0"/>
+   <position name="posCenter"           unit="cm" x="0" y="0" z="0"/>
+   <rotation name="rUWireAboutX"        unit="deg" x="131.63" y="0" z="0"/>
+   <rotation name="rPlus90AboutX"       unit="deg" x="90" y="0" z="0"/>
+   <rotation name="rPlus90AboutY"       unit="deg" x="0" y="90" z="0"/>
+   <rotation name="rPlus90AboutXPlus90AboutY" unit="deg" x="90" y="90" z="0"/>
+   <rotation name="rMinus90AboutX"      unit="deg" x="270" y="0" z="0"/>
+   <rotation name="rMinus90AboutY"      unit="deg" x="0" y="270" z="0"/>
+   <rotation name="rMinus90AboutYMinus90AboutX"       unit="deg" x="270" y="270" z="0"/>
+   <rotation name="rPlus180AboutX"	unit="deg" x="180" y="0"   z="0"/>
+   <rotation name="rPlus180AboutY"	unit="deg" x="0" y="180"   z="0"/>
+   <rotation name="rPlus180AboutXPlus180AboutY"	unit="deg" x="180" y="180"   z="0"/>
+   <rotation name="rIdentity"		unit="deg" x="0" y="0"   z="0"/>
+</define>
+<materials>
+  <element name="videRef" formula="VACUUM" Z="1">  <atom value="1"/> </element>
+  <element name="copper" formula="Cu" Z="29">  <atom value="63.546"/>  </element>
+  <element name="beryllium" formula="Be" Z="4">  <atom value="9.0121831"/>  </element>
+  <element name="bromine" formula="Br" Z="35"> <atom value="79.904"/> </element>
+  <element name="hydrogen" formula="H" Z="1">  <atom value="1.0079"/> </element>
+  <element name="nitrogen" formula="N" Z="7">  <atom value="14.0067"/> </element>
+  <element name="oxygen" formula="O" Z="8">  <atom value="15.999"/> </element>
+  <element name="aluminum" formula="Al" Z="13"> <atom value="26.9815"/>  </element>
+  <element name="silicon" formula="Si" Z="14"> <atom value="28.0855"/>  </element>
+  <element name="carbon" formula="C" Z="6">  <atom value="12.0107"/>  </element>
+  <element name="potassium" formula="K" Z="19"> <atom value="39.0983"/>  </element>
+  <element name="chromium" formula="Cr" Z="24"> <atom value="51.9961"/>  </element>
+  <element name="iron" formula="Fe" Z="26"> <atom value="55.8450"/>  </element>
+  <element name="nickel" formula="Ni" Z="28"> <atom value="58.6934"/>  </element>
+  <element name="calcium" formula="Ca" Z="20"> <atom value="40.078"/>   </element>
+  <element name="magnesium" formula="Mg" Z="12"> <atom value="24.305"/>   </element>
+  <element name="sodium" formula="Na" Z="11"> <atom value="22.99"/>    </element>
+  <element name="titanium" formula="Ti" Z="22"> <atom value="47.867"/>   </element>
+  <element name="argon" formula="Ar" Z="18"> <atom value="39.9480"/>  </element>
+  <element name="sulphur" formula="S" Z="16"> <atom value="32.065"/>  </element>
+  <element name="phosphorus" formula="P" Z="15"> <atom value="30.973"/>  </element>
+
+  <material name="Vacuum" formula="Vacuum">
+   <D value="1.e-25" unit="g/cm3"/>
+   <fraction n="1.0" ref="videRef"/>
+  </material>
+
+  <material name="ALUMINUM_Al" formula="ALUMINUM_Al">
+   <D value="2.6990" unit="g/cm3"/>
+   <fraction n="1.0000" ref="aluminum"/>
+  </material>
+
+  <material name="SILICON_Si" formula="SILICON_Si">
+   <D value="2.3300" unit="g/cm3"/>
+   <fraction n="1.0000" ref="silicon"/>
+  </material>
+
+  <material name="epoxy_resin" formula="C38H40O6Br4">
+   <D value="1.1250" unit="g/cm3"/>
+   <composite n="38" ref="carbon"/>
+   <composite n="40" ref="hydrogen"/>
+   <composite n="6" ref="oxygen"/>
+   <composite n="4" ref="bromine"/>
+  </material>
+
+  <material name="SiO2" formula="SiO2">
+   <D value="2.2" unit="g/cm3"/>
+   <composite n="1" ref="silicon"/>
+   <composite n="2" ref="oxygen"/>
+  </material>
+
+  <material name="Al2O3" formula="Al2O3">
+   <D value="3.97" unit="g/cm3"/>
+   <composite n="2" ref="aluminum"/>
+   <composite n="3" ref="oxygen"/>
+  </material>
+
+  <material name="Fe2O3" formula="Fe2O3">
+   <D value="5.24" unit="g/cm3"/>
+   <composite n="2" ref="iron"/>
+   <composite n="3" ref="oxygen"/>
+  </material>
+
+  <material name="CaO" formula="CaO">
+   <D value="3.35" unit="g/cm3"/>
+   <composite n="1" ref="calcium"/>
+   <composite n="1" ref="oxygen"/>
+  </material>
+
+  <material name="Delrin" formula="CH2O">
+    <D value="1.41" unit="g/cm3"/>
+    <composite n="1" ref="carbon"/>
+    <composite n="2" ref="hydrogen"/>
+    <composite n="1" ref="oxygen"/>
+  </material>
+
+  <material name="MgO" formula="MgO">
+   <D value="3.58" unit="g/cm3"/>
+   <composite n="1" ref="magnesium"/>
+   <composite n="1" ref="oxygen"/>
+  </material>
+
+  <material name="Na2O" formula="Na2O">
+   <D value="2.27" unit="g/cm3"/>
+   <composite n="2" ref="sodium"/>
+   <composite n="1" ref="oxygen"/>
+  </material>
+
+  <material name="TiO2" formula="TiO2">
+   <D value="4.23" unit="g/cm3"/>
+   <composite n="1" ref="titanium"/>
+   <composite n="2" ref="oxygen"/>
+  </material>
+
+  <material name="FeO" formula="FeO">
+   <D value="5.745" unit="g/cm3"/>
+   <composite n="1" ref="iron"/>
+   <composite n="1" ref="oxygen"/>
+  </material>
+
+  <material name="CO2" formula="CO2">
+   <D value="1.562" unit="g/cm3"/>
+   <composite n="1" ref="iron"/>
+   <composite n="2" ref="oxygen"/>
+  </material>
+
+  <material name="P2O5" formula="P2O5">
+   <D value="1.562" unit="g/cm3"/>
+   <composite n="2" ref="phosphorus"/>
+   <composite n="5" ref="oxygen"/>
+  </material>
+
+  <material formula=" " name="DUSEL_Rock">
+    <D value="2.82" unit="g/cm3"/>
+    <fraction n="0.5267" ref="SiO2"/>
+    <fraction n="0.1174" ref="FeO"/>
+    <fraction n="0.1025" ref="Al2O3"/>
+    <fraction n="0.0473" ref="MgO"/>
+    <fraction n="0.0422" ref="CO2"/>
+    <fraction n="0.0382" ref="CaO"/>
+    <fraction n="0.0240" ref="carbon"/>
+    <fraction n="0.0186" ref="sulphur"/>
+    <fraction n="0.0053" ref="Na2O"/>
+    <fraction n="0.00070" ref="P2O5"/>
+    <fraction n="0.0771" ref="oxygen"/>
+  </material> 
+
+  <material formula="Air" name="Air">
+   <D value="0.001205" unit="g/cm3"/>
+   <fraction n="0.781154" ref="nitrogen"/>
+   <fraction n="0.209476" ref="oxygen"/>
+   <fraction n="0.00934" ref="argon"/>
+  </material>
+
+  <material name="fibrous_glass">
+   <D value="2.74351" unit="g/cm3"/>
+   <fraction n="0.600" ref="SiO2"/>
+   <fraction n="0.118" ref="Al2O3"/>
+   <fraction n="0.001" ref="Fe2O3"/>
+   <fraction n="0.224" ref="CaO"/>
+   <fraction n="0.034" ref="MgO"/>
+   <fraction n="0.010" ref="Na2O"/>
+   <fraction n="0.013" ref="TiO2"/>
+  </material>
+
+  <!-- density referenced from EHN1-Cold Cryostats Technical Requirements:
+       https://edms.cern.ch/document/1543254 -->
+  <material name="FD_foam">
+   <D value="0.09" unit="g/cm3"/>
+   <fraction n="0.95" ref="Air"/>
+   <fraction n="0.05" ref="fibrous_glass"/>
+  </material>
+
+  <!-- Foam density is 70 kg / m^3 for the 3x1x1 -->
+  <material name="foam_3x1x1dp">
+   <D value="0.07" unit="g/cm3"/>
+   <fraction n="0.95" ref="Air"/>
+   <fraction n="0.05" ref="fibrous_glass"/>
+  </material>
+
+  <!-- Copied from protodune_v4.gdml -->
+  <material name="foam_protoDUNEdp">
+   <D value="0.135" unit="g/cm3"/>
+   <composite n="17" ref="carbon"/>
+   <composite n="16" ref="hydrogen"/>
+   <composite n="2" ref="nitrogen"/>
+   <composite n="4" ref="oxygen"/>
+  </material>
+
+  <material name="FR4">
+   <D value="1.98281" unit="g/cm3"/>
+   <fraction n="0.47" ref="epoxy_resin"/>
+   <fraction n="0.53" ref="fibrous_glass"/>
+  </material>
+
+  <material name="STEEL_STAINLESS_Fe7Cr2Ni" formula="STEEL_STAINLESS_Fe7Cr2Ni">
+   <D value="7.9300" unit="g/cm3"/>
+   <fraction n="0.0010" ref="carbon"/>
+   <fraction n="0.1792" ref="chromium"/>
+   <fraction n="0.7298" ref="iron"/>
+   <fraction n="0.0900" ref="nickel"/>
+  </material>
+
+  <material name="Copper_Beryllium_alloy25" formula="Copper_Beryllium_alloy25">
+   <D value="8.26" unit="g/cm3"/>
+   <fraction n="0.981" ref="copper"/>
+   <fraction n="0.019" ref="beryllium"/>
+  </material>
+
+  <material name="LAr" formula="LAr">
+   <D value="1.40" unit="g/cm3"/>
+   <fraction n="1.0000" ref="argon"/>
+  </material>
+
+  <material name="ArGas" formula="ArGas">
+   <D value="0.00166" unit="g/cm3"/>
+   <fraction n="1.0" ref="argon"/>
+  </material>
+
+  <material formula=" " name="G10">
+   <D value="1.7" unit="g/cm3"/>
+   <fraction n="0.2805" ref="silicon"/>
+   <fraction n="0.3954" ref="oxygen"/>
+   <fraction n="0.2990" ref="carbon"/>
+   <fraction n="0.0251" ref="hydrogen"/>
+  </material>
+
+  <material formula=" " name="Granite">
+   <D value="2.7" unit="g/cm3"/>
+   <fraction n="0.438" ref="oxygen"/>
+   <fraction n="0.257" ref="silicon"/>
+   <fraction n="0.222" ref="sodium"/>
+   <fraction n="0.049" ref="aluminum"/>
+   <fraction n="0.019" ref="iron"/>
+   <fraction n="0.015" ref="potassium"/>
+  </material>
+
+  <material formula=" " name="ShotRock">
+   <D value="1.62" unit="g/cm3"/>
+   <fraction n="0.438" ref="oxygen"/>
+   <fraction n="0.257" ref="silicon"/>
+   <fraction n="0.222" ref="sodium"/>
+   <fraction n="0.049" ref="aluminum"/>
+   <fraction n="0.019" ref="iron"/>
+   <fraction n="0.015" ref="potassium"/>
+  </material>
+
+  <material formula=" " name="Dirt">
+   <D value="1.7" unit="g/cm3"/>
+   <fraction n="0.438" ref="oxygen"/>
+   <fraction n="0.257" ref="silicon"/>
+   <fraction n="0.222" ref="sodium"/>
+   <fraction n="0.049" ref="aluminum"/>
+   <fraction n="0.019" ref="iron"/>
+   <fraction n="0.015" ref="potassium"/>
+  </material>
+
+  <material formula=" " name="Concrete">
+   <D value="2.3" unit="g/cm3"/>
+   <fraction n="0.530" ref="oxygen"/>
+   <fraction n="0.335" ref="silicon"/>
+   <fraction n="0.060" ref="calcium"/>
+   <fraction n="0.015" ref="sodium"/>
+   <fraction n="0.020" ref="iron"/>
+   <fraction n="0.040" ref="aluminum"/>
+  </material>
+
+  <material formula="H2O" name="Water">
+   <D value="1.0" unit="g/cm3"/>
+   <fraction n="0.1119" ref="hydrogen"/>
+   <fraction n="0.8881" ref="oxygen"/>
+  </material>
+
+  <material formula="Ti" name="Titanium">
+   <D value="4.506" unit="g/cm3"/>
+   <fraction n="1." ref="titanium"/>
+  </material>
+
+  <material name="TPB" formula="TPB">
+   <D value="1.40" unit="g/cm3"/>
+   <fraction n="1.0000" ref="argon"/>
+  </material>
+
+  <material name="Glass">
+   <D value="2.74351" unit="g/cm3"/>
+   <fraction n="0.600" ref="SiO2"/>
+   <fraction n="0.118" ref="Al2O3"/>
+   <fraction n="0.001" ref="Fe2O3"/>
+   <fraction n="0.224" ref="CaO"/>
+   <fraction n="0.034" ref="MgO"/>
+   <fraction n="0.010" ref="Na2O"/>
+   <fraction n="0.013" ref="TiO2"/>
+  </material>
+
+  <material name="Acrylic">
+   <D value="1.19" unit="g/cm3"/>
+   <fraction n="0.600" ref="carbon"/>
+   <fraction n="0.320" ref="oxygen"/>
+   <fraction n="0.080" ref="hydrogen"/>
+  </material>
+
+  <material name="NiGas1atm80K">
+   <D value="0.0039" unit="g/cm3"/>
+   <fraction n="1.000" ref="nitrogen"/>
+  </material>
+
+  <material name="NiGas">
+   <D value="0.001165" unit="g/cm3"/>
+   <fraction n="1.000" ref="nitrogen"/>
+  </material>
+
+  <material name="PolyurethaneFoam">
+   <D value="0.088" unit="g/cm3"/>
+   <composite n="17" ref="carbon"/>
+   <composite n="16" ref="hydrogen"/>
+   <composite n="2" ref="nitrogen"/>
+   <composite n="4" ref="oxygen"/>
+  </material>
+
+  <material name="ProtoDUNEFoam">
+   <D value="0.135" unit="g/cm3"/>
+   <composite n="17" ref="carbon"/>
+   <composite n="16" ref="hydrogen"/>
+   <composite n="2" ref="nitrogen"/>
+   <composite n="4" ref="oxygen"/>
+  </material>
+
+  <material name="LightPolyurethaneFoam">
+   <D value="0.009" unit="g/cm3"/>
+   <composite n="17" ref="carbon"/>
+   <composite n="16" ref="hydrogen"/>
+   <composite n="2" ref="nitrogen"/>
+   <composite n="4" ref="oxygen"/>
+  </material>
+
+  <material name="ProtoDUNEBWFoam">
+   <D value="0.021" unit="g/cm3"/>
+   <composite n="17" ref="carbon"/>
+   <composite n="16" ref="hydrogen"/>
+   <composite n="2" ref="nitrogen"/>
+   <composite n="4" ref="oxygen"/>
+  </material>
+
+  <material name="GlassWool">
+   <D value="0.035" unit="g/cm3"/>
+   <fraction n="0.65" ref="SiO2"/>
+   <fraction n="0.09" ref="Al2O3"/>
+   <fraction n="0.07" ref="CaO"/>
+   <fraction n="0.03" ref="MgO"/>
+   <fraction n="0.16" ref="Na2O"/>
+  </material>
+
+  <material name="Polystyrene">
+   <D value="1.06" unit="g/cm3"/>
+   <composite n="8" ref="carbon"/>
+   <composite n="8" ref="hydrogen"/>
+  </material>
+
+
+
+  <!-- preliminary values -->
+  <material name="AirSteelMixture" formula="AirSteelMixture">
+   <D value=" 0.001205*(1-0.5) + 7.9300*0.5 " unit="g/cm3"/>
+   <fraction n="0.5" ref="STEEL_STAINLESS_Fe7Cr2Ni"/>
+   <fraction n="0.5"   ref="Air"/>
+  </material>
+  <material name="vm2000" formula="vm2000">
+    <D value="1.2" unit="g/cm3"/>
+    <composite n="2" ref="carbon"/>
+    <composite n="4" ref="hydrogen"/>
+  </material>
+
+</materials>
+<solids>
+     <torus name="FieldShaperCorner" rmin="0.5" rmax="2.285" rtor="2.3" deltaphi="90" startphi="0" aunit="deg" lunit="cm"/>
+     <tube name="FieldShaperLongtube" rmin="0.5" rmax="2.285" z="2091.6126" deltaphi="360" startphi="0" aunit="deg" lunit="cm"/>
+     <tube name="FieldShaperLongtubeSlim" rmin="0.5" rmax="0.75" z="2091.6126" deltaphi="360" startphi="0" aunit="deg" lunit="cm"/>
+     <tube name="FieldShaperShorttube" rmin="0.5" rmax="2.285" z="1348" deltaphi="360" startphi="0" aunit="deg" lunit="cm"/>
+
+    <union name="FSunion1">
+      <first ref="FieldShaperLongtube"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos1" unit="cm" x="-2.3" y="0" z="1045.8063"/>
+		<rotation name="rot1" unit="deg" x="90" y="0" z="0" />
+    </union>
+
+    <union name="FSunion2">
+      <first ref="FSunion1"/>
+      <second ref="FieldShaperShorttube"/>
+   		<position name="esquinapos2" unit="cm" x="-676.3" y="0" z="1048.1063"/>
+   		<rotation name="rot2" unit="deg" x="0" y="90" z="0" />
+    </union>
+
+    <union name="FSunion3">
+      <first ref="FSunion2"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos3" unit="cm" x="-1350.3" y="0" z="1045.8063"/>
+		<rotation name="rot3" unit="deg" x="90" y="270" z="0" />
+    </union>
+
+    <union name="FSunion4">
+      <first ref="FSunion3"/>
+      <second ref="FieldShaperLongtube"/>
+   		<position name="esquinapos4" unit="cm" x="-1352.6" y="0" z="0"/>
+    </union>
+
+    <union name="FSunion5">
+      <first ref="FSunion4"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos5" unit="cm" x="-1350.3" y="0" z="-1045.8063"/>
+		<rotation name="rot5" unit="deg" x="90" y="180" z="0" />
+    </union>
+
+    <union name="FSunion6">
+      <first ref="FSunion5"/>
+      <second ref="FieldShaperShorttube"/>
+   		<position name="esquinapos6" unit="cm" x="-676.3" y="0" z="-1048.1063"/>
+		<rotation name="rot6" unit="deg" x="0" y="90" z="0" />
+    </union>
+
+    <union name="FieldShaperSolid">
+      <first ref="FSunion6"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos7" unit="cm" x="-2.3" y="0" z="-1045.8063"/>
+		<rotation name="rot7" unit="deg" x="90" y="90" z="0" />
+    </union>
+    
+    <union name="FSunionSlim1">
+      <first ref="FieldShaperLongtubeSlim"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos1" unit="cm" x="-2.3" y="0" z="1045.8063"/>
+		<rotation name="rot1" unit="deg" x="90" y="0" z="0" />
+    </union>
+
+    <union name="FSunionSlim2">
+      <first ref="FSunionSlim1"/>
+      <second ref="FieldShaperShorttube"/>
+   		<position name="esquinapos2" unit="cm" x="-676.3" y="0" z="1048.1063"/>
+   		<rotation name="rot2" unit="deg" x="0" y="90" z="0" />
+    </union>
+
+    <union name="FSunionSlim3">
+      <first ref="FSunionSlim2"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos3" unit="cm" x="-1350.3" y="0" z="1045.8063"/>
+		<rotation name="rot3" unit="deg" x="90" y="270" z="0" />
+    </union>
+
+    <union name="FSunionSlim4">
+      <first ref="FSunionSlim3"/>
+      <second ref="FieldShaperLongtubeSlim"/>
+   		<position name="esquinapos4" unit="cm" x="-1352.6" y="0" z="0"/>
+    </union>
+
+    <union name="FSunionSlim5">
+      <first ref="FSunionSlim4"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos5" unit="cm" x="-1350.3" y="0" z="-1045.8063"/>
+		<rotation name="rot5" unit="deg" x="90" y="180" z="0" />
+    </union>
+
+    <union name="FSunionSlim6">
+      <first ref="FSunionSlim5"/>
+      <second ref="FieldShaperShorttube"/>
+   		<position name="esquinapos6" unit="cm" x="-676.3" y="0" z="-1048.1063"/>
+		<rotation name="rot6" unit="deg" x="0" y="90" z="0" />
+    </union>
+
+    <union name="FieldShaperSolidSlim">
+      <first ref="FSunionSlim6"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos7" unit="cm" x="-2.3" y="0" z="-1045.8063"/>
+		<rotation name="rot7" unit="deg" x="90" y="90" z="0" />
+    </union>
+    
+
+   <box name="CRM"
+      x="650.08" 
+      y="168" 
+      z="148.9009"
+      lunit="cm"/>
+   <box name="CRMUPlane" 
+      x="0.02" 
+      y="168" 
+      z="148.9009"
+      lunit="cm"/>
+   <box name="CRMYPlane" 
+      x="0.02" 
+      y="168" 
+      z="148.9009"
+      lunit="cm"/>
+   <box name="CRMZPlane" 
+      x="0.02"
+      y="168"
+      z="148.9009"
+      lunit="cm"/>
+   <box name="CRMActive" 
+      x="650"
+      y="168"
+      z="148.9009"
+      lunit="cm"/>
+
+    <box name="ArapucaOut" lunit="cm"
+      x="65"
+      y="2.5"
+      z="65"/>
+
+    <box name="ArapucaIn" lunit="cm"
+      x="60"
+      y="2.5"
+      z="60"/>
+
+     <subtraction name="ArapucaWalls">
+      <first  ref="ArapucaOut"/>
+      <second ref="ArapucaIn"/>
+      <position name="posArapucaSub" x="0" y="1.25" z="0." unit="cm"/>
+      </subtraction>
+
+    <box name="ArapucaAcceptanceWindow" lunit="cm"
+      x="60"
+      y="1"
+      z="60"/>
+
+    <box name="ArapucaDoubleIn" lunit="cm"
+      x="60"
+      y="3.5"
+      z="60"/>
+
+     <subtraction name="ArapucaDoubleWalls">
+      <first  ref="ArapucaOut"/>
+      <second ref="ArapucaDoubleIn"/>
+      <position name="posArapucaDoubleSub" x="0" y="0" z="0" unit="cm"/>
+      </subtraction>
+
+    <box name="ArapucaDoubleAcceptanceWindow" lunit="cm"
+      x="2.48"
+      y="60"
+      z="60"/>
+
+    <box name="ArapucaCathodeAcceptanceWindow" lunit="cm"
+      x="1"
+      y="60"
+      z="60"/>
+
+
+    <box name="Cryostat" lunit="cm" 
+      x="850.32" 
+      y="1548.24" 
+      z="2291.8526"/>
+
+    <box name="ArgonInterior" lunit="cm" 
+      x="850.08"
+      y="1548"
+      z="2291.6126"/>
+
+    <box name="GaseousArgon" lunit="cm" 
+      x="100 - 0.01"
+      y="1548"
+      z="2291.6126"/>
+
+    <box name="ExternalAuxOut" lunit="cm" 
+      x="850.08 - 100"
+      y="1548 - 2*2.5 - 2*40"
+      z="2291.6126"/>
+
+    <box name="ExternalAuxIn" lunit="cm" 
+      x="850.08"
+      y="1359.17"
+      z="2291.6126 + 1"/>
+
+   <subtraction name="ExternalActive">
+      <first ref="ExternalAuxOut"/>
+      <second ref="ExternalAuxIn"/>
+    </subtraction>
+
+    <subtraction name="SteelShell">
+      <first ref="Cryostat"/>
+      <second ref="ArgonInterior"/>
+    </subtraction>
+
+
+
+    <box name="CathodeBlock" lunit="cm"
+      x="4"
+      y="336"
+      z="297.8018" />
+
+    <box name="CathodeVoid" lunit="cm"
+      x="5"
+      y="76.35"
+      z="67" />
+
+    <subtraction name="Cathode1">
+      <first ref="CathodeBlock"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub1" x="0" y="-122.525" z="-108.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode2">
+      <first ref="Cathode1"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub2" x="0" y="-122.525" z="-37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode3">
+      <first ref="Cathode2"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub3" x="0" y="-122.525" z="37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode4">
+      <first ref="Cathode3"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub4" x="0" y="-122.525" z="108.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode5">
+      <first ref="Cathode4"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub5" x="0" y="-42.175" z="-108.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode6">
+      <first ref="Cathode5"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub6" x="0" y="-42.175" z="-37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode7">
+      <first ref="Cathode6"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub7" x="0" y="-42.175" z="37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode8">
+      <first ref="Cathode7"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub8" x="0" y="-42.175" z="108.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode9">
+      <first ref="Cathode8"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub9" x="0" y="42.175" z="-108.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode10">
+      <first ref="Cathode9"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub10" x="0" y="42.175" z="-37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode11">
+      <first ref="Cathode10"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub11" x="0" y="42.175" z="37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode12">
+      <first ref="Cathode11"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub12" x="0" y="42.175" z="108.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode13">
+      <first ref="Cathode12"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub13" x="0" y="122.525" z="-108.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode14">
+      <first ref="Cathode13"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub14" x="0" y="122.525" z="-37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode15">
+      <first ref="Cathode14"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub15" x="0" y="122.525" z="37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="CathodeGrid">
+      <first ref="Cathode15"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub16" x="0" y="122.525" z="108.5" unit="cm"/>
+    </subtraction>
+
+   <box name="AnodePlate" 
+      x="0.01"
+      y="336"
+      z="297.8018"
+      lunit="cm"/>
+
+    <box name="FoamPadBlock" lunit="cm"
+      x="1010.32"
+      y="1708.24"
+      z="2451.8526" />
+
+    <subtraction name="FoamPadding">
+      <first ref="FoamPadBlock"/>
+      <second ref="Cryostat"/>
+      <positionref ref="posCenter"/>
+    </subtraction>
+
+    <box name="SteelSupportBlock" lunit="cm"
+      x="1210.32"
+      y="1908.24"
+      z="2651.8526" />
+
+    <subtraction name="SteelSupport">
+      <first ref="SteelSupportBlock"/>
+      <second ref="FoamPadBlock"/>
+      <positionref ref="posCenter"/>
+    </subtraction>
+
+    <box name="DetEnclosure" lunit="cm" 
+      x="1310.32"
+      y="2108.24"
+      z="2851.8526"/>
+
+
+    <box name="World" lunit="cm" 
+      x="9310.32" 
+      y="10108.24" 
+      z="10851.8526"/>
+</solids>
+<structure>
+<volume name="volFieldShaper">
+  <materialref ref="Al2O3"/>
+  <solidref ref="FieldShaperSolid"/>
+</volume>
+<volume name="volFieldShaperSlim">
+  <materialref ref="Al2O3"/>
+  <solidref ref="FieldShaperSolidSlim"/>
+</volume>
+
+
+    <volume name="volTPCActive">
+      <materialref ref="LAr"/>
+      <solidref ref="CRMActive"/>
+      <auxiliary auxtype="SensDet" auxvalue="SimEnergyDeposit"/>
+      <auxiliary auxtype="StepLimit" auxunit="cm" auxvalue="0.5208*cm"/>
+      <auxiliary auxtype="Efield" auxunit="V/cm" auxvalue="500*V/cm"/>
+      <colorref ref="blue"/>
+    </volume>
+   <volume name="volTPCPlaneU">
+     <materialref ref="LAr"/>
+     <solidref ref="CRMUPlane"/>
+   </volume>
+  <volume name="volTPCPlaneY">
+    <materialref ref="LAr"/>
+    <solidref ref="CRMYPlane"/>
+  </volume>
+  <volume name="volTPCPlaneZ">
+    <materialref ref="LAr"/>
+    <solidref ref="CRMZPlane"/>
+  </volume>
+   <volume name="volTPC">
+     <materialref ref="LAr"/>
+       <solidref ref="CRM"/>
+       <physvol>
+       <volumeref ref="volTPCPlaneU"/>
+       <position name="posPlaneU" unit="cm" 
+         x="324.99" y="0" z="0"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCPlaneY"/>
+       <position name="posPlaneY" unit="cm" 
+         x="325.01" y="0" z="0"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCPlaneZ"/>
+       <position name="posPlaneZ" unit="cm" 
+         x="325.03" y="0" z="0"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCActive"/>
+       <position name="posActive" unit="cm" 
+        x="-0.04" y="" z="0"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+   </volume>
+ 
+    <volume name="volSteelShell">
+      <materialref ref="STEEL_STAINLESS_Fe7Cr2Ni" />
+      <solidref ref="SteelShell" />
+    </volume>
+    <volume name="volGroundGrid">
+      <materialref ref="STEEL_STAINLESS_Fe7Cr2Ni" />
+      <solidref ref="CathodeGrid" />
+    </volume>    
+    <volume name="volAnodePlate">
+     <materialref ref="vm2000"/>
+     <solidref ref="AnodePlate"/>
+    </volume>
+    <volume name="volGaseousArgon">
+      <materialref ref="ArGas"/>
+      <solidref ref="GaseousArgon"/>
+    </volume>
+    <volume name="volExternalActive">
+      <materialref ref="LAr"/>
+      <solidref ref="ExternalActive"/>
+      <auxiliary auxtype="SensDet" auxvalue="SimEnergyDeposit"/>
+      <auxiliary auxtype="StepLimit" auxunit="cm" auxvalue="0.5208*cm"/>
+      <auxiliary auxtype="Efield" auxunit="V/cm" auxvalue="0*V/cm"/>
+      <colorref ref="green"/>
+    </volume>
+    <volume name="volArapucaDouble_0-0-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-0-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-0-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-0-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-0-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-0-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-0-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-0-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-1-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-1-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-1-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-1-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-1-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-1-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-1-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-1-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-2-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-2-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-2-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-2-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-2-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-2-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-2-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-2-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-3-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-3-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-3-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-3-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-3-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-3-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-3-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-3-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-4-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-4-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-4-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-4-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-4-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-4-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-4-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-4-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-5-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-5-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-5-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-5-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-5-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-5-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-5-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-5-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-6-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-6-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-6-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-6-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-6-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-6-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-6-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-6-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-0-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-0-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-0-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-0-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-0-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-0-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-0-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-0-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-1-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-1-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-1-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-1-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-1-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-1-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-1-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-1-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-2-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-2-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-2-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-2-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-2-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-2-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-2-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-2-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-3-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-3-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-3-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-3-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-3-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-3-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-3-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-3-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-4-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-4-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-4-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-4-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-4-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-4-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-4-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-4-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-5-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-5-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-5-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-5-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-5-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-5-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-5-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-5-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-6-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-6-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-6-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-6-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-6-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-6-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-6-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-6-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-0-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-0-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-0-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-0-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-0-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-0-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-0-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-0-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-1-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-1-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-1-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-1-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-1-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-1-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-1-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-1-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-2-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-2-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-2-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-2-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-2-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-2-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-2-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-2-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-3-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-3-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-3-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-3-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-3-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-3-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-3-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-3-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-4-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-4-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-4-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-4-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-4-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-4-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-4-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-4-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-5-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-5-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-5-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-5-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-5-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-5-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-5-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-5-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-6-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-6-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-6-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-6-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-6-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-6-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-6-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-6-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-0-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-0-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-0-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-0-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-0-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-0-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-0-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-0-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-1-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-1-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-1-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-1-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-1-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-1-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-1-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-1-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-2-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-2-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-2-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-2-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-2-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-2-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-2-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-2-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-3-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-3-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-3-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-3-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-3-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-3-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-3-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-3-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-4-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-4-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-4-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-4-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-4-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-4-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-4-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-4-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-5-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-5-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-5-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-5-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-5-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-5-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-5-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-5-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-6-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-6-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-6-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-6-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-6-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-6-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-6-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-6-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_0-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_0-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_0-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_0-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_0-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_0-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_0-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_0-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_0-4">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_0-4">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_0-5">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_0-5">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_0-6">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_0-6">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_0-7">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_0-7">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_1-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_1-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_1-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_1-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_1-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_1-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_1-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_1-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_1-4">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_1-4">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_1-5">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_1-5">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_1-6">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_1-6">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_1-7">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_1-7">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_2-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_2-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_2-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_2-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_2-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_2-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_2-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_2-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_2-4">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_2-4">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_2-5">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_2-5">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_2-6">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_2-6">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_2-7">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_2-7">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_3-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_3-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_3-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_3-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_3-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_3-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_3-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_3-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_3-4">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_3-4">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_3-5">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_3-5">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_3-6">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_3-6">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_3-7">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_3-7">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_4-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_4-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_4-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_4-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_4-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_4-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_4-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_4-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_4-4">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_4-4">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_4-5">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_4-5">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_4-6">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_4-6">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_4-7">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_4-7">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_5-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_5-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_5-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_5-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_5-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_5-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_5-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_5-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_5-4">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_5-4">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_5-5">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_5-5">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_5-6">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_5-6">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_5-7">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_5-7">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_6-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_6-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_6-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_6-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_6-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_6-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_6-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_6-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_6-4">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_6-4">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_6-5">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_6-5">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_6-6">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_6-6">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_6-7">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_6-7">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+
+    <volume name="volCryostat">
+      <materialref ref="LAr" />
+      <solidref ref="Cryostat" />
+      <physvol>
+        <volumeref ref="volGaseousArgon"/>
+        <position name="posGaseousArgon" unit="cm" x="375.045" y="0" z="0"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volSteelShell"/>
+        <position name="posSteelShell" unit="cm" x="0" y="0" z="0"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volExternalActive"/>
+        <position name="posExternalActive" unit="cm" x="-100/2" y="0" z="0"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-0" unit="cm"
+           x="0" y="-589.5" z="-970.85585"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-1" unit="cm"
+           x="0" y="-421.5" z="-970.85585"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-2" unit="cm"
+           x="0" y="-252.5" z="-970.85585"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-3" unit="cm"
+           x="0" y="-84.5" z="-970.85585"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-4" unit="cm"
+           x="0" y="84.5" z="-970.85585"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-5" unit="cm"
+           x="0" y="252.5" z="-970.85585"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-6" unit="cm"
+           x="0" y="421.5" z="-970.85585"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-7" unit="cm"
+           x="0" y="589.5" z="-970.85585"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-8" unit="cm"
+           x="0" y="-589.5" z="-821.95495"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-9" unit="cm"
+           x="0" y="-421.5" z="-821.95495"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-10" unit="cm"
+           x="0" y="-252.5" z="-821.95495"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-11" unit="cm"
+           x="0" y="-84.5" z="-821.95495"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-12" unit="cm"
+           x="0" y="84.5" z="-821.95495"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-13" unit="cm"
+           x="0" y="252.5" z="-821.95495"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-14" unit="cm"
+           x="0" y="421.5" z="-821.95495"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-15" unit="cm"
+           x="0" y="589.5" z="-821.95495"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-16" unit="cm"
+           x="0" y="-589.5" z="-672.05405"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-17" unit="cm"
+           x="0" y="-421.5" z="-672.05405"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-18" unit="cm"
+           x="0" y="-252.5" z="-672.05405"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-19" unit="cm"
+           x="0" y="-84.5" z="-672.05405"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-20" unit="cm"
+           x="0" y="84.5" z="-672.05405"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-21" unit="cm"
+           x="0" y="252.5" z="-672.05405"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-22" unit="cm"
+           x="0" y="421.5" z="-672.05405"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-23" unit="cm"
+           x="0" y="589.5" z="-672.05405"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-24" unit="cm"
+           x="0" y="-589.5" z="-523.15315"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-25" unit="cm"
+           x="0" y="-421.5" z="-523.15315"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-26" unit="cm"
+           x="0" y="-252.5" z="-523.15315"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-27" unit="cm"
+           x="0" y="-84.5" z="-523.15315"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-28" unit="cm"
+           x="0" y="84.5" z="-523.15315"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-29" unit="cm"
+           x="0" y="252.5" z="-523.15315"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-30" unit="cm"
+           x="0" y="421.5" z="-523.15315"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-31" unit="cm"
+           x="0" y="589.5" z="-523.15315"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-32" unit="cm"
+           x="0" y="-589.5" z="-373.25225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-33" unit="cm"
+           x="0" y="-421.5" z="-373.25225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-34" unit="cm"
+           x="0" y="-252.5" z="-373.25225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-35" unit="cm"
+           x="0" y="-84.5" z="-373.25225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-36" unit="cm"
+           x="0" y="84.5" z="-373.25225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-37" unit="cm"
+           x="0" y="252.5" z="-373.25225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-38" unit="cm"
+           x="0" y="421.5" z="-373.25225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-39" unit="cm"
+           x="0" y="589.5" z="-373.25225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-40" unit="cm"
+           x="0" y="-589.5" z="-224.35135"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-41" unit="cm"
+           x="0" y="-421.5" z="-224.35135"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-42" unit="cm"
+           x="0" y="-252.5" z="-224.35135"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-43" unit="cm"
+           x="0" y="-84.5" z="-224.35135"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-44" unit="cm"
+           x="0" y="84.5" z="-224.35135"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-45" unit="cm"
+           x="0" y="252.5" z="-224.35135"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-46" unit="cm"
+           x="0" y="421.5" z="-224.35135"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-47" unit="cm"
+           x="0" y="589.5" z="-224.35135"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-48" unit="cm"
+           x="0" y="-589.5" z="-74.45045"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-49" unit="cm"
+           x="0" y="-421.5" z="-74.45045"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-50" unit="cm"
+           x="0" y="-252.5" z="-74.45045"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-51" unit="cm"
+           x="0" y="-84.5" z="-74.45045"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-52" unit="cm"
+           x="0" y="84.5" z="-74.45045"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-53" unit="cm"
+           x="0" y="252.5" z="-74.45045"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-54" unit="cm"
+           x="0" y="421.5" z="-74.45045"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-55" unit="cm"
+           x="0" y="589.5" z="-74.45045"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-56" unit="cm"
+           x="0" y="-589.5" z="74.45045"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-57" unit="cm"
+           x="0" y="-421.5" z="74.45045"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-58" unit="cm"
+           x="0" y="-252.5" z="74.45045"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-59" unit="cm"
+           x="0" y="-84.5" z="74.45045"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-60" unit="cm"
+           x="0" y="84.5" z="74.45045"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-61" unit="cm"
+           x="0" y="252.5" z="74.45045"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-62" unit="cm"
+           x="0" y="421.5" z="74.45045"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-63" unit="cm"
+           x="0" y="589.5" z="74.45045"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-64" unit="cm"
+           x="0" y="-589.5" z="224.35135"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-65" unit="cm"
+           x="0" y="-421.5" z="224.35135"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-66" unit="cm"
+           x="0" y="-252.5" z="224.35135"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-67" unit="cm"
+           x="0" y="-84.5" z="224.35135"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-68" unit="cm"
+           x="0" y="84.5" z="224.35135"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-69" unit="cm"
+           x="0" y="252.5" z="224.35135"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-70" unit="cm"
+           x="0" y="421.5" z="224.35135"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-71" unit="cm"
+           x="0" y="589.5" z="224.35135"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-72" unit="cm"
+           x="0" y="-589.5" z="373.25225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-73" unit="cm"
+           x="0" y="-421.5" z="373.25225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-74" unit="cm"
+           x="0" y="-252.5" z="373.25225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-75" unit="cm"
+           x="0" y="-84.5" z="373.25225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-76" unit="cm"
+           x="0" y="84.5" z="373.25225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-77" unit="cm"
+           x="0" y="252.5" z="373.25225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-78" unit="cm"
+           x="0" y="421.5" z="373.25225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-79" unit="cm"
+           x="0" y="589.5" z="373.25225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-80" unit="cm"
+           x="0" y="-589.5" z="523.15315"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-81" unit="cm"
+           x="0" y="-421.5" z="523.15315"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-82" unit="cm"
+           x="0" y="-252.5" z="523.15315"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-83" unit="cm"
+           x="0" y="-84.5" z="523.15315"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-84" unit="cm"
+           x="0" y="84.5" z="523.15315"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-85" unit="cm"
+           x="0" y="252.5" z="523.15315"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-86" unit="cm"
+           x="0" y="421.5" z="523.15315"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-87" unit="cm"
+           x="0" y="589.5" z="523.15315"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-88" unit="cm"
+           x="0" y="-589.5" z="672.05405"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-89" unit="cm"
+           x="0" y="-421.5" z="672.05405"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-90" unit="cm"
+           x="0" y="-252.5" z="672.05405"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-91" unit="cm"
+           x="0" y="-84.5" z="672.05405"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-92" unit="cm"
+           x="0" y="84.5" z="672.05405"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-93" unit="cm"
+           x="0" y="252.5" z="672.05405"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-94" unit="cm"
+           x="0" y="421.5" z="672.05405"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-95" unit="cm"
+           x="0" y="589.5" z="672.05405"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-96" unit="cm"
+           x="0" y="-589.5" z="821.95495"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-97" unit="cm"
+           x="0" y="-421.5" z="821.95495"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-98" unit="cm"
+           x="0" y="-252.5" z="821.95495"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-99" unit="cm"
+           x="0" y="-84.5" z="821.95495"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-100" unit="cm"
+           x="0" y="84.5" z="821.95495"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-101" unit="cm"
+           x="0" y="252.5" z="821.95495"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-102" unit="cm"
+           x="0" y="421.5" z="821.95495"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-103" unit="cm"
+           x="0" y="589.5" z="821.95495"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-104" unit="cm"
+           x="0" y="-589.5" z="970.85585"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-105" unit="cm"
+           x="0" y="-421.5" z="970.85585"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-106" unit="cm"
+           x="0" y="-252.5" z="970.85585"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-107" unit="cm"
+           x="0" y="-84.5" z="970.85585"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-108" unit="cm"
+           x="0" y="84.5" z="970.85585"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-109" unit="cm"
+           x="0" y="252.5" z="970.85585"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-110" unit="cm"
+           x="0" y="421.5" z="970.85585"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-111" unit="cm"
+           x="0" y="589.5" z="970.85585"/>
+      </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper0" unit="cm"  x="-322.04" y="-676.3" z="0" />
+     <rotation name="rotFS0" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper1" unit="cm"  x="-316.04" y="-676.3" z="0" />
+     <rotation name="rotFS1" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper2" unit="cm"  x="-310.04" y="-676.3" z="0" />
+     <rotation name="rotFS2" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper3" unit="cm"  x="-304.04" y="-676.3" z="0" />
+     <rotation name="rotFS3" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper4" unit="cm"  x="-298.04" y="-676.3" z="0" />
+     <rotation name="rotFS4" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper5" unit="cm"  x="-292.04" y="-676.3" z="0" />
+     <rotation name="rotFS5" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper6" unit="cm"  x="-286.04" y="-676.3" z="0" />
+     <rotation name="rotFS6" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper7" unit="cm"  x="-280.04" y="-676.3" z="0" />
+     <rotation name="rotFS7" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper8" unit="cm"  x="-274.04" y="-676.3" z="0" />
+     <rotation name="rotFS8" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper9" unit="cm"  x="-268.04" y="-676.3" z="0" />
+     <rotation name="rotFS9" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper10" unit="cm"  x="-262.04" y="-676.3" z="0" />
+     <rotation name="rotFS10" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper11" unit="cm"  x="-256.04" y="-676.3" z="0" />
+     <rotation name="rotFS11" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper12" unit="cm"  x="-250.04" y="-676.3" z="0" />
+     <rotation name="rotFS12" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper13" unit="cm"  x="-244.04" y="-676.3" z="0" />
+     <rotation name="rotFS13" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper14" unit="cm"  x="-238.04" y="-676.3" z="0" />
+     <rotation name="rotFS14" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper15" unit="cm"  x="-232.04" y="-676.3" z="0" />
+     <rotation name="rotFS15" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper16" unit="cm"  x="-226.04" y="-676.3" z="0" />
+     <rotation name="rotFS16" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper17" unit="cm"  x="-220.04" y="-676.3" z="0" />
+     <rotation name="rotFS17" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper18" unit="cm"  x="-214.04" y="-676.3" z="0" />
+     <rotation name="rotFS18" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper19" unit="cm"  x="-208.04" y="-676.3" z="0" />
+     <rotation name="rotFS19" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper20" unit="cm"  x="-202.04" y="-676.3" z="0" />
+     <rotation name="rotFS20" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper21" unit="cm"  x="-196.04" y="-676.3" z="0" />
+     <rotation name="rotFS21" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper22" unit="cm"  x="-190.04" y="-676.3" z="0" />
+     <rotation name="rotFS22" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper23" unit="cm"  x="-184.04" y="-676.3" z="0" />
+     <rotation name="rotFS23" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper24" unit="cm"  x="-178.04" y="-676.3" z="0" />
+     <rotation name="rotFS24" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper25" unit="cm"  x="-172.04" y="-676.3" z="0" />
+     <rotation name="rotFS25" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper26" unit="cm"  x="-166.04" y="-676.3" z="0" />
+     <rotation name="rotFS26" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper27" unit="cm"  x="-160.04" y="-676.3" z="0" />
+     <rotation name="rotFS27" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper28" unit="cm"  x="-154.04" y="-676.3" z="0" />
+     <rotation name="rotFS28" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper29" unit="cm"  x="-148.04" y="-676.3" z="0" />
+     <rotation name="rotFS29" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper30" unit="cm"  x="-142.04" y="-676.3" z="0" />
+     <rotation name="rotFS30" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper31" unit="cm"  x="-136.04" y="-676.3" z="0" />
+     <rotation name="rotFS31" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper32" unit="cm"  x="-130.04" y="-676.3" z="0" />
+     <rotation name="rotFS32" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper33" unit="cm"  x="-124.04" y="-676.3" z="0" />
+     <rotation name="rotFS33" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper34" unit="cm"  x="-118.04" y="-676.3" z="0" />
+     <rotation name="rotFS34" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper35" unit="cm"  x="-112.04" y="-676.3" z="0" />
+     <rotation name="rotFS35" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper36" unit="cm"  x="-106.04" y="-676.3" z="0" />
+     <rotation name="rotFS36" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper37" unit="cm"  x="-100.04" y="-676.3" z="0" />
+     <rotation name="rotFS37" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper38" unit="cm"  x="-94.04" y="-676.3" z="0" />
+     <rotation name="rotFS38" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper39" unit="cm"  x="-88.04" y="-676.3" z="0" />
+     <rotation name="rotFS39" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper40" unit="cm"  x="-82.04" y="-676.3" z="0" />
+     <rotation name="rotFS40" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper41" unit="cm"  x="-76.04" y="-676.3" z="0" />
+     <rotation name="rotFS41" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper42" unit="cm"  x="-70.04" y="-676.3" z="0" />
+     <rotation name="rotFS42" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper43" unit="cm"  x="-64.04" y="-676.3" z="0" />
+     <rotation name="rotFS43" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper44" unit="cm"  x="-58.04" y="-676.3" z="0" />
+     <rotation name="rotFS44" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper45" unit="cm"  x="-52.04" y="-676.3" z="0" />
+     <rotation name="rotFS45" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper46" unit="cm"  x="-46.04" y="-676.3" z="0" />
+     <rotation name="rotFS46" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper47" unit="cm"  x="-40.04" y="-676.3" z="0" />
+     <rotation name="rotFS47" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper48" unit="cm"  x="-34.04" y="-676.3" z="0" />
+     <rotation name="rotFS48" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper49" unit="cm"  x="-28.04" y="-676.3" z="0" />
+     <rotation name="rotFS49" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper50" unit="cm"  x="-22.04" y="-676.3" z="0" />
+     <rotation name="rotFS50" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper51" unit="cm"  x="-16.04" y="-676.3" z="0" />
+     <rotation name="rotFS51" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper52" unit="cm"  x="-10.04" y="-676.3" z="0" />
+     <rotation name="rotFS52" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper53" unit="cm"  x="-4.04000000000001" y="-676.3" z="0" />
+     <rotation name="rotFS53" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper54" unit="cm"  x="1.95999999999999" y="-676.3" z="0" />
+     <rotation name="rotFS54" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper55" unit="cm"  x="7.95999999999999" y="-676.3" z="0" />
+     <rotation name="rotFS55" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper56" unit="cm"  x="13.96" y="-676.3" z="0" />
+     <rotation name="rotFS56" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper57" unit="cm"  x="19.96" y="-676.3" z="0" />
+     <rotation name="rotFS57" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper58" unit="cm"  x="25.96" y="-676.3" z="0" />
+     <rotation name="rotFS58" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper59" unit="cm"  x="31.96" y="-676.3" z="0" />
+     <rotation name="rotFS59" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper60" unit="cm"  x="37.96" y="-676.3" z="0" />
+     <rotation name="rotFS60" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper61" unit="cm"  x="43.96" y="-676.3" z="0" />
+     <rotation name="rotFS61" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper62" unit="cm"  x="49.96" y="-676.3" z="0" />
+     <rotation name="rotFS62" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper63" unit="cm"  x="55.96" y="-676.3" z="0" />
+     <rotation name="rotFS63" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper64" unit="cm"  x="61.96" y="-676.3" z="0" />
+     <rotation name="rotFS64" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper65" unit="cm"  x="67.96" y="-676.3" z="0" />
+     <rotation name="rotFS65" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper66" unit="cm"  x="73.96" y="-676.3" z="0" />
+     <rotation name="rotFS66" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper67" unit="cm"  x="79.96" y="-676.3" z="0" />
+     <rotation name="rotFS67" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper68" unit="cm"  x="85.96" y="-676.3" z="0" />
+     <rotation name="rotFS68" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper69" unit="cm"  x="91.96" y="-676.3" z="0" />
+     <rotation name="rotFS69" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper70" unit="cm"  x="97.96" y="-676.3" z="0" />
+     <rotation name="rotFS70" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper71" unit="cm"  x="103.96" y="-676.3" z="0" />
+     <rotation name="rotFS71" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper72" unit="cm"  x="109.96" y="-676.3" z="0" />
+     <rotation name="rotFS72" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper73" unit="cm"  x="115.96" y="-676.3" z="0" />
+     <rotation name="rotFS73" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper74" unit="cm"  x="121.96" y="-676.3" z="0" />
+     <rotation name="rotFS74" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper75" unit="cm"  x="127.96" y="-676.3" z="0" />
+     <rotation name="rotFS75" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper76" unit="cm"  x="133.96" y="-676.3" z="0" />
+     <rotation name="rotFS76" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper77" unit="cm"  x="139.96" y="-676.3" z="0" />
+     <rotation name="rotFS77" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper78" unit="cm"  x="145.96" y="-676.3" z="0" />
+     <rotation name="rotFS78" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper79" unit="cm"  x="151.96" y="-676.3" z="0" />
+     <rotation name="rotFS79" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper80" unit="cm"  x="157.96" y="-676.3" z="0" />
+     <rotation name="rotFS80" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper81" unit="cm"  x="163.96" y="-676.3" z="0" />
+     <rotation name="rotFS81" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper82" unit="cm"  x="169.96" y="-676.3" z="0" />
+     <rotation name="rotFS82" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper83" unit="cm"  x="175.96" y="-676.3" z="0" />
+     <rotation name="rotFS83" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper84" unit="cm"  x="181.96" y="-676.3" z="0" />
+     <rotation name="rotFS84" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper85" unit="cm"  x="187.96" y="-676.3" z="0" />
+     <rotation name="rotFS85" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper86" unit="cm"  x="193.96" y="-676.3" z="0" />
+     <rotation name="rotFS86" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper87" unit="cm"  x="199.96" y="-676.3" z="0" />
+     <rotation name="rotFS87" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper88" unit="cm"  x="205.96" y="-676.3" z="0" />
+     <rotation name="rotFS88" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper89" unit="cm"  x="211.96" y="-676.3" z="0" />
+     <rotation name="rotFS89" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper90" unit="cm"  x="217.96" y="-676.3" z="0" />
+     <rotation name="rotFS90" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper91" unit="cm"  x="223.96" y="-676.3" z="0" />
+     <rotation name="rotFS91" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper92" unit="cm"  x="229.96" y="-676.3" z="0" />
+     <rotation name="rotFS92" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper93" unit="cm"  x="235.96" y="-676.3" z="0" />
+     <rotation name="rotFS93" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper94" unit="cm"  x="241.96" y="-676.3" z="0" />
+     <rotation name="rotFS94" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper95" unit="cm"  x="247.96" y="-676.3" z="0" />
+     <rotation name="rotFS95" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper96" unit="cm"  x="253.96" y="-676.3" z="0" />
+     <rotation name="rotFS96" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper97" unit="cm"  x="259.96" y="-676.3" z="0" />
+     <rotation name="rotFS97" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper98" unit="cm"  x="265.96" y="-676.3" z="0" />
+     <rotation name="rotFS98" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper99" unit="cm"  x="271.96" y="-676.3" z="0" />
+     <rotation name="rotFS99" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper100" unit="cm"  x="277.96" y="-676.3" z="0" />
+     <rotation name="rotFS100" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper101" unit="cm"  x="283.96" y="-676.3" z="0" />
+     <rotation name="rotFS101" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper102" unit="cm"  x="289.96" y="-676.3" z="0" />
+     <rotation name="rotFS102" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper103" unit="cm"  x="295.96" y="-676.3" z="0" />
+     <rotation name="rotFS103" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper104" unit="cm"  x="301.96" y="-676.3" z="0" />
+     <rotation name="rotFS104" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper105" unit="cm"  x="307.96" y="-676.3" z="0" />
+     <rotation name="rotFS105" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper106" unit="cm"  x="313.96" y="-676.3" z="0" />
+     <rotation name="rotFS106" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper107" unit="cm"  x="319.96" y="-676.3" z="0" />
+     <rotation name="rotFS107" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-0" unit="cm" x="-328.04" y="-506" z="-896.9054"/>
+      </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-0" unit="cm" 
+         x="325.045" y="-506" z="-896.9054"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-1" unit="cm" x="-328.04" y="-170" z="-896.9054"/>
+      </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-1" unit="cm" 
+         x="325.045" y="-170" z="-896.9054"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-2" unit="cm" x="-328.04" y="166" z="-896.9054"/>
+      </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-2" unit="cm" 
+         x="325.045" y="166" z="-896.9054"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-3" unit="cm" x="-328.04" y="502" z="-896.9054"/>
+      </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-3" unit="cm" 
+         x="325.045" y="502" z="-896.9054"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-4" unit="cm" x="-328.04" y="-506" z="-599.1036"/>
+      </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-4" unit="cm" 
+         x="325.045" y="-506" z="-599.1036"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-5" unit="cm" x="-328.04" y="-170" z="-599.1036"/>
+      </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-5" unit="cm" 
+         x="325.045" y="-170" z="-599.1036"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-6" unit="cm" x="-328.04" y="166" z="-599.1036"/>
+      </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-6" unit="cm" 
+         x="325.045" y="166" z="-599.1036"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-7" unit="cm" x="-328.04" y="502" z="-599.1036"/>
+      </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-7" unit="cm" 
+         x="325.045" y="502" z="-599.1036"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-8" unit="cm" x="-328.04" y="-506" z="-301.3018"/>
+      </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-8" unit="cm" 
+         x="325.045" y="-506" z="-301.3018"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-9" unit="cm" x="-328.04" y="-170" z="-301.3018"/>
+      </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-9" unit="cm" 
+         x="325.045" y="-170" z="-301.3018"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-10" unit="cm" x="-328.04" y="166" z="-301.3018"/>
+      </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-10" unit="cm" 
+         x="325.045" y="166" z="-301.3018"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-11" unit="cm" x="-328.04" y="502" z="-301.3018"/>
+      </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-11" unit="cm" 
+         x="325.045" y="502" z="-301.3018"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-12" unit="cm" x="-328.04" y="-506" z="-3.49999999999989"/>
+      </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-12" unit="cm" 
+         x="325.045" y="-506" z="-3.49999999999989"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-13" unit="cm" x="-328.04" y="-170" z="-3.49999999999989"/>
+      </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-13" unit="cm" 
+         x="325.045" y="-170" z="-3.49999999999989"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-14" unit="cm" x="-328.04" y="166" z="-3.49999999999989"/>
+      </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-14" unit="cm" 
+         x="325.045" y="166" z="-3.49999999999989"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-15" unit="cm" x="-328.04" y="502" z="-3.49999999999989"/>
+      </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-15" unit="cm" 
+         x="325.045" y="502" z="-3.49999999999989"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-16" unit="cm" x="-328.04" y="-506" z="294.3018"/>
+      </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-16" unit="cm" 
+         x="325.045" y="-506" z="294.3018"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-17" unit="cm" x="-328.04" y="-170" z="294.3018"/>
+      </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-17" unit="cm" 
+         x="325.045" y="-170" z="294.3018"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-18" unit="cm" x="-328.04" y="166" z="294.3018"/>
+      </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-18" unit="cm" 
+         x="325.045" y="166" z="294.3018"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-19" unit="cm" x="-328.04" y="502" z="294.3018"/>
+      </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-19" unit="cm" 
+         x="325.045" y="502" z="294.3018"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-20" unit="cm" x="-328.04" y="-506" z="592.1036"/>
+      </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-20" unit="cm" 
+         x="325.045" y="-506" z="592.1036"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-21" unit="cm" x="-328.04" y="-170" z="592.1036"/>
+      </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-21" unit="cm" 
+         x="325.045" y="-170" z="592.1036"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-22" unit="cm" x="-328.04" y="166" z="592.1036"/>
+      </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-22" unit="cm" 
+         x="325.045" y="166" z="592.1036"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-23" unit="cm" x="-328.04" y="502" z="592.1036"/>
+      </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-23" unit="cm" 
+         x="325.045" y="502" z="592.1036"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-24" unit="cm" x="-328.04" y="-506" z="889.9054"/>
+      </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-24" unit="cm" 
+         x="325.045" y="-506" z="889.9054"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-25" unit="cm" x="-328.04" y="-170" z="889.9054"/>
+      </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-25" unit="cm" 
+         x="325.045" y="-170" z="889.9054"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-26" unit="cm" x="-328.04" y="166" z="889.9054"/>
+      </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-26" unit="cm" 
+         x="325.045" y="166" z="889.9054"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-27" unit="cm" x="-328.04" y="502" z="889.9054"/>
+      </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-27" unit="cm" 
+         x="325.045" y="502" z="889.9054"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-0-0"/>
+       <position name="posArapucaDouble0-Frame-0-0" unit="cm" 
+         x="-328.04"
+	 y="-633.7" 
+	 z="-859.4054"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-0"/>
+       <position name="posOpArapucaDouble0-Frame-0-0" unit="cm" 
+         x="-327.3"
+	 y="-633.7" 
+	 z="-859.4054"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-0-1"/>
+       <position name="posArapucaDouble1-Frame-0-0" unit="cm" 
+         x="-328.04"
+	 y="-543" 
+	 z="-1005.4054"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-1"/>
+       <position name="posOpArapucaDouble1-Frame-0-0" unit="cm" 
+         x="-327.3"
+	 y="-543" 
+	 z="-1005.4054"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-0-2"/>
+       <position name="posArapucaDouble2-Frame-0-0" unit="cm" 
+         x="-328.04"
+	 y="-469" 
+	 z="-788.4054"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-2"/>
+       <position name="posOpArapucaDouble2-Frame-0-0" unit="cm" 
+         x="-327.3"
+	 y="-469" 
+	 z="-788.4054"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-0-3"/>
+       <position name="posArapucaDouble3-Frame-0-0" unit="cm" 
+         x="-328.04"
+	 y="-378.3" 
+	 z="-934.4054"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-3"/>
+       <position name="posOpArapucaDouble3-Frame-0-0" unit="cm" 
+         x="-327.3"
+	 y="-378.3" 
+	 z="-934.4054"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-1-0"/>
+       <position name="posArapucaDouble0-Frame-0-1" unit="cm" 
+         x="-328.04"
+	 y="-633.7" 
+	 z="-561.6036"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-0"/>
+       <position name="posOpArapucaDouble0-Frame-0-1" unit="cm" 
+         x="-327.3"
+	 y="-633.7" 
+	 z="-561.6036"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-1-1"/>
+       <position name="posArapucaDouble1-Frame-0-1" unit="cm" 
+         x="-328.04"
+	 y="-543" 
+	 z="-707.6036"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-1"/>
+       <position name="posOpArapucaDouble1-Frame-0-1" unit="cm" 
+         x="-327.3"
+	 y="-543" 
+	 z="-707.6036"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-1-2"/>
+       <position name="posArapucaDouble2-Frame-0-1" unit="cm" 
+         x="-328.04"
+	 y="-469" 
+	 z="-490.6036"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-2"/>
+       <position name="posOpArapucaDouble2-Frame-0-1" unit="cm" 
+         x="-327.3"
+	 y="-469" 
+	 z="-490.6036"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-1-3"/>
+       <position name="posArapucaDouble3-Frame-0-1" unit="cm" 
+         x="-328.04"
+	 y="-378.3" 
+	 z="-636.6036"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-3"/>
+       <position name="posOpArapucaDouble3-Frame-0-1" unit="cm" 
+         x="-327.3"
+	 y="-378.3" 
+	 z="-636.6036"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-2-0"/>
+       <position name="posArapucaDouble0-Frame-0-2" unit="cm" 
+         x="-328.04"
+	 y="-633.7" 
+	 z="-263.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-0"/>
+       <position name="posOpArapucaDouble0-Frame-0-2" unit="cm" 
+         x="-327.3"
+	 y="-633.7" 
+	 z="-263.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-2-1"/>
+       <position name="posArapucaDouble1-Frame-0-2" unit="cm" 
+         x="-328.04"
+	 y="-543" 
+	 z="-409.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-1"/>
+       <position name="posOpArapucaDouble1-Frame-0-2" unit="cm" 
+         x="-327.3"
+	 y="-543" 
+	 z="-409.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-2-2"/>
+       <position name="posArapucaDouble2-Frame-0-2" unit="cm" 
+         x="-328.04"
+	 y="-469" 
+	 z="-192.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-2"/>
+       <position name="posOpArapucaDouble2-Frame-0-2" unit="cm" 
+         x="-327.3"
+	 y="-469" 
+	 z="-192.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-2-3"/>
+       <position name="posArapucaDouble3-Frame-0-2" unit="cm" 
+         x="-328.04"
+	 y="-378.3" 
+	 z="-338.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-3"/>
+       <position name="posOpArapucaDouble3-Frame-0-2" unit="cm" 
+         x="-327.3"
+	 y="-378.3" 
+	 z="-338.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-3-0"/>
+       <position name="posArapucaDouble0-Frame-0-3" unit="cm" 
+         x="-328.04"
+	 y="-633.7" 
+	 z="34.0000000000001"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-3-0"/>
+       <position name="posOpArapucaDouble0-Frame-0-3" unit="cm" 
+         x="-327.3"
+	 y="-633.7" 
+	 z="34.0000000000001"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-3-1"/>
+       <position name="posArapucaDouble1-Frame-0-3" unit="cm" 
+         x="-328.04"
+	 y="-543" 
+	 z="-112"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-3-1"/>
+       <position name="posOpArapucaDouble1-Frame-0-3" unit="cm" 
+         x="-327.3"
+	 y="-543" 
+	 z="-112"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-3-2"/>
+       <position name="posArapucaDouble2-Frame-0-3" unit="cm" 
+         x="-328.04"
+	 y="-469" 
+	 z="105"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-3-2"/>
+       <position name="posOpArapucaDouble2-Frame-0-3" unit="cm" 
+         x="-327.3"
+	 y="-469" 
+	 z="105"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-3-3"/>
+       <position name="posArapucaDouble3-Frame-0-3" unit="cm" 
+         x="-328.04"
+	 y="-378.3" 
+	 z="-40.9999999999999"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-3-3"/>
+       <position name="posOpArapucaDouble3-Frame-0-3" unit="cm" 
+         x="-327.3"
+	 y="-378.3" 
+	 z="-40.9999999999999"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-4-0"/>
+       <position name="posArapucaDouble0-Frame-0-4" unit="cm" 
+         x="-328.04"
+	 y="-633.7" 
+	 z="331.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-4-0"/>
+       <position name="posOpArapucaDouble0-Frame-0-4" unit="cm" 
+         x="-327.3"
+	 y="-633.7" 
+	 z="331.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-4-1"/>
+       <position name="posArapucaDouble1-Frame-0-4" unit="cm" 
+         x="-328.04"
+	 y="-543" 
+	 z="185.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-4-1"/>
+       <position name="posOpArapucaDouble1-Frame-0-4" unit="cm" 
+         x="-327.3"
+	 y="-543" 
+	 z="185.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-4-2"/>
+       <position name="posArapucaDouble2-Frame-0-4" unit="cm" 
+         x="-328.04"
+	 y="-469" 
+	 z="402.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-4-2"/>
+       <position name="posOpArapucaDouble2-Frame-0-4" unit="cm" 
+         x="-327.3"
+	 y="-469" 
+	 z="402.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-4-3"/>
+       <position name="posArapucaDouble3-Frame-0-4" unit="cm" 
+         x="-328.04"
+	 y="-378.3" 
+	 z="256.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-4-3"/>
+       <position name="posOpArapucaDouble3-Frame-0-4" unit="cm" 
+         x="-327.3"
+	 y="-378.3" 
+	 z="256.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-5-0"/>
+       <position name="posArapucaDouble0-Frame-0-5" unit="cm" 
+         x="-328.04"
+	 y="-633.7" 
+	 z="629.6036"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-5-0"/>
+       <position name="posOpArapucaDouble0-Frame-0-5" unit="cm" 
+         x="-327.3"
+	 y="-633.7" 
+	 z="629.6036"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-5-1"/>
+       <position name="posArapucaDouble1-Frame-0-5" unit="cm" 
+         x="-328.04"
+	 y="-543" 
+	 z="483.6036"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-5-1"/>
+       <position name="posOpArapucaDouble1-Frame-0-5" unit="cm" 
+         x="-327.3"
+	 y="-543" 
+	 z="483.6036"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-5-2"/>
+       <position name="posArapucaDouble2-Frame-0-5" unit="cm" 
+         x="-328.04"
+	 y="-469" 
+	 z="700.6036"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-5-2"/>
+       <position name="posOpArapucaDouble2-Frame-0-5" unit="cm" 
+         x="-327.3"
+	 y="-469" 
+	 z="700.6036"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-5-3"/>
+       <position name="posArapucaDouble3-Frame-0-5" unit="cm" 
+         x="-328.04"
+	 y="-378.3" 
+	 z="554.6036"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-5-3"/>
+       <position name="posOpArapucaDouble3-Frame-0-5" unit="cm" 
+         x="-327.3"
+	 y="-378.3" 
+	 z="554.6036"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-6-0"/>
+       <position name="posArapucaDouble0-Frame-0-6" unit="cm" 
+         x="-328.04"
+	 y="-633.7" 
+	 z="927.4054"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-6-0"/>
+       <position name="posOpArapucaDouble0-Frame-0-6" unit="cm" 
+         x="-327.3"
+	 y="-633.7" 
+	 z="927.4054"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-6-1"/>
+       <position name="posArapucaDouble1-Frame-0-6" unit="cm" 
+         x="-328.04"
+	 y="-543" 
+	 z="781.4054"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-6-1"/>
+       <position name="posOpArapucaDouble1-Frame-0-6" unit="cm" 
+         x="-327.3"
+	 y="-543" 
+	 z="781.4054"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-6-2"/>
+       <position name="posArapucaDouble2-Frame-0-6" unit="cm" 
+         x="-328.04"
+	 y="-469" 
+	 z="998.4054"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-6-2"/>
+       <position name="posOpArapucaDouble2-Frame-0-6" unit="cm" 
+         x="-327.3"
+	 y="-469" 
+	 z="998.4054"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-6-3"/>
+       <position name="posArapucaDouble3-Frame-0-6" unit="cm" 
+         x="-328.04"
+	 y="-378.3" 
+	 z="852.4054"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-6-3"/>
+       <position name="posOpArapucaDouble3-Frame-0-6" unit="cm" 
+         x="-327.3"
+	 y="-378.3" 
+	 z="852.4054"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-0-0"/>
+       <position name="posArapucaDouble0-Frame-1-0" unit="cm" 
+         x="-328.04"
+	 y="-297.7" 
+	 z="-859.4054"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-0"/>
+       <position name="posOpArapucaDouble0-Frame-1-0" unit="cm" 
+         x="-327.3"
+	 y="-297.7" 
+	 z="-859.4054"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-0-1"/>
+       <position name="posArapucaDouble1-Frame-1-0" unit="cm" 
+         x="-328.04"
+	 y="-207" 
+	 z="-1005.4054"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-1"/>
+       <position name="posOpArapucaDouble1-Frame-1-0" unit="cm" 
+         x="-327.3"
+	 y="-207" 
+	 z="-1005.4054"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-0-2"/>
+       <position name="posArapucaDouble2-Frame-1-0" unit="cm" 
+         x="-328.04"
+	 y="-133" 
+	 z="-788.4054"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-2"/>
+       <position name="posOpArapucaDouble2-Frame-1-0" unit="cm" 
+         x="-327.3"
+	 y="-133" 
+	 z="-788.4054"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-0-3"/>
+       <position name="posArapucaDouble3-Frame-1-0" unit="cm" 
+         x="-328.04"
+	 y="-42.3" 
+	 z="-934.4054"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-3"/>
+       <position name="posOpArapucaDouble3-Frame-1-0" unit="cm" 
+         x="-327.3"
+	 y="-42.3" 
+	 z="-934.4054"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-1-0"/>
+       <position name="posArapucaDouble0-Frame-1-1" unit="cm" 
+         x="-328.04"
+	 y="-297.7" 
+	 z="-561.6036"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-0"/>
+       <position name="posOpArapucaDouble0-Frame-1-1" unit="cm" 
+         x="-327.3"
+	 y="-297.7" 
+	 z="-561.6036"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-1-1"/>
+       <position name="posArapucaDouble1-Frame-1-1" unit="cm" 
+         x="-328.04"
+	 y="-207" 
+	 z="-707.6036"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-1"/>
+       <position name="posOpArapucaDouble1-Frame-1-1" unit="cm" 
+         x="-327.3"
+	 y="-207" 
+	 z="-707.6036"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-1-2"/>
+       <position name="posArapucaDouble2-Frame-1-1" unit="cm" 
+         x="-328.04"
+	 y="-133" 
+	 z="-490.6036"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-2"/>
+       <position name="posOpArapucaDouble2-Frame-1-1" unit="cm" 
+         x="-327.3"
+	 y="-133" 
+	 z="-490.6036"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-1-3"/>
+       <position name="posArapucaDouble3-Frame-1-1" unit="cm" 
+         x="-328.04"
+	 y="-42.3" 
+	 z="-636.6036"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-3"/>
+       <position name="posOpArapucaDouble3-Frame-1-1" unit="cm" 
+         x="-327.3"
+	 y="-42.3" 
+	 z="-636.6036"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-2-0"/>
+       <position name="posArapucaDouble0-Frame-1-2" unit="cm" 
+         x="-328.04"
+	 y="-297.7" 
+	 z="-263.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-0"/>
+       <position name="posOpArapucaDouble0-Frame-1-2" unit="cm" 
+         x="-327.3"
+	 y="-297.7" 
+	 z="-263.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-2-1"/>
+       <position name="posArapucaDouble1-Frame-1-2" unit="cm" 
+         x="-328.04"
+	 y="-207" 
+	 z="-409.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-1"/>
+       <position name="posOpArapucaDouble1-Frame-1-2" unit="cm" 
+         x="-327.3"
+	 y="-207" 
+	 z="-409.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-2-2"/>
+       <position name="posArapucaDouble2-Frame-1-2" unit="cm" 
+         x="-328.04"
+	 y="-133" 
+	 z="-192.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-2"/>
+       <position name="posOpArapucaDouble2-Frame-1-2" unit="cm" 
+         x="-327.3"
+	 y="-133" 
+	 z="-192.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-2-3"/>
+       <position name="posArapucaDouble3-Frame-1-2" unit="cm" 
+         x="-328.04"
+	 y="-42.3" 
+	 z="-338.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-3"/>
+       <position name="posOpArapucaDouble3-Frame-1-2" unit="cm" 
+         x="-327.3"
+	 y="-42.3" 
+	 z="-338.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-3-0"/>
+       <position name="posArapucaDouble0-Frame-1-3" unit="cm" 
+         x="-328.04"
+	 y="-297.7" 
+	 z="34.0000000000001"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-3-0"/>
+       <position name="posOpArapucaDouble0-Frame-1-3" unit="cm" 
+         x="-327.3"
+	 y="-297.7" 
+	 z="34.0000000000001"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-3-1"/>
+       <position name="posArapucaDouble1-Frame-1-3" unit="cm" 
+         x="-328.04"
+	 y="-207" 
+	 z="-112"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-3-1"/>
+       <position name="posOpArapucaDouble1-Frame-1-3" unit="cm" 
+         x="-327.3"
+	 y="-207" 
+	 z="-112"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-3-2"/>
+       <position name="posArapucaDouble2-Frame-1-3" unit="cm" 
+         x="-328.04"
+	 y="-133" 
+	 z="105"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-3-2"/>
+       <position name="posOpArapucaDouble2-Frame-1-3" unit="cm" 
+         x="-327.3"
+	 y="-133" 
+	 z="105"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-3-3"/>
+       <position name="posArapucaDouble3-Frame-1-3" unit="cm" 
+         x="-328.04"
+	 y="-42.3" 
+	 z="-40.9999999999999"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-3-3"/>
+       <position name="posOpArapucaDouble3-Frame-1-3" unit="cm" 
+         x="-327.3"
+	 y="-42.3" 
+	 z="-40.9999999999999"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-4-0"/>
+       <position name="posArapucaDouble0-Frame-1-4" unit="cm" 
+         x="-328.04"
+	 y="-297.7" 
+	 z="331.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-4-0"/>
+       <position name="posOpArapucaDouble0-Frame-1-4" unit="cm" 
+         x="-327.3"
+	 y="-297.7" 
+	 z="331.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-4-1"/>
+       <position name="posArapucaDouble1-Frame-1-4" unit="cm" 
+         x="-328.04"
+	 y="-207" 
+	 z="185.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-4-1"/>
+       <position name="posOpArapucaDouble1-Frame-1-4" unit="cm" 
+         x="-327.3"
+	 y="-207" 
+	 z="185.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-4-2"/>
+       <position name="posArapucaDouble2-Frame-1-4" unit="cm" 
+         x="-328.04"
+	 y="-133" 
+	 z="402.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-4-2"/>
+       <position name="posOpArapucaDouble2-Frame-1-4" unit="cm" 
+         x="-327.3"
+	 y="-133" 
+	 z="402.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-4-3"/>
+       <position name="posArapucaDouble3-Frame-1-4" unit="cm" 
+         x="-328.04"
+	 y="-42.3" 
+	 z="256.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-4-3"/>
+       <position name="posOpArapucaDouble3-Frame-1-4" unit="cm" 
+         x="-327.3"
+	 y="-42.3" 
+	 z="256.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-5-0"/>
+       <position name="posArapucaDouble0-Frame-1-5" unit="cm" 
+         x="-328.04"
+	 y="-297.7" 
+	 z="629.6036"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-5-0"/>
+       <position name="posOpArapucaDouble0-Frame-1-5" unit="cm" 
+         x="-327.3"
+	 y="-297.7" 
+	 z="629.6036"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-5-1"/>
+       <position name="posArapucaDouble1-Frame-1-5" unit="cm" 
+         x="-328.04"
+	 y="-207" 
+	 z="483.6036"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-5-1"/>
+       <position name="posOpArapucaDouble1-Frame-1-5" unit="cm" 
+         x="-327.3"
+	 y="-207" 
+	 z="483.6036"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-5-2"/>
+       <position name="posArapucaDouble2-Frame-1-5" unit="cm" 
+         x="-328.04"
+	 y="-133" 
+	 z="700.6036"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-5-2"/>
+       <position name="posOpArapucaDouble2-Frame-1-5" unit="cm" 
+         x="-327.3"
+	 y="-133" 
+	 z="700.6036"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-5-3"/>
+       <position name="posArapucaDouble3-Frame-1-5" unit="cm" 
+         x="-328.04"
+	 y="-42.3" 
+	 z="554.6036"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-5-3"/>
+       <position name="posOpArapucaDouble3-Frame-1-5" unit="cm" 
+         x="-327.3"
+	 y="-42.3" 
+	 z="554.6036"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-6-0"/>
+       <position name="posArapucaDouble0-Frame-1-6" unit="cm" 
+         x="-328.04"
+	 y="-297.7" 
+	 z="927.4054"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-6-0"/>
+       <position name="posOpArapucaDouble0-Frame-1-6" unit="cm" 
+         x="-327.3"
+	 y="-297.7" 
+	 z="927.4054"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-6-1"/>
+       <position name="posArapucaDouble1-Frame-1-6" unit="cm" 
+         x="-328.04"
+	 y="-207" 
+	 z="781.4054"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-6-1"/>
+       <position name="posOpArapucaDouble1-Frame-1-6" unit="cm" 
+         x="-327.3"
+	 y="-207" 
+	 z="781.4054"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-6-2"/>
+       <position name="posArapucaDouble2-Frame-1-6" unit="cm" 
+         x="-328.04"
+	 y="-133" 
+	 z="998.4054"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-6-2"/>
+       <position name="posOpArapucaDouble2-Frame-1-6" unit="cm" 
+         x="-327.3"
+	 y="-133" 
+	 z="998.4054"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-6-3"/>
+       <position name="posArapucaDouble3-Frame-1-6" unit="cm" 
+         x="-328.04"
+	 y="-42.3" 
+	 z="852.4054"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-6-3"/>
+       <position name="posOpArapucaDouble3-Frame-1-6" unit="cm" 
+         x="-327.3"
+	 y="-42.3" 
+	 z="852.4054"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-0-0"/>
+       <position name="posArapucaDouble0-Frame-2-0" unit="cm" 
+         x="-328.04"
+	 y="38.3" 
+	 z="-859.4054"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-0"/>
+       <position name="posOpArapucaDouble0-Frame-2-0" unit="cm" 
+         x="-327.3"
+	 y="38.3" 
+	 z="-859.4054"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-0-1"/>
+       <position name="posArapucaDouble1-Frame-2-0" unit="cm" 
+         x="-328.04"
+	 y="129" 
+	 z="-1005.4054"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-1"/>
+       <position name="posOpArapucaDouble1-Frame-2-0" unit="cm" 
+         x="-327.3"
+	 y="129" 
+	 z="-1005.4054"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-0-2"/>
+       <position name="posArapucaDouble2-Frame-2-0" unit="cm" 
+         x="-328.04"
+	 y="203" 
+	 z="-788.4054"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-2"/>
+       <position name="posOpArapucaDouble2-Frame-2-0" unit="cm" 
+         x="-327.3"
+	 y="203" 
+	 z="-788.4054"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-0-3"/>
+       <position name="posArapucaDouble3-Frame-2-0" unit="cm" 
+         x="-328.04"
+	 y="293.7" 
+	 z="-934.4054"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-3"/>
+       <position name="posOpArapucaDouble3-Frame-2-0" unit="cm" 
+         x="-327.3"
+	 y="293.7" 
+	 z="-934.4054"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-1-0"/>
+       <position name="posArapucaDouble0-Frame-2-1" unit="cm" 
+         x="-328.04"
+	 y="38.3" 
+	 z="-561.6036"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-0"/>
+       <position name="posOpArapucaDouble0-Frame-2-1" unit="cm" 
+         x="-327.3"
+	 y="38.3" 
+	 z="-561.6036"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-1-1"/>
+       <position name="posArapucaDouble1-Frame-2-1" unit="cm" 
+         x="-328.04"
+	 y="129" 
+	 z="-707.6036"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-1"/>
+       <position name="posOpArapucaDouble1-Frame-2-1" unit="cm" 
+         x="-327.3"
+	 y="129" 
+	 z="-707.6036"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-1-2"/>
+       <position name="posArapucaDouble2-Frame-2-1" unit="cm" 
+         x="-328.04"
+	 y="203" 
+	 z="-490.6036"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-2"/>
+       <position name="posOpArapucaDouble2-Frame-2-1" unit="cm" 
+         x="-327.3"
+	 y="203" 
+	 z="-490.6036"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-1-3"/>
+       <position name="posArapucaDouble3-Frame-2-1" unit="cm" 
+         x="-328.04"
+	 y="293.7" 
+	 z="-636.6036"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-3"/>
+       <position name="posOpArapucaDouble3-Frame-2-1" unit="cm" 
+         x="-327.3"
+	 y="293.7" 
+	 z="-636.6036"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-2-0"/>
+       <position name="posArapucaDouble0-Frame-2-2" unit="cm" 
+         x="-328.04"
+	 y="38.3" 
+	 z="-263.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-0"/>
+       <position name="posOpArapucaDouble0-Frame-2-2" unit="cm" 
+         x="-327.3"
+	 y="38.3" 
+	 z="-263.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-2-1"/>
+       <position name="posArapucaDouble1-Frame-2-2" unit="cm" 
+         x="-328.04"
+	 y="129" 
+	 z="-409.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-1"/>
+       <position name="posOpArapucaDouble1-Frame-2-2" unit="cm" 
+         x="-327.3"
+	 y="129" 
+	 z="-409.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-2-2"/>
+       <position name="posArapucaDouble2-Frame-2-2" unit="cm" 
+         x="-328.04"
+	 y="203" 
+	 z="-192.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-2"/>
+       <position name="posOpArapucaDouble2-Frame-2-2" unit="cm" 
+         x="-327.3"
+	 y="203" 
+	 z="-192.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-2-3"/>
+       <position name="posArapucaDouble3-Frame-2-2" unit="cm" 
+         x="-328.04"
+	 y="293.7" 
+	 z="-338.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-3"/>
+       <position name="posOpArapucaDouble3-Frame-2-2" unit="cm" 
+         x="-327.3"
+	 y="293.7" 
+	 z="-338.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-3-0"/>
+       <position name="posArapucaDouble0-Frame-2-3" unit="cm" 
+         x="-328.04"
+	 y="38.3" 
+	 z="34.0000000000001"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-3-0"/>
+       <position name="posOpArapucaDouble0-Frame-2-3" unit="cm" 
+         x="-327.3"
+	 y="38.3" 
+	 z="34.0000000000001"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-3-1"/>
+       <position name="posArapucaDouble1-Frame-2-3" unit="cm" 
+         x="-328.04"
+	 y="129" 
+	 z="-112"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-3-1"/>
+       <position name="posOpArapucaDouble1-Frame-2-3" unit="cm" 
+         x="-327.3"
+	 y="129" 
+	 z="-112"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-3-2"/>
+       <position name="posArapucaDouble2-Frame-2-3" unit="cm" 
+         x="-328.04"
+	 y="203" 
+	 z="105"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-3-2"/>
+       <position name="posOpArapucaDouble2-Frame-2-3" unit="cm" 
+         x="-327.3"
+	 y="203" 
+	 z="105"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-3-3"/>
+       <position name="posArapucaDouble3-Frame-2-3" unit="cm" 
+         x="-328.04"
+	 y="293.7" 
+	 z="-40.9999999999999"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-3-3"/>
+       <position name="posOpArapucaDouble3-Frame-2-3" unit="cm" 
+         x="-327.3"
+	 y="293.7" 
+	 z="-40.9999999999999"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-4-0"/>
+       <position name="posArapucaDouble0-Frame-2-4" unit="cm" 
+         x="-328.04"
+	 y="38.3" 
+	 z="331.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-4-0"/>
+       <position name="posOpArapucaDouble0-Frame-2-4" unit="cm" 
+         x="-327.3"
+	 y="38.3" 
+	 z="331.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-4-1"/>
+       <position name="posArapucaDouble1-Frame-2-4" unit="cm" 
+         x="-328.04"
+	 y="129" 
+	 z="185.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-4-1"/>
+       <position name="posOpArapucaDouble1-Frame-2-4" unit="cm" 
+         x="-327.3"
+	 y="129" 
+	 z="185.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-4-2"/>
+       <position name="posArapucaDouble2-Frame-2-4" unit="cm" 
+         x="-328.04"
+	 y="203" 
+	 z="402.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-4-2"/>
+       <position name="posOpArapucaDouble2-Frame-2-4" unit="cm" 
+         x="-327.3"
+	 y="203" 
+	 z="402.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-4-3"/>
+       <position name="posArapucaDouble3-Frame-2-4" unit="cm" 
+         x="-328.04"
+	 y="293.7" 
+	 z="256.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-4-3"/>
+       <position name="posOpArapucaDouble3-Frame-2-4" unit="cm" 
+         x="-327.3"
+	 y="293.7" 
+	 z="256.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-5-0"/>
+       <position name="posArapucaDouble0-Frame-2-5" unit="cm" 
+         x="-328.04"
+	 y="38.3" 
+	 z="629.6036"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-5-0"/>
+       <position name="posOpArapucaDouble0-Frame-2-5" unit="cm" 
+         x="-327.3"
+	 y="38.3" 
+	 z="629.6036"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-5-1"/>
+       <position name="posArapucaDouble1-Frame-2-5" unit="cm" 
+         x="-328.04"
+	 y="129" 
+	 z="483.6036"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-5-1"/>
+       <position name="posOpArapucaDouble1-Frame-2-5" unit="cm" 
+         x="-327.3"
+	 y="129" 
+	 z="483.6036"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-5-2"/>
+       <position name="posArapucaDouble2-Frame-2-5" unit="cm" 
+         x="-328.04"
+	 y="203" 
+	 z="700.6036"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-5-2"/>
+       <position name="posOpArapucaDouble2-Frame-2-5" unit="cm" 
+         x="-327.3"
+	 y="203" 
+	 z="700.6036"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-5-3"/>
+       <position name="posArapucaDouble3-Frame-2-5" unit="cm" 
+         x="-328.04"
+	 y="293.7" 
+	 z="554.6036"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-5-3"/>
+       <position name="posOpArapucaDouble3-Frame-2-5" unit="cm" 
+         x="-327.3"
+	 y="293.7" 
+	 z="554.6036"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-6-0"/>
+       <position name="posArapucaDouble0-Frame-2-6" unit="cm" 
+         x="-328.04"
+	 y="38.3" 
+	 z="927.4054"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-6-0"/>
+       <position name="posOpArapucaDouble0-Frame-2-6" unit="cm" 
+         x="-327.3"
+	 y="38.3" 
+	 z="927.4054"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-6-1"/>
+       <position name="posArapucaDouble1-Frame-2-6" unit="cm" 
+         x="-328.04"
+	 y="129" 
+	 z="781.4054"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-6-1"/>
+       <position name="posOpArapucaDouble1-Frame-2-6" unit="cm" 
+         x="-327.3"
+	 y="129" 
+	 z="781.4054"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-6-2"/>
+       <position name="posArapucaDouble2-Frame-2-6" unit="cm" 
+         x="-328.04"
+	 y="203" 
+	 z="998.4054"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-6-2"/>
+       <position name="posOpArapucaDouble2-Frame-2-6" unit="cm" 
+         x="-327.3"
+	 y="203" 
+	 z="998.4054"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-6-3"/>
+       <position name="posArapucaDouble3-Frame-2-6" unit="cm" 
+         x="-328.04"
+	 y="293.7" 
+	 z="852.4054"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-6-3"/>
+       <position name="posOpArapucaDouble3-Frame-2-6" unit="cm" 
+         x="-327.3"
+	 y="293.7" 
+	 z="852.4054"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-0-0"/>
+       <position name="posArapucaDouble0-Frame-3-0" unit="cm" 
+         x="-328.04"
+	 y="374.3" 
+	 z="-859.4054"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-0"/>
+       <position name="posOpArapucaDouble0-Frame-3-0" unit="cm" 
+         x="-327.3"
+	 y="374.3" 
+	 z="-859.4054"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-0-1"/>
+       <position name="posArapucaDouble1-Frame-3-0" unit="cm" 
+         x="-328.04"
+	 y="465" 
+	 z="-1005.4054"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-1"/>
+       <position name="posOpArapucaDouble1-Frame-3-0" unit="cm" 
+         x="-327.3"
+	 y="465" 
+	 z="-1005.4054"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-0-2"/>
+       <position name="posArapucaDouble2-Frame-3-0" unit="cm" 
+         x="-328.04"
+	 y="539" 
+	 z="-788.4054"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-2"/>
+       <position name="posOpArapucaDouble2-Frame-3-0" unit="cm" 
+         x="-327.3"
+	 y="539" 
+	 z="-788.4054"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-0-3"/>
+       <position name="posArapucaDouble3-Frame-3-0" unit="cm" 
+         x="-328.04"
+	 y="629.7" 
+	 z="-934.4054"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-3"/>
+       <position name="posOpArapucaDouble3-Frame-3-0" unit="cm" 
+         x="-327.3"
+	 y="629.7" 
+	 z="-934.4054"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-1-0"/>
+       <position name="posArapucaDouble0-Frame-3-1" unit="cm" 
+         x="-328.04"
+	 y="374.3" 
+	 z="-561.6036"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-0"/>
+       <position name="posOpArapucaDouble0-Frame-3-1" unit="cm" 
+         x="-327.3"
+	 y="374.3" 
+	 z="-561.6036"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-1-1"/>
+       <position name="posArapucaDouble1-Frame-3-1" unit="cm" 
+         x="-328.04"
+	 y="465" 
+	 z="-707.6036"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-1"/>
+       <position name="posOpArapucaDouble1-Frame-3-1" unit="cm" 
+         x="-327.3"
+	 y="465" 
+	 z="-707.6036"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-1-2"/>
+       <position name="posArapucaDouble2-Frame-3-1" unit="cm" 
+         x="-328.04"
+	 y="539" 
+	 z="-490.6036"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-2"/>
+       <position name="posOpArapucaDouble2-Frame-3-1" unit="cm" 
+         x="-327.3"
+	 y="539" 
+	 z="-490.6036"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-1-3"/>
+       <position name="posArapucaDouble3-Frame-3-1" unit="cm" 
+         x="-328.04"
+	 y="629.7" 
+	 z="-636.6036"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-3"/>
+       <position name="posOpArapucaDouble3-Frame-3-1" unit="cm" 
+         x="-327.3"
+	 y="629.7" 
+	 z="-636.6036"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-2-0"/>
+       <position name="posArapucaDouble0-Frame-3-2" unit="cm" 
+         x="-328.04"
+	 y="374.3" 
+	 z="-263.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-0"/>
+       <position name="posOpArapucaDouble0-Frame-3-2" unit="cm" 
+         x="-327.3"
+	 y="374.3" 
+	 z="-263.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-2-1"/>
+       <position name="posArapucaDouble1-Frame-3-2" unit="cm" 
+         x="-328.04"
+	 y="465" 
+	 z="-409.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-1"/>
+       <position name="posOpArapucaDouble1-Frame-3-2" unit="cm" 
+         x="-327.3"
+	 y="465" 
+	 z="-409.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-2-2"/>
+       <position name="posArapucaDouble2-Frame-3-2" unit="cm" 
+         x="-328.04"
+	 y="539" 
+	 z="-192.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-2"/>
+       <position name="posOpArapucaDouble2-Frame-3-2" unit="cm" 
+         x="-327.3"
+	 y="539" 
+	 z="-192.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-2-3"/>
+       <position name="posArapucaDouble3-Frame-3-2" unit="cm" 
+         x="-328.04"
+	 y="629.7" 
+	 z="-338.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-3"/>
+       <position name="posOpArapucaDouble3-Frame-3-2" unit="cm" 
+         x="-327.3"
+	 y="629.7" 
+	 z="-338.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-3-0"/>
+       <position name="posArapucaDouble0-Frame-3-3" unit="cm" 
+         x="-328.04"
+	 y="374.3" 
+	 z="34.0000000000001"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-3-0"/>
+       <position name="posOpArapucaDouble0-Frame-3-3" unit="cm" 
+         x="-327.3"
+	 y="374.3" 
+	 z="34.0000000000001"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-3-1"/>
+       <position name="posArapucaDouble1-Frame-3-3" unit="cm" 
+         x="-328.04"
+	 y="465" 
+	 z="-112"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-3-1"/>
+       <position name="posOpArapucaDouble1-Frame-3-3" unit="cm" 
+         x="-327.3"
+	 y="465" 
+	 z="-112"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-3-2"/>
+       <position name="posArapucaDouble2-Frame-3-3" unit="cm" 
+         x="-328.04"
+	 y="539" 
+	 z="105"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-3-2"/>
+       <position name="posOpArapucaDouble2-Frame-3-3" unit="cm" 
+         x="-327.3"
+	 y="539" 
+	 z="105"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-3-3"/>
+       <position name="posArapucaDouble3-Frame-3-3" unit="cm" 
+         x="-328.04"
+	 y="629.7" 
+	 z="-40.9999999999999"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-3-3"/>
+       <position name="posOpArapucaDouble3-Frame-3-3" unit="cm" 
+         x="-327.3"
+	 y="629.7" 
+	 z="-40.9999999999999"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-4-0"/>
+       <position name="posArapucaDouble0-Frame-3-4" unit="cm" 
+         x="-328.04"
+	 y="374.3" 
+	 z="331.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-4-0"/>
+       <position name="posOpArapucaDouble0-Frame-3-4" unit="cm" 
+         x="-327.3"
+	 y="374.3" 
+	 z="331.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-4-1"/>
+       <position name="posArapucaDouble1-Frame-3-4" unit="cm" 
+         x="-328.04"
+	 y="465" 
+	 z="185.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-4-1"/>
+       <position name="posOpArapucaDouble1-Frame-3-4" unit="cm" 
+         x="-327.3"
+	 y="465" 
+	 z="185.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-4-2"/>
+       <position name="posArapucaDouble2-Frame-3-4" unit="cm" 
+         x="-328.04"
+	 y="539" 
+	 z="402.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-4-2"/>
+       <position name="posOpArapucaDouble2-Frame-3-4" unit="cm" 
+         x="-327.3"
+	 y="539" 
+	 z="402.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-4-3"/>
+       <position name="posArapucaDouble3-Frame-3-4" unit="cm" 
+         x="-328.04"
+	 y="629.7" 
+	 z="256.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-4-3"/>
+       <position name="posOpArapucaDouble3-Frame-3-4" unit="cm" 
+         x="-327.3"
+	 y="629.7" 
+	 z="256.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-5-0"/>
+       <position name="posArapucaDouble0-Frame-3-5" unit="cm" 
+         x="-328.04"
+	 y="374.3" 
+	 z="629.6036"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-5-0"/>
+       <position name="posOpArapucaDouble0-Frame-3-5" unit="cm" 
+         x="-327.3"
+	 y="374.3" 
+	 z="629.6036"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-5-1"/>
+       <position name="posArapucaDouble1-Frame-3-5" unit="cm" 
+         x="-328.04"
+	 y="465" 
+	 z="483.6036"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-5-1"/>
+       <position name="posOpArapucaDouble1-Frame-3-5" unit="cm" 
+         x="-327.3"
+	 y="465" 
+	 z="483.6036"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-5-2"/>
+       <position name="posArapucaDouble2-Frame-3-5" unit="cm" 
+         x="-328.04"
+	 y="539" 
+	 z="700.6036"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-5-2"/>
+       <position name="posOpArapucaDouble2-Frame-3-5" unit="cm" 
+         x="-327.3"
+	 y="539" 
+	 z="700.6036"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-5-3"/>
+       <position name="posArapucaDouble3-Frame-3-5" unit="cm" 
+         x="-328.04"
+	 y="629.7" 
+	 z="554.6036"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-5-3"/>
+       <position name="posOpArapucaDouble3-Frame-3-5" unit="cm" 
+         x="-327.3"
+	 y="629.7" 
+	 z="554.6036"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-6-0"/>
+       <position name="posArapucaDouble0-Frame-3-6" unit="cm" 
+         x="-328.04"
+	 y="374.3" 
+	 z="927.4054"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-6-0"/>
+       <position name="posOpArapucaDouble0-Frame-3-6" unit="cm" 
+         x="-327.3"
+	 y="374.3" 
+	 z="927.4054"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-6-1"/>
+       <position name="posArapucaDouble1-Frame-3-6" unit="cm" 
+         x="-328.04"
+	 y="465" 
+	 z="781.4054"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-6-1"/>
+       <position name="posOpArapucaDouble1-Frame-3-6" unit="cm" 
+         x="-327.3"
+	 y="465" 
+	 z="781.4054"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-6-2"/>
+       <position name="posArapucaDouble2-Frame-3-6" unit="cm" 
+         x="-328.04"
+	 y="539" 
+	 z="998.4054"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-6-2"/>
+       <position name="posOpArapucaDouble2-Frame-3-6" unit="cm" 
+         x="-327.3"
+	 y="539" 
+	 z="998.4054"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-6-3"/>
+       <position name="posArapucaDouble3-Frame-3-6" unit="cm" 
+         x="-328.04"
+	 y="629.7" 
+	 z="852.4054"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-6-3"/>
+       <position name="posOpArapucaDouble3-Frame-3-6" unit="cm" 
+         x="-327.3"
+	 y="629.7" 
+	 z="852.4054"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_0-0"/>
+       <position name="posArapuca0-Lat-0" unit="cm" 
+         x="285.03"
+	 y="-734" 
+	 z="-893.4054"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_0-0"/>
+       <position name="posOpArapuca0-Lat-0" unit="cm" 
+         x="285.03"
+	 y="-733.26" 
+	 z="-893.4054"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_0-1"/>
+       <position name="posArapuca1-Lat-0" unit="cm" 
+         x="210.03"
+	 y="-734" 
+	 z="-893.4054"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_0-1"/>
+       <position name="posOpArapuca1-Lat-0" unit="cm" 
+         x="210.03"
+	 y="-733.26" 
+	 z="-893.4054"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_0-2"/>
+       <position name="posArapuca2-Lat-0" unit="cm" 
+         x="135.03"
+	 y="-734" 
+	 z="-893.4054"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_0-2"/>
+       <position name="posOpArapuca2-Lat-0" unit="cm" 
+         x="135.03"
+	 y="-733.26" 
+	 z="-893.4054"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_0-3"/>
+       <position name="posArapuca3-Lat-0" unit="cm" 
+         x="60.03"
+	 y="-734" 
+	 z="-893.4054"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_0-3"/>
+       <position name="posOpArapuca3-Lat-0" unit="cm" 
+         x="60.03"
+	 y="-733.26" 
+	 z="-893.4054"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_0-4"/>
+       <position name="posArapuca4-Lat-0" unit="cm" 
+         x="285.03"
+	 y="734" 
+	 z="-893.4054"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_0-4"/>
+       <position name="posOpArapuca4-Lat-0" unit="cm" 
+         x="285.03"
+	 y="733.26" 
+	 z="-893.4054"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_0-5"/>
+       <position name="posArapuca5-Lat-0" unit="cm" 
+         x="210.03"
+	 y="734" 
+	 z="-893.4054"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_0-5"/>
+       <position name="posOpArapuca5-Lat-0" unit="cm" 
+         x="210.03"
+	 y="733.26" 
+	 z="-893.4054"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_0-6"/>
+       <position name="posArapuca6-Lat-0" unit="cm" 
+         x="135.03"
+	 y="734" 
+	 z="-893.4054"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_0-6"/>
+       <position name="posOpArapuca6-Lat-0" unit="cm" 
+         x="135.03"
+	 y="733.26" 
+	 z="-893.4054"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_0-7"/>
+       <position name="posArapuca7-Lat-0" unit="cm" 
+         x="60.03"
+	 y="734" 
+	 z="-893.4054"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_0-7"/>
+       <position name="posOpArapuca7-Lat-0" unit="cm" 
+         x="60.03"
+	 y="733.26" 
+	 z="-893.4054"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_1-0"/>
+       <position name="posArapuca0-Lat-1" unit="cm" 
+         x="285.03"
+	 y="-734" 
+	 z="-595.6036"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_1-0"/>
+       <position name="posOpArapuca0-Lat-1" unit="cm" 
+         x="285.03"
+	 y="-733.26" 
+	 z="-595.6036"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_1-1"/>
+       <position name="posArapuca1-Lat-1" unit="cm" 
+         x="210.03"
+	 y="-734" 
+	 z="-595.6036"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_1-1"/>
+       <position name="posOpArapuca1-Lat-1" unit="cm" 
+         x="210.03"
+	 y="-733.26" 
+	 z="-595.6036"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_1-2"/>
+       <position name="posArapuca2-Lat-1" unit="cm" 
+         x="135.03"
+	 y="-734" 
+	 z="-595.6036"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_1-2"/>
+       <position name="posOpArapuca2-Lat-1" unit="cm" 
+         x="135.03"
+	 y="-733.26" 
+	 z="-595.6036"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_1-3"/>
+       <position name="posArapuca3-Lat-1" unit="cm" 
+         x="60.03"
+	 y="-734" 
+	 z="-595.6036"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_1-3"/>
+       <position name="posOpArapuca3-Lat-1" unit="cm" 
+         x="60.03"
+	 y="-733.26" 
+	 z="-595.6036"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_1-4"/>
+       <position name="posArapuca4-Lat-1" unit="cm" 
+         x="285.03"
+	 y="734" 
+	 z="-595.6036"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_1-4"/>
+       <position name="posOpArapuca4-Lat-1" unit="cm" 
+         x="285.03"
+	 y="733.26" 
+	 z="-595.6036"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_1-5"/>
+       <position name="posArapuca5-Lat-1" unit="cm" 
+         x="210.03"
+	 y="734" 
+	 z="-595.6036"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_1-5"/>
+       <position name="posOpArapuca5-Lat-1" unit="cm" 
+         x="210.03"
+	 y="733.26" 
+	 z="-595.6036"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_1-6"/>
+       <position name="posArapuca6-Lat-1" unit="cm" 
+         x="135.03"
+	 y="734" 
+	 z="-595.6036"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_1-6"/>
+       <position name="posOpArapuca6-Lat-1" unit="cm" 
+         x="135.03"
+	 y="733.26" 
+	 z="-595.6036"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_1-7"/>
+       <position name="posArapuca7-Lat-1" unit="cm" 
+         x="60.03"
+	 y="734" 
+	 z="-595.6036"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_1-7"/>
+       <position name="posOpArapuca7-Lat-1" unit="cm" 
+         x="60.03"
+	 y="733.26" 
+	 z="-595.6036"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_2-0"/>
+       <position name="posArapuca0-Lat-2" unit="cm" 
+         x="285.03"
+	 y="-734" 
+	 z="-297.8018"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_2-0"/>
+       <position name="posOpArapuca0-Lat-2" unit="cm" 
+         x="285.03"
+	 y="-733.26" 
+	 z="-297.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_2-1"/>
+       <position name="posArapuca1-Lat-2" unit="cm" 
+         x="210.03"
+	 y="-734" 
+	 z="-297.8018"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_2-1"/>
+       <position name="posOpArapuca1-Lat-2" unit="cm" 
+         x="210.03"
+	 y="-733.26" 
+	 z="-297.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_2-2"/>
+       <position name="posArapuca2-Lat-2" unit="cm" 
+         x="135.03"
+	 y="-734" 
+	 z="-297.8018"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_2-2"/>
+       <position name="posOpArapuca2-Lat-2" unit="cm" 
+         x="135.03"
+	 y="-733.26" 
+	 z="-297.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_2-3"/>
+       <position name="posArapuca3-Lat-2" unit="cm" 
+         x="60.03"
+	 y="-734" 
+	 z="-297.8018"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_2-3"/>
+       <position name="posOpArapuca3-Lat-2" unit="cm" 
+         x="60.03"
+	 y="-733.26" 
+	 z="-297.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_2-4"/>
+       <position name="posArapuca4-Lat-2" unit="cm" 
+         x="285.03"
+	 y="734" 
+	 z="-297.8018"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_2-4"/>
+       <position name="posOpArapuca4-Lat-2" unit="cm" 
+         x="285.03"
+	 y="733.26" 
+	 z="-297.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_2-5"/>
+       <position name="posArapuca5-Lat-2" unit="cm" 
+         x="210.03"
+	 y="734" 
+	 z="-297.8018"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_2-5"/>
+       <position name="posOpArapuca5-Lat-2" unit="cm" 
+         x="210.03"
+	 y="733.26" 
+	 z="-297.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_2-6"/>
+       <position name="posArapuca6-Lat-2" unit="cm" 
+         x="135.03"
+	 y="734" 
+	 z="-297.8018"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_2-6"/>
+       <position name="posOpArapuca6-Lat-2" unit="cm" 
+         x="135.03"
+	 y="733.26" 
+	 z="-297.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_2-7"/>
+       <position name="posArapuca7-Lat-2" unit="cm" 
+         x="60.03"
+	 y="734" 
+	 z="-297.8018"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_2-7"/>
+       <position name="posOpArapuca7-Lat-2" unit="cm" 
+         x="60.03"
+	 y="733.26" 
+	 z="-297.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_3-0"/>
+       <position name="posArapuca0-Lat-3" unit="cm" 
+         x="285.03"
+	 y="-734" 
+	 z="1.13686837721616e-13"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_3-0"/>
+       <position name="posOpArapuca0-Lat-3" unit="cm" 
+         x="285.03"
+	 y="-733.26" 
+	 z="1.13686837721616e-13"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_3-1"/>
+       <position name="posArapuca1-Lat-3" unit="cm" 
+         x="210.03"
+	 y="-734" 
+	 z="1.13686837721616e-13"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_3-1"/>
+       <position name="posOpArapuca1-Lat-3" unit="cm" 
+         x="210.03"
+	 y="-733.26" 
+	 z="1.13686837721616e-13"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_3-2"/>
+       <position name="posArapuca2-Lat-3" unit="cm" 
+         x="135.03"
+	 y="-734" 
+	 z="1.13686837721616e-13"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_3-2"/>
+       <position name="posOpArapuca2-Lat-3" unit="cm" 
+         x="135.03"
+	 y="-733.26" 
+	 z="1.13686837721616e-13"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_3-3"/>
+       <position name="posArapuca3-Lat-3" unit="cm" 
+         x="60.03"
+	 y="-734" 
+	 z="1.13686837721616e-13"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_3-3"/>
+       <position name="posOpArapuca3-Lat-3" unit="cm" 
+         x="60.03"
+	 y="-733.26" 
+	 z="1.13686837721616e-13"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_3-4"/>
+       <position name="posArapuca4-Lat-3" unit="cm" 
+         x="285.03"
+	 y="734" 
+	 z="1.13686837721616e-13"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_3-4"/>
+       <position name="posOpArapuca4-Lat-3" unit="cm" 
+         x="285.03"
+	 y="733.26" 
+	 z="1.13686837721616e-13"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_3-5"/>
+       <position name="posArapuca5-Lat-3" unit="cm" 
+         x="210.03"
+	 y="734" 
+	 z="1.13686837721616e-13"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_3-5"/>
+       <position name="posOpArapuca5-Lat-3" unit="cm" 
+         x="210.03"
+	 y="733.26" 
+	 z="1.13686837721616e-13"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_3-6"/>
+       <position name="posArapuca6-Lat-3" unit="cm" 
+         x="135.03"
+	 y="734" 
+	 z="1.13686837721616e-13"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_3-6"/>
+       <position name="posOpArapuca6-Lat-3" unit="cm" 
+         x="135.03"
+	 y="733.26" 
+	 z="1.13686837721616e-13"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_3-7"/>
+       <position name="posArapuca7-Lat-3" unit="cm" 
+         x="60.03"
+	 y="734" 
+	 z="1.13686837721616e-13"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_3-7"/>
+       <position name="posOpArapuca7-Lat-3" unit="cm" 
+         x="60.03"
+	 y="733.26" 
+	 z="1.13686837721616e-13"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_4-0"/>
+       <position name="posArapuca0-Lat-4" unit="cm" 
+         x="285.03"
+	 y="-734" 
+	 z="297.8018"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_4-0"/>
+       <position name="posOpArapuca0-Lat-4" unit="cm" 
+         x="285.03"
+	 y="-733.26" 
+	 z="297.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_4-1"/>
+       <position name="posArapuca1-Lat-4" unit="cm" 
+         x="210.03"
+	 y="-734" 
+	 z="297.8018"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_4-1"/>
+       <position name="posOpArapuca1-Lat-4" unit="cm" 
+         x="210.03"
+	 y="-733.26" 
+	 z="297.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_4-2"/>
+       <position name="posArapuca2-Lat-4" unit="cm" 
+         x="135.03"
+	 y="-734" 
+	 z="297.8018"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_4-2"/>
+       <position name="posOpArapuca2-Lat-4" unit="cm" 
+         x="135.03"
+	 y="-733.26" 
+	 z="297.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_4-3"/>
+       <position name="posArapuca3-Lat-4" unit="cm" 
+         x="60.03"
+	 y="-734" 
+	 z="297.8018"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_4-3"/>
+       <position name="posOpArapuca3-Lat-4" unit="cm" 
+         x="60.03"
+	 y="-733.26" 
+	 z="297.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_4-4"/>
+       <position name="posArapuca4-Lat-4" unit="cm" 
+         x="285.03"
+	 y="734" 
+	 z="297.8018"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_4-4"/>
+       <position name="posOpArapuca4-Lat-4" unit="cm" 
+         x="285.03"
+	 y="733.26" 
+	 z="297.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_4-5"/>
+       <position name="posArapuca5-Lat-4" unit="cm" 
+         x="210.03"
+	 y="734" 
+	 z="297.8018"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_4-5"/>
+       <position name="posOpArapuca5-Lat-4" unit="cm" 
+         x="210.03"
+	 y="733.26" 
+	 z="297.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_4-6"/>
+       <position name="posArapuca6-Lat-4" unit="cm" 
+         x="135.03"
+	 y="734" 
+	 z="297.8018"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_4-6"/>
+       <position name="posOpArapuca6-Lat-4" unit="cm" 
+         x="135.03"
+	 y="733.26" 
+	 z="297.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_4-7"/>
+       <position name="posArapuca7-Lat-4" unit="cm" 
+         x="60.03"
+	 y="734" 
+	 z="297.8018"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_4-7"/>
+       <position name="posOpArapuca7-Lat-4" unit="cm" 
+         x="60.03"
+	 y="733.26" 
+	 z="297.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_5-0"/>
+       <position name="posArapuca0-Lat-5" unit="cm" 
+         x="285.03"
+	 y="-734" 
+	 z="595.6036"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_5-0"/>
+       <position name="posOpArapuca0-Lat-5" unit="cm" 
+         x="285.03"
+	 y="-733.26" 
+	 z="595.6036"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_5-1"/>
+       <position name="posArapuca1-Lat-5" unit="cm" 
+         x="210.03"
+	 y="-734" 
+	 z="595.6036"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_5-1"/>
+       <position name="posOpArapuca1-Lat-5" unit="cm" 
+         x="210.03"
+	 y="-733.26" 
+	 z="595.6036"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_5-2"/>
+       <position name="posArapuca2-Lat-5" unit="cm" 
+         x="135.03"
+	 y="-734" 
+	 z="595.6036"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_5-2"/>
+       <position name="posOpArapuca2-Lat-5" unit="cm" 
+         x="135.03"
+	 y="-733.26" 
+	 z="595.6036"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_5-3"/>
+       <position name="posArapuca3-Lat-5" unit="cm" 
+         x="60.03"
+	 y="-734" 
+	 z="595.6036"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_5-3"/>
+       <position name="posOpArapuca3-Lat-5" unit="cm" 
+         x="60.03"
+	 y="-733.26" 
+	 z="595.6036"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_5-4"/>
+       <position name="posArapuca4-Lat-5" unit="cm" 
+         x="285.03"
+	 y="734" 
+	 z="595.6036"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_5-4"/>
+       <position name="posOpArapuca4-Lat-5" unit="cm" 
+         x="285.03"
+	 y="733.26" 
+	 z="595.6036"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_5-5"/>
+       <position name="posArapuca5-Lat-5" unit="cm" 
+         x="210.03"
+	 y="734" 
+	 z="595.6036"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_5-5"/>
+       <position name="posOpArapuca5-Lat-5" unit="cm" 
+         x="210.03"
+	 y="733.26" 
+	 z="595.6036"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_5-6"/>
+       <position name="posArapuca6-Lat-5" unit="cm" 
+         x="135.03"
+	 y="734" 
+	 z="595.6036"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_5-6"/>
+       <position name="posOpArapuca6-Lat-5" unit="cm" 
+         x="135.03"
+	 y="733.26" 
+	 z="595.6036"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_5-7"/>
+       <position name="posArapuca7-Lat-5" unit="cm" 
+         x="60.03"
+	 y="734" 
+	 z="595.6036"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_5-7"/>
+       <position name="posOpArapuca7-Lat-5" unit="cm" 
+         x="60.03"
+	 y="733.26" 
+	 z="595.6036"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_6-0"/>
+       <position name="posArapuca0-Lat-6" unit="cm" 
+         x="285.03"
+	 y="-734" 
+	 z="893.4054"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_6-0"/>
+       <position name="posOpArapuca0-Lat-6" unit="cm" 
+         x="285.03"
+	 y="-733.26" 
+	 z="893.4054"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_6-1"/>
+       <position name="posArapuca1-Lat-6" unit="cm" 
+         x="210.03"
+	 y="-734" 
+	 z="893.4054"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_6-1"/>
+       <position name="posOpArapuca1-Lat-6" unit="cm" 
+         x="210.03"
+	 y="-733.26" 
+	 z="893.4054"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_6-2"/>
+       <position name="posArapuca2-Lat-6" unit="cm" 
+         x="135.03"
+	 y="-734" 
+	 z="893.4054"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_6-2"/>
+       <position name="posOpArapuca2-Lat-6" unit="cm" 
+         x="135.03"
+	 y="-733.26" 
+	 z="893.4054"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_6-3"/>
+       <position name="posArapuca3-Lat-6" unit="cm" 
+         x="60.03"
+	 y="-734" 
+	 z="893.4054"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_6-3"/>
+       <position name="posOpArapuca3-Lat-6" unit="cm" 
+         x="60.03"
+	 y="-733.26" 
+	 z="893.4054"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_6-4"/>
+       <position name="posArapuca4-Lat-6" unit="cm" 
+         x="285.03"
+	 y="734" 
+	 z="893.4054"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_6-4"/>
+       <position name="posOpArapuca4-Lat-6" unit="cm" 
+         x="285.03"
+	 y="733.26" 
+	 z="893.4054"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_6-5"/>
+       <position name="posArapuca5-Lat-6" unit="cm" 
+         x="210.03"
+	 y="734" 
+	 z="893.4054"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_6-5"/>
+       <position name="posOpArapuca5-Lat-6" unit="cm" 
+         x="210.03"
+	 y="733.26" 
+	 z="893.4054"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_6-6"/>
+       <position name="posArapuca6-Lat-6" unit="cm" 
+         x="135.03"
+	 y="734" 
+	 z="893.4054"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_6-6"/>
+       <position name="posOpArapuca6-Lat-6" unit="cm" 
+         x="135.03"
+	 y="733.26" 
+	 z="893.4054"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_6-7"/>
+       <position name="posArapuca7-Lat-6" unit="cm" 
+         x="60.03"
+	 y="734" 
+	 z="893.4054"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_6-7"/>
+       <position name="posOpArapuca7-Lat-6" unit="cm" 
+         x="60.03"
+	 y="733.26" 
+	 z="893.4054"/>
+     </physvol>
+    </volume>
+
+    <volume name="volFoamPadding">
+      <materialref ref="fibrous_glass"/>
+      <solidref ref="FoamPadding"/>
+    </volume>
+
+    <volume name="volSteelSupport">
+      <materialref ref="AirSteelMixture"/>
+      <solidref ref="SteelSupport"/>
+    </volume>
+
+    <volume name="volDetEnclosure">
+      <materialref ref="Air"/>
+      <solidref ref="DetEnclosure"/>
+
+       <physvol>
+           <volumeref ref="volFoamPadding"/>
+           <positionref ref="posCryoInDetEnc"/>
+       </physvol>
+       <physvol>
+           <volumeref ref="volSteelSupport"/>
+           <positionref ref="posCryoInDetEnc"/>
+       </physvol>
+       <physvol>
+           <volumeref ref="volCryostat"/>
+           <positionref ref="posCryoInDetEnc"/>
+       </physvol>
+    </volume>
+
+    <volume name="volWorld" >
+      <materialref ref="DUSEL_Rock"/>
+      <solidref ref="World"/>
+
+      <physvol>
+        <volumeref ref="volDetEnclosure"/>
+	<position name="posDetEnclosure" unit="cm" x="50.04" y="-1.13686837721616e-13" z="1045.8063"/>
+      </physvol>
+
+    </volume>
+</structure>
+  <setup name="Default" version="1.0">
+    <world ref="volWorld"/>
+  </setup>
+</gdml_simple_extension>

--- a/dunecore/Geometry/gdml/dunevd10kt_3view_v4_refactored_1x8x6ref.gdml
+++ b/dunecore/Geometry/gdml/dunevd10kt_3view_v4_refactored_1x8x6ref.gdml
@@ -1,0 +1,10069 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<gdml_simple_extension xmlns:gdml_simple_extension="http://www.example.org"
+                       xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"          
+                       xs:noNamespaceSchemaLocation="RefactoredGDMLSchema/SimpleExtension.xsd"> 
+<extension>
+   <color name="magenta"     R="0.0"  G="1.0"  B="0.0"  A="1.0" />
+   <color name="green"       R="0.0"  G="1.0"  B="0.0"  A="1.0" />
+   <color name="red"         R="1.0"  G="0.0"  B="0.0"  A="1.0" />
+   <color name="blue"        R="0.0"  G="0.0"  B="1.0"  A="1.0" />
+   <color name="yellow"      R="1.0"  G="1.0"  B="0.0"  A="1.0" />    
+</extension>
+<define>
+
+<!--
+
+
+
+-->
+
+   <position name="posCryoInDetEnc"     unit="cm" x="-50.0000000000001" y="0" z="0"/>
+   <position name="posCenter"           unit="cm" x="0" y="0" z="0"/>
+   <rotation name="rUWireAboutX"        unit="deg" x="131.63" y="0" z="0"/>
+   <rotation name="rPlus90AboutX"       unit="deg" x="90" y="0" z="0"/>
+   <rotation name="rPlus90AboutY"       unit="deg" x="0" y="90" z="0"/>
+   <rotation name="rPlus90AboutXPlus90AboutY" unit="deg" x="90" y="90" z="0"/>
+   <rotation name="rMinus90AboutX"      unit="deg" x="270" y="0" z="0"/>
+   <rotation name="rMinus90AboutY"      unit="deg" x="0" y="270" z="0"/>
+   <rotation name="rMinus90AboutYMinus90AboutX"       unit="deg" x="270" y="270" z="0"/>
+   <rotation name="rPlus180AboutX"	unit="deg" x="180" y="0"   z="0"/>
+   <rotation name="rPlus180AboutY"	unit="deg" x="0" y="180"   z="0"/>
+   <rotation name="rPlus180AboutXPlus180AboutY"	unit="deg" x="180" y="180"   z="0"/>
+   <rotation name="rIdentity"		unit="deg" x="0" y="0"   z="0"/>
+</define>
+<materials>
+  <element name="videRef" formula="VACUUM" Z="1">  <atom value="1"/> </element>
+  <element name="copper" formula="Cu" Z="29">  <atom value="63.546"/>  </element>
+  <element name="beryllium" formula="Be" Z="4">  <atom value="9.0121831"/>  </element>
+  <element name="bromine" formula="Br" Z="35"> <atom value="79.904"/> </element>
+  <element name="hydrogen" formula="H" Z="1">  <atom value="1.0079"/> </element>
+  <element name="nitrogen" formula="N" Z="7">  <atom value="14.0067"/> </element>
+  <element name="oxygen" formula="O" Z="8">  <atom value="15.999"/> </element>
+  <element name="aluminum" formula="Al" Z="13"> <atom value="26.9815"/>  </element>
+  <element name="silicon" formula="Si" Z="14"> <atom value="28.0855"/>  </element>
+  <element name="carbon" formula="C" Z="6">  <atom value="12.0107"/>  </element>
+  <element name="potassium" formula="K" Z="19"> <atom value="39.0983"/>  </element>
+  <element name="chromium" formula="Cr" Z="24"> <atom value="51.9961"/>  </element>
+  <element name="iron" formula="Fe" Z="26"> <atom value="55.8450"/>  </element>
+  <element name="nickel" formula="Ni" Z="28"> <atom value="58.6934"/>  </element>
+  <element name="calcium" formula="Ca" Z="20"> <atom value="40.078"/>   </element>
+  <element name="magnesium" formula="Mg" Z="12"> <atom value="24.305"/>   </element>
+  <element name="sodium" formula="Na" Z="11"> <atom value="22.99"/>    </element>
+  <element name="titanium" formula="Ti" Z="22"> <atom value="47.867"/>   </element>
+  <element name="argon" formula="Ar" Z="18"> <atom value="39.9480"/>  </element>
+  <element name="sulphur" formula="S" Z="16"> <atom value="32.065"/>  </element>
+  <element name="phosphorus" formula="P" Z="15"> <atom value="30.973"/>  </element>
+
+  <material name="Vacuum" formula="Vacuum">
+   <D value="1.e-25" unit="g/cm3"/>
+   <fraction n="1.0" ref="videRef"/>
+  </material>
+
+  <material name="ALUMINUM_Al" formula="ALUMINUM_Al">
+   <D value="2.6990" unit="g/cm3"/>
+   <fraction n="1.0000" ref="aluminum"/>
+  </material>
+
+  <material name="SILICON_Si" formula="SILICON_Si">
+   <D value="2.3300" unit="g/cm3"/>
+   <fraction n="1.0000" ref="silicon"/>
+  </material>
+
+  <material name="epoxy_resin" formula="C38H40O6Br4">
+   <D value="1.1250" unit="g/cm3"/>
+   <composite n="38" ref="carbon"/>
+   <composite n="40" ref="hydrogen"/>
+   <composite n="6" ref="oxygen"/>
+   <composite n="4" ref="bromine"/>
+  </material>
+
+  <material name="SiO2" formula="SiO2">
+   <D value="2.2" unit="g/cm3"/>
+   <composite n="1" ref="silicon"/>
+   <composite n="2" ref="oxygen"/>
+  </material>
+
+  <material name="Al2O3" formula="Al2O3">
+   <D value="3.97" unit="g/cm3"/>
+   <composite n="2" ref="aluminum"/>
+   <composite n="3" ref="oxygen"/>
+  </material>
+
+  <material name="Fe2O3" formula="Fe2O3">
+   <D value="5.24" unit="g/cm3"/>
+   <composite n="2" ref="iron"/>
+   <composite n="3" ref="oxygen"/>
+  </material>
+
+  <material name="CaO" formula="CaO">
+   <D value="3.35" unit="g/cm3"/>
+   <composite n="1" ref="calcium"/>
+   <composite n="1" ref="oxygen"/>
+  </material>
+
+  <material name="Delrin" formula="CH2O">
+    <D value="1.41" unit="g/cm3"/>
+    <composite n="1" ref="carbon"/>
+    <composite n="2" ref="hydrogen"/>
+    <composite n="1" ref="oxygen"/>
+  </material>
+
+  <material name="MgO" formula="MgO">
+   <D value="3.58" unit="g/cm3"/>
+   <composite n="1" ref="magnesium"/>
+   <composite n="1" ref="oxygen"/>
+  </material>
+
+  <material name="Na2O" formula="Na2O">
+   <D value="2.27" unit="g/cm3"/>
+   <composite n="2" ref="sodium"/>
+   <composite n="1" ref="oxygen"/>
+  </material>
+
+  <material name="TiO2" formula="TiO2">
+   <D value="4.23" unit="g/cm3"/>
+   <composite n="1" ref="titanium"/>
+   <composite n="2" ref="oxygen"/>
+  </material>
+
+  <material name="FeO" formula="FeO">
+   <D value="5.745" unit="g/cm3"/>
+   <composite n="1" ref="iron"/>
+   <composite n="1" ref="oxygen"/>
+  </material>
+
+  <material name="CO2" formula="CO2">
+   <D value="1.562" unit="g/cm3"/>
+   <composite n="1" ref="iron"/>
+   <composite n="2" ref="oxygen"/>
+  </material>
+
+  <material name="P2O5" formula="P2O5">
+   <D value="1.562" unit="g/cm3"/>
+   <composite n="2" ref="phosphorus"/>
+   <composite n="5" ref="oxygen"/>
+  </material>
+
+  <material formula=" " name="DUSEL_Rock">
+    <D value="2.82" unit="g/cm3"/>
+    <fraction n="0.5267" ref="SiO2"/>
+    <fraction n="0.1174" ref="FeO"/>
+    <fraction n="0.1025" ref="Al2O3"/>
+    <fraction n="0.0473" ref="MgO"/>
+    <fraction n="0.0422" ref="CO2"/>
+    <fraction n="0.0382" ref="CaO"/>
+    <fraction n="0.0240" ref="carbon"/>
+    <fraction n="0.0186" ref="sulphur"/>
+    <fraction n="0.0053" ref="Na2O"/>
+    <fraction n="0.00070" ref="P2O5"/>
+    <fraction n="0.0771" ref="oxygen"/>
+  </material> 
+
+  <material formula="Air" name="Air">
+   <D value="0.001205" unit="g/cm3"/>
+   <fraction n="0.781154" ref="nitrogen"/>
+   <fraction n="0.209476" ref="oxygen"/>
+   <fraction n="0.00934" ref="argon"/>
+  </material>
+
+  <material name="fibrous_glass">
+   <D value="2.74351" unit="g/cm3"/>
+   <fraction n="0.600" ref="SiO2"/>
+   <fraction n="0.118" ref="Al2O3"/>
+   <fraction n="0.001" ref="Fe2O3"/>
+   <fraction n="0.224" ref="CaO"/>
+   <fraction n="0.034" ref="MgO"/>
+   <fraction n="0.010" ref="Na2O"/>
+   <fraction n="0.013" ref="TiO2"/>
+  </material>
+
+  <!-- density referenced from EHN1-Cold Cryostats Technical Requirements:
+       https://edms.cern.ch/document/1543254 -->
+  <material name="FD_foam">
+   <D value="0.09" unit="g/cm3"/>
+   <fraction n="0.95" ref="Air"/>
+   <fraction n="0.05" ref="fibrous_glass"/>
+  </material>
+
+  <!-- Foam density is 70 kg / m^3 for the 3x1x1 -->
+  <material name="foam_3x1x1dp">
+   <D value="0.07" unit="g/cm3"/>
+   <fraction n="0.95" ref="Air"/>
+   <fraction n="0.05" ref="fibrous_glass"/>
+  </material>
+
+  <!-- Copied from protodune_v4.gdml -->
+  <material name="foam_protoDUNEdp">
+   <D value="0.135" unit="g/cm3"/>
+   <composite n="17" ref="carbon"/>
+   <composite n="16" ref="hydrogen"/>
+   <composite n="2" ref="nitrogen"/>
+   <composite n="4" ref="oxygen"/>
+  </material>
+
+  <material name="FR4">
+   <D value="1.98281" unit="g/cm3"/>
+   <fraction n="0.47" ref="epoxy_resin"/>
+   <fraction n="0.53" ref="fibrous_glass"/>
+  </material>
+
+  <material name="STEEL_STAINLESS_Fe7Cr2Ni" formula="STEEL_STAINLESS_Fe7Cr2Ni">
+   <D value="7.9300" unit="g/cm3"/>
+   <fraction n="0.0010" ref="carbon"/>
+   <fraction n="0.1792" ref="chromium"/>
+   <fraction n="0.7298" ref="iron"/>
+   <fraction n="0.0900" ref="nickel"/>
+  </material>
+
+  <material name="Copper_Beryllium_alloy25" formula="Copper_Beryllium_alloy25">
+   <D value="8.26" unit="g/cm3"/>
+   <fraction n="0.981" ref="copper"/>
+   <fraction n="0.019" ref="beryllium"/>
+  </material>
+
+  <material name="LAr" formula="LAr">
+   <D value="1.40" unit="g/cm3"/>
+   <fraction n="1.0000" ref="argon"/>
+  </material>
+
+  <material name="ArGas" formula="ArGas">
+   <D value="0.00166" unit="g/cm3"/>
+   <fraction n="1.0" ref="argon"/>
+  </material>
+
+  <material formula=" " name="G10">
+   <D value="1.7" unit="g/cm3"/>
+   <fraction n="0.2805" ref="silicon"/>
+   <fraction n="0.3954" ref="oxygen"/>
+   <fraction n="0.2990" ref="carbon"/>
+   <fraction n="0.0251" ref="hydrogen"/>
+  </material>
+
+  <material formula=" " name="Granite">
+   <D value="2.7" unit="g/cm3"/>
+   <fraction n="0.438" ref="oxygen"/>
+   <fraction n="0.257" ref="silicon"/>
+   <fraction n="0.222" ref="sodium"/>
+   <fraction n="0.049" ref="aluminum"/>
+   <fraction n="0.019" ref="iron"/>
+   <fraction n="0.015" ref="potassium"/>
+  </material>
+
+  <material formula=" " name="ShotRock">
+   <D value="1.62" unit="g/cm3"/>
+   <fraction n="0.438" ref="oxygen"/>
+   <fraction n="0.257" ref="silicon"/>
+   <fraction n="0.222" ref="sodium"/>
+   <fraction n="0.049" ref="aluminum"/>
+   <fraction n="0.019" ref="iron"/>
+   <fraction n="0.015" ref="potassium"/>
+  </material>
+
+  <material formula=" " name="Dirt">
+   <D value="1.7" unit="g/cm3"/>
+   <fraction n="0.438" ref="oxygen"/>
+   <fraction n="0.257" ref="silicon"/>
+   <fraction n="0.222" ref="sodium"/>
+   <fraction n="0.049" ref="aluminum"/>
+   <fraction n="0.019" ref="iron"/>
+   <fraction n="0.015" ref="potassium"/>
+  </material>
+
+  <material formula=" " name="Concrete">
+   <D value="2.3" unit="g/cm3"/>
+   <fraction n="0.530" ref="oxygen"/>
+   <fraction n="0.335" ref="silicon"/>
+   <fraction n="0.060" ref="calcium"/>
+   <fraction n="0.015" ref="sodium"/>
+   <fraction n="0.020" ref="iron"/>
+   <fraction n="0.040" ref="aluminum"/>
+  </material>
+
+  <material formula="H2O" name="Water">
+   <D value="1.0" unit="g/cm3"/>
+   <fraction n="0.1119" ref="hydrogen"/>
+   <fraction n="0.8881" ref="oxygen"/>
+  </material>
+
+  <material formula="Ti" name="Titanium">
+   <D value="4.506" unit="g/cm3"/>
+   <fraction n="1." ref="titanium"/>
+  </material>
+
+  <material name="TPB" formula="TPB">
+   <D value="1.40" unit="g/cm3"/>
+   <fraction n="1.0000" ref="argon"/>
+  </material>
+
+  <material name="Glass">
+   <D value="2.74351" unit="g/cm3"/>
+   <fraction n="0.600" ref="SiO2"/>
+   <fraction n="0.118" ref="Al2O3"/>
+   <fraction n="0.001" ref="Fe2O3"/>
+   <fraction n="0.224" ref="CaO"/>
+   <fraction n="0.034" ref="MgO"/>
+   <fraction n="0.010" ref="Na2O"/>
+   <fraction n="0.013" ref="TiO2"/>
+  </material>
+
+  <material name="Acrylic">
+   <D value="1.19" unit="g/cm3"/>
+   <fraction n="0.600" ref="carbon"/>
+   <fraction n="0.320" ref="oxygen"/>
+   <fraction n="0.080" ref="hydrogen"/>
+  </material>
+
+  <material name="NiGas1atm80K">
+   <D value="0.0039" unit="g/cm3"/>
+   <fraction n="1.000" ref="nitrogen"/>
+  </material>
+
+  <material name="NiGas">
+   <D value="0.001165" unit="g/cm3"/>
+   <fraction n="1.000" ref="nitrogen"/>
+  </material>
+
+  <material name="PolyurethaneFoam">
+   <D value="0.088" unit="g/cm3"/>
+   <composite n="17" ref="carbon"/>
+   <composite n="16" ref="hydrogen"/>
+   <composite n="2" ref="nitrogen"/>
+   <composite n="4" ref="oxygen"/>
+  </material>
+
+  <material name="ProtoDUNEFoam">
+   <D value="0.135" unit="g/cm3"/>
+   <composite n="17" ref="carbon"/>
+   <composite n="16" ref="hydrogen"/>
+   <composite n="2" ref="nitrogen"/>
+   <composite n="4" ref="oxygen"/>
+  </material>
+
+  <material name="LightPolyurethaneFoam">
+   <D value="0.009" unit="g/cm3"/>
+   <composite n="17" ref="carbon"/>
+   <composite n="16" ref="hydrogen"/>
+   <composite n="2" ref="nitrogen"/>
+   <composite n="4" ref="oxygen"/>
+  </material>
+
+  <material name="ProtoDUNEBWFoam">
+   <D value="0.021" unit="g/cm3"/>
+   <composite n="17" ref="carbon"/>
+   <composite n="16" ref="hydrogen"/>
+   <composite n="2" ref="nitrogen"/>
+   <composite n="4" ref="oxygen"/>
+  </material>
+
+  <material name="GlassWool">
+   <D value="0.035" unit="g/cm3"/>
+   <fraction n="0.65" ref="SiO2"/>
+   <fraction n="0.09" ref="Al2O3"/>
+   <fraction n="0.07" ref="CaO"/>
+   <fraction n="0.03" ref="MgO"/>
+   <fraction n="0.16" ref="Na2O"/>
+  </material>
+
+  <material name="Polystyrene">
+   <D value="1.06" unit="g/cm3"/>
+   <composite n="8" ref="carbon"/>
+   <composite n="8" ref="hydrogen"/>
+  </material>
+
+
+
+  <!-- preliminary values -->
+  <material name="AirSteelMixture" formula="AirSteelMixture">
+   <D value=" 0.001205*(1-0.5) + 7.9300*0.5 " unit="g/cm3"/>
+   <fraction n="0.5" ref="STEEL_STAINLESS_Fe7Cr2Ni"/>
+   <fraction n="0.5"   ref="Air"/>
+  </material>
+  <material name="vm2000" formula="vm2000">
+    <D value="1.2" unit="g/cm3"/>
+    <composite n="2" ref="carbon"/>
+    <composite n="4" ref="hydrogen"/>
+  </material>
+
+</materials>
+<solids>
+     <torus name="FieldShaperCorner" rmin="0.5" rmax="2.285" rtor="2.3" deltaphi="90" startphi="0" aunit="deg" lunit="cm"/>
+     <tube name="FieldShaperLongtube" rmin="0.5" rmax="2.285" z="896.4054" deltaphi="360" startphi="0" aunit="deg" lunit="cm"/>
+     <tube name="FieldShaperLongtubeSlim" rmin="0.5" rmax="0.75" z="896.4054" deltaphi="360" startphi="0" aunit="deg" lunit="cm"/>
+     <tube name="FieldShaperShorttube" rmin="0.5" rmax="2.285" z="1348" deltaphi="360" startphi="0" aunit="deg" lunit="cm"/>
+
+    <union name="FSunion1">
+      <first ref="FieldShaperLongtube"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos1" unit="cm" x="-2.3" y="0" z="448.2027"/>
+		<rotation name="rot1" unit="deg" x="90" y="0" z="0" />
+    </union>
+
+    <union name="FSunion2">
+      <first ref="FSunion1"/>
+      <second ref="FieldShaperShorttube"/>
+   		<position name="esquinapos2" unit="cm" x="-676.3" y="0" z="450.5027"/>
+   		<rotation name="rot2" unit="deg" x="0" y="90" z="0" />
+    </union>
+
+    <union name="FSunion3">
+      <first ref="FSunion2"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos3" unit="cm" x="-1350.3" y="0" z="448.2027"/>
+		<rotation name="rot3" unit="deg" x="90" y="270" z="0" />
+    </union>
+
+    <union name="FSunion4">
+      <first ref="FSunion3"/>
+      <second ref="FieldShaperLongtube"/>
+   		<position name="esquinapos4" unit="cm" x="-1352.6" y="0" z="0"/>
+    </union>
+
+    <union name="FSunion5">
+      <first ref="FSunion4"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos5" unit="cm" x="-1350.3" y="0" z="-448.2027"/>
+		<rotation name="rot5" unit="deg" x="90" y="180" z="0" />
+    </union>
+
+    <union name="FSunion6">
+      <first ref="FSunion5"/>
+      <second ref="FieldShaperShorttube"/>
+   		<position name="esquinapos6" unit="cm" x="-676.3" y="0" z="-450.5027"/>
+		<rotation name="rot6" unit="deg" x="0" y="90" z="0" />
+    </union>
+
+    <union name="FieldShaperSolid">
+      <first ref="FSunion6"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos7" unit="cm" x="-2.3" y="0" z="-448.2027"/>
+		<rotation name="rot7" unit="deg" x="90" y="90" z="0" />
+    </union>
+    
+    <union name="FSunionSlim1">
+      <first ref="FieldShaperLongtubeSlim"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos1" unit="cm" x="-2.3" y="0" z="448.2027"/>
+		<rotation name="rot1" unit="deg" x="90" y="0" z="0" />
+    </union>
+
+    <union name="FSunionSlim2">
+      <first ref="FSunionSlim1"/>
+      <second ref="FieldShaperShorttube"/>
+   		<position name="esquinapos2" unit="cm" x="-676.3" y="0" z="450.5027"/>
+   		<rotation name="rot2" unit="deg" x="0" y="90" z="0" />
+    </union>
+
+    <union name="FSunionSlim3">
+      <first ref="FSunionSlim2"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos3" unit="cm" x="-1350.3" y="0" z="448.2027"/>
+		<rotation name="rot3" unit="deg" x="90" y="270" z="0" />
+    </union>
+
+    <union name="FSunionSlim4">
+      <first ref="FSunionSlim3"/>
+      <second ref="FieldShaperLongtubeSlim"/>
+   		<position name="esquinapos4" unit="cm" x="-1352.6" y="0" z="0"/>
+    </union>
+
+    <union name="FSunionSlim5">
+      <first ref="FSunionSlim4"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos5" unit="cm" x="-1350.3" y="0" z="-448.2027"/>
+		<rotation name="rot5" unit="deg" x="90" y="180" z="0" />
+    </union>
+
+    <union name="FSunionSlim6">
+      <first ref="FSunionSlim5"/>
+      <second ref="FieldShaperShorttube"/>
+   		<position name="esquinapos6" unit="cm" x="-676.3" y="0" z="-450.5027"/>
+		<rotation name="rot6" unit="deg" x="0" y="90" z="0" />
+    </union>
+
+    <union name="FieldShaperSolidSlim">
+      <first ref="FSunionSlim6"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos7" unit="cm" x="-2.3" y="0" z="-448.2027"/>
+		<rotation name="rot7" unit="deg" x="90" y="90" z="0" />
+    </union>
+    
+
+   <box name="CRM"
+      x="650.08" 
+      y="168" 
+      z="148.9009"
+      lunit="cm"/>
+   <box name="CRMUPlane" 
+      x="0.02" 
+      y="168" 
+      z="148.9009"
+      lunit="cm"/>
+   <box name="CRMYPlane" 
+      x="0.02" 
+      y="168" 
+      z="148.9009"
+      lunit="cm"/>
+   <box name="CRMZPlane" 
+      x="0.02"
+      y="168"
+      z="148.9009"
+      lunit="cm"/>
+   <box name="CRMActive" 
+      x="650"
+      y="168"
+      z="148.9009"
+      lunit="cm"/>
+   <tube name="CRMWireU0"
+      rmax="0.5*0.02"
+      z="0.875550971308563"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU1"
+      rmax="0.5*0.02"
+      z="2.62665291392569"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU2"
+      rmax="0.5*0.02"
+      z="4.37775485654281"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU3"
+      rmax="0.5*0.02"
+      z="6.12885679915994"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU4"
+      rmax="0.5*0.02"
+      z="7.87995874177706"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU5"
+      rmax="0.5*0.02"
+      z="9.63106068439417"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU6"
+      rmax="0.5*0.02"
+      z="11.3821626270113"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU7"
+      rmax="0.5*0.02"
+      z="13.1332645696284"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU8"
+      rmax="0.5*0.02"
+      z="14.8843665122456"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU9"
+      rmax="0.5*0.02"
+      z="16.6354684548627"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU10"
+      rmax="0.5*0.02"
+      z="18.3865703974798"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU11"
+      rmax="0.5*0.02"
+      z="20.1376723400969"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU12"
+      rmax="0.5*0.02"
+      z="21.8887742827141"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU13"
+      rmax="0.5*0.02"
+      z="23.6398762253312"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU14"
+      rmax="0.5*0.02"
+      z="25.3909781679483"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU15"
+      rmax="0.5*0.02"
+      z="27.1420801105654"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU16"
+      rmax="0.5*0.02"
+      z="28.8931820531826"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU17"
+      rmax="0.5*0.02"
+      z="30.6442839957997"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU18"
+      rmax="0.5*0.02"
+      z="32.3953859384168"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU19"
+      rmax="0.5*0.02"
+      z="34.1464878810339"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU20"
+      rmax="0.5*0.02"
+      z="35.897589823651"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU21"
+      rmax="0.5*0.02"
+      z="37.6486917662682"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU22"
+      rmax="0.5*0.02"
+      z="39.3997937088853"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU23"
+      rmax="0.5*0.02"
+      z="41.1508956515024"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU24"
+      rmax="0.5*0.02"
+      z="42.9019975941195"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU25"
+      rmax="0.5*0.02"
+      z="44.6530995367366"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU26"
+      rmax="0.5*0.02"
+      z="46.4042014793538"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU27"
+      rmax="0.5*0.02"
+      z="48.1553034219709"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU28"
+      rmax="0.5*0.02"
+      z="49.906405364588"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU29"
+      rmax="0.5*0.02"
+      z="51.6575073072051"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU30"
+      rmax="0.5*0.02"
+      z="53.4086092498223"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU31"
+      rmax="0.5*0.02"
+      z="55.1597111924394"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU32"
+      rmax="0.5*0.02"
+      z="56.9108131350565"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU33"
+      rmax="0.5*0.02"
+      z="58.6619150776736"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU34"
+      rmax="0.5*0.02"
+      z="60.4130170202907"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU35"
+      rmax="0.5*0.02"
+      z="62.1641189629079"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU36"
+      rmax="0.5*0.02"
+      z="63.915220905525"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU37"
+      rmax="0.5*0.02"
+      z="65.6663228481421"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU38"
+      rmax="0.5*0.02"
+      z="67.4174247907592"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU39"
+      rmax="0.5*0.02"
+      z="69.1685267333764"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU40"
+      rmax="0.5*0.02"
+      z="70.9196286759935"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU41"
+      rmax="0.5*0.02"
+      z="72.6707306186106"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU42"
+      rmax="0.5*0.02"
+      z="74.4218325612277"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU43"
+      rmax="0.5*0.02"
+      z="76.1729345038449"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU44"
+      rmax="0.5*0.02"
+      z="77.924036446462"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU45"
+      rmax="0.5*0.02"
+      z="79.6751383890791"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU46"
+      rmax="0.5*0.02"
+      z="81.4262403316963"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU47"
+      rmax="0.5*0.02"
+      z="83.1773422743134"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU48"
+      rmax="0.5*0.02"
+      z="84.9284442169305"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU49"
+      rmax="0.5*0.02"
+      z="86.6795461595477"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU50"
+      rmax="0.5*0.02"
+      z="88.4306481021648"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU51"
+      rmax="0.5*0.02"
+      z="90.1817500447819"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU52"
+      rmax="0.5*0.02"
+      z="91.932851987399"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU53"
+      rmax="0.5*0.02"
+      z="93.6839539300162"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU54"
+      rmax="0.5*0.02"
+      z="95.4350558726333"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU55"
+      rmax="0.5*0.02"
+      z="97.1861578152504"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU56"
+      rmax="0.5*0.02"
+      z="98.9372597578676"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU57"
+      rmax="0.5*0.02"
+      z="100.688361700485"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU58"
+      rmax="0.5*0.02"
+      z="102.439463643102"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU59"
+      rmax="0.5*0.02"
+      z="104.190565585719"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU60"
+      rmax="0.5*0.02"
+      z="105.941667528336"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU61"
+      rmax="0.5*0.02"
+      z="107.692769470953"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU62"
+      rmax="0.5*0.02"
+      z="109.44387141357"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU63"
+      rmax="0.5*0.02"
+      z="111.194973356187"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU64"
+      rmax="0.5*0.02"
+      z="112.946075298805"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU65"
+      rmax="0.5*0.02"
+      z="114.697177241422"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU66"
+      rmax="0.5*0.02"
+      z="116.448279184039"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU67"
+      rmax="0.5*0.02"
+      z="118.199381126656"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU68"
+      rmax="0.5*0.02"
+      z="119.950483069273"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU69"
+      rmax="0.5*0.02"
+      z="121.70158501189"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU70"
+      rmax="0.5*0.02"
+      z="123.452686954507"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU71"
+      rmax="0.5*0.02"
+      z="125.203788897124"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU72"
+      rmax="0.5*0.02"
+      z="126.954890839742"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU73"
+      rmax="0.5*0.02"
+      z="128.705992782359"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU74"
+      rmax="0.5*0.02"
+      z="130.457094724976"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU75"
+      rmax="0.5*0.02"
+      z="132.208196667593"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU76"
+      rmax="0.5*0.02"
+      z="133.95929861021"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU77"
+      rmax="0.5*0.02"
+      z="135.710400552827"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU78"
+      rmax="0.5*0.02"
+      z="137.461502495444"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU79"
+      rmax="0.5*0.02"
+      z="139.212604438061"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU80"
+      rmax="0.5*0.02"
+      z="140.963706380679"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU81"
+      rmax="0.5*0.02"
+      z="142.714808323296"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU82"
+      rmax="0.5*0.02"
+      z="144.465910265913"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU83"
+      rmax="0.5*0.02"
+      z="146.21701220853"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU84"
+      rmax="0.5*0.02"
+      z="147.968114151147"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU85"
+      rmax="0.5*0.02"
+      z="149.719216093764"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU86"
+      rmax="0.5*0.02"
+      z="151.470318036381"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU87"
+      rmax="0.5*0.02"
+      z="153.221419978999"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU88"
+      rmax="0.5*0.02"
+      z="154.972521921616"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU89"
+      rmax="0.5*0.02"
+      z="156.723623864233"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU90"
+      rmax="0.5*0.02"
+      z="158.47472580685"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU91"
+      rmax="0.5*0.02"
+      z="160.225827749467"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU92"
+      rmax="0.5*0.02"
+      z="161.976929692084"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU93"
+      rmax="0.5*0.02"
+      z="163.728031634701"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU94"
+      rmax="0.5*0.02"
+      z="165.479133577318"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU95"
+      rmax="0.5*0.02"
+      z="167.230235519936"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU96"
+      rmax="0.5*0.02"
+      z="168.981337462553"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU97"
+      rmax="0.5*0.02"
+      z="170.73243940517"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU98"
+      rmax="0.5*0.02"
+      z="172.483541347787"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU99"
+      rmax="0.5*0.02"
+      z="174.234643290404"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU100"
+      rmax="0.5*0.02"
+      z="175.985745233021"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU101"
+      rmax="0.5*0.02"
+      z="177.736847175638"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU102"
+      rmax="0.5*0.02"
+      z="179.487949118255"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU103"
+      rmax="0.5*0.02"
+      z="181.239051060873"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU104"
+      rmax="0.5*0.02"
+      z="182.99015300349"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU105"
+      rmax="0.5*0.02"
+      z="184.741254946107"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU106"
+      rmax="0.5*0.02"
+      z="186.492356888724"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU107"
+      rmax="0.5*0.02"
+      z="188.243458831341"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU108"
+      rmax="0.5*0.02"
+      z="189.994560773958"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU109"
+      rmax="0.5*0.02"
+      z="191.745662716575"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU110"
+      rmax="0.5*0.02"
+      z="193.496764659192"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU111"
+      rmax="0.5*0.02"
+      z="195.24786660181"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU112"
+      rmax="0.5*0.02"
+      z="196.998968544427"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU113"
+      rmax="0.5*0.02"
+      z="198.750070487044"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU114"
+      rmax="0.5*0.02"
+      z="200.501172429661"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU115"
+      rmax="0.5*0.02"
+      z="202.252274372278"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU116"
+      rmax="0.5*0.02"
+      z="204.003376314895"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU117"
+      rmax="0.5*0.02"
+      z="205.754478257512"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU118"
+      rmax="0.5*0.02"
+      z="207.505580200129"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU119"
+      rmax="0.5*0.02"
+      z="209.256682142747"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU120"
+      rmax="0.5*0.02"
+      z="211.007784085364"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU121"
+      rmax="0.5*0.02"
+      z="212.758886027981"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU122"
+      rmax="0.5*0.02"
+      z="214.509987970598"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU123"
+      rmax="0.5*0.02"
+      z="216.261089913215"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU124"
+      rmax="0.5*0.02"
+      z="218.012191855832"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU125"
+      rmax="0.5*0.02"
+      z="219.763293798449"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU126"
+      rmax="0.5*0.02"
+      z="221.514395741067"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU127"
+      rmax="0.5*0.02"
+      z="223.265497683684"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU128"
+      rmax="0.5*0.02"
+      z="223.265497683683"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU129"
+      rmax="0.5*0.02"
+      z="221.514395741066"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU130"
+      rmax="0.5*0.02"
+      z="219.763293798449"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU131"
+      rmax="0.5*0.02"
+      z="218.012191855832"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU132"
+      rmax="0.5*0.02"
+      z="216.261089913215"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU133"
+      rmax="0.5*0.02"
+      z="214.509987970597"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU134"
+      rmax="0.5*0.02"
+      z="212.75888602798"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU135"
+      rmax="0.5*0.02"
+      z="211.007784085363"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU136"
+      rmax="0.5*0.02"
+      z="209.256682142746"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU137"
+      rmax="0.5*0.02"
+      z="207.505580200129"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU138"
+      rmax="0.5*0.02"
+      z="205.754478257512"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU139"
+      rmax="0.5*0.02"
+      z="204.003376314895"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU140"
+      rmax="0.5*0.02"
+      z="202.252274372277"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU141"
+      rmax="0.5*0.02"
+      z="200.50117242966"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU142"
+      rmax="0.5*0.02"
+      z="198.750070487043"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU143"
+      rmax="0.5*0.02"
+      z="196.998968544426"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU144"
+      rmax="0.5*0.02"
+      z="195.247866601809"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU145"
+      rmax="0.5*0.02"
+      z="193.496764659192"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU146"
+      rmax="0.5*0.02"
+      z="191.745662716575"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU147"
+      rmax="0.5*0.02"
+      z="189.994560773958"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU148"
+      rmax="0.5*0.02"
+      z="188.243458831341"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU149"
+      rmax="0.5*0.02"
+      z="186.492356888723"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU150"
+      rmax="0.5*0.02"
+      z="184.741254946106"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU151"
+      rmax="0.5*0.02"
+      z="182.990153003489"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU152"
+      rmax="0.5*0.02"
+      z="181.239051060872"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU153"
+      rmax="0.5*0.02"
+      z="179.487949118255"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU154"
+      rmax="0.5*0.02"
+      z="177.736847175638"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU155"
+      rmax="0.5*0.02"
+      z="175.985745233021"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU156"
+      rmax="0.5*0.02"
+      z="174.234643290404"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU157"
+      rmax="0.5*0.02"
+      z="172.483541347787"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU158"
+      rmax="0.5*0.02"
+      z="170.73243940517"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU159"
+      rmax="0.5*0.02"
+      z="168.981337462552"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU160"
+      rmax="0.5*0.02"
+      z="167.230235519935"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU161"
+      rmax="0.5*0.02"
+      z="165.479133577318"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU162"
+      rmax="0.5*0.02"
+      z="163.728031634701"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU163"
+      rmax="0.5*0.02"
+      z="161.976929692084"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU164"
+      rmax="0.5*0.02"
+      z="160.225827749467"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU165"
+      rmax="0.5*0.02"
+      z="158.47472580685"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU166"
+      rmax="0.5*0.02"
+      z="156.723623864233"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU167"
+      rmax="0.5*0.02"
+      z="154.972521921616"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU168"
+      rmax="0.5*0.02"
+      z="153.221419978999"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU169"
+      rmax="0.5*0.02"
+      z="151.470318036381"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU170"
+      rmax="0.5*0.02"
+      z="149.719216093764"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU171"
+      rmax="0.5*0.02"
+      z="147.968114151147"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU172"
+      rmax="0.5*0.02"
+      z="146.21701220853"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU173"
+      rmax="0.5*0.02"
+      z="144.465910265913"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU174"
+      rmax="0.5*0.02"
+      z="142.714808323296"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU175"
+      rmax="0.5*0.02"
+      z="140.963706380679"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU176"
+      rmax="0.5*0.02"
+      z="139.212604438062"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU177"
+      rmax="0.5*0.02"
+      z="137.461502495445"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU178"
+      rmax="0.5*0.02"
+      z="135.710400552828"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU179"
+      rmax="0.5*0.02"
+      z="133.95929861021"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU180"
+      rmax="0.5*0.02"
+      z="132.208196667593"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU181"
+      rmax="0.5*0.02"
+      z="130.457094724976"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU182"
+      rmax="0.5*0.02"
+      z="128.705992782359"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU183"
+      rmax="0.5*0.02"
+      z="126.954890839742"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU184"
+      rmax="0.5*0.02"
+      z="125.203788897125"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU185"
+      rmax="0.5*0.02"
+      z="123.452686954508"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU186"
+      rmax="0.5*0.02"
+      z="121.701585011891"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU187"
+      rmax="0.5*0.02"
+      z="119.950483069274"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU188"
+      rmax="0.5*0.02"
+      z="118.199381126657"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU189"
+      rmax="0.5*0.02"
+      z="116.448279184039"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU190"
+      rmax="0.5*0.02"
+      z="114.697177241422"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU191"
+      rmax="0.5*0.02"
+      z="112.946075298805"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU192"
+      rmax="0.5*0.02"
+      z="111.194973356188"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU193"
+      rmax="0.5*0.02"
+      z="109.443871413571"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU194"
+      rmax="0.5*0.02"
+      z="107.692769470954"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU195"
+      rmax="0.5*0.02"
+      z="105.941667528337"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU196"
+      rmax="0.5*0.02"
+      z="104.19056558572"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU197"
+      rmax="0.5*0.02"
+      z="102.439463643103"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU198"
+      rmax="0.5*0.02"
+      z="100.688361700486"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU199"
+      rmax="0.5*0.02"
+      z="98.9372597578684"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU200"
+      rmax="0.5*0.02"
+      z="97.1861578152513"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU201"
+      rmax="0.5*0.02"
+      z="95.4350558726343"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU202"
+      rmax="0.5*0.02"
+      z="93.6839539300172"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU203"
+      rmax="0.5*0.02"
+      z="91.9328519874001"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU204"
+      rmax="0.5*0.02"
+      z="90.181750044783"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU205"
+      rmax="0.5*0.02"
+      z="88.4306481021658"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU206"
+      rmax="0.5*0.02"
+      z="86.6795461595488"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU207"
+      rmax="0.5*0.02"
+      z="84.9284442169317"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU208"
+      rmax="0.5*0.02"
+      z="83.1773422743145"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU209"
+      rmax="0.5*0.02"
+      z="81.4262403316975"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU210"
+      rmax="0.5*0.02"
+      z="79.6751383890803"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU211"
+      rmax="0.5*0.02"
+      z="77.9240364464633"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU212"
+      rmax="0.5*0.02"
+      z="76.1729345038461"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU213"
+      rmax="0.5*0.02"
+      z="74.4218325612291"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU214"
+      rmax="0.5*0.02"
+      z="72.670730618612"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU215"
+      rmax="0.5*0.02"
+      z="70.9196286759948"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU216"
+      rmax="0.5*0.02"
+      z="69.1685267333778"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU217"
+      rmax="0.5*0.02"
+      z="67.4174247907606"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU218"
+      rmax="0.5*0.02"
+      z="65.6663228481435"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU219"
+      rmax="0.5*0.02"
+      z="63.9152209055265"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU220"
+      rmax="0.5*0.02"
+      z="62.1641189629093"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU221"
+      rmax="0.5*0.02"
+      z="60.4130170202923"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU222"
+      rmax="0.5*0.02"
+      z="58.6619150776752"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU223"
+      rmax="0.5*0.02"
+      z="56.910813135058"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU224"
+      rmax="0.5*0.02"
+      z="55.159711192441"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU225"
+      rmax="0.5*0.02"
+      z="53.4086092498239"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU226"
+      rmax="0.5*0.02"
+      z="51.6575073072067"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU227"
+      rmax="0.5*0.02"
+      z="49.9064053645897"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU228"
+      rmax="0.5*0.02"
+      z="48.1553034219725"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU229"
+      rmax="0.5*0.02"
+      z="46.4042014793555"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU230"
+      rmax="0.5*0.02"
+      z="44.6530995367384"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU231"
+      rmax="0.5*0.02"
+      z="42.9019975941212"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU232"
+      rmax="0.5*0.02"
+      z="41.1508956515042"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU233"
+      rmax="0.5*0.02"
+      z="39.399793708887"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU234"
+      rmax="0.5*0.02"
+      z="37.64869176627"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU235"
+      rmax="0.5*0.02"
+      z="35.8975898236529"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU236"
+      rmax="0.5*0.02"
+      z="34.1464878810357"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU237"
+      rmax="0.5*0.02"
+      z="32.3953859384187"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU238"
+      rmax="0.5*0.02"
+      z="30.6442839958015"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU239"
+      rmax="0.5*0.02"
+      z="28.8931820531845"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU240"
+      rmax="0.5*0.02"
+      z="27.1420801105674"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU241"
+      rmax="0.5*0.02"
+      z="25.3909781679502"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU242"
+      rmax="0.5*0.02"
+      z="23.6398762253332"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU243"
+      rmax="0.5*0.02"
+      z="21.888774282716"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU244"
+      rmax="0.5*0.02"
+      z="20.1376723400989"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU245"
+      rmax="0.5*0.02"
+      z="18.3865703974819"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU246"
+      rmax="0.5*0.02"
+      z="16.6354684548648"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU247"
+      rmax="0.5*0.02"
+      z="14.8843665122477"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU248"
+      rmax="0.5*0.02"
+      z="13.1332645696306"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU249"
+      rmax="0.5*0.02"
+      z="11.3821626270135"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU250"
+      rmax="0.5*0.02"
+      z="9.63106068439639"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU251"
+      rmax="0.5*0.02"
+      z="7.87995874177926"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU252"
+      rmax="0.5*0.02"
+      z="6.12885679916218"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU253"
+      rmax="0.5*0.02"
+      z="4.37775485654507"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU254"
+      rmax="0.5*0.02"
+      z="2.62665291392794"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU255"
+      rmax="0.5*0.02"
+      z="0.875550971310878"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireY"
+      rmax="0.5*0.02"
+      z="148.9009"               
+      deltaphi="360" 
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireZ"
+      rmax="0.5*0.02"
+      z="168"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+
+    <box name="ArapucaOut" lunit="cm"
+      x="65"
+      y="2.5"
+      z="65"/>
+
+    <box name="ArapucaIn" lunit="cm"
+      x="60"
+      y="2.5"
+      z="60"/>
+
+     <subtraction name="ArapucaWalls">
+      <first  ref="ArapucaOut"/>
+      <second ref="ArapucaIn"/>
+      <position name="posArapucaSub" x="0" y="1.25" z="0." unit="cm"/>
+      </subtraction>
+
+    <box name="ArapucaAcceptanceWindow" lunit="cm"
+      x="60"
+      y="1"
+      z="60"/>
+
+    <box name="ArapucaDoubleIn" lunit="cm"
+      x="60"
+      y="3.5"
+      z="60"/>
+
+     <subtraction name="ArapucaDoubleWalls">
+      <first  ref="ArapucaOut"/>
+      <second ref="ArapucaDoubleIn"/>
+      <position name="posArapucaDoubleSub" x="0" y="0" z="0" unit="cm"/>
+      </subtraction>
+
+    <box name="ArapucaDoubleAcceptanceWindow" lunit="cm"
+      x="2.48"
+      y="60"
+      z="60"/>
+
+    <box name="ArapucaCathodeAcceptanceWindow" lunit="cm"
+      x="1"
+      y="60"
+      z="60"/>
+
+
+    <box name="Cryostat" lunit="cm" 
+      x="850.32" 
+      y="1548.24" 
+      z="1096.6454"/>
+
+    <box name="ArgonInterior" lunit="cm" 
+      x="850.08"
+      y="1548"
+      z="1096.4054"/>
+
+    <box name="GaseousArgon" lunit="cm" 
+      x="100 - 0.01"
+      y="1548"
+      z="1096.4054"/>
+
+    <box name="ExternalAuxOut" lunit="cm" 
+      x="850.08 - 100"
+      y="1548 - 2*2.5 - 2*40"
+      z="1096.4054"/>
+
+    <box name="ExternalAuxIn" lunit="cm" 
+      x="850.08"
+      y="1359.17"
+      z="1096.4054 + 1"/>
+
+   <subtraction name="ExternalActive">
+      <first ref="ExternalAuxOut"/>
+      <second ref="ExternalAuxIn"/>
+    </subtraction>
+
+    <subtraction name="SteelShell">
+      <first ref="Cryostat"/>
+      <second ref="ArgonInterior"/>
+    </subtraction>
+
+
+
+    <box name="CathodeBlock" lunit="cm"
+      x="4"
+      y="336"
+      z="297.8018" />
+
+    <box name="CathodeVoid" lunit="cm"
+      x="5"
+      y="76.35"
+      z="67" />
+
+    <subtraction name="Cathode1">
+      <first ref="CathodeBlock"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub1" x="0" y="-122.525" z="-108.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode2">
+      <first ref="Cathode1"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub2" x="0" y="-122.525" z="-37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode3">
+      <first ref="Cathode2"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub3" x="0" y="-122.525" z="37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode4">
+      <first ref="Cathode3"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub4" x="0" y="-122.525" z="108.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode5">
+      <first ref="Cathode4"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub5" x="0" y="-42.175" z="-108.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode6">
+      <first ref="Cathode5"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub6" x="0" y="-42.175" z="-37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode7">
+      <first ref="Cathode6"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub7" x="0" y="-42.175" z="37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode8">
+      <first ref="Cathode7"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub8" x="0" y="-42.175" z="108.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode9">
+      <first ref="Cathode8"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub9" x="0" y="42.175" z="-108.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode10">
+      <first ref="Cathode9"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub10" x="0" y="42.175" z="-37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode11">
+      <first ref="Cathode10"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub11" x="0" y="42.175" z="37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode12">
+      <first ref="Cathode11"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub12" x="0" y="42.175" z="108.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode13">
+      <first ref="Cathode12"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub13" x="0" y="122.525" z="-108.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode14">
+      <first ref="Cathode13"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub14" x="0" y="122.525" z="-37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode15">
+      <first ref="Cathode14"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub15" x="0" y="122.525" z="37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="CathodeGrid">
+      <first ref="Cathode15"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub16" x="0" y="122.525" z="108.5" unit="cm"/>
+    </subtraction>
+
+   <box name="AnodePlate" 
+      x="0.01"
+      y="336"
+      z="297.8018"
+      lunit="cm"/>
+
+    <box name="FoamPadBlock" lunit="cm"
+      x="1010.32"
+      y="1708.24"
+      z="1256.6454" />
+
+    <subtraction name="FoamPadding">
+      <first ref="FoamPadBlock"/>
+      <second ref="Cryostat"/>
+      <positionref ref="posCenter"/>
+    </subtraction>
+
+    <box name="SteelSupportBlock" lunit="cm"
+      x="1210.32"
+      y="1908.24"
+      z="1456.6454" />
+
+    <subtraction name="SteelSupport">
+      <first ref="SteelSupportBlock"/>
+      <second ref="FoamPadBlock"/>
+      <positionref ref="posCenter"/>
+    </subtraction>
+
+    <box name="DetEnclosure" lunit="cm" 
+      x="1310.32"
+      y="2108.24"
+      z="1656.6454"/>
+
+
+    <box name="World" lunit="cm" 
+      x="9310.32" 
+      y="10108.24" 
+      z="9656.6454"/>
+</solids>
+<structure>
+<volume name="volFieldShaper">
+  <materialref ref="Al2O3"/>
+  <solidref ref="FieldShaperSolid"/>
+</volume>
+<volume name="volFieldShaperSlim">
+  <materialref ref="Al2O3"/>
+  <solidref ref="FieldShaperSolidSlim"/>
+</volume>
+
+
+    <volume name="volTPCActive">
+      <materialref ref="LAr"/>
+      <solidref ref="CRMActive"/>
+      <auxiliary auxtype="SensDet" auxvalue="SimEnergyDeposit"/>
+      <auxiliary auxtype="StepLimit" auxunit="cm" auxvalue="0.5208*cm"/>
+      <auxiliary auxtype="Efield" auxunit="V/cm" auxvalue="500*V/cm"/>
+      <colorref ref="blue"/>
+    </volume>
+    <volume name="volTPCWireU0">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU0"/>
+    </volume>
+    <volume name="volTPCWireU1">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU1"/>
+    </volume>
+    <volume name="volTPCWireU2">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU2"/>
+    </volume>
+    <volume name="volTPCWireU3">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU3"/>
+    </volume>
+    <volume name="volTPCWireU4">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU4"/>
+    </volume>
+    <volume name="volTPCWireU5">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU5"/>
+    </volume>
+    <volume name="volTPCWireU6">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU6"/>
+    </volume>
+    <volume name="volTPCWireU7">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU7"/>
+    </volume>
+    <volume name="volTPCWireU8">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU8"/>
+    </volume>
+    <volume name="volTPCWireU9">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU9"/>
+    </volume>
+    <volume name="volTPCWireU10">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU10"/>
+    </volume>
+    <volume name="volTPCWireU11">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU11"/>
+    </volume>
+    <volume name="volTPCWireU12">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU12"/>
+    </volume>
+    <volume name="volTPCWireU13">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU13"/>
+    </volume>
+    <volume name="volTPCWireU14">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU14"/>
+    </volume>
+    <volume name="volTPCWireU15">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU15"/>
+    </volume>
+    <volume name="volTPCWireU16">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU16"/>
+    </volume>
+    <volume name="volTPCWireU17">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU17"/>
+    </volume>
+    <volume name="volTPCWireU18">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU18"/>
+    </volume>
+    <volume name="volTPCWireU19">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU19"/>
+    </volume>
+    <volume name="volTPCWireU20">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU20"/>
+    </volume>
+    <volume name="volTPCWireU21">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU21"/>
+    </volume>
+    <volume name="volTPCWireU22">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU22"/>
+    </volume>
+    <volume name="volTPCWireU23">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU23"/>
+    </volume>
+    <volume name="volTPCWireU24">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU24"/>
+    </volume>
+    <volume name="volTPCWireU25">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU25"/>
+    </volume>
+    <volume name="volTPCWireU26">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU26"/>
+    </volume>
+    <volume name="volTPCWireU27">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU27"/>
+    </volume>
+    <volume name="volTPCWireU28">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU28"/>
+    </volume>
+    <volume name="volTPCWireU29">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU29"/>
+    </volume>
+    <volume name="volTPCWireU30">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU30"/>
+    </volume>
+    <volume name="volTPCWireU31">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU31"/>
+    </volume>
+    <volume name="volTPCWireU32">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU32"/>
+    </volume>
+    <volume name="volTPCWireU33">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU33"/>
+    </volume>
+    <volume name="volTPCWireU34">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU34"/>
+    </volume>
+    <volume name="volTPCWireU35">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU35"/>
+    </volume>
+    <volume name="volTPCWireU36">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU36"/>
+    </volume>
+    <volume name="volTPCWireU37">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU37"/>
+    </volume>
+    <volume name="volTPCWireU38">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU38"/>
+    </volume>
+    <volume name="volTPCWireU39">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU39"/>
+    </volume>
+    <volume name="volTPCWireU40">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU40"/>
+    </volume>
+    <volume name="volTPCWireU41">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU41"/>
+    </volume>
+    <volume name="volTPCWireU42">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU42"/>
+    </volume>
+    <volume name="volTPCWireU43">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU43"/>
+    </volume>
+    <volume name="volTPCWireU44">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU44"/>
+    </volume>
+    <volume name="volTPCWireU45">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU45"/>
+    </volume>
+    <volume name="volTPCWireU46">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU46"/>
+    </volume>
+    <volume name="volTPCWireU47">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU47"/>
+    </volume>
+    <volume name="volTPCWireU48">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU48"/>
+    </volume>
+    <volume name="volTPCWireU49">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU49"/>
+    </volume>
+    <volume name="volTPCWireU50">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU50"/>
+    </volume>
+    <volume name="volTPCWireU51">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU51"/>
+    </volume>
+    <volume name="volTPCWireU52">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU52"/>
+    </volume>
+    <volume name="volTPCWireU53">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU53"/>
+    </volume>
+    <volume name="volTPCWireU54">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU54"/>
+    </volume>
+    <volume name="volTPCWireU55">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU55"/>
+    </volume>
+    <volume name="volTPCWireU56">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU56"/>
+    </volume>
+    <volume name="volTPCWireU57">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU57"/>
+    </volume>
+    <volume name="volTPCWireU58">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU58"/>
+    </volume>
+    <volume name="volTPCWireU59">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU59"/>
+    </volume>
+    <volume name="volTPCWireU60">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU60"/>
+    </volume>
+    <volume name="volTPCWireU61">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU61"/>
+    </volume>
+    <volume name="volTPCWireU62">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU62"/>
+    </volume>
+    <volume name="volTPCWireU63">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU63"/>
+    </volume>
+    <volume name="volTPCWireU64">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU64"/>
+    </volume>
+    <volume name="volTPCWireU65">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU65"/>
+    </volume>
+    <volume name="volTPCWireU66">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU66"/>
+    </volume>
+    <volume name="volTPCWireU67">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU67"/>
+    </volume>
+    <volume name="volTPCWireU68">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU68"/>
+    </volume>
+    <volume name="volTPCWireU69">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU69"/>
+    </volume>
+    <volume name="volTPCWireU70">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU70"/>
+    </volume>
+    <volume name="volTPCWireU71">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU71"/>
+    </volume>
+    <volume name="volTPCWireU72">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU72"/>
+    </volume>
+    <volume name="volTPCWireU73">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU73"/>
+    </volume>
+    <volume name="volTPCWireU74">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU74"/>
+    </volume>
+    <volume name="volTPCWireU75">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU75"/>
+    </volume>
+    <volume name="volTPCWireU76">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU76"/>
+    </volume>
+    <volume name="volTPCWireU77">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU77"/>
+    </volume>
+    <volume name="volTPCWireU78">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU78"/>
+    </volume>
+    <volume name="volTPCWireU79">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU79"/>
+    </volume>
+    <volume name="volTPCWireU80">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU80"/>
+    </volume>
+    <volume name="volTPCWireU81">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU81"/>
+    </volume>
+    <volume name="volTPCWireU82">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU82"/>
+    </volume>
+    <volume name="volTPCWireU83">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU83"/>
+    </volume>
+    <volume name="volTPCWireU84">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU84"/>
+    </volume>
+    <volume name="volTPCWireU85">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU85"/>
+    </volume>
+    <volume name="volTPCWireU86">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU86"/>
+    </volume>
+    <volume name="volTPCWireU87">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU87"/>
+    </volume>
+    <volume name="volTPCWireU88">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU88"/>
+    </volume>
+    <volume name="volTPCWireU89">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU89"/>
+    </volume>
+    <volume name="volTPCWireU90">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU90"/>
+    </volume>
+    <volume name="volTPCWireU91">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU91"/>
+    </volume>
+    <volume name="volTPCWireU92">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU92"/>
+    </volume>
+    <volume name="volTPCWireU93">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU93"/>
+    </volume>
+    <volume name="volTPCWireU94">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU94"/>
+    </volume>
+    <volume name="volTPCWireU95">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU95"/>
+    </volume>
+    <volume name="volTPCWireU96">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU96"/>
+    </volume>
+    <volume name="volTPCWireU97">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU97"/>
+    </volume>
+    <volume name="volTPCWireU98">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU98"/>
+    </volume>
+    <volume name="volTPCWireU99">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU99"/>
+    </volume>
+    <volume name="volTPCWireU100">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU100"/>
+    </volume>
+    <volume name="volTPCWireU101">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU101"/>
+    </volume>
+    <volume name="volTPCWireU102">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU102"/>
+    </volume>
+    <volume name="volTPCWireU103">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU103"/>
+    </volume>
+    <volume name="volTPCWireU104">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU104"/>
+    </volume>
+    <volume name="volTPCWireU105">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU105"/>
+    </volume>
+    <volume name="volTPCWireU106">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU106"/>
+    </volume>
+    <volume name="volTPCWireU107">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU107"/>
+    </volume>
+    <volume name="volTPCWireU108">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU108"/>
+    </volume>
+    <volume name="volTPCWireU109">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU109"/>
+    </volume>
+    <volume name="volTPCWireU110">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU110"/>
+    </volume>
+    <volume name="volTPCWireU111">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU111"/>
+    </volume>
+    <volume name="volTPCWireU112">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU112"/>
+    </volume>
+    <volume name="volTPCWireU113">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU113"/>
+    </volume>
+    <volume name="volTPCWireU114">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU114"/>
+    </volume>
+    <volume name="volTPCWireU115">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU115"/>
+    </volume>
+    <volume name="volTPCWireU116">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU116"/>
+    </volume>
+    <volume name="volTPCWireU117">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU117"/>
+    </volume>
+    <volume name="volTPCWireU118">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU118"/>
+    </volume>
+    <volume name="volTPCWireU119">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU119"/>
+    </volume>
+    <volume name="volTPCWireU120">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU120"/>
+    </volume>
+    <volume name="volTPCWireU121">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU121"/>
+    </volume>
+    <volume name="volTPCWireU122">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU122"/>
+    </volume>
+    <volume name="volTPCWireU123">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU123"/>
+    </volume>
+    <volume name="volTPCWireU124">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU124"/>
+    </volume>
+    <volume name="volTPCWireU125">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU125"/>
+    </volume>
+    <volume name="volTPCWireU126">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU126"/>
+    </volume>
+    <volume name="volTPCWireU127">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU127"/>
+    </volume>
+    <volume name="volTPCWireU128">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU128"/>
+    </volume>
+    <volume name="volTPCWireU129">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU129"/>
+    </volume>
+    <volume name="volTPCWireU130">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU130"/>
+    </volume>
+    <volume name="volTPCWireU131">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU131"/>
+    </volume>
+    <volume name="volTPCWireU132">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU132"/>
+    </volume>
+    <volume name="volTPCWireU133">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU133"/>
+    </volume>
+    <volume name="volTPCWireU134">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU134"/>
+    </volume>
+    <volume name="volTPCWireU135">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU135"/>
+    </volume>
+    <volume name="volTPCWireU136">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU136"/>
+    </volume>
+    <volume name="volTPCWireU137">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU137"/>
+    </volume>
+    <volume name="volTPCWireU138">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU138"/>
+    </volume>
+    <volume name="volTPCWireU139">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU139"/>
+    </volume>
+    <volume name="volTPCWireU140">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU140"/>
+    </volume>
+    <volume name="volTPCWireU141">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU141"/>
+    </volume>
+    <volume name="volTPCWireU142">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU142"/>
+    </volume>
+    <volume name="volTPCWireU143">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU143"/>
+    </volume>
+    <volume name="volTPCWireU144">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU144"/>
+    </volume>
+    <volume name="volTPCWireU145">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU145"/>
+    </volume>
+    <volume name="volTPCWireU146">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU146"/>
+    </volume>
+    <volume name="volTPCWireU147">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU147"/>
+    </volume>
+    <volume name="volTPCWireU148">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU148"/>
+    </volume>
+    <volume name="volTPCWireU149">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU149"/>
+    </volume>
+    <volume name="volTPCWireU150">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU150"/>
+    </volume>
+    <volume name="volTPCWireU151">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU151"/>
+    </volume>
+    <volume name="volTPCWireU152">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU152"/>
+    </volume>
+    <volume name="volTPCWireU153">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU153"/>
+    </volume>
+    <volume name="volTPCWireU154">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU154"/>
+    </volume>
+    <volume name="volTPCWireU155">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU155"/>
+    </volume>
+    <volume name="volTPCWireU156">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU156"/>
+    </volume>
+    <volume name="volTPCWireU157">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU157"/>
+    </volume>
+    <volume name="volTPCWireU158">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU158"/>
+    </volume>
+    <volume name="volTPCWireU159">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU159"/>
+    </volume>
+    <volume name="volTPCWireU160">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU160"/>
+    </volume>
+    <volume name="volTPCWireU161">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU161"/>
+    </volume>
+    <volume name="volTPCWireU162">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU162"/>
+    </volume>
+    <volume name="volTPCWireU163">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU163"/>
+    </volume>
+    <volume name="volTPCWireU164">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU164"/>
+    </volume>
+    <volume name="volTPCWireU165">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU165"/>
+    </volume>
+    <volume name="volTPCWireU166">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU166"/>
+    </volume>
+    <volume name="volTPCWireU167">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU167"/>
+    </volume>
+    <volume name="volTPCWireU168">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU168"/>
+    </volume>
+    <volume name="volTPCWireU169">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU169"/>
+    </volume>
+    <volume name="volTPCWireU170">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU170"/>
+    </volume>
+    <volume name="volTPCWireU171">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU171"/>
+    </volume>
+    <volume name="volTPCWireU172">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU172"/>
+    </volume>
+    <volume name="volTPCWireU173">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU173"/>
+    </volume>
+    <volume name="volTPCWireU174">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU174"/>
+    </volume>
+    <volume name="volTPCWireU175">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU175"/>
+    </volume>
+    <volume name="volTPCWireU176">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU176"/>
+    </volume>
+    <volume name="volTPCWireU177">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU177"/>
+    </volume>
+    <volume name="volTPCWireU178">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU178"/>
+    </volume>
+    <volume name="volTPCWireU179">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU179"/>
+    </volume>
+    <volume name="volTPCWireU180">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU180"/>
+    </volume>
+    <volume name="volTPCWireU181">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU181"/>
+    </volume>
+    <volume name="volTPCWireU182">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU182"/>
+    </volume>
+    <volume name="volTPCWireU183">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU183"/>
+    </volume>
+    <volume name="volTPCWireU184">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU184"/>
+    </volume>
+    <volume name="volTPCWireU185">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU185"/>
+    </volume>
+    <volume name="volTPCWireU186">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU186"/>
+    </volume>
+    <volume name="volTPCWireU187">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU187"/>
+    </volume>
+    <volume name="volTPCWireU188">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU188"/>
+    </volume>
+    <volume name="volTPCWireU189">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU189"/>
+    </volume>
+    <volume name="volTPCWireU190">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU190"/>
+    </volume>
+    <volume name="volTPCWireU191">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU191"/>
+    </volume>
+    <volume name="volTPCWireU192">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU192"/>
+    </volume>
+    <volume name="volTPCWireU193">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU193"/>
+    </volume>
+    <volume name="volTPCWireU194">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU194"/>
+    </volume>
+    <volume name="volTPCWireU195">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU195"/>
+    </volume>
+    <volume name="volTPCWireU196">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU196"/>
+    </volume>
+    <volume name="volTPCWireU197">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU197"/>
+    </volume>
+    <volume name="volTPCWireU198">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU198"/>
+    </volume>
+    <volume name="volTPCWireU199">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU199"/>
+    </volume>
+    <volume name="volTPCWireU200">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU200"/>
+    </volume>
+    <volume name="volTPCWireU201">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU201"/>
+    </volume>
+    <volume name="volTPCWireU202">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU202"/>
+    </volume>
+    <volume name="volTPCWireU203">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU203"/>
+    </volume>
+    <volume name="volTPCWireU204">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU204"/>
+    </volume>
+    <volume name="volTPCWireU205">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU205"/>
+    </volume>
+    <volume name="volTPCWireU206">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU206"/>
+    </volume>
+    <volume name="volTPCWireU207">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU207"/>
+    </volume>
+    <volume name="volTPCWireU208">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU208"/>
+    </volume>
+    <volume name="volTPCWireU209">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU209"/>
+    </volume>
+    <volume name="volTPCWireU210">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU210"/>
+    </volume>
+    <volume name="volTPCWireU211">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU211"/>
+    </volume>
+    <volume name="volTPCWireU212">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU212"/>
+    </volume>
+    <volume name="volTPCWireU213">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU213"/>
+    </volume>
+    <volume name="volTPCWireU214">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU214"/>
+    </volume>
+    <volume name="volTPCWireU215">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU215"/>
+    </volume>
+    <volume name="volTPCWireU216">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU216"/>
+    </volume>
+    <volume name="volTPCWireU217">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU217"/>
+    </volume>
+    <volume name="volTPCWireU218">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU218"/>
+    </volume>
+    <volume name="volTPCWireU219">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU219"/>
+    </volume>
+    <volume name="volTPCWireU220">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU220"/>
+    </volume>
+    <volume name="volTPCWireU221">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU221"/>
+    </volume>
+    <volume name="volTPCWireU222">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU222"/>
+    </volume>
+    <volume name="volTPCWireU223">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU223"/>
+    </volume>
+    <volume name="volTPCWireU224">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU224"/>
+    </volume>
+    <volume name="volTPCWireU225">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU225"/>
+    </volume>
+    <volume name="volTPCWireU226">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU226"/>
+    </volume>
+    <volume name="volTPCWireU227">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU227"/>
+    </volume>
+    <volume name="volTPCWireU228">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU228"/>
+    </volume>
+    <volume name="volTPCWireU229">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU229"/>
+    </volume>
+    <volume name="volTPCWireU230">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU230"/>
+    </volume>
+    <volume name="volTPCWireU231">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU231"/>
+    </volume>
+    <volume name="volTPCWireU232">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU232"/>
+    </volume>
+    <volume name="volTPCWireU233">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU233"/>
+    </volume>
+    <volume name="volTPCWireU234">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU234"/>
+    </volume>
+    <volume name="volTPCWireU235">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU235"/>
+    </volume>
+    <volume name="volTPCWireU236">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU236"/>
+    </volume>
+    <volume name="volTPCWireU237">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU237"/>
+    </volume>
+    <volume name="volTPCWireU238">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU238"/>
+    </volume>
+    <volume name="volTPCWireU239">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU239"/>
+    </volume>
+    <volume name="volTPCWireU240">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU240"/>
+    </volume>
+    <volume name="volTPCWireU241">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU241"/>
+    </volume>
+    <volume name="volTPCWireU242">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU242"/>
+    </volume>
+    <volume name="volTPCWireU243">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU243"/>
+    </volume>
+    <volume name="volTPCWireU244">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU244"/>
+    </volume>
+    <volume name="volTPCWireU245">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU245"/>
+    </volume>
+    <volume name="volTPCWireU246">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU246"/>
+    </volume>
+    <volume name="volTPCWireU247">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU247"/>
+    </volume>
+    <volume name="volTPCWireU248">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU248"/>
+    </volume>
+    <volume name="volTPCWireU249">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU249"/>
+    </volume>
+    <volume name="volTPCWireU250">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU250"/>
+    </volume>
+    <volume name="volTPCWireU251">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU251"/>
+    </volume>
+    <volume name="volTPCWireU252">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU252"/>
+    </volume>
+    <volume name="volTPCWireU253">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU253"/>
+    </volume>
+    <volume name="volTPCWireU254">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU254"/>
+    </volume>
+    <volume name="volTPCWireU255">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU255"/>
+    </volume>
+    <volume name="volTPCWireY">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireY"/>
+    </volume>
+    <volume name="volTPCWireZ">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireZ"/>
+    </volume>
+   <volume name="volTPCPlaneU">
+     <materialref ref="LAr"/>
+     <solidref ref="CRMUPlane"/>
+     <physvol>
+       <volumeref ref="volTPCWireU0"/> 
+       <position name="posWireU0" unit="cm" x="0" y="-83.4399379809595" z="-74.1596073595279"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU1"/> 
+       <position name="posWireU1" unit="cm" x="0" y="-82.7855070948343" z="-73.5779633802374"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU2"/> 
+       <position name="posWireU2" unit="cm" x="0" y="-82.1310762087091" z="-72.996319400947"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU3"/> 
+       <position name="posWireU3" unit="cm" x="0" y="-81.476645322584" z="-72.4146754216566"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU4"/> 
+       <position name="posWireU4" unit="cm" x="0" y="-80.8222144364588" z="-71.8330314423662"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU5"/> 
+       <position name="posWireU5" unit="cm" x="0" y="-80.1677835503336" z="-71.2513874630758"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU6"/> 
+       <position name="posWireU6" unit="cm" x="0" y="-79.5133526642084" z="-70.6697434837854"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU7"/> 
+       <position name="posWireU7" unit="cm" x="0" y="-78.8589217780833" z="-70.0880995044949"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU8"/> 
+       <position name="posWireU8" unit="cm" x="0" y="-78.2044908919581" z="-69.5064555252045"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU9"/> 
+       <position name="posWireU9" unit="cm" x="0" y="-77.5500600058329" z="-68.9248115459141"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU10"/> 
+       <position name="posWireU10" unit="cm" x="0" y="-76.8956291197078" z="-68.3431675666237"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU11"/> 
+       <position name="posWireU11" unit="cm" x="0" y="-76.2411982335826" z="-67.7615235873333"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU12"/> 
+       <position name="posWireU12" unit="cm" x="0" y="-75.5867673474574" z="-67.1798796080429"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU13"/> 
+       <position name="posWireU13" unit="cm" x="0" y="-74.9323364613322" z="-66.5982356287525"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU14"/> 
+       <position name="posWireU14" unit="cm" x="0" y="-74.2779055752071" z="-66.016591649462"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU15"/> 
+       <position name="posWireU15" unit="cm" x="0" y="-73.6234746890819" z="-65.4349476701716"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU16"/> 
+       <position name="posWireU16" unit="cm" x="0" y="-72.9690438029567" z="-64.8533036908812"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU17"/> 
+       <position name="posWireU17" unit="cm" x="0" y="-72.3146129168315" z="-64.2716597115908"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU18"/> 
+       <position name="posWireU18" unit="cm" x="0" y="-71.6601820307064" z="-63.6900157323004"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU19"/> 
+       <position name="posWireU19" unit="cm" x="0" y="-71.0057511445812" z="-63.10837175301"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU20"/> 
+       <position name="posWireU20" unit="cm" x="0" y="-70.351320258456" z="-62.5267277737196"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU21"/> 
+       <position name="posWireU21" unit="cm" x="0" y="-69.6968893723309" z="-61.9450837944292"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU22"/> 
+       <position name="posWireU22" unit="cm" x="0" y="-69.0424584862057" z="-61.3634398151387"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU23"/> 
+       <position name="posWireU23" unit="cm" x="0" y="-68.3880276000805" z="-60.7817958358483"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU24"/> 
+       <position name="posWireU24" unit="cm" x="0" y="-67.7335967139554" z="-60.2001518565579"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU25"/> 
+       <position name="posWireU25" unit="cm" x="0" y="-67.0791658278302" z="-59.6185078772675"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU26"/> 
+       <position name="posWireU26" unit="cm" x="0" y="-66.424734941705" z="-59.0368638979771"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU27"/> 
+       <position name="posWireU27" unit="cm" x="0" y="-65.7703040555798" z="-58.4552199186867"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU28"/> 
+       <position name="posWireU28" unit="cm" x="0" y="-65.1158731694547" z="-57.8735759393963"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU29"/> 
+       <position name="posWireU29" unit="cm" x="0" y="-64.4614422833295" z="-57.2919319601058"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU30"/> 
+       <position name="posWireU30" unit="cm" x="0" y="-63.8070113972043" z="-56.7102879808154"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU31"/> 
+       <position name="posWireU31" unit="cm" x="0" y="-63.1525805110792" z="-56.128644001525"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU32"/> 
+       <position name="posWireU32" unit="cm" x="0" y="-62.498149624954" z="-55.5470000222346"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU33"/> 
+       <position name="posWireU33" unit="cm" x="0" y="-61.8437187388288" z="-54.9653560429442"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU34"/> 
+       <position name="posWireU34" unit="cm" x="0" y="-61.1892878527036" z="-54.3837120636538"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU35"/> 
+       <position name="posWireU35" unit="cm" x="0" y="-60.5348569665785" z="-53.8020680843634"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU36"/> 
+       <position name="posWireU36" unit="cm" x="0" y="-59.8804260804533" z="-53.220424105073"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU37"/> 
+       <position name="posWireU37" unit="cm" x="0" y="-59.2259951943281" z="-52.6387801257825"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU38"/> 
+       <position name="posWireU38" unit="cm" x="0" y="-58.571564308203" z="-52.0571361464921"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU39"/> 
+       <position name="posWireU39" unit="cm" x="0" y="-57.9171334220778" z="-51.4754921672017"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU40"/> 
+       <position name="posWireU40" unit="cm" x="0" y="-57.2627025359526" z="-50.8938481879113"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU41"/> 
+       <position name="posWireU41" unit="cm" x="0" y="-56.6082716498274" z="-50.3122042086209"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU42"/> 
+       <position name="posWireU42" unit="cm" x="0" y="-55.9538407637023" z="-49.7305602293305"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU43"/> 
+       <position name="posWireU43" unit="cm" x="0" y="-55.2994098775771" z="-49.14891625004"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU44"/> 
+       <position name="posWireU44" unit="cm" x="0" y="-54.6449789914519" z="-48.5672722707496"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU45"/> 
+       <position name="posWireU45" unit="cm" x="0" y="-53.9905481053267" z="-47.9856282914592"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU46"/> 
+       <position name="posWireU46" unit="cm" x="0" y="-53.3361172192016" z="-47.4039843121688"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU47"/> 
+       <position name="posWireU47" unit="cm" x="0" y="-52.6816863330764" z="-46.8223403328784"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU48"/> 
+       <position name="posWireU48" unit="cm" x="0" y="-52.0272554469512" z="-46.240696353588"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU49"/> 
+       <position name="posWireU49" unit="cm" x="0" y="-51.372824560826" z="-45.6590523742975"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU50"/> 
+       <position name="posWireU50" unit="cm" x="0" y="-50.7183936747009" z="-45.0774083950071"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU51"/> 
+       <position name="posWireU51" unit="cm" x="0" y="-50.0639627885757" z="-44.4957644157167"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU52"/> 
+       <position name="posWireU52" unit="cm" x="0" y="-49.4095319024505" z="-43.9141204364263"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU53"/> 
+       <position name="posWireU53" unit="cm" x="0" y="-48.7551010163253" z="-43.3324764571359"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU54"/> 
+       <position name="posWireU54" unit="cm" x="0" y="-48.1006701302002" z="-42.7508324778455"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU55"/> 
+       <position name="posWireU55" unit="cm" x="0" y="-47.446239244075" z="-42.1691884985551"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU56"/> 
+       <position name="posWireU56" unit="cm" x="0" y="-46.7918083579498" z="-41.5875445192646"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU57"/> 
+       <position name="posWireU57" unit="cm" x="0" y="-46.1373774718246" z="-41.0059005399742"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU58"/> 
+       <position name="posWireU58" unit="cm" x="0" y="-45.4829465856995" z="-40.4242565606838"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU59"/> 
+       <position name="posWireU59" unit="cm" x="0" y="-44.8285156995743" z="-39.8426125813934"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU60"/> 
+       <position name="posWireU60" unit="cm" x="0" y="-44.1740848134491" z="-39.260968602103"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU61"/> 
+       <position name="posWireU61" unit="cm" x="0" y="-43.5196539273239" z="-38.6793246228126"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU62"/> 
+       <position name="posWireU62" unit="cm" x="0" y="-42.8652230411988" z="-38.0976806435221"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU63"/> 
+       <position name="posWireU63" unit="cm" x="0" y="-42.2107921550736" z="-37.5160366642317"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU64"/> 
+       <position name="posWireU64" unit="cm" x="0" y="-41.5563612689484" z="-36.9343926849413"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU65"/> 
+       <position name="posWireU65" unit="cm" x="0" y="-40.9019303828233" z="-36.3527487056509"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU66"/> 
+       <position name="posWireU66" unit="cm" x="0" y="-40.2474994966981" z="-35.7711047263605"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU67"/> 
+       <position name="posWireU67" unit="cm" x="0" y="-39.5930686105729" z="-35.1894607470701"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU68"/> 
+       <position name="posWireU68" unit="cm" x="0" y="-38.9386377244477" z="-34.6078167677796"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU69"/> 
+       <position name="posWireU69" unit="cm" x="0" y="-38.2842068383226" z="-34.0261727884892"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU70"/> 
+       <position name="posWireU70" unit="cm" x="0" y="-37.6297759521974" z="-33.4445288091988"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU71"/> 
+       <position name="posWireU71" unit="cm" x="0" y="-36.9753450660722" z="-32.8628848299084"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU72"/> 
+       <position name="posWireU72" unit="cm" x="0" y="-36.320914179947" z="-32.281240850618"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU73"/> 
+       <position name="posWireU73" unit="cm" x="0" y="-35.6664832938219" z="-31.6995968713276"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU74"/> 
+       <position name="posWireU74" unit="cm" x="0" y="-35.0120524076967" z="-31.1179528920372"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU75"/> 
+       <position name="posWireU75" unit="cm" x="0" y="-34.3576215215715" z="-30.5363089127467"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU76"/> 
+       <position name="posWireU76" unit="cm" x="0" y="-33.7031906354463" z="-29.9546649334563"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU77"/> 
+       <position name="posWireU77" unit="cm" x="0" y="-33.0487597493212" z="-29.3730209541659"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU78"/> 
+       <position name="posWireU78" unit="cm" x="0" y="-32.394328863196" z="-28.7913769748755"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU79"/> 
+       <position name="posWireU79" unit="cm" x="0" y="-31.7398979770708" z="-28.2097329955851"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU80"/> 
+       <position name="posWireU80" unit="cm" x="0" y="-31.0854670909456" z="-27.6280890162947"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU81"/> 
+       <position name="posWireU81" unit="cm" x="0" y="-30.4310362048205" z="-27.0464450370042"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU82"/> 
+       <position name="posWireU82" unit="cm" x="0" y="-29.7766053186953" z="-26.4648010577138"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU83"/> 
+       <position name="posWireU83" unit="cm" x="0" y="-29.1221744325701" z="-25.8831570784234"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU84"/> 
+       <position name="posWireU84" unit="cm" x="0" y="-28.467743546445" z="-25.301513099133"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU85"/> 
+       <position name="posWireU85" unit="cm" x="0" y="-27.8133126603198" z="-24.7198691198426"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU86"/> 
+       <position name="posWireU86" unit="cm" x="0" y="-27.1588817741946" z="-24.1382251405522"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU87"/> 
+       <position name="posWireU87" unit="cm" x="0" y="-26.5044508880694" z="-23.5565811612617"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU88"/> 
+       <position name="posWireU88" unit="cm" x="0" y="-25.8500200019443" z="-22.9749371819713"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU89"/> 
+       <position name="posWireU89" unit="cm" x="0" y="-25.1955891158191" z="-22.3932932026809"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU90"/> 
+       <position name="posWireU90" unit="cm" x="0" y="-24.5411582296939" z="-21.8116492233905"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU91"/> 
+       <position name="posWireU91" unit="cm" x="0" y="-23.8867273435687" z="-21.2300052441001"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU92"/> 
+       <position name="posWireU92" unit="cm" x="0" y="-23.2322964574436" z="-20.6483612648097"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU93"/> 
+       <position name="posWireU93" unit="cm" x="0" y="-22.5778655713184" z="-20.0667172855192"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU94"/> 
+       <position name="posWireU94" unit="cm" x="0" y="-21.9234346851932" z="-19.4850733062288"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU95"/> 
+       <position name="posWireU95" unit="cm" x="0" y="-21.269003799068" z="-18.9034293269384"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU96"/> 
+       <position name="posWireU96" unit="cm" x="0" y="-20.6145729129429" z="-18.321785347648"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU97"/> 
+       <position name="posWireU97" unit="cm" x="0" y="-19.9601420268177" z="-17.7401413683576"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU98"/> 
+       <position name="posWireU98" unit="cm" x="0" y="-19.3057111406925" z="-17.1584973890672"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU99"/> 
+       <position name="posWireU99" unit="cm" x="0" y="-18.6512802545673" z="-16.5768534097767"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU100"/> 
+       <position name="posWireU100" unit="cm" x="0" y="-17.9968493684422" z="-15.9952094304863"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU101"/> 
+       <position name="posWireU101" unit="cm" x="0" y="-17.342418482317" z="-15.4135654511959"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU102"/> 
+       <position name="posWireU102" unit="cm" x="0" y="-16.6879875961918" z="-14.8319214719055"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU103"/> 
+       <position name="posWireU103" unit="cm" x="0" y="-16.0335567100666" z="-14.2502774926151"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU104"/> 
+       <position name="posWireU104" unit="cm" x="0" y="-15.3791258239415" z="-13.6686335133247"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU105"/> 
+       <position name="posWireU105" unit="cm" x="0" y="-14.7246949378163" z="-13.0869895340343"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU106"/> 
+       <position name="posWireU106" unit="cm" x="0" y="-14.0702640516911" z="-12.5053455547438"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU107"/> 
+       <position name="posWireU107" unit="cm" x="0" y="-13.415833165566" z="-11.9237015754534"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU108"/> 
+       <position name="posWireU108" unit="cm" x="0" y="-12.7614022794408" z="-11.342057596163"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU109"/> 
+       <position name="posWireU109" unit="cm" x="0" y="-12.1069713933156" z="-10.7604136168726"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU110"/> 
+       <position name="posWireU110" unit="cm" x="0" y="-11.4525405071904" z="-10.1787696375822"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU111"/> 
+       <position name="posWireU111" unit="cm" x="0" y="-10.7981096210653" z="-9.59712565829176"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU112"/> 
+       <position name="posWireU112" unit="cm" x="0" y="-10.1436787349401" z="-9.01548167900135"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU113"/> 
+       <position name="posWireU113" unit="cm" x="0" y="-9.4892478488149" z="-8.43383769971093"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU114"/> 
+       <position name="posWireU114" unit="cm" x="0" y="-8.83481696268973" z="-7.85219372042052"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU115"/> 
+       <position name="posWireU115" unit="cm" x="0" y="-8.18038607656456" z="-7.2705497411301"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU116"/> 
+       <position name="posWireU116" unit="cm" x="0" y="-7.52595519043939" z="-6.68890576183968"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU117"/> 
+       <position name="posWireU117" unit="cm" x="0" y="-6.87152430431422" z="-6.10726178254927"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU118"/> 
+       <position name="posWireU118" unit="cm" x="0" y="-6.21709341818904" z="-5.52561780325885"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU119"/> 
+       <position name="posWireU119" unit="cm" x="0" y="-5.56266253206387" z="-4.94397382396843"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU120"/> 
+       <position name="posWireU120" unit="cm" x="0" y="-4.90823164593868" z="-4.36232984467803"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU121"/> 
+       <position name="posWireU121" unit="cm" x="0" y="-4.25380075981352" z="-3.78068586538761"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU122"/> 
+       <position name="posWireU122" unit="cm" x="0" y="-3.59936987368835" z="-3.19904188609719"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU123"/> 
+       <position name="posWireU123" unit="cm" x="0" y="-2.94493898756318" z="-2.61739790680677"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU124"/> 
+       <position name="posWireU124" unit="cm" x="0" y="-2.29050810143798" z="-2.03575392751635"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU125"/> 
+       <position name="posWireU125" unit="cm" x="0" y="-1.63607721531281" z="-1.45410994822593"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU126"/> 
+       <position name="posWireU126" unit="cm" x="0" y="-0.98164632918764" z="-0.872465968935515"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU127"/> 
+       <position name="posWireU127" unit="cm" x="0" y="-0.327215443062471" z="-0.290821989645096"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU128"/> 
+       <position name="posWireU128" unit="cm" x="0" y="0.327215443062705" z="0.290821989645316"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU129"/> 
+       <position name="posWireU129" unit="cm" x="0" y="0.981646329187875" z="0.872465968935728"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU130"/> 
+       <position name="posWireU130" unit="cm" x="0" y="1.63607721531305" z="1.45410994822615"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU131"/> 
+       <position name="posWireU131" unit="cm" x="0" y="2.29050810143823" z="2.03575392751656"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU132"/> 
+       <position name="posWireU132" unit="cm" x="0" y="2.9449389875634" z="2.61739790680698"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU133"/> 
+       <position name="posWireU133" unit="cm" x="0" y="3.59936987368857" z="3.19904188609739"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU134"/> 
+       <position name="posWireU134" unit="cm" x="0" y="4.25380075981374" z="3.7806858653878"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU135"/> 
+       <position name="posWireU135" unit="cm" x="0" y="4.90823164593891" z="4.36232984467821"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU136"/> 
+       <position name="posWireU136" unit="cm" x="0" y="5.56266253206409" z="4.94397382396863"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU137"/> 
+       <position name="posWireU137" unit="cm" x="0" y="6.21709341818926" z="5.52561780325905"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU138"/> 
+       <position name="posWireU138" unit="cm" x="0" y="6.87152430431443" z="6.10726178254946"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU139"/> 
+       <position name="posWireU139" unit="cm" x="0" y="7.5259551904396" z="6.68890576183988"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU140"/> 
+       <position name="posWireU140" unit="cm" x="0" y="8.18038607656479" z="7.2705497411303"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU141"/> 
+       <position name="posWireU141" unit="cm" x="0" y="8.83481696268996" z="7.85219372042071"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU142"/> 
+       <position name="posWireU142" unit="cm" x="0" y="9.48924784881513" z="8.43383769971113"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU143"/> 
+       <position name="posWireU143" unit="cm" x="0" y="10.1436787349403" z="9.01548167900155"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU144"/> 
+       <position name="posWireU144" unit="cm" x="0" y="10.7981096210655" z="9.59712565829196"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU145"/> 
+       <position name="posWireU145" unit="cm" x="0" y="11.4525405071907" z="10.1787696375824"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU146"/> 
+       <position name="posWireU146" unit="cm" x="0" y="12.1069713933158" z="10.7604136168728"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU147"/> 
+       <position name="posWireU147" unit="cm" x="0" y="12.761402279441" z="11.3420575961632"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU148"/> 
+       <position name="posWireU148" unit="cm" x="0" y="13.4158331655662" z="11.9237015754536"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU149"/> 
+       <position name="posWireU149" unit="cm" x="0" y="14.0702640516913" z="12.505345554744"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU150"/> 
+       <position name="posWireU150" unit="cm" x="0" y="14.7246949378165" z="13.0869895340344"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU151"/> 
+       <position name="posWireU151" unit="cm" x="0" y="15.3791258239416" z="13.6686335133248"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU152"/> 
+       <position name="posWireU152" unit="cm" x="0" y="16.0335567100668" z="14.2502774926152"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU153"/> 
+       <position name="posWireU153" unit="cm" x="0" y="16.687987596192" z="14.8319214719056"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU154"/> 
+       <position name="posWireU154" unit="cm" x="0" y="17.3424184823171" z="15.413565451196"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU155"/> 
+       <position name="posWireU155" unit="cm" x="0" y="17.9968493684423" z="15.9952094304864"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU156"/> 
+       <position name="posWireU156" unit="cm" x="0" y="18.6512802545675" z="16.5768534097769"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU157"/> 
+       <position name="posWireU157" unit="cm" x="0" y="19.3057111406926" z="17.1584973890673"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU158"/> 
+       <position name="posWireU158" unit="cm" x="0" y="19.9601420268178" z="17.7401413683577"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU159"/> 
+       <position name="posWireU159" unit="cm" x="0" y="20.614572912943" z="18.3217853476481"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU160"/> 
+       <position name="posWireU160" unit="cm" x="0" y="21.2690037990681" z="18.9034293269385"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU161"/> 
+       <position name="posWireU161" unit="cm" x="0" y="21.9234346851933" z="19.4850733062289"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU162"/> 
+       <position name="posWireU162" unit="cm" x="0" y="22.5778655713184" z="20.0667172855193"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU163"/> 
+       <position name="posWireU163" unit="cm" x="0" y="23.2322964574436" z="20.6483612648097"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU164"/> 
+       <position name="posWireU164" unit="cm" x="0" y="23.8867273435688" z="21.2300052441001"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU165"/> 
+       <position name="posWireU165" unit="cm" x="0" y="24.5411582296939" z="21.8116492233905"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU166"/> 
+       <position name="posWireU166" unit="cm" x="0" y="25.1955891158191" z="22.3932932026809"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU167"/> 
+       <position name="posWireU167" unit="cm" x="0" y="25.8500200019443" z="22.9749371819713"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU168"/> 
+       <position name="posWireU168" unit="cm" x="0" y="26.5044508880694" z="23.5565811612617"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU169"/> 
+       <position name="posWireU169" unit="cm" x="0" y="27.1588817741946" z="24.1382251405521"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU170"/> 
+       <position name="posWireU170" unit="cm" x="0" y="27.8133126603198" z="24.7198691198426"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU171"/> 
+       <position name="posWireU171" unit="cm" x="0" y="28.4677435464449" z="25.301513099133"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU172"/> 
+       <position name="posWireU172" unit="cm" x="0" y="29.1221744325701" z="25.8831570784234"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU173"/> 
+       <position name="posWireU173" unit="cm" x="0" y="29.7766053186952" z="26.4648010577138"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU174"/> 
+       <position name="posWireU174" unit="cm" x="0" y="30.4310362048204" z="27.0464450370042"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU175"/> 
+       <position name="posWireU175" unit="cm" x="0" y="31.0854670909456" z="27.6280890162946"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU176"/> 
+       <position name="posWireU176" unit="cm" x="0" y="31.7398979770707" z="28.209732995585"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU177"/> 
+       <position name="posWireU177" unit="cm" x="0" y="32.3943288631959" z="28.7913769748754"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU178"/> 
+       <position name="posWireU178" unit="cm" x="0" y="33.0487597493211" z="29.3730209541658"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU179"/> 
+       <position name="posWireU179" unit="cm" x="0" y="33.7031906354462" z="29.9546649334562"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU180"/> 
+       <position name="posWireU180" unit="cm" x="0" y="34.3576215215714" z="30.5363089127466"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU181"/> 
+       <position name="posWireU181" unit="cm" x="0" y="35.0120524076965" z="31.117952892037"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU182"/> 
+       <position name="posWireU182" unit="cm" x="0" y="35.6664832938217" z="31.6995968713274"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU183"/> 
+       <position name="posWireU183" unit="cm" x="0" y="36.3209141799469" z="32.2812408506178"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU184"/> 
+       <position name="posWireU184" unit="cm" x="0" y="36.975345066072" z="32.8628848299082"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU185"/> 
+       <position name="posWireU185" unit="cm" x="0" y="37.6297759521972" z="33.4445288091987"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU186"/> 
+       <position name="posWireU186" unit="cm" x="0" y="38.2842068383224" z="34.026172788489"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU187"/> 
+       <position name="posWireU187" unit="cm" x="0" y="38.9386377244475" z="34.6078167677795"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU188"/> 
+       <position name="posWireU188" unit="cm" x="0" y="39.5930686105727" z="35.1894607470699"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU189"/> 
+       <position name="posWireU189" unit="cm" x="0" y="40.2474994966978" z="35.7711047263603"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU190"/> 
+       <position name="posWireU190" unit="cm" x="0" y="40.901930382823" z="36.3527487056507"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU191"/> 
+       <position name="posWireU191" unit="cm" x="0" y="41.5563612689482" z="36.9343926849411"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU192"/> 
+       <position name="posWireU192" unit="cm" x="0" y="42.2107921550733" z="37.5160366642315"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU193"/> 
+       <position name="posWireU193" unit="cm" x="0" y="42.8652230411985" z="38.0976806435219"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU194"/> 
+       <position name="posWireU194" unit="cm" x="0" y="43.5196539273237" z="38.6793246228123"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU195"/> 
+       <position name="posWireU195" unit="cm" x="0" y="44.1740848134488" z="39.2609686021027"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU196"/> 
+       <position name="posWireU196" unit="cm" x="0" y="44.828515699574" z="39.8426125813931"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU197"/> 
+       <position name="posWireU197" unit="cm" x="0" y="45.4829465856992" z="40.4242565606835"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU198"/> 
+       <position name="posWireU198" unit="cm" x="0" y="46.1373774718243" z="41.0059005399739"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU199"/> 
+       <position name="posWireU199" unit="cm" x="0" y="46.7918083579495" z="41.5875445192643"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU200"/> 
+       <position name="posWireU200" unit="cm" x="0" y="47.4462392440746" z="42.1691884985547"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU201"/> 
+       <position name="posWireU201" unit="cm" x="0" y="48.1006701301998" z="42.7508324778452"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU202"/> 
+       <position name="posWireU202" unit="cm" x="0" y="48.755101016325" z="43.3324764571356"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU203"/> 
+       <position name="posWireU203" unit="cm" x="0" y="49.4095319024501" z="43.9141204364259"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU204"/> 
+       <position name="posWireU204" unit="cm" x="0" y="50.0639627885753" z="44.4957644157164"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU205"/> 
+       <position name="posWireU205" unit="cm" x="0" y="50.7183936747005" z="45.0774083950068"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU206"/> 
+       <position name="posWireU206" unit="cm" x="0" y="51.3728245608256" z="45.6590523742972"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU207"/> 
+       <position name="posWireU207" unit="cm" x="0" y="52.0272554469508" z="46.2406963535876"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU208"/> 
+       <position name="posWireU208" unit="cm" x="0" y="52.681686333076" z="46.822340332878"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU209"/> 
+       <position name="posWireU209" unit="cm" x="0" y="53.3361172192011" z="47.4039843121684"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU210"/> 
+       <position name="posWireU210" unit="cm" x="0" y="53.9905481053263" z="47.9856282914588"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU211"/> 
+       <position name="posWireU211" unit="cm" x="0" y="54.6449789914514" z="48.5672722707492"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU212"/> 
+       <position name="posWireU212" unit="cm" x="0" y="55.2994098775766" z="49.1489162500396"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU213"/> 
+       <position name="posWireU213" unit="cm" x="0" y="55.9538407637018" z="49.73056022933"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU214"/> 
+       <position name="posWireU214" unit="cm" x="0" y="56.6082716498269" z="50.3122042086204"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU215"/> 
+       <position name="posWireU215" unit="cm" x="0" y="57.2627025359521" z="50.8938481879108"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU216"/> 
+       <position name="posWireU216" unit="cm" x="0" y="57.9171334220772" z="51.4754921672012"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU217"/> 
+       <position name="posWireU217" unit="cm" x="0" y="58.5715643082024" z="52.0571361464917"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU218"/> 
+       <position name="posWireU218" unit="cm" x="0" y="59.2259951943276" z="52.6387801257821"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU219"/> 
+       <position name="posWireU219" unit="cm" x="0" y="59.8804260804527" z="53.2204241050725"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU220"/> 
+       <position name="posWireU220" unit="cm" x="0" y="60.5348569665779" z="53.8020680843629"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU221"/> 
+       <position name="posWireU221" unit="cm" x="0" y="61.1892878527031" z="54.3837120636533"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU222"/> 
+       <position name="posWireU222" unit="cm" x="0" y="61.8437187388282" z="54.9653560429437"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU223"/> 
+       <position name="posWireU223" unit="cm" x="0" y="62.4981496249534" z="55.5470000222341"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU224"/> 
+       <position name="posWireU224" unit="cm" x="0" y="63.1525805110786" z="56.1286440015245"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU225"/> 
+       <position name="posWireU225" unit="cm" x="0" y="63.8070113972037" z="56.7102879808149"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU226"/> 
+       <position name="posWireU226" unit="cm" x="0" y="64.4614422833289" z="57.2919319601053"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU227"/> 
+       <position name="posWireU227" unit="cm" x="0" y="65.115873169454" z="57.8735759393957"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU228"/> 
+       <position name="posWireU228" unit="cm" x="0" y="65.7703040555792" z="58.4552199186861"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU229"/> 
+       <position name="posWireU229" unit="cm" x="0" y="66.4247349417044" z="59.0368638979765"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU230"/> 
+       <position name="posWireU230" unit="cm" x="0" y="67.0791658278295" z="59.6185078772669"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU231"/> 
+       <position name="posWireU231" unit="cm" x="0" y="67.7335967139547" z="60.2001518565573"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU232"/> 
+       <position name="posWireU232" unit="cm" x="0" y="68.3880276000799" z="60.7817958358477"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU233"/> 
+       <position name="posWireU233" unit="cm" x="0" y="69.042458486205" z="61.3634398151382"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU234"/> 
+       <position name="posWireU234" unit="cm" x="0" y="69.6968893723302" z="61.9450837944285"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU235"/> 
+       <position name="posWireU235" unit="cm" x="0" y="70.3513202584554" z="62.526727773719"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU236"/> 
+       <position name="posWireU236" unit="cm" x="0" y="71.0057511445805" z="63.1083717530094"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU237"/> 
+       <position name="posWireU237" unit="cm" x="0" y="71.6601820307057" z="63.6900157322998"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU238"/> 
+       <position name="posWireU238" unit="cm" x="0" y="72.3146129168309" z="64.2716597115902"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU239"/> 
+       <position name="posWireU239" unit="cm" x="0" y="72.969043802956" z="64.8533036908806"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU240"/> 
+       <position name="posWireU240" unit="cm" x="0" y="73.6234746890812" z="65.434947670171"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU241"/> 
+       <position name="posWireU241" unit="cm" x="0" y="74.2779055752063" z="66.0165916494614"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU242"/> 
+       <position name="posWireU242" unit="cm" x="0" y="74.9323364613315" z="66.5982356287518"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU243"/> 
+       <position name="posWireU243" unit="cm" x="0" y="75.5867673474567" z="67.1798796080422"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU244"/> 
+       <position name="posWireU244" unit="cm" x="0" y="76.2411982335818" z="67.7615235873326"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU245"/> 
+       <position name="posWireU245" unit="cm" x="0" y="76.895629119707" z="68.343167566623"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU246"/> 
+       <position name="posWireU246" unit="cm" x="0" y="77.5500600058322" z="68.9248115459134"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU247"/> 
+       <position name="posWireU247" unit="cm" x="0" y="78.2044908919573" z="69.5064555252038"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU248"/> 
+       <position name="posWireU248" unit="cm" x="0" y="78.8589217780825" z="70.0880995044943"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU249"/> 
+       <position name="posWireU249" unit="cm" x="0" y="79.5133526642076" z="70.6697434837847"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU250"/> 
+       <position name="posWireU250" unit="cm" x="0" y="80.1677835503328" z="71.251387463075"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU251"/> 
+       <position name="posWireU251" unit="cm" x="0" y="80.822214436458" z="71.8330314423655"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU252"/> 
+       <position name="posWireU252" unit="cm" x="0" y="81.4766453225831" z="72.4146754216559"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU253"/> 
+       <position name="posWireU253" unit="cm" x="0" y="82.1310762087083" z="72.9963194009463"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU254"/> 
+       <position name="posWireU254" unit="cm" x="0" y="82.7855070948335" z="73.5779633802367"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU255"/> 
+       <position name="posWireU255" unit="cm" x="0" y="83.4399379809586" z="74.1596073595271"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+   </volume>
+  <volume name="volTPCPlaneY">
+    <materialref ref="LAr"/>
+    <solidref ref="CRMYPlane"/>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY0" unit="cm" x="0" y="-83.7375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY1" unit="cm" x="0" y="-83.2125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY2" unit="cm" x="0" y="-82.6875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY3" unit="cm" x="0" y="-82.1625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY4" unit="cm" x="0" y="-81.6375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY5" unit="cm" x="0" y="-81.1125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY6" unit="cm" x="0" y="-80.5875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY7" unit="cm" x="0" y="-80.0625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY8" unit="cm" x="0" y="-79.5375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY9" unit="cm" x="0" y="-79.0125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY10" unit="cm" x="0" y="-78.4875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY11" unit="cm" x="0" y="-77.9625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY12" unit="cm" x="0" y="-77.4375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY13" unit="cm" x="0" y="-76.9125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY14" unit="cm" x="0" y="-76.3875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY15" unit="cm" x="0" y="-75.8625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY16" unit="cm" x="0" y="-75.3375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY17" unit="cm" x="0" y="-74.8125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY18" unit="cm" x="0" y="-74.2875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY19" unit="cm" x="0" y="-73.7625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY20" unit="cm" x="0" y="-73.2375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY21" unit="cm" x="0" y="-72.7125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY22" unit="cm" x="0" y="-72.1875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY23" unit="cm" x="0" y="-71.6625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY24" unit="cm" x="0" y="-71.1375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY25" unit="cm" x="0" y="-70.6125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY26" unit="cm" x="0" y="-70.0875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY27" unit="cm" x="0" y="-69.5625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY28" unit="cm" x="0" y="-69.0375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY29" unit="cm" x="0" y="-68.5125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY30" unit="cm" x="0" y="-67.9875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY31" unit="cm" x="0" y="-67.4625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY32" unit="cm" x="0" y="-66.9375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY33" unit="cm" x="0" y="-66.4125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY34" unit="cm" x="0" y="-65.8875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY35" unit="cm" x="0" y="-65.3625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY36" unit="cm" x="0" y="-64.8375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY37" unit="cm" x="0" y="-64.3125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY38" unit="cm" x="0" y="-63.7875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY39" unit="cm" x="0" y="-63.2625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY40" unit="cm" x="0" y="-62.7375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY41" unit="cm" x="0" y="-62.2125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY42" unit="cm" x="0" y="-61.6875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY43" unit="cm" x="0" y="-61.1625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY44" unit="cm" x="0" y="-60.6375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY45" unit="cm" x="0" y="-60.1125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY46" unit="cm" x="0" y="-59.5875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY47" unit="cm" x="0" y="-59.0625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY48" unit="cm" x="0" y="-58.5375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY49" unit="cm" x="0" y="-58.0125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY50" unit="cm" x="0" y="-57.4875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY51" unit="cm" x="0" y="-56.9625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY52" unit="cm" x="0" y="-56.4375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY53" unit="cm" x="0" y="-55.9125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY54" unit="cm" x="0" y="-55.3875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY55" unit="cm" x="0" y="-54.8625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY56" unit="cm" x="0" y="-54.3375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY57" unit="cm" x="0" y="-53.8125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY58" unit="cm" x="0" y="-53.2875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY59" unit="cm" x="0" y="-52.7625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY60" unit="cm" x="0" y="-52.2375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY61" unit="cm" x="0" y="-51.7125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY62" unit="cm" x="0" y="-51.1875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY63" unit="cm" x="0" y="-50.6625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY64" unit="cm" x="0" y="-50.1375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY65" unit="cm" x="0" y="-49.6125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY66" unit="cm" x="0" y="-49.0875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY67" unit="cm" x="0" y="-48.5625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY68" unit="cm" x="0" y="-48.0375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY69" unit="cm" x="0" y="-47.5125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY70" unit="cm" x="0" y="-46.9875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY71" unit="cm" x="0" y="-46.4625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY72" unit="cm" x="0" y="-45.9375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY73" unit="cm" x="0" y="-45.4125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY74" unit="cm" x="0" y="-44.8875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY75" unit="cm" x="0" y="-44.3625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY76" unit="cm" x="0" y="-43.8375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY77" unit="cm" x="0" y="-43.3125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY78" unit="cm" x="0" y="-42.7875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY79" unit="cm" x="0" y="-42.2625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY80" unit="cm" x="0" y="-41.7375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY81" unit="cm" x="0" y="-41.2125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY82" unit="cm" x="0" y="-40.6875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY83" unit="cm" x="0" y="-40.1625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY84" unit="cm" x="0" y="-39.6375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY85" unit="cm" x="0" y="-39.1125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY86" unit="cm" x="0" y="-38.5875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY87" unit="cm" x="0" y="-38.0625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY88" unit="cm" x="0" y="-37.5375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY89" unit="cm" x="0" y="-37.0125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY90" unit="cm" x="0" y="-36.4875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY91" unit="cm" x="0" y="-35.9625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY92" unit="cm" x="0" y="-35.4375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY93" unit="cm" x="0" y="-34.9125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY94" unit="cm" x="0" y="-34.3875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY95" unit="cm" x="0" y="-33.8625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY96" unit="cm" x="0" y="-33.3375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY97" unit="cm" x="0" y="-32.8125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY98" unit="cm" x="0" y="-32.2875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY99" unit="cm" x="0" y="-31.7625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY100" unit="cm" x="0" y="-31.2375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY101" unit="cm" x="0" y="-30.7125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY102" unit="cm" x="0" y="-30.1875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY103" unit="cm" x="0" y="-29.6625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY104" unit="cm" x="0" y="-29.1375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY105" unit="cm" x="0" y="-28.6125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY106" unit="cm" x="0" y="-28.0875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY107" unit="cm" x="0" y="-27.5625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY108" unit="cm" x="0" y="-27.0375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY109" unit="cm" x="0" y="-26.5125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY110" unit="cm" x="0" y="-25.9875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY111" unit="cm" x="0" y="-25.4625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY112" unit="cm" x="0" y="-24.9375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY113" unit="cm" x="0" y="-24.4125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY114" unit="cm" x="0" y="-23.8875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY115" unit="cm" x="0" y="-23.3625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY116" unit="cm" x="0" y="-22.8375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY117" unit="cm" x="0" y="-22.3125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY118" unit="cm" x="0" y="-21.7875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY119" unit="cm" x="0" y="-21.2625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY120" unit="cm" x="0" y="-20.7375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY121" unit="cm" x="0" y="-20.2125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY122" unit="cm" x="0" y="-19.6875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY123" unit="cm" x="0" y="-19.1625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY124" unit="cm" x="0" y="-18.6375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY125" unit="cm" x="0" y="-18.1125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY126" unit="cm" x="0" y="-17.5875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY127" unit="cm" x="0" y="-17.0625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY128" unit="cm" x="0" y="-16.5375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY129" unit="cm" x="0" y="-16.0125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY130" unit="cm" x="0" y="-15.4875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY131" unit="cm" x="0" y="-14.9625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY132" unit="cm" x="0" y="-14.4375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY133" unit="cm" x="0" y="-13.9125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY134" unit="cm" x="0" y="-13.3875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY135" unit="cm" x="0" y="-12.8625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY136" unit="cm" x="0" y="-12.3375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY137" unit="cm" x="0" y="-11.8125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY138" unit="cm" x="0" y="-11.2875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY139" unit="cm" x="0" y="-10.7625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY140" unit="cm" x="0" y="-10.2375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY141" unit="cm" x="0" y="-9.7125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY142" unit="cm" x="0" y="-9.1875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY143" unit="cm" x="0" y="-8.6625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY144" unit="cm" x="0" y="-8.1375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY145" unit="cm" x="0" y="-7.6125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY146" unit="cm" x="0" y="-7.0875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY147" unit="cm" x="0" y="-6.5625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY148" unit="cm" x="0" y="-6.0375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY149" unit="cm" x="0" y="-5.5125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY150" unit="cm" x="0" y="-4.9875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY151" unit="cm" x="0" y="-4.4625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY152" unit="cm" x="0" y="-3.9375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY153" unit="cm" x="0" y="-3.4125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY154" unit="cm" x="0" y="-2.8875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY155" unit="cm" x="0" y="-2.3625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY156" unit="cm" x="0" y="-1.8375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY157" unit="cm" x="0" y="-1.3125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY158" unit="cm" x="0" y="-0.7875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY159" unit="cm" x="0" y="-0.2625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY160" unit="cm" x="0" y="0.2625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY161" unit="cm" x="0" y="0.7875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY162" unit="cm" x="0" y="1.3125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY163" unit="cm" x="0" y="1.8375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY164" unit="cm" x="0" y="2.3625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY165" unit="cm" x="0" y="2.8875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY166" unit="cm" x="0" y="3.4125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY167" unit="cm" x="0" y="3.9375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY168" unit="cm" x="0" y="4.4625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY169" unit="cm" x="0" y="4.9875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY170" unit="cm" x="0" y="5.5125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY171" unit="cm" x="0" y="6.0375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY172" unit="cm" x="0" y="6.5625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY173" unit="cm" x="0" y="7.0875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY174" unit="cm" x="0" y="7.6125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY175" unit="cm" x="0" y="8.1375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY176" unit="cm" x="0" y="8.6625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY177" unit="cm" x="0" y="9.1875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY178" unit="cm" x="0" y="9.7125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY179" unit="cm" x="0" y="10.2375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY180" unit="cm" x="0" y="10.7625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY181" unit="cm" x="0" y="11.2875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY182" unit="cm" x="0" y="11.8125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY183" unit="cm" x="0" y="12.3375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY184" unit="cm" x="0" y="12.8625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY185" unit="cm" x="0" y="13.3875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY186" unit="cm" x="0" y="13.9125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY187" unit="cm" x="0" y="14.4375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY188" unit="cm" x="0" y="14.9625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY189" unit="cm" x="0" y="15.4875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY190" unit="cm" x="0" y="16.0125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY191" unit="cm" x="0" y="16.5375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY192" unit="cm" x="0" y="17.0625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY193" unit="cm" x="0" y="17.5875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY194" unit="cm" x="0" y="18.1125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY195" unit="cm" x="0" y="18.6375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY196" unit="cm" x="0" y="19.1625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY197" unit="cm" x="0" y="19.6875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY198" unit="cm" x="0" y="20.2125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY199" unit="cm" x="0" y="20.7375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY200" unit="cm" x="0" y="21.2625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY201" unit="cm" x="0" y="21.7875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY202" unit="cm" x="0" y="22.3125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY203" unit="cm" x="0" y="22.8375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY204" unit="cm" x="0" y="23.3625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY205" unit="cm" x="0" y="23.8875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY206" unit="cm" x="0" y="24.4125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY207" unit="cm" x="0" y="24.9375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY208" unit="cm" x="0" y="25.4625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY209" unit="cm" x="0" y="25.9875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY210" unit="cm" x="0" y="26.5125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY211" unit="cm" x="0" y="27.0375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY212" unit="cm" x="0" y="27.5625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY213" unit="cm" x="0" y="28.0875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY214" unit="cm" x="0" y="28.6125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY215" unit="cm" x="0" y="29.1375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY216" unit="cm" x="0" y="29.6625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY217" unit="cm" x="0" y="30.1875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY218" unit="cm" x="0" y="30.7125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY219" unit="cm" x="0" y="31.2375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY220" unit="cm" x="0" y="31.7625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY221" unit="cm" x="0" y="32.2875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY222" unit="cm" x="0" y="32.8125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY223" unit="cm" x="0" y="33.3375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY224" unit="cm" x="0" y="33.8625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY225" unit="cm" x="0" y="34.3875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY226" unit="cm" x="0" y="34.9125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY227" unit="cm" x="0" y="35.4375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY228" unit="cm" x="0" y="35.9625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY229" unit="cm" x="0" y="36.4875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY230" unit="cm" x="0" y="37.0125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY231" unit="cm" x="0" y="37.5375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY232" unit="cm" x="0" y="38.0625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY233" unit="cm" x="0" y="38.5875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY234" unit="cm" x="0" y="39.1125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY235" unit="cm" x="0" y="39.6375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY236" unit="cm" x="0" y="40.1625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY237" unit="cm" x="0" y="40.6875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY238" unit="cm" x="0" y="41.2125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY239" unit="cm" x="0" y="41.7375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY240" unit="cm" x="0" y="42.2625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY241" unit="cm" x="0" y="42.7875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY242" unit="cm" x="0" y="43.3125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY243" unit="cm" x="0" y="43.8375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY244" unit="cm" x="0" y="44.3625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY245" unit="cm" x="0" y="44.8875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY246" unit="cm" x="0" y="45.4125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY247" unit="cm" x="0" y="45.9375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY248" unit="cm" x="0" y="46.4625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY249" unit="cm" x="0" y="46.9875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY250" unit="cm" x="0" y="47.5125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY251" unit="cm" x="0" y="48.0375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY252" unit="cm" x="0" y="48.5625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY253" unit="cm" x="0" y="49.0875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY254" unit="cm" x="0" y="49.6125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY255" unit="cm" x="0" y="50.1375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY256" unit="cm" x="0" y="50.6625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY257" unit="cm" x="0" y="51.1875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY258" unit="cm" x="0" y="51.7125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY259" unit="cm" x="0" y="52.2375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY260" unit="cm" x="0" y="52.7625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY261" unit="cm" x="0" y="53.2875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY262" unit="cm" x="0" y="53.8125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY263" unit="cm" x="0" y="54.3375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY264" unit="cm" x="0" y="54.8625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY265" unit="cm" x="0" y="55.3875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY266" unit="cm" x="0" y="55.9125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY267" unit="cm" x="0" y="56.4375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY268" unit="cm" x="0" y="56.9625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY269" unit="cm" x="0" y="57.4875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY270" unit="cm" x="0" y="58.0125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY271" unit="cm" x="0" y="58.5375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY272" unit="cm" x="0" y="59.0625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY273" unit="cm" x="0" y="59.5875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY274" unit="cm" x="0" y="60.1125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY275" unit="cm" x="0" y="60.6375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY276" unit="cm" x="0" y="61.1625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY277" unit="cm" x="0" y="61.6875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY278" unit="cm" x="0" y="62.2125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY279" unit="cm" x="0" y="62.7375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY280" unit="cm" x="0" y="63.2625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY281" unit="cm" x="0" y="63.7875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY282" unit="cm" x="0" y="64.3125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY283" unit="cm" x="0" y="64.8375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY284" unit="cm" x="0" y="65.3625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY285" unit="cm" x="0" y="65.8875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY286" unit="cm" x="0" y="66.4125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY287" unit="cm" x="0" y="66.9375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY288" unit="cm" x="0" y="67.4625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY289" unit="cm" x="0" y="67.9875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY290" unit="cm" x="0" y="68.5125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY291" unit="cm" x="0" y="69.0375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY292" unit="cm" x="0" y="69.5625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY293" unit="cm" x="0" y="70.0875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY294" unit="cm" x="0" y="70.6125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY295" unit="cm" x="0" y="71.1375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY296" unit="cm" x="0" y="71.6625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY297" unit="cm" x="0" y="72.1875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY298" unit="cm" x="0" y="72.7125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY299" unit="cm" x="0" y="73.2375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY300" unit="cm" x="0" y="73.7625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY301" unit="cm" x="0" y="74.2875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY302" unit="cm" x="0" y="74.8125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY303" unit="cm" x="0" y="75.3375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY304" unit="cm" x="0" y="75.8625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY305" unit="cm" x="0" y="76.3875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY306" unit="cm" x="0" y="76.9125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY307" unit="cm" x="0" y="77.4375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY308" unit="cm" x="0" y="77.9625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY309" unit="cm" x="0" y="78.4875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY310" unit="cm" x="0" y="79.0125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY311" unit="cm" x="0" y="79.5375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY312" unit="cm" x="0" y="80.0625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY313" unit="cm" x="0" y="80.5875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY314" unit="cm" x="0" y="81.1125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY315" unit="cm" x="0" y="81.6375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY316" unit="cm" x="0" y="82.1625" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY317" unit="cm" x="0" y="82.6875" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY318" unit="cm" x="0" y="83.2125" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY319" unit="cm" x="0" y="83.7375" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+  </volume>
+  <volume name="volTPCPlaneZ">
+    <materialref ref="LAr"/>
+    <solidref ref="CRMZPlane"/>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ0" unit="cm" x="0" y="0" z="-74.1895"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ1" unit="cm" x="0" y="0" z="-73.6725"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ2" unit="cm" x="0" y="0" z="-73.1555"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ3" unit="cm" x="0" y="0" z="-72.6385"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ4" unit="cm" x="0" y="0" z="-72.1215"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ5" unit="cm" x="0" y="0" z="-71.6045"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ6" unit="cm" x="0" y="0" z="-71.0875"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ7" unit="cm" x="0" y="0" z="-70.5705"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ8" unit="cm" x="0" y="0" z="-70.0535"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ9" unit="cm" x="0" y="0" z="-69.5365"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ10" unit="cm" x="0" y="0" z="-69.0195"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ11" unit="cm" x="0" y="0" z="-68.5025"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ12" unit="cm" x="0" y="0" z="-67.9855"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ13" unit="cm" x="0" y="0" z="-67.4685"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ14" unit="cm" x="0" y="0" z="-66.9515"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ15" unit="cm" x="0" y="0" z="-66.4345"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ16" unit="cm" x="0" y="0" z="-65.9175"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ17" unit="cm" x="0" y="0" z="-65.4005"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ18" unit="cm" x="0" y="0" z="-64.8835"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ19" unit="cm" x="0" y="0" z="-64.3665"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ20" unit="cm" x="0" y="0" z="-63.8495"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ21" unit="cm" x="0" y="0" z="-63.3325"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ22" unit="cm" x="0" y="0" z="-62.8155"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ23" unit="cm" x="0" y="0" z="-62.2985"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ24" unit="cm" x="0" y="0" z="-61.7815"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ25" unit="cm" x="0" y="0" z="-61.2645"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ26" unit="cm" x="0" y="0" z="-60.7475"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ27" unit="cm" x="0" y="0" z="-60.2305"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ28" unit="cm" x="0" y="0" z="-59.7135"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ29" unit="cm" x="0" y="0" z="-59.1965"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ30" unit="cm" x="0" y="0" z="-58.6795"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ31" unit="cm" x="0" y="0" z="-58.1625"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ32" unit="cm" x="0" y="0" z="-57.6455"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ33" unit="cm" x="0" y="0" z="-57.1285"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ34" unit="cm" x="0" y="0" z="-56.6115"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ35" unit="cm" x="0" y="0" z="-56.0945"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ36" unit="cm" x="0" y="0" z="-55.5775"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ37" unit="cm" x="0" y="0" z="-55.0605"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ38" unit="cm" x="0" y="0" z="-54.5435"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ39" unit="cm" x="0" y="0" z="-54.0265"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ40" unit="cm" x="0" y="0" z="-53.5095"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ41" unit="cm" x="0" y="0" z="-52.9925"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ42" unit="cm" x="0" y="0" z="-52.4755"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ43" unit="cm" x="0" y="0" z="-51.9585"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ44" unit="cm" x="0" y="0" z="-51.4415"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ45" unit="cm" x="0" y="0" z="-50.9245"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ46" unit="cm" x="0" y="0" z="-50.4075"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ47" unit="cm" x="0" y="0" z="-49.8905"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ48" unit="cm" x="0" y="0" z="-49.3735"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ49" unit="cm" x="0" y="0" z="-48.8565"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ50" unit="cm" x="0" y="0" z="-48.3395"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ51" unit="cm" x="0" y="0" z="-47.8225"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ52" unit="cm" x="0" y="0" z="-47.3055"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ53" unit="cm" x="0" y="0" z="-46.7885"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ54" unit="cm" x="0" y="0" z="-46.2715"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ55" unit="cm" x="0" y="0" z="-45.7545"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ56" unit="cm" x="0" y="0" z="-45.2375"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ57" unit="cm" x="0" y="0" z="-44.7205"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ58" unit="cm" x="0" y="0" z="-44.2035"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ59" unit="cm" x="0" y="0" z="-43.6865"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ60" unit="cm" x="0" y="0" z="-43.1695"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ61" unit="cm" x="0" y="0" z="-42.6525"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ62" unit="cm" x="0" y="0" z="-42.1355"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ63" unit="cm" x="0" y="0" z="-41.6185"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ64" unit="cm" x="0" y="0" z="-41.1015"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ65" unit="cm" x="0" y="0" z="-40.5845"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ66" unit="cm" x="0" y="0" z="-40.0675"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ67" unit="cm" x="0" y="0" z="-39.5505"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ68" unit="cm" x="0" y="0" z="-39.0335"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ69" unit="cm" x="0" y="0" z="-38.5165"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ70" unit="cm" x="0" y="0" z="-37.9995"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ71" unit="cm" x="0" y="0" z="-37.4825"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ72" unit="cm" x="0" y="0" z="-36.9655"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ73" unit="cm" x="0" y="0" z="-36.4485"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ74" unit="cm" x="0" y="0" z="-35.9315"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ75" unit="cm" x="0" y="0" z="-35.4145"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ76" unit="cm" x="0" y="0" z="-34.8975"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ77" unit="cm" x="0" y="0" z="-34.3805"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ78" unit="cm" x="0" y="0" z="-33.8635"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ79" unit="cm" x="0" y="0" z="-33.3465"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ80" unit="cm" x="0" y="0" z="-32.8295"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ81" unit="cm" x="0" y="0" z="-32.3125"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ82" unit="cm" x="0" y="0" z="-31.7955"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ83" unit="cm" x="0" y="0" z="-31.2785"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ84" unit="cm" x="0" y="0" z="-30.7615"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ85" unit="cm" x="0" y="0" z="-30.2445"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ86" unit="cm" x="0" y="0" z="-29.7275"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ87" unit="cm" x="0" y="0" z="-29.2105"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ88" unit="cm" x="0" y="0" z="-28.6935"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ89" unit="cm" x="0" y="0" z="-28.1765"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ90" unit="cm" x="0" y="0" z="-27.6595"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ91" unit="cm" x="0" y="0" z="-27.1425"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ92" unit="cm" x="0" y="0" z="-26.6255"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ93" unit="cm" x="0" y="0" z="-26.1085"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ94" unit="cm" x="0" y="0" z="-25.5915"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ95" unit="cm" x="0" y="0" z="-25.0745"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ96" unit="cm" x="0" y="0" z="-24.5575"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ97" unit="cm" x="0" y="0" z="-24.0405"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ98" unit="cm" x="0" y="0" z="-23.5235"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ99" unit="cm" x="0" y="0" z="-23.0065"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ100" unit="cm" x="0" y="0" z="-22.4895"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ101" unit="cm" x="0" y="0" z="-21.9725"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ102" unit="cm" x="0" y="0" z="-21.4555"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ103" unit="cm" x="0" y="0" z="-20.9385"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ104" unit="cm" x="0" y="0" z="-20.4215"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ105" unit="cm" x="0" y="0" z="-19.9045"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ106" unit="cm" x="0" y="0" z="-19.3875"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ107" unit="cm" x="0" y="0" z="-18.8705"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ108" unit="cm" x="0" y="0" z="-18.3535"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ109" unit="cm" x="0" y="0" z="-17.8365"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ110" unit="cm" x="0" y="0" z="-17.3195"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ111" unit="cm" x="0" y="0" z="-16.8025"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ112" unit="cm" x="0" y="0" z="-16.2855"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ113" unit="cm" x="0" y="0" z="-15.7685"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ114" unit="cm" x="0" y="0" z="-15.2515"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ115" unit="cm" x="0" y="0" z="-14.7345"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ116" unit="cm" x="0" y="0" z="-14.2175"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ117" unit="cm" x="0" y="0" z="-13.7005"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ118" unit="cm" x="0" y="0" z="-13.1835"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ119" unit="cm" x="0" y="0" z="-12.6665"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ120" unit="cm" x="0" y="0" z="-12.1495"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ121" unit="cm" x="0" y="0" z="-11.6325"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ122" unit="cm" x="0" y="0" z="-11.1155"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ123" unit="cm" x="0" y="0" z="-10.5985"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ124" unit="cm" x="0" y="0" z="-10.0815"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ125" unit="cm" x="0" y="0" z="-9.5645"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ126" unit="cm" x="0" y="0" z="-9.0475"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ127" unit="cm" x="0" y="0" z="-8.5305"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ128" unit="cm" x="0" y="0" z="-8.0135"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ129" unit="cm" x="0" y="0" z="-7.4965"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ130" unit="cm" x="0" y="0" z="-6.9795"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ131" unit="cm" x="0" y="0" z="-6.4625"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ132" unit="cm" x="0" y="0" z="-5.9455"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ133" unit="cm" x="0" y="0" z="-5.4285"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ134" unit="cm" x="0" y="0" z="-4.9115"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ135" unit="cm" x="0" y="0" z="-4.3945"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ136" unit="cm" x="0" y="0" z="-3.8775"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ137" unit="cm" x="0" y="0" z="-3.3605"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ138" unit="cm" x="0" y="0" z="-2.8435"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ139" unit="cm" x="0" y="0" z="-2.3265"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ140" unit="cm" x="0" y="0" z="-1.8095"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ141" unit="cm" x="0" y="0" z="-1.2925"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ142" unit="cm" x="0" y="0" z="-0.7755"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ143" unit="cm" x="0" y="0" z="-0.2585"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ144" unit="cm" x="0" y="0" z="0.2585"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ145" unit="cm" x="0" y="0" z="0.7755"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ146" unit="cm" x="0" y="0" z="1.2925"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ147" unit="cm" x="0" y="0" z="1.8095"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ148" unit="cm" x="0" y="0" z="2.3265"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ149" unit="cm" x="0" y="0" z="2.8435"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ150" unit="cm" x="0" y="0" z="3.3605"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ151" unit="cm" x="0" y="0" z="3.8775"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ152" unit="cm" x="0" y="0" z="4.3945"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ153" unit="cm" x="0" y="0" z="4.9115"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ154" unit="cm" x="0" y="0" z="5.4285"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ155" unit="cm" x="0" y="0" z="5.9455"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ156" unit="cm" x="0" y="0" z="6.4625"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ157" unit="cm" x="0" y="0" z="6.9795"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ158" unit="cm" x="0" y="0" z="7.4965"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ159" unit="cm" x="0" y="0" z="8.0135"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ160" unit="cm" x="0" y="0" z="8.5305"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ161" unit="cm" x="0" y="0" z="9.0475"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ162" unit="cm" x="0" y="0" z="9.5645"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ163" unit="cm" x="0" y="0" z="10.0815"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ164" unit="cm" x="0" y="0" z="10.5985"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ165" unit="cm" x="0" y="0" z="11.1155"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ166" unit="cm" x="0" y="0" z="11.6325"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ167" unit="cm" x="0" y="0" z="12.1495"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ168" unit="cm" x="0" y="0" z="12.6665"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ169" unit="cm" x="0" y="0" z="13.1835"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ170" unit="cm" x="0" y="0" z="13.7005"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ171" unit="cm" x="0" y="0" z="14.2175"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ172" unit="cm" x="0" y="0" z="14.7345"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ173" unit="cm" x="0" y="0" z="15.2515"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ174" unit="cm" x="0" y="0" z="15.7685"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ175" unit="cm" x="0" y="0" z="16.2855"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ176" unit="cm" x="0" y="0" z="16.8025"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ177" unit="cm" x="0" y="0" z="17.3195"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ178" unit="cm" x="0" y="0" z="17.8365"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ179" unit="cm" x="0" y="0" z="18.3535"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ180" unit="cm" x="0" y="0" z="18.8705"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ181" unit="cm" x="0" y="0" z="19.3875"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ182" unit="cm" x="0" y="0" z="19.9045"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ183" unit="cm" x="0" y="0" z="20.4215"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ184" unit="cm" x="0" y="0" z="20.9385"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ185" unit="cm" x="0" y="0" z="21.4555"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ186" unit="cm" x="0" y="0" z="21.9725"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ187" unit="cm" x="0" y="0" z="22.4895"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ188" unit="cm" x="0" y="0" z="23.0065"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ189" unit="cm" x="0" y="0" z="23.5235"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ190" unit="cm" x="0" y="0" z="24.0405"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ191" unit="cm" x="0" y="0" z="24.5575"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ192" unit="cm" x="0" y="0" z="25.0745"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ193" unit="cm" x="0" y="0" z="25.5915"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ194" unit="cm" x="0" y="0" z="26.1085"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ195" unit="cm" x="0" y="0" z="26.6255"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ196" unit="cm" x="0" y="0" z="27.1425"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ197" unit="cm" x="0" y="0" z="27.6595"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ198" unit="cm" x="0" y="0" z="28.1765"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ199" unit="cm" x="0" y="0" z="28.6935"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ200" unit="cm" x="0" y="0" z="29.2105"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ201" unit="cm" x="0" y="0" z="29.7275"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ202" unit="cm" x="0" y="0" z="30.2445"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ203" unit="cm" x="0" y="0" z="30.7615"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ204" unit="cm" x="0" y="0" z="31.2785"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ205" unit="cm" x="0" y="0" z="31.7955"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ206" unit="cm" x="0" y="0" z="32.3125"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ207" unit="cm" x="0" y="0" z="32.8295"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ208" unit="cm" x="0" y="0" z="33.3465"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ209" unit="cm" x="0" y="0" z="33.8635"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ210" unit="cm" x="0" y="0" z="34.3805"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ211" unit="cm" x="0" y="0" z="34.8975"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ212" unit="cm" x="0" y="0" z="35.4145"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ213" unit="cm" x="0" y="0" z="35.9315"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ214" unit="cm" x="0" y="0" z="36.4485"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ215" unit="cm" x="0" y="0" z="36.9655"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ216" unit="cm" x="0" y="0" z="37.4825"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ217" unit="cm" x="0" y="0" z="37.9995"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ218" unit="cm" x="0" y="0" z="38.5165"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ219" unit="cm" x="0" y="0" z="39.0335"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ220" unit="cm" x="0" y="0" z="39.5505"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ221" unit="cm" x="0" y="0" z="40.0675"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ222" unit="cm" x="0" y="0" z="40.5845"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ223" unit="cm" x="0" y="0" z="41.1015"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ224" unit="cm" x="0" y="0" z="41.6185"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ225" unit="cm" x="0" y="0" z="42.1355"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ226" unit="cm" x="0" y="0" z="42.6525"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ227" unit="cm" x="0" y="0" z="43.1695"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ228" unit="cm" x="0" y="0" z="43.6865"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ229" unit="cm" x="0" y="0" z="44.2035"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ230" unit="cm" x="0" y="0" z="44.7205"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ231" unit="cm" x="0" y="0" z="45.2375"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ232" unit="cm" x="0" y="0" z="45.7545"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ233" unit="cm" x="0" y="0" z="46.2715"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ234" unit="cm" x="0" y="0" z="46.7885"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ235" unit="cm" x="0" y="0" z="47.3055"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ236" unit="cm" x="0" y="0" z="47.8225"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ237" unit="cm" x="0" y="0" z="48.3395"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ238" unit="cm" x="0" y="0" z="48.8565"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ239" unit="cm" x="0" y="0" z="49.3735"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ240" unit="cm" x="0" y="0" z="49.8905"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ241" unit="cm" x="0" y="0" z="50.4075"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ242" unit="cm" x="0" y="0" z="50.9245"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ243" unit="cm" x="0" y="0" z="51.4415"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ244" unit="cm" x="0" y="0" z="51.9585"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ245" unit="cm" x="0" y="0" z="52.4755"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ246" unit="cm" x="0" y="0" z="52.9925"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ247" unit="cm" x="0" y="0" z="53.5095"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ248" unit="cm" x="0" y="0" z="54.0265"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ249" unit="cm" x="0" y="0" z="54.5435"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ250" unit="cm" x="0" y="0" z="55.0605"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ251" unit="cm" x="0" y="0" z="55.5775"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ252" unit="cm" x="0" y="0" z="56.0945"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ253" unit="cm" x="0" y="0" z="56.6115"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ254" unit="cm" x="0" y="0" z="57.1285"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ255" unit="cm" x="0" y="0" z="57.6455"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ256" unit="cm" x="0" y="0" z="58.1625"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ257" unit="cm" x="0" y="0" z="58.6795"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ258" unit="cm" x="0" y="0" z="59.1965"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ259" unit="cm" x="0" y="0" z="59.7135"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ260" unit="cm" x="0" y="0" z="60.2305"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ261" unit="cm" x="0" y="0" z="60.7475"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ262" unit="cm" x="0" y="0" z="61.2645"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ263" unit="cm" x="0" y="0" z="61.7815"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ264" unit="cm" x="0" y="0" z="62.2985"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ265" unit="cm" x="0" y="0" z="62.8155"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ266" unit="cm" x="0" y="0" z="63.3325"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ267" unit="cm" x="0" y="0" z="63.8495"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ268" unit="cm" x="0" y="0" z="64.3665"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ269" unit="cm" x="0" y="0" z="64.8835"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ270" unit="cm" x="0" y="0" z="65.4005"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ271" unit="cm" x="0" y="0" z="65.9175"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ272" unit="cm" x="0" y="0" z="66.4345"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ273" unit="cm" x="0" y="0" z="66.9515"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ274" unit="cm" x="0" y="0" z="67.4685"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ275" unit="cm" x="0" y="0" z="67.9855"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ276" unit="cm" x="0" y="0" z="68.5025"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ277" unit="cm" x="0" y="0" z="69.0195"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ278" unit="cm" x="0" y="0" z="69.5365"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ279" unit="cm" x="0" y="0" z="70.0535"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ280" unit="cm" x="0" y="0" z="70.5705"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ281" unit="cm" x="0" y="0" z="71.0875"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ282" unit="cm" x="0" y="0" z="71.6045"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ283" unit="cm" x="0" y="0" z="72.1215"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ284" unit="cm" x="0" y="0" z="72.6385"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ285" unit="cm" x="0" y="0" z="73.1555"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ286" unit="cm" x="0" y="0" z="73.6725"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ287" unit="cm" x="0" y="0" z="74.1895"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+  </volume>
+   <volume name="volTPC">
+     <materialref ref="LAr"/>
+       <solidref ref="CRM"/>
+       <physvol>
+       <volumeref ref="volTPCPlaneU"/>
+       <position name="posPlaneU" unit="cm" 
+         x="324.99" y="0" z="0"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCPlaneY"/>
+       <position name="posPlaneY" unit="cm" 
+         x="325.01" y="0" z="0"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCPlaneZ"/>
+       <position name="posPlaneZ" unit="cm" 
+         x="325.03" y="0" z="0"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCActive"/>
+       <position name="posActive" unit="cm" 
+        x="-0.04" y="" z="0"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+   </volume>
+ 
+    <volume name="volSteelShell">
+      <materialref ref="STEEL_STAINLESS_Fe7Cr2Ni" />
+      <solidref ref="SteelShell" />
+    </volume>
+    <volume name="volGroundGrid">
+      <materialref ref="STEEL_STAINLESS_Fe7Cr2Ni" />
+      <solidref ref="CathodeGrid" />
+    </volume>    
+    <volume name="volAnodePlate">
+     <materialref ref="vm2000"/>
+     <solidref ref="AnodePlate"/>
+    </volume>
+    <volume name="volGaseousArgon">
+      <materialref ref="ArGas"/>
+      <solidref ref="GaseousArgon"/>
+    </volume>
+    <volume name="volExternalActive">
+      <materialref ref="LAr"/>
+      <solidref ref="ExternalActive"/>
+      <auxiliary auxtype="SensDet" auxvalue="SimEnergyDeposit"/>
+      <auxiliary auxtype="StepLimit" auxunit="cm" auxvalue="0.5208*cm"/>
+      <auxiliary auxtype="Efield" auxunit="V/cm" auxvalue="0*V/cm"/>
+      <colorref ref="green"/>
+    </volume>
+    <volume name="volArapucaDouble_0-0-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-0-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-0-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-0-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-0-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-0-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-0-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-0-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-1-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-1-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-1-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-1-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-1-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-1-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-1-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-1-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-2-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-2-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-2-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-2-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-2-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-2-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-2-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-2-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-0-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-0-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-0-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-0-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-0-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-0-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-0-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-0-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-1-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-1-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-1-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-1-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-1-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-1-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-1-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-1-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-2-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-2-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-2-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-2-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-2-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-2-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-2-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-2-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-0-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-0-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-0-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-0-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-0-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-0-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-0-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-0-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-1-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-1-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-1-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-1-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-1-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-1-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-1-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-1-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-2-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-2-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-2-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-2-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-2-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-2-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-2-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-2-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-0-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-0-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-0-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-0-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-0-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-0-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-0-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-0-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-1-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-1-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-1-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-1-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-1-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-1-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-1-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-1-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-2-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-2-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-2-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-2-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-2-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-2-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-2-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-2-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_0-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_0-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_0-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_0-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_0-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_0-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_0-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_0-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_0-4">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_0-4">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_0-5">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_0-5">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_0-6">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_0-6">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_0-7">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_0-7">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_1-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_1-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_1-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_1-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_1-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_1-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_1-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_1-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_1-4">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_1-4">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_1-5">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_1-5">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_1-6">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_1-6">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_1-7">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_1-7">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_2-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_2-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_2-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_2-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_2-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_2-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_2-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_2-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_2-4">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_2-4">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_2-5">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_2-5">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_2-6">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_2-6">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_2-7">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_2-7">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+
+    <volume name="volCryostat">
+      <materialref ref="LAr" />
+      <solidref ref="Cryostat" />
+      <physvol>
+        <volumeref ref="volGaseousArgon"/>
+        <position name="posGaseousArgon" unit="cm" x="375.045" y="0" z="0"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volSteelShell"/>
+        <position name="posSteelShell" unit="cm" x="0" y="0" z="0"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volExternalActive"/>
+        <position name="posExternalActive" unit="cm" x="-100/2" y="0" z="0"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-0" unit="cm"
+           x="0" y="-589.5" z="-373.25225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-1" unit="cm"
+           x="0" y="-421.5" z="-373.25225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-2" unit="cm"
+           x="0" y="-252.5" z="-373.25225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-3" unit="cm"
+           x="0" y="-84.5" z="-373.25225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-4" unit="cm"
+           x="0" y="84.5" z="-373.25225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-5" unit="cm"
+           x="0" y="252.5" z="-373.25225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-6" unit="cm"
+           x="0" y="421.5" z="-373.25225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-7" unit="cm"
+           x="0" y="589.5" z="-373.25225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-8" unit="cm"
+           x="0" y="-589.5" z="-224.35135"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-9" unit="cm"
+           x="0" y="-421.5" z="-224.35135"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-10" unit="cm"
+           x="0" y="-252.5" z="-224.35135"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-11" unit="cm"
+           x="0" y="-84.5" z="-224.35135"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-12" unit="cm"
+           x="0" y="84.5" z="-224.35135"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-13" unit="cm"
+           x="0" y="252.5" z="-224.35135"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-14" unit="cm"
+           x="0" y="421.5" z="-224.35135"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-15" unit="cm"
+           x="0" y="589.5" z="-224.35135"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-16" unit="cm"
+           x="0" y="-589.5" z="-74.45045"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-17" unit="cm"
+           x="0" y="-421.5" z="-74.45045"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-18" unit="cm"
+           x="0" y="-252.5" z="-74.45045"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-19" unit="cm"
+           x="0" y="-84.5" z="-74.45045"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-20" unit="cm"
+           x="0" y="84.5" z="-74.45045"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-21" unit="cm"
+           x="0" y="252.5" z="-74.45045"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-22" unit="cm"
+           x="0" y="421.5" z="-74.45045"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-23" unit="cm"
+           x="0" y="589.5" z="-74.45045"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-24" unit="cm"
+           x="0" y="-589.5" z="74.45045"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-25" unit="cm"
+           x="0" y="-421.5" z="74.45045"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-26" unit="cm"
+           x="0" y="-252.5" z="74.45045"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-27" unit="cm"
+           x="0" y="-84.5" z="74.45045"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-28" unit="cm"
+           x="0" y="84.5" z="74.45045"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-29" unit="cm"
+           x="0" y="252.5" z="74.45045"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-30" unit="cm"
+           x="0" y="421.5" z="74.45045"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-31" unit="cm"
+           x="0" y="589.5" z="74.45045"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-32" unit="cm"
+           x="0" y="-589.5" z="224.35135"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-33" unit="cm"
+           x="0" y="-421.5" z="224.35135"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-34" unit="cm"
+           x="0" y="-252.5" z="224.35135"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-35" unit="cm"
+           x="0" y="-84.5" z="224.35135"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-36" unit="cm"
+           x="0" y="84.5" z="224.35135"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-37" unit="cm"
+           x="0" y="252.5" z="224.35135"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-38" unit="cm"
+           x="0" y="421.5" z="224.35135"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-39" unit="cm"
+           x="0" y="589.5" z="224.35135"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-40" unit="cm"
+           x="0" y="-589.5" z="373.25225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-41" unit="cm"
+           x="0" y="-421.5" z="373.25225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-42" unit="cm"
+           x="0" y="-252.5" z="373.25225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-43" unit="cm"
+           x="0" y="-84.5" z="373.25225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-44" unit="cm"
+           x="0" y="84.5" z="373.25225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-45" unit="cm"
+           x="0" y="252.5" z="373.25225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-46" unit="cm"
+           x="0" y="421.5" z="373.25225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-47" unit="cm"
+           x="0" y="589.5" z="373.25225"/>
+      </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper0" unit="cm"  x="-322.04" y="-676.3" z="0" />
+     <rotation name="rotFS0" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper1" unit="cm"  x="-316.04" y="-676.3" z="0" />
+     <rotation name="rotFS1" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper2" unit="cm"  x="-310.04" y="-676.3" z="0" />
+     <rotation name="rotFS2" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper3" unit="cm"  x="-304.04" y="-676.3" z="0" />
+     <rotation name="rotFS3" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper4" unit="cm"  x="-298.04" y="-676.3" z="0" />
+     <rotation name="rotFS4" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper5" unit="cm"  x="-292.04" y="-676.3" z="0" />
+     <rotation name="rotFS5" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper6" unit="cm"  x="-286.04" y="-676.3" z="0" />
+     <rotation name="rotFS6" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper7" unit="cm"  x="-280.04" y="-676.3" z="0" />
+     <rotation name="rotFS7" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper8" unit="cm"  x="-274.04" y="-676.3" z="0" />
+     <rotation name="rotFS8" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper9" unit="cm"  x="-268.04" y="-676.3" z="0" />
+     <rotation name="rotFS9" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper10" unit="cm"  x="-262.04" y="-676.3" z="0" />
+     <rotation name="rotFS10" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper11" unit="cm"  x="-256.04" y="-676.3" z="0" />
+     <rotation name="rotFS11" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper12" unit="cm"  x="-250.04" y="-676.3" z="0" />
+     <rotation name="rotFS12" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper13" unit="cm"  x="-244.04" y="-676.3" z="0" />
+     <rotation name="rotFS13" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper14" unit="cm"  x="-238.04" y="-676.3" z="0" />
+     <rotation name="rotFS14" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper15" unit="cm"  x="-232.04" y="-676.3" z="0" />
+     <rotation name="rotFS15" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper16" unit="cm"  x="-226.04" y="-676.3" z="0" />
+     <rotation name="rotFS16" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper17" unit="cm"  x="-220.04" y="-676.3" z="0" />
+     <rotation name="rotFS17" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper18" unit="cm"  x="-214.04" y="-676.3" z="0" />
+     <rotation name="rotFS18" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper19" unit="cm"  x="-208.04" y="-676.3" z="0" />
+     <rotation name="rotFS19" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper20" unit="cm"  x="-202.04" y="-676.3" z="0" />
+     <rotation name="rotFS20" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper21" unit="cm"  x="-196.04" y="-676.3" z="0" />
+     <rotation name="rotFS21" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper22" unit="cm"  x="-190.04" y="-676.3" z="0" />
+     <rotation name="rotFS22" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper23" unit="cm"  x="-184.04" y="-676.3" z="0" />
+     <rotation name="rotFS23" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper24" unit="cm"  x="-178.04" y="-676.3" z="0" />
+     <rotation name="rotFS24" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper25" unit="cm"  x="-172.04" y="-676.3" z="0" />
+     <rotation name="rotFS25" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper26" unit="cm"  x="-166.04" y="-676.3" z="0" />
+     <rotation name="rotFS26" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper27" unit="cm"  x="-160.04" y="-676.3" z="0" />
+     <rotation name="rotFS27" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper28" unit="cm"  x="-154.04" y="-676.3" z="0" />
+     <rotation name="rotFS28" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper29" unit="cm"  x="-148.04" y="-676.3" z="0" />
+     <rotation name="rotFS29" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper30" unit="cm"  x="-142.04" y="-676.3" z="0" />
+     <rotation name="rotFS30" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper31" unit="cm"  x="-136.04" y="-676.3" z="0" />
+     <rotation name="rotFS31" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper32" unit="cm"  x="-130.04" y="-676.3" z="0" />
+     <rotation name="rotFS32" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper33" unit="cm"  x="-124.04" y="-676.3" z="0" />
+     <rotation name="rotFS33" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper34" unit="cm"  x="-118.04" y="-676.3" z="0" />
+     <rotation name="rotFS34" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper35" unit="cm"  x="-112.04" y="-676.3" z="0" />
+     <rotation name="rotFS35" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper36" unit="cm"  x="-106.04" y="-676.3" z="0" />
+     <rotation name="rotFS36" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper37" unit="cm"  x="-100.04" y="-676.3" z="0" />
+     <rotation name="rotFS37" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper38" unit="cm"  x="-94.04" y="-676.3" z="0" />
+     <rotation name="rotFS38" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper39" unit="cm"  x="-88.04" y="-676.3" z="0" />
+     <rotation name="rotFS39" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper40" unit="cm"  x="-82.04" y="-676.3" z="0" />
+     <rotation name="rotFS40" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper41" unit="cm"  x="-76.04" y="-676.3" z="0" />
+     <rotation name="rotFS41" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper42" unit="cm"  x="-70.04" y="-676.3" z="0" />
+     <rotation name="rotFS42" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper43" unit="cm"  x="-64.04" y="-676.3" z="0" />
+     <rotation name="rotFS43" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper44" unit="cm"  x="-58.04" y="-676.3" z="0" />
+     <rotation name="rotFS44" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper45" unit="cm"  x="-52.04" y="-676.3" z="0" />
+     <rotation name="rotFS45" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper46" unit="cm"  x="-46.04" y="-676.3" z="0" />
+     <rotation name="rotFS46" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper47" unit="cm"  x="-40.04" y="-676.3" z="0" />
+     <rotation name="rotFS47" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper48" unit="cm"  x="-34.04" y="-676.3" z="0" />
+     <rotation name="rotFS48" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper49" unit="cm"  x="-28.04" y="-676.3" z="0" />
+     <rotation name="rotFS49" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper50" unit="cm"  x="-22.04" y="-676.3" z="0" />
+     <rotation name="rotFS50" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper51" unit="cm"  x="-16.04" y="-676.3" z="0" />
+     <rotation name="rotFS51" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper52" unit="cm"  x="-10.04" y="-676.3" z="0" />
+     <rotation name="rotFS52" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper53" unit="cm"  x="-4.04000000000001" y="-676.3" z="0" />
+     <rotation name="rotFS53" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper54" unit="cm"  x="1.95999999999999" y="-676.3" z="0" />
+     <rotation name="rotFS54" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper55" unit="cm"  x="7.95999999999999" y="-676.3" z="0" />
+     <rotation name="rotFS55" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper56" unit="cm"  x="13.96" y="-676.3" z="0" />
+     <rotation name="rotFS56" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper57" unit="cm"  x="19.96" y="-676.3" z="0" />
+     <rotation name="rotFS57" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper58" unit="cm"  x="25.96" y="-676.3" z="0" />
+     <rotation name="rotFS58" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper59" unit="cm"  x="31.96" y="-676.3" z="0" />
+     <rotation name="rotFS59" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper60" unit="cm"  x="37.96" y="-676.3" z="0" />
+     <rotation name="rotFS60" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper61" unit="cm"  x="43.96" y="-676.3" z="0" />
+     <rotation name="rotFS61" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper62" unit="cm"  x="49.96" y="-676.3" z="0" />
+     <rotation name="rotFS62" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper63" unit="cm"  x="55.96" y="-676.3" z="0" />
+     <rotation name="rotFS63" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper64" unit="cm"  x="61.96" y="-676.3" z="0" />
+     <rotation name="rotFS64" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper65" unit="cm"  x="67.96" y="-676.3" z="0" />
+     <rotation name="rotFS65" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper66" unit="cm"  x="73.96" y="-676.3" z="0" />
+     <rotation name="rotFS66" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper67" unit="cm"  x="79.96" y="-676.3" z="0" />
+     <rotation name="rotFS67" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper68" unit="cm"  x="85.96" y="-676.3" z="0" />
+     <rotation name="rotFS68" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper69" unit="cm"  x="91.96" y="-676.3" z="0" />
+     <rotation name="rotFS69" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper70" unit="cm"  x="97.96" y="-676.3" z="0" />
+     <rotation name="rotFS70" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper71" unit="cm"  x="103.96" y="-676.3" z="0" />
+     <rotation name="rotFS71" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper72" unit="cm"  x="109.96" y="-676.3" z="0" />
+     <rotation name="rotFS72" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper73" unit="cm"  x="115.96" y="-676.3" z="0" />
+     <rotation name="rotFS73" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper74" unit="cm"  x="121.96" y="-676.3" z="0" />
+     <rotation name="rotFS74" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper75" unit="cm"  x="127.96" y="-676.3" z="0" />
+     <rotation name="rotFS75" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper76" unit="cm"  x="133.96" y="-676.3" z="0" />
+     <rotation name="rotFS76" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper77" unit="cm"  x="139.96" y="-676.3" z="0" />
+     <rotation name="rotFS77" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper78" unit="cm"  x="145.96" y="-676.3" z="0" />
+     <rotation name="rotFS78" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper79" unit="cm"  x="151.96" y="-676.3" z="0" />
+     <rotation name="rotFS79" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper80" unit="cm"  x="157.96" y="-676.3" z="0" />
+     <rotation name="rotFS80" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper81" unit="cm"  x="163.96" y="-676.3" z="0" />
+     <rotation name="rotFS81" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper82" unit="cm"  x="169.96" y="-676.3" z="0" />
+     <rotation name="rotFS82" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper83" unit="cm"  x="175.96" y="-676.3" z="0" />
+     <rotation name="rotFS83" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper84" unit="cm"  x="181.96" y="-676.3" z="0" />
+     <rotation name="rotFS84" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper85" unit="cm"  x="187.96" y="-676.3" z="0" />
+     <rotation name="rotFS85" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper86" unit="cm"  x="193.96" y="-676.3" z="0" />
+     <rotation name="rotFS86" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper87" unit="cm"  x="199.96" y="-676.3" z="0" />
+     <rotation name="rotFS87" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper88" unit="cm"  x="205.96" y="-676.3" z="0" />
+     <rotation name="rotFS88" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper89" unit="cm"  x="211.96" y="-676.3" z="0" />
+     <rotation name="rotFS89" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper90" unit="cm"  x="217.96" y="-676.3" z="0" />
+     <rotation name="rotFS90" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper91" unit="cm"  x="223.96" y="-676.3" z="0" />
+     <rotation name="rotFS91" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper92" unit="cm"  x="229.96" y="-676.3" z="0" />
+     <rotation name="rotFS92" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper93" unit="cm"  x="235.96" y="-676.3" z="0" />
+     <rotation name="rotFS93" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper94" unit="cm"  x="241.96" y="-676.3" z="0" />
+     <rotation name="rotFS94" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper95" unit="cm"  x="247.96" y="-676.3" z="0" />
+     <rotation name="rotFS95" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper96" unit="cm"  x="253.96" y="-676.3" z="0" />
+     <rotation name="rotFS96" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper97" unit="cm"  x="259.96" y="-676.3" z="0" />
+     <rotation name="rotFS97" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper98" unit="cm"  x="265.96" y="-676.3" z="0" />
+     <rotation name="rotFS98" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper99" unit="cm"  x="271.96" y="-676.3" z="0" />
+     <rotation name="rotFS99" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper100" unit="cm"  x="277.96" y="-676.3" z="0" />
+     <rotation name="rotFS100" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper101" unit="cm"  x="283.96" y="-676.3" z="0" />
+     <rotation name="rotFS101" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper102" unit="cm"  x="289.96" y="-676.3" z="0" />
+     <rotation name="rotFS102" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper103" unit="cm"  x="295.96" y="-676.3" z="0" />
+     <rotation name="rotFS103" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper104" unit="cm"  x="301.96" y="-676.3" z="0" />
+     <rotation name="rotFS104" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper105" unit="cm"  x="307.96" y="-676.3" z="0" />
+     <rotation name="rotFS105" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper106" unit="cm"  x="313.96" y="-676.3" z="0" />
+     <rotation name="rotFS106" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper107" unit="cm"  x="319.96" y="-676.3" z="0" />
+     <rotation name="rotFS107" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-0" unit="cm" x="-328.04" y="-506" z="-299.3018"/>
+      </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-0" unit="cm" 
+         x="325.045" y="-506" z="-299.3018"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-1" unit="cm" x="-328.04" y="-170" z="-299.3018"/>
+      </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-1" unit="cm" 
+         x="325.045" y="-170" z="-299.3018"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-2" unit="cm" x="-328.04" y="166" z="-299.3018"/>
+      </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-2" unit="cm" 
+         x="325.045" y="166" z="-299.3018"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-3" unit="cm" x="-328.04" y="502" z="-299.3018"/>
+      </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-3" unit="cm" 
+         x="325.045" y="502" z="-299.3018"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-4" unit="cm" x="-328.04" y="-506" z="-1.50000000000006"/>
+      </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-4" unit="cm" 
+         x="325.045" y="-506" z="-1.50000000000006"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-5" unit="cm" x="-328.04" y="-170" z="-1.50000000000006"/>
+      </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-5" unit="cm" 
+         x="325.045" y="-170" z="-1.50000000000006"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-6" unit="cm" x="-328.04" y="166" z="-1.50000000000006"/>
+      </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-6" unit="cm" 
+         x="325.045" y="166" z="-1.50000000000006"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-7" unit="cm" x="-328.04" y="502" z="-1.50000000000006"/>
+      </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-7" unit="cm" 
+         x="325.045" y="502" z="-1.50000000000006"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-8" unit="cm" x="-328.04" y="-506" z="296.3018"/>
+      </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-8" unit="cm" 
+         x="325.045" y="-506" z="296.3018"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-9" unit="cm" x="-328.04" y="-170" z="296.3018"/>
+      </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-9" unit="cm" 
+         x="325.045" y="-170" z="296.3018"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-10" unit="cm" x="-328.04" y="166" z="296.3018"/>
+      </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-10" unit="cm" 
+         x="325.045" y="166" z="296.3018"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-11" unit="cm" x="-328.04" y="502" z="296.3018"/>
+      </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-11" unit="cm" 
+         x="325.045" y="502" z="296.3018"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-0-0"/>
+       <position name="posArapucaDouble0-Frame-0-0" unit="cm" 
+         x="-328.04"
+	 y="-633.7" 
+	 z="-261.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-0"/>
+       <position name="posOpArapucaDouble0-Frame-0-0" unit="cm" 
+         x="-327.3"
+	 y="-633.7" 
+	 z="-261.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-0-1"/>
+       <position name="posArapucaDouble1-Frame-0-0" unit="cm" 
+         x="-328.04"
+	 y="-543" 
+	 z="-407.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-1"/>
+       <position name="posOpArapucaDouble1-Frame-0-0" unit="cm" 
+         x="-327.3"
+	 y="-543" 
+	 z="-407.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-0-2"/>
+       <position name="posArapucaDouble2-Frame-0-0" unit="cm" 
+         x="-328.04"
+	 y="-469" 
+	 z="-190.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-2"/>
+       <position name="posOpArapucaDouble2-Frame-0-0" unit="cm" 
+         x="-327.3"
+	 y="-469" 
+	 z="-190.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-0-3"/>
+       <position name="posArapucaDouble3-Frame-0-0" unit="cm" 
+         x="-328.04"
+	 y="-378.3" 
+	 z="-336.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-3"/>
+       <position name="posOpArapucaDouble3-Frame-0-0" unit="cm" 
+         x="-327.3"
+	 y="-378.3" 
+	 z="-336.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-1-0"/>
+       <position name="posArapucaDouble0-Frame-0-1" unit="cm" 
+         x="-328.04"
+	 y="-633.7" 
+	 z="35.9999999999999"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-0"/>
+       <position name="posOpArapucaDouble0-Frame-0-1" unit="cm" 
+         x="-327.3"
+	 y="-633.7" 
+	 z="35.9999999999999"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-1-1"/>
+       <position name="posArapucaDouble1-Frame-0-1" unit="cm" 
+         x="-328.04"
+	 y="-543" 
+	 z="-110"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-1"/>
+       <position name="posOpArapucaDouble1-Frame-0-1" unit="cm" 
+         x="-327.3"
+	 y="-543" 
+	 z="-110"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-1-2"/>
+       <position name="posArapucaDouble2-Frame-0-1" unit="cm" 
+         x="-328.04"
+	 y="-469" 
+	 z="107"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-2"/>
+       <position name="posOpArapucaDouble2-Frame-0-1" unit="cm" 
+         x="-327.3"
+	 y="-469" 
+	 z="107"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-1-3"/>
+       <position name="posArapucaDouble3-Frame-0-1" unit="cm" 
+         x="-328.04"
+	 y="-378.3" 
+	 z="-39.0000000000001"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-3"/>
+       <position name="posOpArapucaDouble3-Frame-0-1" unit="cm" 
+         x="-327.3"
+	 y="-378.3" 
+	 z="-39.0000000000001"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-2-0"/>
+       <position name="posArapucaDouble0-Frame-0-2" unit="cm" 
+         x="-328.04"
+	 y="-633.7" 
+	 z="333.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-0"/>
+       <position name="posOpArapucaDouble0-Frame-0-2" unit="cm" 
+         x="-327.3"
+	 y="-633.7" 
+	 z="333.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-2-1"/>
+       <position name="posArapucaDouble1-Frame-0-2" unit="cm" 
+         x="-328.04"
+	 y="-543" 
+	 z="187.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-1"/>
+       <position name="posOpArapucaDouble1-Frame-0-2" unit="cm" 
+         x="-327.3"
+	 y="-543" 
+	 z="187.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-2-2"/>
+       <position name="posArapucaDouble2-Frame-0-2" unit="cm" 
+         x="-328.04"
+	 y="-469" 
+	 z="404.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-2"/>
+       <position name="posOpArapucaDouble2-Frame-0-2" unit="cm" 
+         x="-327.3"
+	 y="-469" 
+	 z="404.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-2-3"/>
+       <position name="posArapucaDouble3-Frame-0-2" unit="cm" 
+         x="-328.04"
+	 y="-378.3" 
+	 z="258.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-3"/>
+       <position name="posOpArapucaDouble3-Frame-0-2" unit="cm" 
+         x="-327.3"
+	 y="-378.3" 
+	 z="258.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-0-0"/>
+       <position name="posArapucaDouble0-Frame-1-0" unit="cm" 
+         x="-328.04"
+	 y="-297.7" 
+	 z="-261.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-0"/>
+       <position name="posOpArapucaDouble0-Frame-1-0" unit="cm" 
+         x="-327.3"
+	 y="-297.7" 
+	 z="-261.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-0-1"/>
+       <position name="posArapucaDouble1-Frame-1-0" unit="cm" 
+         x="-328.04"
+	 y="-207" 
+	 z="-407.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-1"/>
+       <position name="posOpArapucaDouble1-Frame-1-0" unit="cm" 
+         x="-327.3"
+	 y="-207" 
+	 z="-407.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-0-2"/>
+       <position name="posArapucaDouble2-Frame-1-0" unit="cm" 
+         x="-328.04"
+	 y="-133" 
+	 z="-190.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-2"/>
+       <position name="posOpArapucaDouble2-Frame-1-0" unit="cm" 
+         x="-327.3"
+	 y="-133" 
+	 z="-190.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-0-3"/>
+       <position name="posArapucaDouble3-Frame-1-0" unit="cm" 
+         x="-328.04"
+	 y="-42.3" 
+	 z="-336.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-3"/>
+       <position name="posOpArapucaDouble3-Frame-1-0" unit="cm" 
+         x="-327.3"
+	 y="-42.3" 
+	 z="-336.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-1-0"/>
+       <position name="posArapucaDouble0-Frame-1-1" unit="cm" 
+         x="-328.04"
+	 y="-297.7" 
+	 z="35.9999999999999"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-0"/>
+       <position name="posOpArapucaDouble0-Frame-1-1" unit="cm" 
+         x="-327.3"
+	 y="-297.7" 
+	 z="35.9999999999999"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-1-1"/>
+       <position name="posArapucaDouble1-Frame-1-1" unit="cm" 
+         x="-328.04"
+	 y="-207" 
+	 z="-110"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-1"/>
+       <position name="posOpArapucaDouble1-Frame-1-1" unit="cm" 
+         x="-327.3"
+	 y="-207" 
+	 z="-110"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-1-2"/>
+       <position name="posArapucaDouble2-Frame-1-1" unit="cm" 
+         x="-328.04"
+	 y="-133" 
+	 z="107"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-2"/>
+       <position name="posOpArapucaDouble2-Frame-1-1" unit="cm" 
+         x="-327.3"
+	 y="-133" 
+	 z="107"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-1-3"/>
+       <position name="posArapucaDouble3-Frame-1-1" unit="cm" 
+         x="-328.04"
+	 y="-42.3" 
+	 z="-39.0000000000001"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-3"/>
+       <position name="posOpArapucaDouble3-Frame-1-1" unit="cm" 
+         x="-327.3"
+	 y="-42.3" 
+	 z="-39.0000000000001"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-2-0"/>
+       <position name="posArapucaDouble0-Frame-1-2" unit="cm" 
+         x="-328.04"
+	 y="-297.7" 
+	 z="333.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-0"/>
+       <position name="posOpArapucaDouble0-Frame-1-2" unit="cm" 
+         x="-327.3"
+	 y="-297.7" 
+	 z="333.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-2-1"/>
+       <position name="posArapucaDouble1-Frame-1-2" unit="cm" 
+         x="-328.04"
+	 y="-207" 
+	 z="187.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-1"/>
+       <position name="posOpArapucaDouble1-Frame-1-2" unit="cm" 
+         x="-327.3"
+	 y="-207" 
+	 z="187.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-2-2"/>
+       <position name="posArapucaDouble2-Frame-1-2" unit="cm" 
+         x="-328.04"
+	 y="-133" 
+	 z="404.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-2"/>
+       <position name="posOpArapucaDouble2-Frame-1-2" unit="cm" 
+         x="-327.3"
+	 y="-133" 
+	 z="404.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-2-3"/>
+       <position name="posArapucaDouble3-Frame-1-2" unit="cm" 
+         x="-328.04"
+	 y="-42.3" 
+	 z="258.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-3"/>
+       <position name="posOpArapucaDouble3-Frame-1-2" unit="cm" 
+         x="-327.3"
+	 y="-42.3" 
+	 z="258.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-0-0"/>
+       <position name="posArapucaDouble0-Frame-2-0" unit="cm" 
+         x="-328.04"
+	 y="38.3" 
+	 z="-261.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-0"/>
+       <position name="posOpArapucaDouble0-Frame-2-0" unit="cm" 
+         x="-327.3"
+	 y="38.3" 
+	 z="-261.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-0-1"/>
+       <position name="posArapucaDouble1-Frame-2-0" unit="cm" 
+         x="-328.04"
+	 y="129" 
+	 z="-407.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-1"/>
+       <position name="posOpArapucaDouble1-Frame-2-0" unit="cm" 
+         x="-327.3"
+	 y="129" 
+	 z="-407.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-0-2"/>
+       <position name="posArapucaDouble2-Frame-2-0" unit="cm" 
+         x="-328.04"
+	 y="203" 
+	 z="-190.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-2"/>
+       <position name="posOpArapucaDouble2-Frame-2-0" unit="cm" 
+         x="-327.3"
+	 y="203" 
+	 z="-190.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-0-3"/>
+       <position name="posArapucaDouble3-Frame-2-0" unit="cm" 
+         x="-328.04"
+	 y="293.7" 
+	 z="-336.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-3"/>
+       <position name="posOpArapucaDouble3-Frame-2-0" unit="cm" 
+         x="-327.3"
+	 y="293.7" 
+	 z="-336.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-1-0"/>
+       <position name="posArapucaDouble0-Frame-2-1" unit="cm" 
+         x="-328.04"
+	 y="38.3" 
+	 z="35.9999999999999"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-0"/>
+       <position name="posOpArapucaDouble0-Frame-2-1" unit="cm" 
+         x="-327.3"
+	 y="38.3" 
+	 z="35.9999999999999"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-1-1"/>
+       <position name="posArapucaDouble1-Frame-2-1" unit="cm" 
+         x="-328.04"
+	 y="129" 
+	 z="-110"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-1"/>
+       <position name="posOpArapucaDouble1-Frame-2-1" unit="cm" 
+         x="-327.3"
+	 y="129" 
+	 z="-110"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-1-2"/>
+       <position name="posArapucaDouble2-Frame-2-1" unit="cm" 
+         x="-328.04"
+	 y="203" 
+	 z="107"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-2"/>
+       <position name="posOpArapucaDouble2-Frame-2-1" unit="cm" 
+         x="-327.3"
+	 y="203" 
+	 z="107"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-1-3"/>
+       <position name="posArapucaDouble3-Frame-2-1" unit="cm" 
+         x="-328.04"
+	 y="293.7" 
+	 z="-39.0000000000001"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-3"/>
+       <position name="posOpArapucaDouble3-Frame-2-1" unit="cm" 
+         x="-327.3"
+	 y="293.7" 
+	 z="-39.0000000000001"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-2-0"/>
+       <position name="posArapucaDouble0-Frame-2-2" unit="cm" 
+         x="-328.04"
+	 y="38.3" 
+	 z="333.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-0"/>
+       <position name="posOpArapucaDouble0-Frame-2-2" unit="cm" 
+         x="-327.3"
+	 y="38.3" 
+	 z="333.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-2-1"/>
+       <position name="posArapucaDouble1-Frame-2-2" unit="cm" 
+         x="-328.04"
+	 y="129" 
+	 z="187.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-1"/>
+       <position name="posOpArapucaDouble1-Frame-2-2" unit="cm" 
+         x="-327.3"
+	 y="129" 
+	 z="187.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-2-2"/>
+       <position name="posArapucaDouble2-Frame-2-2" unit="cm" 
+         x="-328.04"
+	 y="203" 
+	 z="404.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-2"/>
+       <position name="posOpArapucaDouble2-Frame-2-2" unit="cm" 
+         x="-327.3"
+	 y="203" 
+	 z="404.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-2-3"/>
+       <position name="posArapucaDouble3-Frame-2-2" unit="cm" 
+         x="-328.04"
+	 y="293.7" 
+	 z="258.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-3"/>
+       <position name="posOpArapucaDouble3-Frame-2-2" unit="cm" 
+         x="-327.3"
+	 y="293.7" 
+	 z="258.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-0-0"/>
+       <position name="posArapucaDouble0-Frame-3-0" unit="cm" 
+         x="-328.04"
+	 y="374.3" 
+	 z="-261.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-0"/>
+       <position name="posOpArapucaDouble0-Frame-3-0" unit="cm" 
+         x="-327.3"
+	 y="374.3" 
+	 z="-261.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-0-1"/>
+       <position name="posArapucaDouble1-Frame-3-0" unit="cm" 
+         x="-328.04"
+	 y="465" 
+	 z="-407.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-1"/>
+       <position name="posOpArapucaDouble1-Frame-3-0" unit="cm" 
+         x="-327.3"
+	 y="465" 
+	 z="-407.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-0-2"/>
+       <position name="posArapucaDouble2-Frame-3-0" unit="cm" 
+         x="-328.04"
+	 y="539" 
+	 z="-190.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-2"/>
+       <position name="posOpArapucaDouble2-Frame-3-0" unit="cm" 
+         x="-327.3"
+	 y="539" 
+	 z="-190.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-0-3"/>
+       <position name="posArapucaDouble3-Frame-3-0" unit="cm" 
+         x="-328.04"
+	 y="629.7" 
+	 z="-336.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-3"/>
+       <position name="posOpArapucaDouble3-Frame-3-0" unit="cm" 
+         x="-327.3"
+	 y="629.7" 
+	 z="-336.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-1-0"/>
+       <position name="posArapucaDouble0-Frame-3-1" unit="cm" 
+         x="-328.04"
+	 y="374.3" 
+	 z="35.9999999999999"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-0"/>
+       <position name="posOpArapucaDouble0-Frame-3-1" unit="cm" 
+         x="-327.3"
+	 y="374.3" 
+	 z="35.9999999999999"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-1-1"/>
+       <position name="posArapucaDouble1-Frame-3-1" unit="cm" 
+         x="-328.04"
+	 y="465" 
+	 z="-110"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-1"/>
+       <position name="posOpArapucaDouble1-Frame-3-1" unit="cm" 
+         x="-327.3"
+	 y="465" 
+	 z="-110"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-1-2"/>
+       <position name="posArapucaDouble2-Frame-3-1" unit="cm" 
+         x="-328.04"
+	 y="539" 
+	 z="107"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-2"/>
+       <position name="posOpArapucaDouble2-Frame-3-1" unit="cm" 
+         x="-327.3"
+	 y="539" 
+	 z="107"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-1-3"/>
+       <position name="posArapucaDouble3-Frame-3-1" unit="cm" 
+         x="-328.04"
+	 y="629.7" 
+	 z="-39.0000000000001"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-3"/>
+       <position name="posOpArapucaDouble3-Frame-3-1" unit="cm" 
+         x="-327.3"
+	 y="629.7" 
+	 z="-39.0000000000001"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-2-0"/>
+       <position name="posArapucaDouble0-Frame-3-2" unit="cm" 
+         x="-328.04"
+	 y="374.3" 
+	 z="333.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-0"/>
+       <position name="posOpArapucaDouble0-Frame-3-2" unit="cm" 
+         x="-327.3"
+	 y="374.3" 
+	 z="333.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-2-1"/>
+       <position name="posArapucaDouble1-Frame-3-2" unit="cm" 
+         x="-328.04"
+	 y="465" 
+	 z="187.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-1"/>
+       <position name="posOpArapucaDouble1-Frame-3-2" unit="cm" 
+         x="-327.3"
+	 y="465" 
+	 z="187.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-2-2"/>
+       <position name="posArapucaDouble2-Frame-3-2" unit="cm" 
+         x="-328.04"
+	 y="539" 
+	 z="404.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-2"/>
+       <position name="posOpArapucaDouble2-Frame-3-2" unit="cm" 
+         x="-327.3"
+	 y="539" 
+	 z="404.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-2-3"/>
+       <position name="posArapucaDouble3-Frame-3-2" unit="cm" 
+         x="-328.04"
+	 y="629.7" 
+	 z="258.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-3"/>
+       <position name="posOpArapucaDouble3-Frame-3-2" unit="cm" 
+         x="-327.3"
+	 y="629.7" 
+	 z="258.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_0-0"/>
+       <position name="posArapuca0-Lat-0" unit="cm" 
+         x="285.03"
+	 y="-734" 
+	 z="-297.8018"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_0-0"/>
+       <position name="posOpArapuca0-Lat-0" unit="cm" 
+         x="285.03"
+	 y="-733.26" 
+	 z="-297.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_0-1"/>
+       <position name="posArapuca1-Lat-0" unit="cm" 
+         x="210.03"
+	 y="-734" 
+	 z="-297.8018"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_0-1"/>
+       <position name="posOpArapuca1-Lat-0" unit="cm" 
+         x="210.03"
+	 y="-733.26" 
+	 z="-297.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_0-2"/>
+       <position name="posArapuca2-Lat-0" unit="cm" 
+         x="135.03"
+	 y="-734" 
+	 z="-297.8018"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_0-2"/>
+       <position name="posOpArapuca2-Lat-0" unit="cm" 
+         x="135.03"
+	 y="-733.26" 
+	 z="-297.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_0-3"/>
+       <position name="posArapuca3-Lat-0" unit="cm" 
+         x="60.03"
+	 y="-734" 
+	 z="-297.8018"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_0-3"/>
+       <position name="posOpArapuca3-Lat-0" unit="cm" 
+         x="60.03"
+	 y="-733.26" 
+	 z="-297.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_0-4"/>
+       <position name="posArapuca4-Lat-0" unit="cm" 
+         x="285.03"
+	 y="734" 
+	 z="-297.8018"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_0-4"/>
+       <position name="posOpArapuca4-Lat-0" unit="cm" 
+         x="285.03"
+	 y="733.26" 
+	 z="-297.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_0-5"/>
+       <position name="posArapuca5-Lat-0" unit="cm" 
+         x="210.03"
+	 y="734" 
+	 z="-297.8018"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_0-5"/>
+       <position name="posOpArapuca5-Lat-0" unit="cm" 
+         x="210.03"
+	 y="733.26" 
+	 z="-297.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_0-6"/>
+       <position name="posArapuca6-Lat-0" unit="cm" 
+         x="135.03"
+	 y="734" 
+	 z="-297.8018"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_0-6"/>
+       <position name="posOpArapuca6-Lat-0" unit="cm" 
+         x="135.03"
+	 y="733.26" 
+	 z="-297.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_0-7"/>
+       <position name="posArapuca7-Lat-0" unit="cm" 
+         x="60.03"
+	 y="734" 
+	 z="-297.8018"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_0-7"/>
+       <position name="posOpArapuca7-Lat-0" unit="cm" 
+         x="60.03"
+	 y="733.26" 
+	 z="-297.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_1-0"/>
+       <position name="posArapuca0-Lat-1" unit="cm" 
+         x="285.03"
+	 y="-734" 
+	 z="2.8421709430404e-13"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_1-0"/>
+       <position name="posOpArapuca0-Lat-1" unit="cm" 
+         x="285.03"
+	 y="-733.26" 
+	 z="2.8421709430404e-13"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_1-1"/>
+       <position name="posArapuca1-Lat-1" unit="cm" 
+         x="210.03"
+	 y="-734" 
+	 z="2.8421709430404e-13"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_1-1"/>
+       <position name="posOpArapuca1-Lat-1" unit="cm" 
+         x="210.03"
+	 y="-733.26" 
+	 z="2.8421709430404e-13"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_1-2"/>
+       <position name="posArapuca2-Lat-1" unit="cm" 
+         x="135.03"
+	 y="-734" 
+	 z="2.8421709430404e-13"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_1-2"/>
+       <position name="posOpArapuca2-Lat-1" unit="cm" 
+         x="135.03"
+	 y="-733.26" 
+	 z="2.8421709430404e-13"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_1-3"/>
+       <position name="posArapuca3-Lat-1" unit="cm" 
+         x="60.03"
+	 y="-734" 
+	 z="2.8421709430404e-13"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_1-3"/>
+       <position name="posOpArapuca3-Lat-1" unit="cm" 
+         x="60.03"
+	 y="-733.26" 
+	 z="2.8421709430404e-13"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_1-4"/>
+       <position name="posArapuca4-Lat-1" unit="cm" 
+         x="285.03"
+	 y="734" 
+	 z="2.8421709430404e-13"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_1-4"/>
+       <position name="posOpArapuca4-Lat-1" unit="cm" 
+         x="285.03"
+	 y="733.26" 
+	 z="2.8421709430404e-13"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_1-5"/>
+       <position name="posArapuca5-Lat-1" unit="cm" 
+         x="210.03"
+	 y="734" 
+	 z="2.8421709430404e-13"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_1-5"/>
+       <position name="posOpArapuca5-Lat-1" unit="cm" 
+         x="210.03"
+	 y="733.26" 
+	 z="2.8421709430404e-13"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_1-6"/>
+       <position name="posArapuca6-Lat-1" unit="cm" 
+         x="135.03"
+	 y="734" 
+	 z="2.8421709430404e-13"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_1-6"/>
+       <position name="posOpArapuca6-Lat-1" unit="cm" 
+         x="135.03"
+	 y="733.26" 
+	 z="2.8421709430404e-13"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_1-7"/>
+       <position name="posArapuca7-Lat-1" unit="cm" 
+         x="60.03"
+	 y="734" 
+	 z="2.8421709430404e-13"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_1-7"/>
+       <position name="posOpArapuca7-Lat-1" unit="cm" 
+         x="60.03"
+	 y="733.26" 
+	 z="2.8421709430404e-13"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_2-0"/>
+       <position name="posArapuca0-Lat-2" unit="cm" 
+         x="285.03"
+	 y="-734" 
+	 z="297.8018"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_2-0"/>
+       <position name="posOpArapuca0-Lat-2" unit="cm" 
+         x="285.03"
+	 y="-733.26" 
+	 z="297.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_2-1"/>
+       <position name="posArapuca1-Lat-2" unit="cm" 
+         x="210.03"
+	 y="-734" 
+	 z="297.8018"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_2-1"/>
+       <position name="posOpArapuca1-Lat-2" unit="cm" 
+         x="210.03"
+	 y="-733.26" 
+	 z="297.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_2-2"/>
+       <position name="posArapuca2-Lat-2" unit="cm" 
+         x="135.03"
+	 y="-734" 
+	 z="297.8018"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_2-2"/>
+       <position name="posOpArapuca2-Lat-2" unit="cm" 
+         x="135.03"
+	 y="-733.26" 
+	 z="297.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_2-3"/>
+       <position name="posArapuca3-Lat-2" unit="cm" 
+         x="60.03"
+	 y="-734" 
+	 z="297.8018"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_2-3"/>
+       <position name="posOpArapuca3-Lat-2" unit="cm" 
+         x="60.03"
+	 y="-733.26" 
+	 z="297.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_2-4"/>
+       <position name="posArapuca4-Lat-2" unit="cm" 
+         x="285.03"
+	 y="734" 
+	 z="297.8018"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_2-4"/>
+       <position name="posOpArapuca4-Lat-2" unit="cm" 
+         x="285.03"
+	 y="733.26" 
+	 z="297.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_2-5"/>
+       <position name="posArapuca5-Lat-2" unit="cm" 
+         x="210.03"
+	 y="734" 
+	 z="297.8018"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_2-5"/>
+       <position name="posOpArapuca5-Lat-2" unit="cm" 
+         x="210.03"
+	 y="733.26" 
+	 z="297.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_2-6"/>
+       <position name="posArapuca6-Lat-2" unit="cm" 
+         x="135.03"
+	 y="734" 
+	 z="297.8018"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_2-6"/>
+       <position name="posOpArapuca6-Lat-2" unit="cm" 
+         x="135.03"
+	 y="733.26" 
+	 z="297.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_2-7"/>
+       <position name="posArapuca7-Lat-2" unit="cm" 
+         x="60.03"
+	 y="734" 
+	 z="297.8018"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_2-7"/>
+       <position name="posOpArapuca7-Lat-2" unit="cm" 
+         x="60.03"
+	 y="733.26" 
+	 z="297.8018"/>
+     </physvol>
+    </volume>
+
+    <volume name="volFoamPadding">
+      <materialref ref="fibrous_glass"/>
+      <solidref ref="FoamPadding"/>
+    </volume>
+
+    <volume name="volSteelSupport">
+      <materialref ref="AirSteelMixture"/>
+      <solidref ref="SteelSupport"/>
+    </volume>
+
+    <volume name="volDetEnclosure">
+      <materialref ref="Air"/>
+      <solidref ref="DetEnclosure"/>
+
+       <physvol>
+           <volumeref ref="volFoamPadding"/>
+           <positionref ref="posCryoInDetEnc"/>
+       </physvol>
+       <physvol>
+           <volumeref ref="volSteelSupport"/>
+           <positionref ref="posCryoInDetEnc"/>
+       </physvol>
+       <physvol>
+           <volumeref ref="volCryostat"/>
+           <positionref ref="posCryoInDetEnc"/>
+       </physvol>
+    </volume>
+
+    <volume name="volWorld" >
+      <materialref ref="DUSEL_Rock"/>
+      <solidref ref="World"/>
+
+      <physvol>
+        <volumeref ref="volDetEnclosure"/>
+	<position name="posDetEnclosure" unit="cm" x="50.04" y="-1.13686837721616e-13" z="448.2027"/>
+      </physvol>
+
+    </volume>
+</structure>
+  <setup name="Default" version="1.0">
+    <world ref="volWorld"/>
+  </setup>
+</gdml_simple_extension>

--- a/dunecore/Geometry/gdml/dunevd10kt_3view_v4_refactored_1x8x6ref_nowires.gdml
+++ b/dunecore/Geometry/gdml/dunevd10kt_3view_v4_refactored_1x8x6ref_nowires.gdml
@@ -1,0 +1,3427 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<gdml_simple_extension xmlns:gdml_simple_extension="http://www.example.org"
+                       xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"          
+                       xs:noNamespaceSchemaLocation="RefactoredGDMLSchema/SimpleExtension.xsd"> 
+<extension>
+   <color name="magenta"     R="0.0"  G="1.0"  B="0.0"  A="1.0" />
+   <color name="green"       R="0.0"  G="1.0"  B="0.0"  A="1.0" />
+   <color name="red"         R="1.0"  G="0.0"  B="0.0"  A="1.0" />
+   <color name="blue"        R="0.0"  G="0.0"  B="1.0"  A="1.0" />
+   <color name="yellow"      R="1.0"  G="1.0"  B="0.0"  A="1.0" />    
+</extension>
+<define>
+
+<!--
+
+
+
+-->
+
+   <position name="posCryoInDetEnc"     unit="cm" x="-50.0000000000001" y="0" z="0"/>
+   <position name="posCenter"           unit="cm" x="0" y="0" z="0"/>
+   <rotation name="rUWireAboutX"        unit="deg" x="131.63" y="0" z="0"/>
+   <rotation name="rPlus90AboutX"       unit="deg" x="90" y="0" z="0"/>
+   <rotation name="rPlus90AboutY"       unit="deg" x="0" y="90" z="0"/>
+   <rotation name="rPlus90AboutXPlus90AboutY" unit="deg" x="90" y="90" z="0"/>
+   <rotation name="rMinus90AboutX"      unit="deg" x="270" y="0" z="0"/>
+   <rotation name="rMinus90AboutY"      unit="deg" x="0" y="270" z="0"/>
+   <rotation name="rMinus90AboutYMinus90AboutX"       unit="deg" x="270" y="270" z="0"/>
+   <rotation name="rPlus180AboutX"	unit="deg" x="180" y="0"   z="0"/>
+   <rotation name="rPlus180AboutY"	unit="deg" x="0" y="180"   z="0"/>
+   <rotation name="rPlus180AboutXPlus180AboutY"	unit="deg" x="180" y="180"   z="0"/>
+   <rotation name="rIdentity"		unit="deg" x="0" y="0"   z="0"/>
+</define>
+<materials>
+  <element name="videRef" formula="VACUUM" Z="1">  <atom value="1"/> </element>
+  <element name="copper" formula="Cu" Z="29">  <atom value="63.546"/>  </element>
+  <element name="beryllium" formula="Be" Z="4">  <atom value="9.0121831"/>  </element>
+  <element name="bromine" formula="Br" Z="35"> <atom value="79.904"/> </element>
+  <element name="hydrogen" formula="H" Z="1">  <atom value="1.0079"/> </element>
+  <element name="nitrogen" formula="N" Z="7">  <atom value="14.0067"/> </element>
+  <element name="oxygen" formula="O" Z="8">  <atom value="15.999"/> </element>
+  <element name="aluminum" formula="Al" Z="13"> <atom value="26.9815"/>  </element>
+  <element name="silicon" formula="Si" Z="14"> <atom value="28.0855"/>  </element>
+  <element name="carbon" formula="C" Z="6">  <atom value="12.0107"/>  </element>
+  <element name="potassium" formula="K" Z="19"> <atom value="39.0983"/>  </element>
+  <element name="chromium" formula="Cr" Z="24"> <atom value="51.9961"/>  </element>
+  <element name="iron" formula="Fe" Z="26"> <atom value="55.8450"/>  </element>
+  <element name="nickel" formula="Ni" Z="28"> <atom value="58.6934"/>  </element>
+  <element name="calcium" formula="Ca" Z="20"> <atom value="40.078"/>   </element>
+  <element name="magnesium" formula="Mg" Z="12"> <atom value="24.305"/>   </element>
+  <element name="sodium" formula="Na" Z="11"> <atom value="22.99"/>    </element>
+  <element name="titanium" formula="Ti" Z="22"> <atom value="47.867"/>   </element>
+  <element name="argon" formula="Ar" Z="18"> <atom value="39.9480"/>  </element>
+  <element name="sulphur" formula="S" Z="16"> <atom value="32.065"/>  </element>
+  <element name="phosphorus" formula="P" Z="15"> <atom value="30.973"/>  </element>
+
+  <material name="Vacuum" formula="Vacuum">
+   <D value="1.e-25" unit="g/cm3"/>
+   <fraction n="1.0" ref="videRef"/>
+  </material>
+
+  <material name="ALUMINUM_Al" formula="ALUMINUM_Al">
+   <D value="2.6990" unit="g/cm3"/>
+   <fraction n="1.0000" ref="aluminum"/>
+  </material>
+
+  <material name="SILICON_Si" formula="SILICON_Si">
+   <D value="2.3300" unit="g/cm3"/>
+   <fraction n="1.0000" ref="silicon"/>
+  </material>
+
+  <material name="epoxy_resin" formula="C38H40O6Br4">
+   <D value="1.1250" unit="g/cm3"/>
+   <composite n="38" ref="carbon"/>
+   <composite n="40" ref="hydrogen"/>
+   <composite n="6" ref="oxygen"/>
+   <composite n="4" ref="bromine"/>
+  </material>
+
+  <material name="SiO2" formula="SiO2">
+   <D value="2.2" unit="g/cm3"/>
+   <composite n="1" ref="silicon"/>
+   <composite n="2" ref="oxygen"/>
+  </material>
+
+  <material name="Al2O3" formula="Al2O3">
+   <D value="3.97" unit="g/cm3"/>
+   <composite n="2" ref="aluminum"/>
+   <composite n="3" ref="oxygen"/>
+  </material>
+
+  <material name="Fe2O3" formula="Fe2O3">
+   <D value="5.24" unit="g/cm3"/>
+   <composite n="2" ref="iron"/>
+   <composite n="3" ref="oxygen"/>
+  </material>
+
+  <material name="CaO" formula="CaO">
+   <D value="3.35" unit="g/cm3"/>
+   <composite n="1" ref="calcium"/>
+   <composite n="1" ref="oxygen"/>
+  </material>
+
+  <material name="Delrin" formula="CH2O">
+    <D value="1.41" unit="g/cm3"/>
+    <composite n="1" ref="carbon"/>
+    <composite n="2" ref="hydrogen"/>
+    <composite n="1" ref="oxygen"/>
+  </material>
+
+  <material name="MgO" formula="MgO">
+   <D value="3.58" unit="g/cm3"/>
+   <composite n="1" ref="magnesium"/>
+   <composite n="1" ref="oxygen"/>
+  </material>
+
+  <material name="Na2O" formula="Na2O">
+   <D value="2.27" unit="g/cm3"/>
+   <composite n="2" ref="sodium"/>
+   <composite n="1" ref="oxygen"/>
+  </material>
+
+  <material name="TiO2" formula="TiO2">
+   <D value="4.23" unit="g/cm3"/>
+   <composite n="1" ref="titanium"/>
+   <composite n="2" ref="oxygen"/>
+  </material>
+
+  <material name="FeO" formula="FeO">
+   <D value="5.745" unit="g/cm3"/>
+   <composite n="1" ref="iron"/>
+   <composite n="1" ref="oxygen"/>
+  </material>
+
+  <material name="CO2" formula="CO2">
+   <D value="1.562" unit="g/cm3"/>
+   <composite n="1" ref="iron"/>
+   <composite n="2" ref="oxygen"/>
+  </material>
+
+  <material name="P2O5" formula="P2O5">
+   <D value="1.562" unit="g/cm3"/>
+   <composite n="2" ref="phosphorus"/>
+   <composite n="5" ref="oxygen"/>
+  </material>
+
+  <material formula=" " name="DUSEL_Rock">
+    <D value="2.82" unit="g/cm3"/>
+    <fraction n="0.5267" ref="SiO2"/>
+    <fraction n="0.1174" ref="FeO"/>
+    <fraction n="0.1025" ref="Al2O3"/>
+    <fraction n="0.0473" ref="MgO"/>
+    <fraction n="0.0422" ref="CO2"/>
+    <fraction n="0.0382" ref="CaO"/>
+    <fraction n="0.0240" ref="carbon"/>
+    <fraction n="0.0186" ref="sulphur"/>
+    <fraction n="0.0053" ref="Na2O"/>
+    <fraction n="0.00070" ref="P2O5"/>
+    <fraction n="0.0771" ref="oxygen"/>
+  </material> 
+
+  <material formula="Air" name="Air">
+   <D value="0.001205" unit="g/cm3"/>
+   <fraction n="0.781154" ref="nitrogen"/>
+   <fraction n="0.209476" ref="oxygen"/>
+   <fraction n="0.00934" ref="argon"/>
+  </material>
+
+  <material name="fibrous_glass">
+   <D value="2.74351" unit="g/cm3"/>
+   <fraction n="0.600" ref="SiO2"/>
+   <fraction n="0.118" ref="Al2O3"/>
+   <fraction n="0.001" ref="Fe2O3"/>
+   <fraction n="0.224" ref="CaO"/>
+   <fraction n="0.034" ref="MgO"/>
+   <fraction n="0.010" ref="Na2O"/>
+   <fraction n="0.013" ref="TiO2"/>
+  </material>
+
+  <!-- density referenced from EHN1-Cold Cryostats Technical Requirements:
+       https://edms.cern.ch/document/1543254 -->
+  <material name="FD_foam">
+   <D value="0.09" unit="g/cm3"/>
+   <fraction n="0.95" ref="Air"/>
+   <fraction n="0.05" ref="fibrous_glass"/>
+  </material>
+
+  <!-- Foam density is 70 kg / m^3 for the 3x1x1 -->
+  <material name="foam_3x1x1dp">
+   <D value="0.07" unit="g/cm3"/>
+   <fraction n="0.95" ref="Air"/>
+   <fraction n="0.05" ref="fibrous_glass"/>
+  </material>
+
+  <!-- Copied from protodune_v4.gdml -->
+  <material name="foam_protoDUNEdp">
+   <D value="0.135" unit="g/cm3"/>
+   <composite n="17" ref="carbon"/>
+   <composite n="16" ref="hydrogen"/>
+   <composite n="2" ref="nitrogen"/>
+   <composite n="4" ref="oxygen"/>
+  </material>
+
+  <material name="FR4">
+   <D value="1.98281" unit="g/cm3"/>
+   <fraction n="0.47" ref="epoxy_resin"/>
+   <fraction n="0.53" ref="fibrous_glass"/>
+  </material>
+
+  <material name="STEEL_STAINLESS_Fe7Cr2Ni" formula="STEEL_STAINLESS_Fe7Cr2Ni">
+   <D value="7.9300" unit="g/cm3"/>
+   <fraction n="0.0010" ref="carbon"/>
+   <fraction n="0.1792" ref="chromium"/>
+   <fraction n="0.7298" ref="iron"/>
+   <fraction n="0.0900" ref="nickel"/>
+  </material>
+
+  <material name="Copper_Beryllium_alloy25" formula="Copper_Beryllium_alloy25">
+   <D value="8.26" unit="g/cm3"/>
+   <fraction n="0.981" ref="copper"/>
+   <fraction n="0.019" ref="beryllium"/>
+  </material>
+
+  <material name="LAr" formula="LAr">
+   <D value="1.40" unit="g/cm3"/>
+   <fraction n="1.0000" ref="argon"/>
+  </material>
+
+  <material name="ArGas" formula="ArGas">
+   <D value="0.00166" unit="g/cm3"/>
+   <fraction n="1.0" ref="argon"/>
+  </material>
+
+  <material formula=" " name="G10">
+   <D value="1.7" unit="g/cm3"/>
+   <fraction n="0.2805" ref="silicon"/>
+   <fraction n="0.3954" ref="oxygen"/>
+   <fraction n="0.2990" ref="carbon"/>
+   <fraction n="0.0251" ref="hydrogen"/>
+  </material>
+
+  <material formula=" " name="Granite">
+   <D value="2.7" unit="g/cm3"/>
+   <fraction n="0.438" ref="oxygen"/>
+   <fraction n="0.257" ref="silicon"/>
+   <fraction n="0.222" ref="sodium"/>
+   <fraction n="0.049" ref="aluminum"/>
+   <fraction n="0.019" ref="iron"/>
+   <fraction n="0.015" ref="potassium"/>
+  </material>
+
+  <material formula=" " name="ShotRock">
+   <D value="1.62" unit="g/cm3"/>
+   <fraction n="0.438" ref="oxygen"/>
+   <fraction n="0.257" ref="silicon"/>
+   <fraction n="0.222" ref="sodium"/>
+   <fraction n="0.049" ref="aluminum"/>
+   <fraction n="0.019" ref="iron"/>
+   <fraction n="0.015" ref="potassium"/>
+  </material>
+
+  <material formula=" " name="Dirt">
+   <D value="1.7" unit="g/cm3"/>
+   <fraction n="0.438" ref="oxygen"/>
+   <fraction n="0.257" ref="silicon"/>
+   <fraction n="0.222" ref="sodium"/>
+   <fraction n="0.049" ref="aluminum"/>
+   <fraction n="0.019" ref="iron"/>
+   <fraction n="0.015" ref="potassium"/>
+  </material>
+
+  <material formula=" " name="Concrete">
+   <D value="2.3" unit="g/cm3"/>
+   <fraction n="0.530" ref="oxygen"/>
+   <fraction n="0.335" ref="silicon"/>
+   <fraction n="0.060" ref="calcium"/>
+   <fraction n="0.015" ref="sodium"/>
+   <fraction n="0.020" ref="iron"/>
+   <fraction n="0.040" ref="aluminum"/>
+  </material>
+
+  <material formula="H2O" name="Water">
+   <D value="1.0" unit="g/cm3"/>
+   <fraction n="0.1119" ref="hydrogen"/>
+   <fraction n="0.8881" ref="oxygen"/>
+  </material>
+
+  <material formula="Ti" name="Titanium">
+   <D value="4.506" unit="g/cm3"/>
+   <fraction n="1." ref="titanium"/>
+  </material>
+
+  <material name="TPB" formula="TPB">
+   <D value="1.40" unit="g/cm3"/>
+   <fraction n="1.0000" ref="argon"/>
+  </material>
+
+  <material name="Glass">
+   <D value="2.74351" unit="g/cm3"/>
+   <fraction n="0.600" ref="SiO2"/>
+   <fraction n="0.118" ref="Al2O3"/>
+   <fraction n="0.001" ref="Fe2O3"/>
+   <fraction n="0.224" ref="CaO"/>
+   <fraction n="0.034" ref="MgO"/>
+   <fraction n="0.010" ref="Na2O"/>
+   <fraction n="0.013" ref="TiO2"/>
+  </material>
+
+  <material name="Acrylic">
+   <D value="1.19" unit="g/cm3"/>
+   <fraction n="0.600" ref="carbon"/>
+   <fraction n="0.320" ref="oxygen"/>
+   <fraction n="0.080" ref="hydrogen"/>
+  </material>
+
+  <material name="NiGas1atm80K">
+   <D value="0.0039" unit="g/cm3"/>
+   <fraction n="1.000" ref="nitrogen"/>
+  </material>
+
+  <material name="NiGas">
+   <D value="0.001165" unit="g/cm3"/>
+   <fraction n="1.000" ref="nitrogen"/>
+  </material>
+
+  <material name="PolyurethaneFoam">
+   <D value="0.088" unit="g/cm3"/>
+   <composite n="17" ref="carbon"/>
+   <composite n="16" ref="hydrogen"/>
+   <composite n="2" ref="nitrogen"/>
+   <composite n="4" ref="oxygen"/>
+  </material>
+
+  <material name="ProtoDUNEFoam">
+   <D value="0.135" unit="g/cm3"/>
+   <composite n="17" ref="carbon"/>
+   <composite n="16" ref="hydrogen"/>
+   <composite n="2" ref="nitrogen"/>
+   <composite n="4" ref="oxygen"/>
+  </material>
+
+  <material name="LightPolyurethaneFoam">
+   <D value="0.009" unit="g/cm3"/>
+   <composite n="17" ref="carbon"/>
+   <composite n="16" ref="hydrogen"/>
+   <composite n="2" ref="nitrogen"/>
+   <composite n="4" ref="oxygen"/>
+  </material>
+
+  <material name="ProtoDUNEBWFoam">
+   <D value="0.021" unit="g/cm3"/>
+   <composite n="17" ref="carbon"/>
+   <composite n="16" ref="hydrogen"/>
+   <composite n="2" ref="nitrogen"/>
+   <composite n="4" ref="oxygen"/>
+  </material>
+
+  <material name="GlassWool">
+   <D value="0.035" unit="g/cm3"/>
+   <fraction n="0.65" ref="SiO2"/>
+   <fraction n="0.09" ref="Al2O3"/>
+   <fraction n="0.07" ref="CaO"/>
+   <fraction n="0.03" ref="MgO"/>
+   <fraction n="0.16" ref="Na2O"/>
+  </material>
+
+  <material name="Polystyrene">
+   <D value="1.06" unit="g/cm3"/>
+   <composite n="8" ref="carbon"/>
+   <composite n="8" ref="hydrogen"/>
+  </material>
+
+
+
+  <!-- preliminary values -->
+  <material name="AirSteelMixture" formula="AirSteelMixture">
+   <D value=" 0.001205*(1-0.5) + 7.9300*0.5 " unit="g/cm3"/>
+   <fraction n="0.5" ref="STEEL_STAINLESS_Fe7Cr2Ni"/>
+   <fraction n="0.5"   ref="Air"/>
+  </material>
+  <material name="vm2000" formula="vm2000">
+    <D value="1.2" unit="g/cm3"/>
+    <composite n="2" ref="carbon"/>
+    <composite n="4" ref="hydrogen"/>
+  </material>
+
+</materials>
+<solids>
+     <torus name="FieldShaperCorner" rmin="0.5" rmax="2.285" rtor="2.3" deltaphi="90" startphi="0" aunit="deg" lunit="cm"/>
+     <tube name="FieldShaperLongtube" rmin="0.5" rmax="2.285" z="896.4054" deltaphi="360" startphi="0" aunit="deg" lunit="cm"/>
+     <tube name="FieldShaperLongtubeSlim" rmin="0.5" rmax="0.75" z="896.4054" deltaphi="360" startphi="0" aunit="deg" lunit="cm"/>
+     <tube name="FieldShaperShorttube" rmin="0.5" rmax="2.285" z="1348" deltaphi="360" startphi="0" aunit="deg" lunit="cm"/>
+
+    <union name="FSunion1">
+      <first ref="FieldShaperLongtube"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos1" unit="cm" x="-2.3" y="0" z="448.2027"/>
+		<rotation name="rot1" unit="deg" x="90" y="0" z="0" />
+    </union>
+
+    <union name="FSunion2">
+      <first ref="FSunion1"/>
+      <second ref="FieldShaperShorttube"/>
+   		<position name="esquinapos2" unit="cm" x="-676.3" y="0" z="450.5027"/>
+   		<rotation name="rot2" unit="deg" x="0" y="90" z="0" />
+    </union>
+
+    <union name="FSunion3">
+      <first ref="FSunion2"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos3" unit="cm" x="-1350.3" y="0" z="448.2027"/>
+		<rotation name="rot3" unit="deg" x="90" y="270" z="0" />
+    </union>
+
+    <union name="FSunion4">
+      <first ref="FSunion3"/>
+      <second ref="FieldShaperLongtube"/>
+   		<position name="esquinapos4" unit="cm" x="-1352.6" y="0" z="0"/>
+    </union>
+
+    <union name="FSunion5">
+      <first ref="FSunion4"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos5" unit="cm" x="-1350.3" y="0" z="-448.2027"/>
+		<rotation name="rot5" unit="deg" x="90" y="180" z="0" />
+    </union>
+
+    <union name="FSunion6">
+      <first ref="FSunion5"/>
+      <second ref="FieldShaperShorttube"/>
+   		<position name="esquinapos6" unit="cm" x="-676.3" y="0" z="-450.5027"/>
+		<rotation name="rot6" unit="deg" x="0" y="90" z="0" />
+    </union>
+
+    <union name="FieldShaperSolid">
+      <first ref="FSunion6"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos7" unit="cm" x="-2.3" y="0" z="-448.2027"/>
+		<rotation name="rot7" unit="deg" x="90" y="90" z="0" />
+    </union>
+    
+    <union name="FSunionSlim1">
+      <first ref="FieldShaperLongtubeSlim"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos1" unit="cm" x="-2.3" y="0" z="448.2027"/>
+		<rotation name="rot1" unit="deg" x="90" y="0" z="0" />
+    </union>
+
+    <union name="FSunionSlim2">
+      <first ref="FSunionSlim1"/>
+      <second ref="FieldShaperShorttube"/>
+   		<position name="esquinapos2" unit="cm" x="-676.3" y="0" z="450.5027"/>
+   		<rotation name="rot2" unit="deg" x="0" y="90" z="0" />
+    </union>
+
+    <union name="FSunionSlim3">
+      <first ref="FSunionSlim2"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos3" unit="cm" x="-1350.3" y="0" z="448.2027"/>
+		<rotation name="rot3" unit="deg" x="90" y="270" z="0" />
+    </union>
+
+    <union name="FSunionSlim4">
+      <first ref="FSunionSlim3"/>
+      <second ref="FieldShaperLongtubeSlim"/>
+   		<position name="esquinapos4" unit="cm" x="-1352.6" y="0" z="0"/>
+    </union>
+
+    <union name="FSunionSlim5">
+      <first ref="FSunionSlim4"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos5" unit="cm" x="-1350.3" y="0" z="-448.2027"/>
+		<rotation name="rot5" unit="deg" x="90" y="180" z="0" />
+    </union>
+
+    <union name="FSunionSlim6">
+      <first ref="FSunionSlim5"/>
+      <second ref="FieldShaperShorttube"/>
+   		<position name="esquinapos6" unit="cm" x="-676.3" y="0" z="-450.5027"/>
+		<rotation name="rot6" unit="deg" x="0" y="90" z="0" />
+    </union>
+
+    <union name="FieldShaperSolidSlim">
+      <first ref="FSunionSlim6"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos7" unit="cm" x="-2.3" y="0" z="-448.2027"/>
+		<rotation name="rot7" unit="deg" x="90" y="90" z="0" />
+    </union>
+    
+
+   <box name="CRM"
+      x="650.08" 
+      y="168" 
+      z="148.9009"
+      lunit="cm"/>
+   <box name="CRMUPlane" 
+      x="0.02" 
+      y="168" 
+      z="148.9009"
+      lunit="cm"/>
+   <box name="CRMYPlane" 
+      x="0.02" 
+      y="168" 
+      z="148.9009"
+      lunit="cm"/>
+   <box name="CRMZPlane" 
+      x="0.02"
+      y="168"
+      z="148.9009"
+      lunit="cm"/>
+   <box name="CRMActive" 
+      x="650"
+      y="168"
+      z="148.9009"
+      lunit="cm"/>
+
+    <box name="ArapucaOut" lunit="cm"
+      x="65"
+      y="2.5"
+      z="65"/>
+
+    <box name="ArapucaIn" lunit="cm"
+      x="60"
+      y="2.5"
+      z="60"/>
+
+     <subtraction name="ArapucaWalls">
+      <first  ref="ArapucaOut"/>
+      <second ref="ArapucaIn"/>
+      <position name="posArapucaSub" x="0" y="1.25" z="0." unit="cm"/>
+      </subtraction>
+
+    <box name="ArapucaAcceptanceWindow" lunit="cm"
+      x="60"
+      y="1"
+      z="60"/>
+
+    <box name="ArapucaDoubleIn" lunit="cm"
+      x="60"
+      y="3.5"
+      z="60"/>
+
+     <subtraction name="ArapucaDoubleWalls">
+      <first  ref="ArapucaOut"/>
+      <second ref="ArapucaDoubleIn"/>
+      <position name="posArapucaDoubleSub" x="0" y="0" z="0" unit="cm"/>
+      </subtraction>
+
+    <box name="ArapucaDoubleAcceptanceWindow" lunit="cm"
+      x="2.48"
+      y="60"
+      z="60"/>
+
+    <box name="ArapucaCathodeAcceptanceWindow" lunit="cm"
+      x="1"
+      y="60"
+      z="60"/>
+
+
+    <box name="Cryostat" lunit="cm" 
+      x="850.32" 
+      y="1548.24" 
+      z="1096.6454"/>
+
+    <box name="ArgonInterior" lunit="cm" 
+      x="850.08"
+      y="1548"
+      z="1096.4054"/>
+
+    <box name="GaseousArgon" lunit="cm" 
+      x="100 - 0.01"
+      y="1548"
+      z="1096.4054"/>
+
+    <box name="ExternalAuxOut" lunit="cm" 
+      x="850.08 - 100"
+      y="1548 - 2*2.5 - 2*40"
+      z="1096.4054"/>
+
+    <box name="ExternalAuxIn" lunit="cm" 
+      x="850.08"
+      y="1359.17"
+      z="1096.4054 + 1"/>
+
+   <subtraction name="ExternalActive">
+      <first ref="ExternalAuxOut"/>
+      <second ref="ExternalAuxIn"/>
+    </subtraction>
+
+    <subtraction name="SteelShell">
+      <first ref="Cryostat"/>
+      <second ref="ArgonInterior"/>
+    </subtraction>
+
+
+
+    <box name="CathodeBlock" lunit="cm"
+      x="4"
+      y="336"
+      z="297.8018" />
+
+    <box name="CathodeVoid" lunit="cm"
+      x="5"
+      y="76.35"
+      z="67" />
+
+    <subtraction name="Cathode1">
+      <first ref="CathodeBlock"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub1" x="0" y="-122.525" z="-108.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode2">
+      <first ref="Cathode1"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub2" x="0" y="-122.525" z="-37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode3">
+      <first ref="Cathode2"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub3" x="0" y="-122.525" z="37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode4">
+      <first ref="Cathode3"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub4" x="0" y="-122.525" z="108.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode5">
+      <first ref="Cathode4"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub5" x="0" y="-42.175" z="-108.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode6">
+      <first ref="Cathode5"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub6" x="0" y="-42.175" z="-37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode7">
+      <first ref="Cathode6"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub7" x="0" y="-42.175" z="37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode8">
+      <first ref="Cathode7"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub8" x="0" y="-42.175" z="108.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode9">
+      <first ref="Cathode8"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub9" x="0" y="42.175" z="-108.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode10">
+      <first ref="Cathode9"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub10" x="0" y="42.175" z="-37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode11">
+      <first ref="Cathode10"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub11" x="0" y="42.175" z="37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode12">
+      <first ref="Cathode11"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub12" x="0" y="42.175" z="108.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode13">
+      <first ref="Cathode12"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub13" x="0" y="122.525" z="-108.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode14">
+      <first ref="Cathode13"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub14" x="0" y="122.525" z="-37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode15">
+      <first ref="Cathode14"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub15" x="0" y="122.525" z="37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="CathodeGrid">
+      <first ref="Cathode15"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub16" x="0" y="122.525" z="108.5" unit="cm"/>
+    </subtraction>
+
+   <box name="AnodePlate" 
+      x="0.01"
+      y="336"
+      z="297.8018"
+      lunit="cm"/>
+
+    <box name="FoamPadBlock" lunit="cm"
+      x="1010.32"
+      y="1708.24"
+      z="1256.6454" />
+
+    <subtraction name="FoamPadding">
+      <first ref="FoamPadBlock"/>
+      <second ref="Cryostat"/>
+      <positionref ref="posCenter"/>
+    </subtraction>
+
+    <box name="SteelSupportBlock" lunit="cm"
+      x="1210.32"
+      y="1908.24"
+      z="1456.6454" />
+
+    <subtraction name="SteelSupport">
+      <first ref="SteelSupportBlock"/>
+      <second ref="FoamPadBlock"/>
+      <positionref ref="posCenter"/>
+    </subtraction>
+
+    <box name="DetEnclosure" lunit="cm" 
+      x="1310.32"
+      y="2108.24"
+      z="1656.6454"/>
+
+
+    <box name="World" lunit="cm" 
+      x="9310.32" 
+      y="10108.24" 
+      z="9656.6454"/>
+</solids>
+<structure>
+<volume name="volFieldShaper">
+  <materialref ref="Al2O3"/>
+  <solidref ref="FieldShaperSolid"/>
+</volume>
+<volume name="volFieldShaperSlim">
+  <materialref ref="Al2O3"/>
+  <solidref ref="FieldShaperSolidSlim"/>
+</volume>
+
+
+    <volume name="volTPCActive">
+      <materialref ref="LAr"/>
+      <solidref ref="CRMActive"/>
+      <auxiliary auxtype="SensDet" auxvalue="SimEnergyDeposit"/>
+      <auxiliary auxtype="StepLimit" auxunit="cm" auxvalue="0.5208*cm"/>
+      <auxiliary auxtype="Efield" auxunit="V/cm" auxvalue="500*V/cm"/>
+      <colorref ref="blue"/>
+    </volume>
+   <volume name="volTPCPlaneU">
+     <materialref ref="LAr"/>
+     <solidref ref="CRMUPlane"/>
+   </volume>
+  <volume name="volTPCPlaneY">
+    <materialref ref="LAr"/>
+    <solidref ref="CRMYPlane"/>
+  </volume>
+  <volume name="volTPCPlaneZ">
+    <materialref ref="LAr"/>
+    <solidref ref="CRMZPlane"/>
+  </volume>
+   <volume name="volTPC">
+     <materialref ref="LAr"/>
+       <solidref ref="CRM"/>
+       <physvol>
+       <volumeref ref="volTPCPlaneU"/>
+       <position name="posPlaneU" unit="cm" 
+         x="324.99" y="0" z="0"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCPlaneY"/>
+       <position name="posPlaneY" unit="cm" 
+         x="325.01" y="0" z="0"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCPlaneZ"/>
+       <position name="posPlaneZ" unit="cm" 
+         x="325.03" y="0" z="0"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCActive"/>
+       <position name="posActive" unit="cm" 
+        x="-0.04" y="" z="0"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+   </volume>
+ 
+    <volume name="volSteelShell">
+      <materialref ref="STEEL_STAINLESS_Fe7Cr2Ni" />
+      <solidref ref="SteelShell" />
+    </volume>
+    <volume name="volGroundGrid">
+      <materialref ref="STEEL_STAINLESS_Fe7Cr2Ni" />
+      <solidref ref="CathodeGrid" />
+    </volume>    
+    <volume name="volAnodePlate">
+     <materialref ref="vm2000"/>
+     <solidref ref="AnodePlate"/>
+    </volume>
+    <volume name="volGaseousArgon">
+      <materialref ref="ArGas"/>
+      <solidref ref="GaseousArgon"/>
+    </volume>
+    <volume name="volExternalActive">
+      <materialref ref="LAr"/>
+      <solidref ref="ExternalActive"/>
+      <auxiliary auxtype="SensDet" auxvalue="SimEnergyDeposit"/>
+      <auxiliary auxtype="StepLimit" auxunit="cm" auxvalue="0.5208*cm"/>
+      <auxiliary auxtype="Efield" auxunit="V/cm" auxvalue="0*V/cm"/>
+      <colorref ref="green"/>
+    </volume>
+    <volume name="volArapucaDouble_0-0-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-0-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-0-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-0-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-0-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-0-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-0-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-0-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-1-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-1-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-1-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-1-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-1-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-1-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-1-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-1-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-2-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-2-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-2-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-2-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-2-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-2-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-2-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-2-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-0-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-0-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-0-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-0-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-0-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-0-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-0-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-0-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-1-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-1-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-1-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-1-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-1-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-1-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-1-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-1-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-2-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-2-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-2-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-2-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-2-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-2-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-2-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-2-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-0-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-0-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-0-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-0-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-0-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-0-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-0-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-0-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-1-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-1-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-1-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-1-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-1-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-1-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-1-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-1-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-2-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-2-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-2-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-2-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-2-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-2-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-2-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-2-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-0-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-0-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-0-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-0-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-0-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-0-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-0-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-0-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-1-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-1-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-1-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-1-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-1-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-1-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-1-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-1-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-2-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-2-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-2-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-2-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-2-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-2-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-2-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-2-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_0-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_0-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_0-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_0-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_0-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_0-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_0-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_0-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_0-4">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_0-4">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_0-5">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_0-5">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_0-6">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_0-6">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_0-7">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_0-7">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_1-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_1-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_1-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_1-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_1-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_1-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_1-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_1-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_1-4">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_1-4">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_1-5">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_1-5">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_1-6">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_1-6">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_1-7">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_1-7">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_2-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_2-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_2-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_2-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_2-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_2-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_2-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_2-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_2-4">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_2-4">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_2-5">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_2-5">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_2-6">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_2-6">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_2-7">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_2-7">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+
+    <volume name="volCryostat">
+      <materialref ref="LAr" />
+      <solidref ref="Cryostat" />
+      <physvol>
+        <volumeref ref="volGaseousArgon"/>
+        <position name="posGaseousArgon" unit="cm" x="375.045" y="0" z="0"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volSteelShell"/>
+        <position name="posSteelShell" unit="cm" x="0" y="0" z="0"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volExternalActive"/>
+        <position name="posExternalActive" unit="cm" x="-100/2" y="0" z="0"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-0" unit="cm"
+           x="0" y="-589.5" z="-373.25225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-1" unit="cm"
+           x="0" y="-421.5" z="-373.25225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-2" unit="cm"
+           x="0" y="-252.5" z="-373.25225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-3" unit="cm"
+           x="0" y="-84.5" z="-373.25225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-4" unit="cm"
+           x="0" y="84.5" z="-373.25225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-5" unit="cm"
+           x="0" y="252.5" z="-373.25225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-6" unit="cm"
+           x="0" y="421.5" z="-373.25225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-7" unit="cm"
+           x="0" y="589.5" z="-373.25225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-8" unit="cm"
+           x="0" y="-589.5" z="-224.35135"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-9" unit="cm"
+           x="0" y="-421.5" z="-224.35135"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-10" unit="cm"
+           x="0" y="-252.5" z="-224.35135"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-11" unit="cm"
+           x="0" y="-84.5" z="-224.35135"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-12" unit="cm"
+           x="0" y="84.5" z="-224.35135"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-13" unit="cm"
+           x="0" y="252.5" z="-224.35135"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-14" unit="cm"
+           x="0" y="421.5" z="-224.35135"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-15" unit="cm"
+           x="0" y="589.5" z="-224.35135"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-16" unit="cm"
+           x="0" y="-589.5" z="-74.45045"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-17" unit="cm"
+           x="0" y="-421.5" z="-74.45045"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-18" unit="cm"
+           x="0" y="-252.5" z="-74.45045"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-19" unit="cm"
+           x="0" y="-84.5" z="-74.45045"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-20" unit="cm"
+           x="0" y="84.5" z="-74.45045"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-21" unit="cm"
+           x="0" y="252.5" z="-74.45045"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-22" unit="cm"
+           x="0" y="421.5" z="-74.45045"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-23" unit="cm"
+           x="0" y="589.5" z="-74.45045"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-24" unit="cm"
+           x="0" y="-589.5" z="74.45045"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-25" unit="cm"
+           x="0" y="-421.5" z="74.45045"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-26" unit="cm"
+           x="0" y="-252.5" z="74.45045"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-27" unit="cm"
+           x="0" y="-84.5" z="74.45045"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-28" unit="cm"
+           x="0" y="84.5" z="74.45045"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-29" unit="cm"
+           x="0" y="252.5" z="74.45045"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-30" unit="cm"
+           x="0" y="421.5" z="74.45045"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-31" unit="cm"
+           x="0" y="589.5" z="74.45045"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-32" unit="cm"
+           x="0" y="-589.5" z="224.35135"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-33" unit="cm"
+           x="0" y="-421.5" z="224.35135"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-34" unit="cm"
+           x="0" y="-252.5" z="224.35135"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-35" unit="cm"
+           x="0" y="-84.5" z="224.35135"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-36" unit="cm"
+           x="0" y="84.5" z="224.35135"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-37" unit="cm"
+           x="0" y="252.5" z="224.35135"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-38" unit="cm"
+           x="0" y="421.5" z="224.35135"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-39" unit="cm"
+           x="0" y="589.5" z="224.35135"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-40" unit="cm"
+           x="0" y="-589.5" z="373.25225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-41" unit="cm"
+           x="0" y="-421.5" z="373.25225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-42" unit="cm"
+           x="0" y="-252.5" z="373.25225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-43" unit="cm"
+           x="0" y="-84.5" z="373.25225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-44" unit="cm"
+           x="0" y="84.5" z="373.25225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-45" unit="cm"
+           x="0" y="252.5" z="373.25225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-46" unit="cm"
+           x="0" y="421.5" z="373.25225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-47" unit="cm"
+           x="0" y="589.5" z="373.25225"/>
+      </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper0" unit="cm"  x="-322.04" y="-676.3" z="0" />
+     <rotation name="rotFS0" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper1" unit="cm"  x="-316.04" y="-676.3" z="0" />
+     <rotation name="rotFS1" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper2" unit="cm"  x="-310.04" y="-676.3" z="0" />
+     <rotation name="rotFS2" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper3" unit="cm"  x="-304.04" y="-676.3" z="0" />
+     <rotation name="rotFS3" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper4" unit="cm"  x="-298.04" y="-676.3" z="0" />
+     <rotation name="rotFS4" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper5" unit="cm"  x="-292.04" y="-676.3" z="0" />
+     <rotation name="rotFS5" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper6" unit="cm"  x="-286.04" y="-676.3" z="0" />
+     <rotation name="rotFS6" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper7" unit="cm"  x="-280.04" y="-676.3" z="0" />
+     <rotation name="rotFS7" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper8" unit="cm"  x="-274.04" y="-676.3" z="0" />
+     <rotation name="rotFS8" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper9" unit="cm"  x="-268.04" y="-676.3" z="0" />
+     <rotation name="rotFS9" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper10" unit="cm"  x="-262.04" y="-676.3" z="0" />
+     <rotation name="rotFS10" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper11" unit="cm"  x="-256.04" y="-676.3" z="0" />
+     <rotation name="rotFS11" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper12" unit="cm"  x="-250.04" y="-676.3" z="0" />
+     <rotation name="rotFS12" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper13" unit="cm"  x="-244.04" y="-676.3" z="0" />
+     <rotation name="rotFS13" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper14" unit="cm"  x="-238.04" y="-676.3" z="0" />
+     <rotation name="rotFS14" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper15" unit="cm"  x="-232.04" y="-676.3" z="0" />
+     <rotation name="rotFS15" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper16" unit="cm"  x="-226.04" y="-676.3" z="0" />
+     <rotation name="rotFS16" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper17" unit="cm"  x="-220.04" y="-676.3" z="0" />
+     <rotation name="rotFS17" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper18" unit="cm"  x="-214.04" y="-676.3" z="0" />
+     <rotation name="rotFS18" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper19" unit="cm"  x="-208.04" y="-676.3" z="0" />
+     <rotation name="rotFS19" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper20" unit="cm"  x="-202.04" y="-676.3" z="0" />
+     <rotation name="rotFS20" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper21" unit="cm"  x="-196.04" y="-676.3" z="0" />
+     <rotation name="rotFS21" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper22" unit="cm"  x="-190.04" y="-676.3" z="0" />
+     <rotation name="rotFS22" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper23" unit="cm"  x="-184.04" y="-676.3" z="0" />
+     <rotation name="rotFS23" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper24" unit="cm"  x="-178.04" y="-676.3" z="0" />
+     <rotation name="rotFS24" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper25" unit="cm"  x="-172.04" y="-676.3" z="0" />
+     <rotation name="rotFS25" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper26" unit="cm"  x="-166.04" y="-676.3" z="0" />
+     <rotation name="rotFS26" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper27" unit="cm"  x="-160.04" y="-676.3" z="0" />
+     <rotation name="rotFS27" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper28" unit="cm"  x="-154.04" y="-676.3" z="0" />
+     <rotation name="rotFS28" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper29" unit="cm"  x="-148.04" y="-676.3" z="0" />
+     <rotation name="rotFS29" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper30" unit="cm"  x="-142.04" y="-676.3" z="0" />
+     <rotation name="rotFS30" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper31" unit="cm"  x="-136.04" y="-676.3" z="0" />
+     <rotation name="rotFS31" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper32" unit="cm"  x="-130.04" y="-676.3" z="0" />
+     <rotation name="rotFS32" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper33" unit="cm"  x="-124.04" y="-676.3" z="0" />
+     <rotation name="rotFS33" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper34" unit="cm"  x="-118.04" y="-676.3" z="0" />
+     <rotation name="rotFS34" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper35" unit="cm"  x="-112.04" y="-676.3" z="0" />
+     <rotation name="rotFS35" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper36" unit="cm"  x="-106.04" y="-676.3" z="0" />
+     <rotation name="rotFS36" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper37" unit="cm"  x="-100.04" y="-676.3" z="0" />
+     <rotation name="rotFS37" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper38" unit="cm"  x="-94.04" y="-676.3" z="0" />
+     <rotation name="rotFS38" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper39" unit="cm"  x="-88.04" y="-676.3" z="0" />
+     <rotation name="rotFS39" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper40" unit="cm"  x="-82.04" y="-676.3" z="0" />
+     <rotation name="rotFS40" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper41" unit="cm"  x="-76.04" y="-676.3" z="0" />
+     <rotation name="rotFS41" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper42" unit="cm"  x="-70.04" y="-676.3" z="0" />
+     <rotation name="rotFS42" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper43" unit="cm"  x="-64.04" y="-676.3" z="0" />
+     <rotation name="rotFS43" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper44" unit="cm"  x="-58.04" y="-676.3" z="0" />
+     <rotation name="rotFS44" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper45" unit="cm"  x="-52.04" y="-676.3" z="0" />
+     <rotation name="rotFS45" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper46" unit="cm"  x="-46.04" y="-676.3" z="0" />
+     <rotation name="rotFS46" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper47" unit="cm"  x="-40.04" y="-676.3" z="0" />
+     <rotation name="rotFS47" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper48" unit="cm"  x="-34.04" y="-676.3" z="0" />
+     <rotation name="rotFS48" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper49" unit="cm"  x="-28.04" y="-676.3" z="0" />
+     <rotation name="rotFS49" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper50" unit="cm"  x="-22.04" y="-676.3" z="0" />
+     <rotation name="rotFS50" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper51" unit="cm"  x="-16.04" y="-676.3" z="0" />
+     <rotation name="rotFS51" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper52" unit="cm"  x="-10.04" y="-676.3" z="0" />
+     <rotation name="rotFS52" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper53" unit="cm"  x="-4.04000000000001" y="-676.3" z="0" />
+     <rotation name="rotFS53" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper54" unit="cm"  x="1.95999999999999" y="-676.3" z="0" />
+     <rotation name="rotFS54" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper55" unit="cm"  x="7.95999999999999" y="-676.3" z="0" />
+     <rotation name="rotFS55" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper56" unit="cm"  x="13.96" y="-676.3" z="0" />
+     <rotation name="rotFS56" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper57" unit="cm"  x="19.96" y="-676.3" z="0" />
+     <rotation name="rotFS57" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper58" unit="cm"  x="25.96" y="-676.3" z="0" />
+     <rotation name="rotFS58" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper59" unit="cm"  x="31.96" y="-676.3" z="0" />
+     <rotation name="rotFS59" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper60" unit="cm"  x="37.96" y="-676.3" z="0" />
+     <rotation name="rotFS60" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper61" unit="cm"  x="43.96" y="-676.3" z="0" />
+     <rotation name="rotFS61" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper62" unit="cm"  x="49.96" y="-676.3" z="0" />
+     <rotation name="rotFS62" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper63" unit="cm"  x="55.96" y="-676.3" z="0" />
+     <rotation name="rotFS63" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper64" unit="cm"  x="61.96" y="-676.3" z="0" />
+     <rotation name="rotFS64" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper65" unit="cm"  x="67.96" y="-676.3" z="0" />
+     <rotation name="rotFS65" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper66" unit="cm"  x="73.96" y="-676.3" z="0" />
+     <rotation name="rotFS66" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper67" unit="cm"  x="79.96" y="-676.3" z="0" />
+     <rotation name="rotFS67" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper68" unit="cm"  x="85.96" y="-676.3" z="0" />
+     <rotation name="rotFS68" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper69" unit="cm"  x="91.96" y="-676.3" z="0" />
+     <rotation name="rotFS69" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper70" unit="cm"  x="97.96" y="-676.3" z="0" />
+     <rotation name="rotFS70" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper71" unit="cm"  x="103.96" y="-676.3" z="0" />
+     <rotation name="rotFS71" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper72" unit="cm"  x="109.96" y="-676.3" z="0" />
+     <rotation name="rotFS72" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper73" unit="cm"  x="115.96" y="-676.3" z="0" />
+     <rotation name="rotFS73" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper74" unit="cm"  x="121.96" y="-676.3" z="0" />
+     <rotation name="rotFS74" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper75" unit="cm"  x="127.96" y="-676.3" z="0" />
+     <rotation name="rotFS75" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper76" unit="cm"  x="133.96" y="-676.3" z="0" />
+     <rotation name="rotFS76" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper77" unit="cm"  x="139.96" y="-676.3" z="0" />
+     <rotation name="rotFS77" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper78" unit="cm"  x="145.96" y="-676.3" z="0" />
+     <rotation name="rotFS78" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper79" unit="cm"  x="151.96" y="-676.3" z="0" />
+     <rotation name="rotFS79" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper80" unit="cm"  x="157.96" y="-676.3" z="0" />
+     <rotation name="rotFS80" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper81" unit="cm"  x="163.96" y="-676.3" z="0" />
+     <rotation name="rotFS81" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper82" unit="cm"  x="169.96" y="-676.3" z="0" />
+     <rotation name="rotFS82" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper83" unit="cm"  x="175.96" y="-676.3" z="0" />
+     <rotation name="rotFS83" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper84" unit="cm"  x="181.96" y="-676.3" z="0" />
+     <rotation name="rotFS84" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper85" unit="cm"  x="187.96" y="-676.3" z="0" />
+     <rotation name="rotFS85" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper86" unit="cm"  x="193.96" y="-676.3" z="0" />
+     <rotation name="rotFS86" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper87" unit="cm"  x="199.96" y="-676.3" z="0" />
+     <rotation name="rotFS87" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper88" unit="cm"  x="205.96" y="-676.3" z="0" />
+     <rotation name="rotFS88" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper89" unit="cm"  x="211.96" y="-676.3" z="0" />
+     <rotation name="rotFS89" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper90" unit="cm"  x="217.96" y="-676.3" z="0" />
+     <rotation name="rotFS90" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper91" unit="cm"  x="223.96" y="-676.3" z="0" />
+     <rotation name="rotFS91" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper92" unit="cm"  x="229.96" y="-676.3" z="0" />
+     <rotation name="rotFS92" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper93" unit="cm"  x="235.96" y="-676.3" z="0" />
+     <rotation name="rotFS93" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper94" unit="cm"  x="241.96" y="-676.3" z="0" />
+     <rotation name="rotFS94" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper95" unit="cm"  x="247.96" y="-676.3" z="0" />
+     <rotation name="rotFS95" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper96" unit="cm"  x="253.96" y="-676.3" z="0" />
+     <rotation name="rotFS96" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper97" unit="cm"  x="259.96" y="-676.3" z="0" />
+     <rotation name="rotFS97" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper98" unit="cm"  x="265.96" y="-676.3" z="0" />
+     <rotation name="rotFS98" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper99" unit="cm"  x="271.96" y="-676.3" z="0" />
+     <rotation name="rotFS99" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper100" unit="cm"  x="277.96" y="-676.3" z="0" />
+     <rotation name="rotFS100" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper101" unit="cm"  x="283.96" y="-676.3" z="0" />
+     <rotation name="rotFS101" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper102" unit="cm"  x="289.96" y="-676.3" z="0" />
+     <rotation name="rotFS102" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper103" unit="cm"  x="295.96" y="-676.3" z="0" />
+     <rotation name="rotFS103" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper104" unit="cm"  x="301.96" y="-676.3" z="0" />
+     <rotation name="rotFS104" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper105" unit="cm"  x="307.96" y="-676.3" z="0" />
+     <rotation name="rotFS105" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper106" unit="cm"  x="313.96" y="-676.3" z="0" />
+     <rotation name="rotFS106" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper107" unit="cm"  x="319.96" y="-676.3" z="0" />
+     <rotation name="rotFS107" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-0" unit="cm" x="-328.04" y="-506" z="-299.3018"/>
+      </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-0" unit="cm" 
+         x="325.045" y="-506" z="-299.3018"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-1" unit="cm" x="-328.04" y="-170" z="-299.3018"/>
+      </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-1" unit="cm" 
+         x="325.045" y="-170" z="-299.3018"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-2" unit="cm" x="-328.04" y="166" z="-299.3018"/>
+      </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-2" unit="cm" 
+         x="325.045" y="166" z="-299.3018"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-3" unit="cm" x="-328.04" y="502" z="-299.3018"/>
+      </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-3" unit="cm" 
+         x="325.045" y="502" z="-299.3018"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-4" unit="cm" x="-328.04" y="-506" z="-1.50000000000006"/>
+      </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-4" unit="cm" 
+         x="325.045" y="-506" z="-1.50000000000006"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-5" unit="cm" x="-328.04" y="-170" z="-1.50000000000006"/>
+      </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-5" unit="cm" 
+         x="325.045" y="-170" z="-1.50000000000006"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-6" unit="cm" x="-328.04" y="166" z="-1.50000000000006"/>
+      </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-6" unit="cm" 
+         x="325.045" y="166" z="-1.50000000000006"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-7" unit="cm" x="-328.04" y="502" z="-1.50000000000006"/>
+      </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-7" unit="cm" 
+         x="325.045" y="502" z="-1.50000000000006"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-8" unit="cm" x="-328.04" y="-506" z="296.3018"/>
+      </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-8" unit="cm" 
+         x="325.045" y="-506" z="296.3018"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-9" unit="cm" x="-328.04" y="-170" z="296.3018"/>
+      </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-9" unit="cm" 
+         x="325.045" y="-170" z="296.3018"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-10" unit="cm" x="-328.04" y="166" z="296.3018"/>
+      </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-10" unit="cm" 
+         x="325.045" y="166" z="296.3018"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid-11" unit="cm" x="-328.04" y="502" z="296.3018"/>
+      </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-11" unit="cm" 
+         x="325.045" y="502" z="296.3018"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-0-0"/>
+       <position name="posArapucaDouble0-Frame-0-0" unit="cm" 
+         x="-328.04"
+	 y="-633.7" 
+	 z="-261.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-0"/>
+       <position name="posOpArapucaDouble0-Frame-0-0" unit="cm" 
+         x="-327.3"
+	 y="-633.7" 
+	 z="-261.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-0-1"/>
+       <position name="posArapucaDouble1-Frame-0-0" unit="cm" 
+         x="-328.04"
+	 y="-543" 
+	 z="-407.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-1"/>
+       <position name="posOpArapucaDouble1-Frame-0-0" unit="cm" 
+         x="-327.3"
+	 y="-543" 
+	 z="-407.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-0-2"/>
+       <position name="posArapucaDouble2-Frame-0-0" unit="cm" 
+         x="-328.04"
+	 y="-469" 
+	 z="-190.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-2"/>
+       <position name="posOpArapucaDouble2-Frame-0-0" unit="cm" 
+         x="-327.3"
+	 y="-469" 
+	 z="-190.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-0-3"/>
+       <position name="posArapucaDouble3-Frame-0-0" unit="cm" 
+         x="-328.04"
+	 y="-378.3" 
+	 z="-336.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-3"/>
+       <position name="posOpArapucaDouble3-Frame-0-0" unit="cm" 
+         x="-327.3"
+	 y="-378.3" 
+	 z="-336.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-1-0"/>
+       <position name="posArapucaDouble0-Frame-0-1" unit="cm" 
+         x="-328.04"
+	 y="-633.7" 
+	 z="35.9999999999999"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-0"/>
+       <position name="posOpArapucaDouble0-Frame-0-1" unit="cm" 
+         x="-327.3"
+	 y="-633.7" 
+	 z="35.9999999999999"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-1-1"/>
+       <position name="posArapucaDouble1-Frame-0-1" unit="cm" 
+         x="-328.04"
+	 y="-543" 
+	 z="-110"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-1"/>
+       <position name="posOpArapucaDouble1-Frame-0-1" unit="cm" 
+         x="-327.3"
+	 y="-543" 
+	 z="-110"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-1-2"/>
+       <position name="posArapucaDouble2-Frame-0-1" unit="cm" 
+         x="-328.04"
+	 y="-469" 
+	 z="107"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-2"/>
+       <position name="posOpArapucaDouble2-Frame-0-1" unit="cm" 
+         x="-327.3"
+	 y="-469" 
+	 z="107"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-1-3"/>
+       <position name="posArapucaDouble3-Frame-0-1" unit="cm" 
+         x="-328.04"
+	 y="-378.3" 
+	 z="-39.0000000000001"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-3"/>
+       <position name="posOpArapucaDouble3-Frame-0-1" unit="cm" 
+         x="-327.3"
+	 y="-378.3" 
+	 z="-39.0000000000001"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-2-0"/>
+       <position name="posArapucaDouble0-Frame-0-2" unit="cm" 
+         x="-328.04"
+	 y="-633.7" 
+	 z="333.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-0"/>
+       <position name="posOpArapucaDouble0-Frame-0-2" unit="cm" 
+         x="-327.3"
+	 y="-633.7" 
+	 z="333.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-2-1"/>
+       <position name="posArapucaDouble1-Frame-0-2" unit="cm" 
+         x="-328.04"
+	 y="-543" 
+	 z="187.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-1"/>
+       <position name="posOpArapucaDouble1-Frame-0-2" unit="cm" 
+         x="-327.3"
+	 y="-543" 
+	 z="187.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-2-2"/>
+       <position name="posArapucaDouble2-Frame-0-2" unit="cm" 
+         x="-328.04"
+	 y="-469" 
+	 z="404.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-2"/>
+       <position name="posOpArapucaDouble2-Frame-0-2" unit="cm" 
+         x="-327.3"
+	 y="-469" 
+	 z="404.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-2-3"/>
+       <position name="posArapucaDouble3-Frame-0-2" unit="cm" 
+         x="-328.04"
+	 y="-378.3" 
+	 z="258.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-3"/>
+       <position name="posOpArapucaDouble3-Frame-0-2" unit="cm" 
+         x="-327.3"
+	 y="-378.3" 
+	 z="258.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-0-0"/>
+       <position name="posArapucaDouble0-Frame-1-0" unit="cm" 
+         x="-328.04"
+	 y="-297.7" 
+	 z="-261.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-0"/>
+       <position name="posOpArapucaDouble0-Frame-1-0" unit="cm" 
+         x="-327.3"
+	 y="-297.7" 
+	 z="-261.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-0-1"/>
+       <position name="posArapucaDouble1-Frame-1-0" unit="cm" 
+         x="-328.04"
+	 y="-207" 
+	 z="-407.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-1"/>
+       <position name="posOpArapucaDouble1-Frame-1-0" unit="cm" 
+         x="-327.3"
+	 y="-207" 
+	 z="-407.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-0-2"/>
+       <position name="posArapucaDouble2-Frame-1-0" unit="cm" 
+         x="-328.04"
+	 y="-133" 
+	 z="-190.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-2"/>
+       <position name="posOpArapucaDouble2-Frame-1-0" unit="cm" 
+         x="-327.3"
+	 y="-133" 
+	 z="-190.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-0-3"/>
+       <position name="posArapucaDouble3-Frame-1-0" unit="cm" 
+         x="-328.04"
+	 y="-42.3" 
+	 z="-336.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-3"/>
+       <position name="posOpArapucaDouble3-Frame-1-0" unit="cm" 
+         x="-327.3"
+	 y="-42.3" 
+	 z="-336.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-1-0"/>
+       <position name="posArapucaDouble0-Frame-1-1" unit="cm" 
+         x="-328.04"
+	 y="-297.7" 
+	 z="35.9999999999999"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-0"/>
+       <position name="posOpArapucaDouble0-Frame-1-1" unit="cm" 
+         x="-327.3"
+	 y="-297.7" 
+	 z="35.9999999999999"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-1-1"/>
+       <position name="posArapucaDouble1-Frame-1-1" unit="cm" 
+         x="-328.04"
+	 y="-207" 
+	 z="-110"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-1"/>
+       <position name="posOpArapucaDouble1-Frame-1-1" unit="cm" 
+         x="-327.3"
+	 y="-207" 
+	 z="-110"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-1-2"/>
+       <position name="posArapucaDouble2-Frame-1-1" unit="cm" 
+         x="-328.04"
+	 y="-133" 
+	 z="107"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-2"/>
+       <position name="posOpArapucaDouble2-Frame-1-1" unit="cm" 
+         x="-327.3"
+	 y="-133" 
+	 z="107"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-1-3"/>
+       <position name="posArapucaDouble3-Frame-1-1" unit="cm" 
+         x="-328.04"
+	 y="-42.3" 
+	 z="-39.0000000000001"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-3"/>
+       <position name="posOpArapucaDouble3-Frame-1-1" unit="cm" 
+         x="-327.3"
+	 y="-42.3" 
+	 z="-39.0000000000001"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-2-0"/>
+       <position name="posArapucaDouble0-Frame-1-2" unit="cm" 
+         x="-328.04"
+	 y="-297.7" 
+	 z="333.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-0"/>
+       <position name="posOpArapucaDouble0-Frame-1-2" unit="cm" 
+         x="-327.3"
+	 y="-297.7" 
+	 z="333.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-2-1"/>
+       <position name="posArapucaDouble1-Frame-1-2" unit="cm" 
+         x="-328.04"
+	 y="-207" 
+	 z="187.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-1"/>
+       <position name="posOpArapucaDouble1-Frame-1-2" unit="cm" 
+         x="-327.3"
+	 y="-207" 
+	 z="187.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-2-2"/>
+       <position name="posArapucaDouble2-Frame-1-2" unit="cm" 
+         x="-328.04"
+	 y="-133" 
+	 z="404.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-2"/>
+       <position name="posOpArapucaDouble2-Frame-1-2" unit="cm" 
+         x="-327.3"
+	 y="-133" 
+	 z="404.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-2-3"/>
+       <position name="posArapucaDouble3-Frame-1-2" unit="cm" 
+         x="-328.04"
+	 y="-42.3" 
+	 z="258.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-3"/>
+       <position name="posOpArapucaDouble3-Frame-1-2" unit="cm" 
+         x="-327.3"
+	 y="-42.3" 
+	 z="258.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-0-0"/>
+       <position name="posArapucaDouble0-Frame-2-0" unit="cm" 
+         x="-328.04"
+	 y="38.3" 
+	 z="-261.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-0"/>
+       <position name="posOpArapucaDouble0-Frame-2-0" unit="cm" 
+         x="-327.3"
+	 y="38.3" 
+	 z="-261.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-0-1"/>
+       <position name="posArapucaDouble1-Frame-2-0" unit="cm" 
+         x="-328.04"
+	 y="129" 
+	 z="-407.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-1"/>
+       <position name="posOpArapucaDouble1-Frame-2-0" unit="cm" 
+         x="-327.3"
+	 y="129" 
+	 z="-407.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-0-2"/>
+       <position name="posArapucaDouble2-Frame-2-0" unit="cm" 
+         x="-328.04"
+	 y="203" 
+	 z="-190.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-2"/>
+       <position name="posOpArapucaDouble2-Frame-2-0" unit="cm" 
+         x="-327.3"
+	 y="203" 
+	 z="-190.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-0-3"/>
+       <position name="posArapucaDouble3-Frame-2-0" unit="cm" 
+         x="-328.04"
+	 y="293.7" 
+	 z="-336.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-3"/>
+       <position name="posOpArapucaDouble3-Frame-2-0" unit="cm" 
+         x="-327.3"
+	 y="293.7" 
+	 z="-336.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-1-0"/>
+       <position name="posArapucaDouble0-Frame-2-1" unit="cm" 
+         x="-328.04"
+	 y="38.3" 
+	 z="35.9999999999999"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-0"/>
+       <position name="posOpArapucaDouble0-Frame-2-1" unit="cm" 
+         x="-327.3"
+	 y="38.3" 
+	 z="35.9999999999999"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-1-1"/>
+       <position name="posArapucaDouble1-Frame-2-1" unit="cm" 
+         x="-328.04"
+	 y="129" 
+	 z="-110"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-1"/>
+       <position name="posOpArapucaDouble1-Frame-2-1" unit="cm" 
+         x="-327.3"
+	 y="129" 
+	 z="-110"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-1-2"/>
+       <position name="posArapucaDouble2-Frame-2-1" unit="cm" 
+         x="-328.04"
+	 y="203" 
+	 z="107"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-2"/>
+       <position name="posOpArapucaDouble2-Frame-2-1" unit="cm" 
+         x="-327.3"
+	 y="203" 
+	 z="107"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-1-3"/>
+       <position name="posArapucaDouble3-Frame-2-1" unit="cm" 
+         x="-328.04"
+	 y="293.7" 
+	 z="-39.0000000000001"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-3"/>
+       <position name="posOpArapucaDouble3-Frame-2-1" unit="cm" 
+         x="-327.3"
+	 y="293.7" 
+	 z="-39.0000000000001"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-2-0"/>
+       <position name="posArapucaDouble0-Frame-2-2" unit="cm" 
+         x="-328.04"
+	 y="38.3" 
+	 z="333.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-0"/>
+       <position name="posOpArapucaDouble0-Frame-2-2" unit="cm" 
+         x="-327.3"
+	 y="38.3" 
+	 z="333.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-2-1"/>
+       <position name="posArapucaDouble1-Frame-2-2" unit="cm" 
+         x="-328.04"
+	 y="129" 
+	 z="187.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-1"/>
+       <position name="posOpArapucaDouble1-Frame-2-2" unit="cm" 
+         x="-327.3"
+	 y="129" 
+	 z="187.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-2-2"/>
+       <position name="posArapucaDouble2-Frame-2-2" unit="cm" 
+         x="-328.04"
+	 y="203" 
+	 z="404.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-2"/>
+       <position name="posOpArapucaDouble2-Frame-2-2" unit="cm" 
+         x="-327.3"
+	 y="203" 
+	 z="404.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-2-3"/>
+       <position name="posArapucaDouble3-Frame-2-2" unit="cm" 
+         x="-328.04"
+	 y="293.7" 
+	 z="258.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-3"/>
+       <position name="posOpArapucaDouble3-Frame-2-2" unit="cm" 
+         x="-327.3"
+	 y="293.7" 
+	 z="258.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-0-0"/>
+       <position name="posArapucaDouble0-Frame-3-0" unit="cm" 
+         x="-328.04"
+	 y="374.3" 
+	 z="-261.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-0"/>
+       <position name="posOpArapucaDouble0-Frame-3-0" unit="cm" 
+         x="-327.3"
+	 y="374.3" 
+	 z="-261.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-0-1"/>
+       <position name="posArapucaDouble1-Frame-3-0" unit="cm" 
+         x="-328.04"
+	 y="465" 
+	 z="-407.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-1"/>
+       <position name="posOpArapucaDouble1-Frame-3-0" unit="cm" 
+         x="-327.3"
+	 y="465" 
+	 z="-407.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-0-2"/>
+       <position name="posArapucaDouble2-Frame-3-0" unit="cm" 
+         x="-328.04"
+	 y="539" 
+	 z="-190.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-2"/>
+       <position name="posOpArapucaDouble2-Frame-3-0" unit="cm" 
+         x="-327.3"
+	 y="539" 
+	 z="-190.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-0-3"/>
+       <position name="posArapucaDouble3-Frame-3-0" unit="cm" 
+         x="-328.04"
+	 y="629.7" 
+	 z="-336.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-3"/>
+       <position name="posOpArapucaDouble3-Frame-3-0" unit="cm" 
+         x="-327.3"
+	 y="629.7" 
+	 z="-336.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-1-0"/>
+       <position name="posArapucaDouble0-Frame-3-1" unit="cm" 
+         x="-328.04"
+	 y="374.3" 
+	 z="35.9999999999999"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-0"/>
+       <position name="posOpArapucaDouble0-Frame-3-1" unit="cm" 
+         x="-327.3"
+	 y="374.3" 
+	 z="35.9999999999999"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-1-1"/>
+       <position name="posArapucaDouble1-Frame-3-1" unit="cm" 
+         x="-328.04"
+	 y="465" 
+	 z="-110"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-1"/>
+       <position name="posOpArapucaDouble1-Frame-3-1" unit="cm" 
+         x="-327.3"
+	 y="465" 
+	 z="-110"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-1-2"/>
+       <position name="posArapucaDouble2-Frame-3-1" unit="cm" 
+         x="-328.04"
+	 y="539" 
+	 z="107"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-2"/>
+       <position name="posOpArapucaDouble2-Frame-3-1" unit="cm" 
+         x="-327.3"
+	 y="539" 
+	 z="107"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-1-3"/>
+       <position name="posArapucaDouble3-Frame-3-1" unit="cm" 
+         x="-328.04"
+	 y="629.7" 
+	 z="-39.0000000000001"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-3"/>
+       <position name="posOpArapucaDouble3-Frame-3-1" unit="cm" 
+         x="-327.3"
+	 y="629.7" 
+	 z="-39.0000000000001"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-2-0"/>
+       <position name="posArapucaDouble0-Frame-3-2" unit="cm" 
+         x="-328.04"
+	 y="374.3" 
+	 z="333.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-0"/>
+       <position name="posOpArapucaDouble0-Frame-3-2" unit="cm" 
+         x="-327.3"
+	 y="374.3" 
+	 z="333.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-2-1"/>
+       <position name="posArapucaDouble1-Frame-3-2" unit="cm" 
+         x="-328.04"
+	 y="465" 
+	 z="187.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-1"/>
+       <position name="posOpArapucaDouble1-Frame-3-2" unit="cm" 
+         x="-327.3"
+	 y="465" 
+	 z="187.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-2-2"/>
+       <position name="posArapucaDouble2-Frame-3-2" unit="cm" 
+         x="-328.04"
+	 y="539" 
+	 z="404.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-2"/>
+       <position name="posOpArapucaDouble2-Frame-3-2" unit="cm" 
+         x="-327.3"
+	 y="539" 
+	 z="404.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-2-3"/>
+       <position name="posArapucaDouble3-Frame-3-2" unit="cm" 
+         x="-328.04"
+	 y="629.7" 
+	 z="258.8018"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-3"/>
+       <position name="posOpArapucaDouble3-Frame-3-2" unit="cm" 
+         x="-327.3"
+	 y="629.7" 
+	 z="258.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_0-0"/>
+       <position name="posArapuca0-Lat-0" unit="cm" 
+         x="285.03"
+	 y="-734" 
+	 z="-297.8018"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_0-0"/>
+       <position name="posOpArapuca0-Lat-0" unit="cm" 
+         x="285.03"
+	 y="-733.26" 
+	 z="-297.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_0-1"/>
+       <position name="posArapuca1-Lat-0" unit="cm" 
+         x="210.03"
+	 y="-734" 
+	 z="-297.8018"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_0-1"/>
+       <position name="posOpArapuca1-Lat-0" unit="cm" 
+         x="210.03"
+	 y="-733.26" 
+	 z="-297.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_0-2"/>
+       <position name="posArapuca2-Lat-0" unit="cm" 
+         x="135.03"
+	 y="-734" 
+	 z="-297.8018"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_0-2"/>
+       <position name="posOpArapuca2-Lat-0" unit="cm" 
+         x="135.03"
+	 y="-733.26" 
+	 z="-297.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_0-3"/>
+       <position name="posArapuca3-Lat-0" unit="cm" 
+         x="60.03"
+	 y="-734" 
+	 z="-297.8018"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_0-3"/>
+       <position name="posOpArapuca3-Lat-0" unit="cm" 
+         x="60.03"
+	 y="-733.26" 
+	 z="-297.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_0-4"/>
+       <position name="posArapuca4-Lat-0" unit="cm" 
+         x="285.03"
+	 y="734" 
+	 z="-297.8018"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_0-4"/>
+       <position name="posOpArapuca4-Lat-0" unit="cm" 
+         x="285.03"
+	 y="733.26" 
+	 z="-297.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_0-5"/>
+       <position name="posArapuca5-Lat-0" unit="cm" 
+         x="210.03"
+	 y="734" 
+	 z="-297.8018"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_0-5"/>
+       <position name="posOpArapuca5-Lat-0" unit="cm" 
+         x="210.03"
+	 y="733.26" 
+	 z="-297.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_0-6"/>
+       <position name="posArapuca6-Lat-0" unit="cm" 
+         x="135.03"
+	 y="734" 
+	 z="-297.8018"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_0-6"/>
+       <position name="posOpArapuca6-Lat-0" unit="cm" 
+         x="135.03"
+	 y="733.26" 
+	 z="-297.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_0-7"/>
+       <position name="posArapuca7-Lat-0" unit="cm" 
+         x="60.03"
+	 y="734" 
+	 z="-297.8018"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_0-7"/>
+       <position name="posOpArapuca7-Lat-0" unit="cm" 
+         x="60.03"
+	 y="733.26" 
+	 z="-297.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_1-0"/>
+       <position name="posArapuca0-Lat-1" unit="cm" 
+         x="285.03"
+	 y="-734" 
+	 z="2.8421709430404e-13"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_1-0"/>
+       <position name="posOpArapuca0-Lat-1" unit="cm" 
+         x="285.03"
+	 y="-733.26" 
+	 z="2.8421709430404e-13"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_1-1"/>
+       <position name="posArapuca1-Lat-1" unit="cm" 
+         x="210.03"
+	 y="-734" 
+	 z="2.8421709430404e-13"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_1-1"/>
+       <position name="posOpArapuca1-Lat-1" unit="cm" 
+         x="210.03"
+	 y="-733.26" 
+	 z="2.8421709430404e-13"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_1-2"/>
+       <position name="posArapuca2-Lat-1" unit="cm" 
+         x="135.03"
+	 y="-734" 
+	 z="2.8421709430404e-13"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_1-2"/>
+       <position name="posOpArapuca2-Lat-1" unit="cm" 
+         x="135.03"
+	 y="-733.26" 
+	 z="2.8421709430404e-13"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_1-3"/>
+       <position name="posArapuca3-Lat-1" unit="cm" 
+         x="60.03"
+	 y="-734" 
+	 z="2.8421709430404e-13"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_1-3"/>
+       <position name="posOpArapuca3-Lat-1" unit="cm" 
+         x="60.03"
+	 y="-733.26" 
+	 z="2.8421709430404e-13"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_1-4"/>
+       <position name="posArapuca4-Lat-1" unit="cm" 
+         x="285.03"
+	 y="734" 
+	 z="2.8421709430404e-13"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_1-4"/>
+       <position name="posOpArapuca4-Lat-1" unit="cm" 
+         x="285.03"
+	 y="733.26" 
+	 z="2.8421709430404e-13"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_1-5"/>
+       <position name="posArapuca5-Lat-1" unit="cm" 
+         x="210.03"
+	 y="734" 
+	 z="2.8421709430404e-13"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_1-5"/>
+       <position name="posOpArapuca5-Lat-1" unit="cm" 
+         x="210.03"
+	 y="733.26" 
+	 z="2.8421709430404e-13"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_1-6"/>
+       <position name="posArapuca6-Lat-1" unit="cm" 
+         x="135.03"
+	 y="734" 
+	 z="2.8421709430404e-13"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_1-6"/>
+       <position name="posOpArapuca6-Lat-1" unit="cm" 
+         x="135.03"
+	 y="733.26" 
+	 z="2.8421709430404e-13"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_1-7"/>
+       <position name="posArapuca7-Lat-1" unit="cm" 
+         x="60.03"
+	 y="734" 
+	 z="2.8421709430404e-13"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_1-7"/>
+       <position name="posOpArapuca7-Lat-1" unit="cm" 
+         x="60.03"
+	 y="733.26" 
+	 z="2.8421709430404e-13"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_2-0"/>
+       <position name="posArapuca0-Lat-2" unit="cm" 
+         x="285.03"
+	 y="-734" 
+	 z="297.8018"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_2-0"/>
+       <position name="posOpArapuca0-Lat-2" unit="cm" 
+         x="285.03"
+	 y="-733.26" 
+	 z="297.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_2-1"/>
+       <position name="posArapuca1-Lat-2" unit="cm" 
+         x="210.03"
+	 y="-734" 
+	 z="297.8018"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_2-1"/>
+       <position name="posOpArapuca1-Lat-2" unit="cm" 
+         x="210.03"
+	 y="-733.26" 
+	 z="297.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_2-2"/>
+       <position name="posArapuca2-Lat-2" unit="cm" 
+         x="135.03"
+	 y="-734" 
+	 z="297.8018"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_2-2"/>
+       <position name="posOpArapuca2-Lat-2" unit="cm" 
+         x="135.03"
+	 y="-733.26" 
+	 z="297.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_2-3"/>
+       <position name="posArapuca3-Lat-2" unit="cm" 
+         x="60.03"
+	 y="-734" 
+	 z="297.8018"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_2-3"/>
+       <position name="posOpArapuca3-Lat-2" unit="cm" 
+         x="60.03"
+	 y="-733.26" 
+	 z="297.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_2-4"/>
+       <position name="posArapuca4-Lat-2" unit="cm" 
+         x="285.03"
+	 y="734" 
+	 z="297.8018"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_2-4"/>
+       <position name="posOpArapuca4-Lat-2" unit="cm" 
+         x="285.03"
+	 y="733.26" 
+	 z="297.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_2-5"/>
+       <position name="posArapuca5-Lat-2" unit="cm" 
+         x="210.03"
+	 y="734" 
+	 z="297.8018"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_2-5"/>
+       <position name="posOpArapuca5-Lat-2" unit="cm" 
+         x="210.03"
+	 y="733.26" 
+	 z="297.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_2-6"/>
+       <position name="posArapuca6-Lat-2" unit="cm" 
+         x="135.03"
+	 y="734" 
+	 z="297.8018"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_2-6"/>
+       <position name="posOpArapuca6-Lat-2" unit="cm" 
+         x="135.03"
+	 y="733.26" 
+	 z="297.8018"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_2-7"/>
+       <position name="posArapuca7-Lat-2" unit="cm" 
+         x="60.03"
+	 y="734" 
+	 z="297.8018"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_2-7"/>
+       <position name="posOpArapuca7-Lat-2" unit="cm" 
+         x="60.03"
+	 y="733.26" 
+	 z="297.8018"/>
+     </physvol>
+    </volume>
+
+    <volume name="volFoamPadding">
+      <materialref ref="fibrous_glass"/>
+      <solidref ref="FoamPadding"/>
+    </volume>
+
+    <volume name="volSteelSupport">
+      <materialref ref="AirSteelMixture"/>
+      <solidref ref="SteelSupport"/>
+    </volume>
+
+    <volume name="volDetEnclosure">
+      <materialref ref="Air"/>
+      <solidref ref="DetEnclosure"/>
+
+       <physvol>
+           <volumeref ref="volFoamPadding"/>
+           <positionref ref="posCryoInDetEnc"/>
+       </physvol>
+       <physvol>
+           <volumeref ref="volSteelSupport"/>
+           <positionref ref="posCryoInDetEnc"/>
+       </physvol>
+       <physvol>
+           <volumeref ref="volCryostat"/>
+           <positionref ref="posCryoInDetEnc"/>
+       </physvol>
+    </volume>
+
+    <volume name="volWorld" >
+      <materialref ref="DUSEL_Rock"/>
+      <solidref ref="World"/>
+
+      <physvol>
+        <volumeref ref="volDetEnclosure"/>
+	<position name="posDetEnclosure" unit="cm" x="50.04" y="-1.13686837721616e-13" z="448.2027"/>
+      </physvol>
+
+    </volume>
+</structure>
+  <setup name="Default" version="1.0">
+    <world ref="volWorld"/>
+  </setup>
+</gdml_simple_extension>

--- a/dunecore/Geometry/gdml/generate_dunevd10kt_3view_30deg_v4_refactored.pl
+++ b/dunecore/Geometry/gdml/generate_dunevd10kt_3view_30deg_v4_refactored.pl
@@ -1,0 +1,1988 @@
+#!/usr/bin/perl
+
+#
+#
+#  First attempt to make a GDML fragment generator for the DUNE vertical drift 
+#  10kt detector geometry with 3 views: +/- Xdeg for induction and 90 deg collection
+#  The lower chamber is not added yet. 
+#  !!!NOTE!!!: the readout is on a positive Y plane (drift along horizontal X)
+#              due to current reco limitations)
+#  No photon detectors declared
+#  Simplified treatment of inter-module dead spaces
+#
+#  Created: Thu Oct  1 16:45:27 CEST 2020
+#           Vyacheslav Galymov <vgalymov@ipnl.in2p3.fr>
+#
+#  Modified:
+#           VG: Added defs to enable use in the refactored sim framework
+#           VG: 23.02.21 Adjust plane dimensions to fit a given number of ch per side
+#           VG: 23.02.21 Group CRUs in CRPs
+#           VG: 02.03.21 The length for the ROP is force to be the lenght
+#                        given by nch_collection x pitch_collection
+#    V2:    Laura Paulucci (lpaulucc@fnal.gov): Sept 2021 PDS added. 
+#             Use option -pds=1 for backup design (membrane only coverage).
+#             Default (pds=0) is the reference design (~4-pi).
+#             This is linked with a larger geometry to account for photon propagation, generate it with -k=4.
+#             Field Cage is turned on with reference and backup designs to match PDS option.
+#	      For not including the pds, please use option -pds=-1
+#    V3:      Mar 2022: Cathode included
+#             Apr 2022: Pitch and number of channels changed. 
+#                       Collection pitch = 5.1 mm (4.89 mm in v2)
+#                       Induction pitch = 7.65 mm (7.335 mm in v2) 
+#                       Reference for changes: https://indico.fnal.gov/event/53111/timetable/
+#    V4:    May 2022: Inclusion of anode plate on top of the 3 wire planes as requested by the background TF.
+#           This is included together with the cathode switch on. In order to avoid overlaps, the gaseous argon
+#           was decreased and displaced by $anodePlateWidth = 0.01 cm. Currently the material of this plate is 
+#           set to vm2000 so that no additional geometry (ReflAnode) is needed to obtain optical fast simulation.
+#           TO DO: include perforated PCB in the gdml (see LEMs in dual phase gdml) 
+#
+#################################################################################
+
+# Each subroutine generates a fragment GDML file, and the last subroutine
+# creates an XML file that make_gdml.pl will use to appropriately arrange
+# the fragment GDML files to create the final desired DUNE GDML file, 
+# to be named by make_gdml output command
+
+##################################################################################
+
+
+#use warnings;
+use gdmlMaterials;
+use Math::Trig;
+use Getopt::Long;
+use Math::BigFloat;
+Math::BigFloat->precision(-16);
+
+###
+GetOptions( "help|h" => \$help,
+	    "suffix|s:s" => \$suffix,
+	    "output|o:s" => \$output,
+	    "wires|w:s" => \$wires,  
+            "workspace|k:s" => \$wkspc,
+            "pdsconfig|pds:s" => \$pdsconfig);
+
+my $FieldCage_switch="on";
+my $Cathode_switch="on";
+
+if ( defined $help )
+{
+    # If the user requested help, print the usage notes and exit.
+    usage();
+    exit;
+}
+
+if ( ! defined $suffix )
+{
+    # The user didn't supply a suffix, so append nothing to the file
+    # names.
+    $suffix = "";
+}
+else
+{
+    # Otherwise, stick a "-" before the suffix, so that a suffix of
+    # "test" applied to filename.gdml becomes "filename-test.gdml".
+    $suffix = "-" . $suffix;
+}
+
+
+$workspace = 0;
+if(defined $wkspc ) 
+{
+    $workspace = $wkspc;
+}
+elsif ( $workspace != 0 )
+{
+    print "\t\tCreating smaller workspace geometry.\n";
+}
+
+if ( ! defined $pdsconfig )
+{
+    $pdsconfig = 0;
+    print "\t\tCreating reference design: 4-pi PDS converage.\n";
+}
+elsif ( $pdsconfig == 1 )
+{
+    print "\t\tCreating backup design: membrane-only PDS coverage.\n";
+}
+
+# set wires on to be the default, unless given an input by the user
+$wires_on = 1; # 1=on, 0=off
+if (defined $wires)
+{
+    $wires_on = $wires;
+}
+
+$tpc_on = 1;
+$basename="_";
+
+
+##################################################################
+############## Parameters for One Readout Panel ##################
+
+# parameters for 1.5 x 1.7 sub-unit Charge Readout Module / Unit
+#$widthPCBActive   = 169.0; # cm 
+#$lengthPCBActive  = 150.0; # cm
+
+# views and channel counts
+%nChans = ('Ind1', 286, 'Ind1Bot', 96, 'Ind2', 286, 'Col', 292);
+$nViews = keys %nChans;
+#print "$nViews %nChans\n";
+
+# first induction view
+$wirePitchU      = 0.765;  # cm
+$wireAngleU      = 150.0;   # deg
+
+# second induction view
+$wirePitchV      = 0.765;  # cm
+$wireAngleV      = 30.0;    # deg
+
+
+# last collection view
+$wirePitchZ      = 0.51;   # cm
+
+# force length to be equal to collection nch x pitch
+$lengthPCBActive = $wirePitchZ * $nChans{'Col'};
+$widthPCBActive  = 167.7006;
+
+#
+$borderCRM       = 0.0;     # border space aroud each CRM 
+
+$widthCRM_active  = $widthPCBActive;  
+$lengthCRM_active = $lengthPCBActive; 
+
+$widthCRM  = $widthPCBActive  + 2 * $borderCRM;
+$lengthCRM = $lengthPCBActive + 2 * $borderCRM;
+
+$borderCRP = 0.5; # cm
+
+# number of CRMs in y and z
+$nCRM_x   = 4 * 2;
+$nCRM_z   = 20 * 2;
+
+# create a smaller geometry
+if( $workspace == 1 )
+{
+    $nCRM_x = 1 * 2;
+    $nCRM_z = 1 * 2;
+}
+
+# create a smaller geometry
+if( $workspace == 2 )
+{
+    $nCRM_x = 2 * 2;
+    $nCRM_z = 2 * 2;
+}
+
+# create a smaller geometry (1x8x6)
+if( $workspace == 3 )
+{
+    $nCRM_x = 4 * 2;
+    $nCRM_z = 3 * 2;
+}
+
+# create pds geometry (1x8x14)
+if( $workspace == 4 )
+{
+    $nCRM_x = 4 * 2;
+    $nCRM_z = 7 * 2;
+}
+
+
+# calculate tpc area based on number of CRMs and their dimensions
+# each CRP should have a 2x2 CRMs
+$widthTPCActive  = $nCRM_x * $widthCRM + $nCRM_x * $borderCRP;  # around 1200 for full module
+$lengthTPCActive = $nCRM_z * $lengthCRM + $nCRM_z * $borderCRP; # around 6000 for full module
+
+# active volume dimensions 
+$driftTPCActive  = 650.0;
+
+# model anode strips as wires of some diameter
+$padWidth          = 0.02;
+$ReadoutPlane      = $nViews * $padWidth; # 3 readout planes (no space b/w)!
+
+# anode plate definition
+$anodePlateWidth   = $padWidth/2.;
+
+##################################################################
+############## Parameters for TPC and inner volume ###############
+
+# inner volume dimensions of the cryostat
+$Argon_x = 1510;
+$Argon_y = 1510;
+$Argon_z = 6200;
+
+# width of gas argon layer on top
+$HeightGaseousAr = 100;
+
+if( $workspace != 0 )
+{
+    #active tpc + 1.0 m buffer on each side
+    $Argon_x = $driftTPCActive + $HeightGaseousAr + $ReadoutPlane + 100;
+    $Argon_y = $widthTPCActive + 200;
+    $Argon_z = $lengthTPCActive + 200;
+}
+
+
+# size of liquid argon buffer
+$xLArBuffer = $Argon_x - $driftTPCActive - $HeightGaseousAr - $ReadoutPlane;
+$yLArBuffer = 0.5 * ($Argon_y - $widthTPCActive);
+$zLArBuffer = 0.5 * ($Argon_z - $lengthTPCActive);
+
+# cryostat 
+$SteelThickness = 0.12; # membrane
+
+$Cryostat_x = $Argon_x + 2*$SteelThickness;
+$Cryostat_y = $Argon_y + 2*$SteelThickness;
+$Cryostat_z = $Argon_z + 2*$SteelThickness;
+
+##################################################################
+############## DetEnc and World relevant parameters  #############
+
+$SteelSupport_x  =  100;
+$SteelSupport_y  =  100;
+$SteelSupport_z  =  100; 
+$FoamPadding     =  80;  
+$FracMassOfSteel =  0.5; #The steel support is not a solid block, but a mixture of air and steel
+$FracMassOfAir   =  1 - $FracMassOfSteel;
+
+
+$SpaceSteelSupportToWall    = 100;
+$SpaceSteelSupportToCeiling = 100;
+
+$DetEncX  =    $Cryostat_x
+                  + 2*($SteelSupport_x + $FoamPadding) + $SpaceSteelSupportToCeiling;
+
+$DetEncY  =    $Cryostat_y
+                  + 2*($SteelSupport_y + $FoamPadding) + 2*$SpaceSteelSupportToWall;
+
+$DetEncZ  =    $Cryostat_z
+                  + 2*($SteelSupport_z + $FoamPadding) + 2*$SpaceSteelSupportToWall;
+
+$posCryoInDetEnc_x = - $DetEncX/2 + $SteelSupport_x + $FoamPadding + $Cryostat_x/2;
+
+
+$RockThickness = 4000;
+
+  # We want the world origin to be vertically centered on active TPC
+  # This is to be added to the x and y position of every volume in volWorld
+
+$OriginXSet =  $DetEncX/2.0
+             - $SteelSupport_x
+             - $FoamPadding
+             - $SteelThickness
+             - $xLArBuffer
+             - $driftTPCActive/2.0;
+
+$OriginYSet =   $DetEncY/2.0
+              - $SpaceSteelSupportToWall
+              - $SteelSupport_y
+              - $FoamPadding
+              - $SteelThickness
+              - $yLArBuffer
+              - $widthTPCActive/2.0;
+
+  # We want the world origin to be at the very front of the fiducial volume.
+  # move it to the front of the enclosure, then back it up through the concrete/foam, 
+  # then through the Cryostat shell, then through the upstream dead LAr (including the
+  # dead LAr on the edge of the TPC)
+  # This is to be added to the z position of every volume in volWorld
+
+$OriginZSet =   $DetEncZ/2.0 
+              - $SpaceSteelSupportToWall
+              - $SteelSupport_z
+              - $FoamPadding
+              - $SteelThickness
+              - $zLArBuffer
+              - $borderCRM;
+
+##################################################################
+############## Field Cage Parameters ###############
+$FieldShaperLongTubeLength  =  $lengthTPCActive;
+$FieldShaperShortTubeLength =  $widthTPCActive;
+#$FieldShaperInnerRadius = 1.485;
+#$FieldShaperOuterRadius = 1.685;
+#$FieldShaperTorRad = 1.69;
+$FieldShaperInnerRadius = 0.5; #cm
+$FieldShaperOuterRadius = 2.285; #cm
+$FieldShaperOuterRadiusSlim = 0.75; #cm
+$FieldShaperTorRad = 2.3; #cm
+
+$FieldShaperLength = $FieldShaperLongTubeLength + 2*$FieldShaperOuterRadius+ 2*$FieldShaperTorRad;
+$FieldShaperWidth =  $FieldShaperShortTubeLength + 2*$FieldShaperOuterRadius+ 2*$FieldShaperTorRad;
+
+$FieldShaperSeparation = 6.0; #cm
+$NFieldShapers = ($driftTPCActive/$FieldShaperSeparation) - 1;
+
+$FieldCageSizeX = $FieldShaperSeparation*$NFieldShapers+2;
+$FieldCageSizeY = $FieldShaperWidth+2;
+$FieldCageSizeZ = $FieldShaperLength+2;
+
+
+##################################################################
+############## Cathode Parameters ###############
+$heightCathode=4.0; #cm
+$CathodeBorder=4.0; #cm
+$widthCathode=2*$widthCRM;
+$lengthCathode=2*$lengthCRM;
+$widthCathodeVoid=76.35;
+$lengthCathodeVoid=67.0;
+
+
+####################################################################
+######################## ARAPUCA Dimensions ########################
+## in cm
+
+$ArapucaOut_x = 65.0; 
+$ArapucaOut_y = 2.5;
+$ArapucaOut_z = 65.0; 
+$ArapucaIn_x = 60.0;
+$ArapucaIn_y = 2.0;
+$ArapucaIn_z = 60.0;
+$ArapucaAcceptanceWindow_x = 60.0;
+$ArapucaAcceptanceWindow_y = 1.0;
+$ArapucaAcceptanceWindow_z = 60.0;
+$GapPD = 0.5; #Arapuca distance from Cathode Frame
+$FrameToArapucaSpace       =    1.0; #Small vertical gap over laterals to avoid overlap
+$FrameToArapucaSpaceLat    =   $yLArBuffer - 60.0; #Arapucas 60 cm behind FC. At this moment, should cover the thickness of Frame + small gap to prevent overlap. VALUE NEEDS TO BE CHECKED!!!
+$VerticalPDdist = 75.0; #distance of arapucas (center to center) in the y direction 
+$HorizontalPDdist = 150.0; #distance of arapucas (center to center) in the x direction
+
+#Positions of the 4 arapucas with respect to the Frame center --> arapucas over the cathode
+$list_posx_bot[0]=-2*$widthCathodeVoid - 2.0*$CathodeBorder + $GapPD + 0.5*$ArapucaOut_x;
+$list_posz_bot[0]= 0.5*$lengthCathodeVoid + $CathodeBorder;
+$list_posx_bot[1]= - $CathodeBorder - $GapPD - 0.5*$ArapucaOut_x;
+$list_posz_bot[1]=-1.5*$lengthCathodeVoid - 2.0*$CathodeBorder;
+$list_posx_bot[2]=-$list_posx_bot[1];
+$list_posz_bot[2]=-$list_posz_bot[1];
+$list_posx_bot[3]=-$list_posx_bot[0];
+$list_posz_bot[3]=-$list_posz_bot[0];
+
+
+#+++++++++++++++++++++++++ End defining variables ++++++++++++++++++++++++++
+
+
+#+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+#+++++++++++++++++++++++++++++++++++++++++ usage +++++++++++++++++++++++++++++++++++++++++
+#+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+sub usage()
+{
+    print "Usage: $0 [-h|--help] [-o|--output <fragments-file>] [-s|--suffix <string>]\n";
+    print "       if -o is omitted, output goes to STDOUT; <fragments-file> is input to make_gdml.pl\n";
+    print "       -s <string> appends the string to the file names; useful for multiple detector versions\n";
+    print "       -h prints this message, then quits\n";
+}
+
+
+sub gen_Extend()
+{
+
+# Create the <define> fragment file name, 
+# add file to list of fragments,
+# and open it
+    $DEF = $basename."_Ext" . $suffix . ".gdml";
+    push (@gdmlFiles, $DEF);
+    $DEF = ">" . $DEF;
+    open(DEF) or die("Could not open file $DEF for writing");
+
+print DEF <<EOF;
+<?xml version='1.0'?>
+<gdml>
+<extension>
+   <color name="magenta"     R="0.0"  G="1.0"  B="0.0"  A="1.0" />
+   <color name="green"       R="0.0"  G="1.0"  B="0.0"  A="1.0" />
+   <color name="red"         R="1.0"  G="0.0"  B="0.0"  A="1.0" />
+   <color name="blue"        R="0.0"  G="0.0"  B="1.0"  A="1.0" />
+   <color name="yellow"      R="1.0"  G="1.0"  B="0.0"  A="1.0" />    
+</extension>
+</gdml>
+EOF
+    close (DEF);
+}
+
+#+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+#++++++++++++++++++++++++++++++++++++++ gen_Define +++++++++++++++++++++++++++++++++++++++
+#+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+sub gen_Define()
+{
+
+# Create the <define> fragment file name, 
+# add file to list of fragments,
+# and open it
+    $DEF = $basename."_Def" . $suffix . ".gdml";
+    push (@gdmlFiles, $DEF);
+    $DEF = ">" . $DEF;
+    open(DEF) or die("Could not open file $DEF for writing");
+
+
+print DEF <<EOF;
+<?xml version='1.0'?>
+<gdml>
+<define>
+
+<!--
+
+
+
+-->
+
+   <position name="posCryoInDetEnc"     unit="cm" x="$posCryoInDetEnc_x" y="0" z="0"/>
+   <position name="posCenter"           unit="cm" x="0" y="0" z="0"/>
+   <rotation name="rUWireAboutX"        unit="deg" x="$wireAngleU" y="0" z="0"/>
+   <rotation name="rVWireAboutX"        unit="deg" x="$wireAngleV" y="0" z="0"/>
+   <rotation name="rPlus90AboutX"       unit="deg" x="90" y="0" z="0"/>
+   <rotation name="rPlus90AboutY"       unit="deg" x="0" y="90" z="0"/>
+   <rotation name="rPlus90AboutXPlus90AboutY" unit="deg" x="90" y="90" z="0"/>
+   <rotation name="rMinus90AboutX"      unit="deg" x="270" y="0" z="0"/>
+   <rotation name="rMinus90AboutY"      unit="deg" x="0" y="270" z="0"/>
+   <rotation name="rMinus90AboutYMinus90AboutX"       unit="deg" x="270" y="270" z="0"/>
+   <rotation name="rPlus180AboutX"	unit="deg" x="180" y="0"   z="0"/>
+   <rotation name="rPlus180AboutY"	unit="deg" x="0" y="180"   z="0"/>
+   <rotation name="rPlus180AboutXPlus180AboutY"	unit="deg" x="180" y="180"   z="0"/>
+   <rotation name="rIdentity"		unit="deg" x="0" y="0"   z="0"/>
+</define>
+</gdml>
+EOF
+    close (DEF);
+}
+
+#+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+#+++++++++++++++++++++++++++++++++++++ gen_Materials +++++++++++++++++++++++++++++++++++++
+#+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+sub gen_Materials()
+{
+
+# Create the <materials> fragment file name,
+# add file to list of output GDML fragments,
+# and open it
+    $MAT = $basename."_Materials" . $suffix . ".gdml";
+    push (@gdmlFiles, $MAT);
+    $MAT = ">" . $MAT;
+
+    open(MAT) or die("Could not open file $MAT for writing");
+
+    # Add any materials special to this geometry by defining a mulitline string
+    # and passing it to the gdmlMaterials::gen_Materials() function.
+my $asmix = <<EOF;
+  <!-- preliminary values -->
+  <material name="AirSteelMixture" formula="AirSteelMixture">
+   <D value=" 0.001205*(1-$FracMassOfSteel) + 7.9300*$FracMassOfSteel " unit="g/cm3"/>
+   <fraction n="$FracMassOfSteel" ref="STEEL_STAINLESS_Fe7Cr2Ni"/>
+   <fraction n="$FracMassOfAir"   ref="Air"/>
+  </material>
+  <material name="vm2000" formula="vm2000">
+    <D value="1.2" unit="g/cm3"/>
+    <composite n="2" ref="carbon"/>
+    <composite n="4" ref="hydrogen"/>
+  </material>
+EOF
+
+    # add the general materials used anywere
+    print MAT gdmlMaterials::gen_Materials( $asmix );
+
+    close(MAT);
+}
+
+
+#+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+#++++++++++++++++++++++++++++++++++++++++ gen_TPC ++++++++++++++++++++++++++++++++++++++++
+#+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+# line clip on the rectangle boundary
+sub lineClip {
+    my $x0  = $_[0];
+    my $y0  = $_[1];
+    my $nx  = $_[2];
+    my $ny  = $_[3];
+    my $rcl = $_[4];
+    my $rcw = $_[5];
+
+    my $tol = 1.0E-4;
+    my @endpts = ();
+    if( abs( nx ) < tol ){
+	push( @endpts, ($x0, 0) );
+	push( @endpts, ($x0, $rcw) );
+	return @endpts;
+    }
+    if( abs( ny ) < tol ){
+	push( @endpts, (0, $y0) );
+	push( @endpts, ($rcl, $y0) );
+	return @endpts;
+    }
+    
+    # left border at x = 0
+    my $y = $y0 - $x0 * $ny/$nx;
+    if( $y >= 0 && $y <= $rcw ){
+	push( @endpts, (0, $y) );
+    }
+
+    # right border at x = l
+    $y = $y0 + ($rcl-$x0) * $ny/$nx;
+    if( $y >= 0 && $y <= $rcw ){
+	push( @endpts, ($rcl, $y) );
+	if( scalar(@endpts) == 4 ){
+	    return @endpts;
+	}
+    }
+
+    # bottom border at y = 0
+    my $x = $x0 - $y0 * $nx/$ny;
+    if( $x >= 0 && $x <= $rcl ){
+	push( @endpts, ($x, 0) );
+	if( scalar(@endpts) == 4 ){
+	    return @endpts;
+	}
+    }
+    
+    # top border at y = w
+    $x = $x0 + ($rcw-$y0)* $nx/$ny;
+    if( $x >= 0 && $x <= $rcl ){
+	push( @endpts, ($x, $rcw) );
+    }
+    
+    return @endpts;
+}
+
+sub gen_Wires
+{
+    my $length = $_[0];  # 
+    my $width  = $_[1];  # 
+    my $nch    = $_[2];  # 
+    my $nchb   = $_[3];  # nch per bottom side
+    my $pitch  = $_[4];  # 
+    my $theta  = $_[5];  # deg
+    my $dia    = $_[6];  #
+    
+    $theta  = $theta * pi()/180.0;
+    my @dirw   = (cos($theta), sin($theta));
+    my @dirp   = (cos($theta - pi()/2), sin($theta - pi()/2));
+
+    # calculate
+    my $alpha = $theta;
+    if( $alpha > pi()/2 ){
+	$alpha = pi() - $alpha;
+    }
+    my $dX = $pitch / sin( $alpha );
+    my $dY = $pitch / sin( pi()/2 - $alpha );
+    if( $length <= 0 ){
+        $length = $dX * $nchb;
+    }
+    if( $width <= 0 ){
+	$width = $dY * ($nch - $nchb);
+    }
+
+    my @orig   = (0, 0);
+    if( $dirp[0] < 0 ){
+	$orig[0] = $length;
+    }
+    if( $dirp[1] < 0 ){
+	$orig[1] = $width;
+    }
+
+    #print "origin    : @orig\n";
+    #print "pitch dir : @dirp\n";
+    #print "wire dir  : @dirw\n";
+    #print "$length x $width cm2\n";
+
+    # gen wires
+    my @winfo  = ();
+    my $offset = $pitch/2;
+    foreach my $ch (0..$nch-1){
+	#print "Processing $ch\n";
+
+	# calculate reference point for this strip
+	my @wcn = (0, 0);
+	$wcn[0] = $orig[0] + $offset * $dirp[0];
+	$wcn[1] = $orig[1] + $offset * $dirp[1];
+
+	# line clip on the rectangle boundary
+	@endpts = lineClip( $wcn[0], $wcn[1], $dirw[0], $dirw[1], $length, $width );
+
+	if( scalar(@endpts) != 4 ){
+	    print "Could not find end points for wire $ch : @endpts\n";
+	    $offset = $offset + $pitch;
+	    next;
+	}
+
+	# re-center on the mid-point
+	$endpts[0] -= $length/2;
+	$endpts[2] -= $length/2;
+	$endpts[1] -= $width/2;
+	$endpts[3] -= $width/2;
+
+	# calculate the strip center in the rectangle of CRU
+	$wcn[0] = ($endpts[0] + $endpts[2])/2;
+	$wcn[1] = ($endpts[1] + $endpts[3])/2;
+
+	# calculate the length
+	my $dx = $endpts[0] - $endpts[2];
+	my $dy = $endpts[1] - $endpts[3];
+	my $wlen = sqrt($dx**2 + $dy**2);
+
+	# put all info together
+	my @wire = ($ch, $wcn[0], $wcn[1], $wlen);
+	push( @wire, @endpts );
+	push( @winfo, \@wire);
+	$offset = $offset + $pitch;
+	#last;
+    }
+    return @winfo;
+}
+
+#
+sub gen_TPC()
+{
+    # CRM active volume
+    my $TPCActive_x = $driftTPCActive;
+    my $TPCActive_y = $widthCRM_active;
+    my $TPCActive_z = $lengthCRM_active;
+
+    # CRM total volume
+    my $TPC_x = $TPCActive_x + $ReadoutPlane;
+    my $TPC_y = $widthCRM;
+    my $TPC_z = $lengthCRM;
+
+    print " TPC dimensions     : $TPC_x x $TPC_y x $TPC_z\n";
+    
+    $TPC = $basename."_TPC" . $suffix . ".gdml";
+    push (@gdmlFiles, $TPC);
+    $TPC = ">" . $TPC;
+    open(TPC) or die("Could not open file $TPC for writing");
+
+    # The standard XML prefix and starting the gdml
+print TPC <<EOF;
+    <?xml version='1.0'?>
+	<gdml>
+EOF
+
+    # compute wires for 1st induction
+    my @winfoU = ();
+    my @winfoV = ();
+    if( $wires_on == 1 ){
+	@winfoU = gen_Wires( $TPCActive_z, 0, # force length
+			     $nChans{'Ind1'}, $nChans{'Ind1Bot'}, 
+			     $wirePitchU, $wireAngleU, $padWidth );
+	@winfoV = gen_Wires( $TPCActive_z, 0, # force length
+			     $nChans{'Ind2'}, $nChans{'Ind1Bot'}, 
+			     $wirePitchV, $wireAngleV, $padWidth );
+
+    }
+
+    # All the TPC solids save the wires.
+print TPC <<EOF;
+    <solids>
+EOF
+
+print TPC <<EOF;
+   <box name="CRM"
+      x="$TPC_x" 
+      y="$TPC_y" 
+      z="$TPC_z"
+      lunit="cm"/>
+   <box name="CRMUPlane" 
+      x="$padWidth" 
+      y="$TPCActive_y" 
+      z="$TPCActive_z"
+      lunit="cm"/>
+   <box name="CRMVPlane" 
+      x="$padWidth" 
+      y="$TPCActive_y" 
+      z="$TPCActive_z"
+      lunit="cm"/>
+   <box name="CRMZPlane" 
+      x="$padWidth"
+      y="$TPCActive_y"
+      z="$TPCActive_z"
+      lunit="cm"/>
+   <box name="CRMActive" 
+      x="$TPCActive_x"
+      y="$TPCActive_y"
+      z="$TPCActive_z"
+      lunit="cm"/>
+EOF
+
+#++++++++++++++++++++++++++++ Wire Solids ++++++++++++++++++++++++++++++
+if($wires_on==1){
+	    
+    foreach my $wire (@winfoU) {
+	my $wid = $wire->[0];
+	my $wln = $wire->[3];
+print TPC <<EOF;
+   <tube name="CRMWireU$wid"
+      rmax="0.5*$padWidth"
+      z="$wln"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+EOF
+    }
+
+    foreach my $wire (@winfoV) {
+	my $wid = $wire->[0];
+	my $wln = $wire->[3];
+print TPC <<EOF;
+   <tube name="CRMWireV$wid"
+      rmax="0.5*$padWidth"
+      z="$wln"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+EOF
+    }
+
+    
+print TPC <<EOF;
+   <tube name="CRMWireZ"
+      rmax="0.5*$padWidth"
+      z="$TPCActive_y"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+EOF
+}
+print TPC <<EOF;
+</solids>
+EOF
+
+
+# Begin structure and create wire logical volumes
+print TPC <<EOF;
+<structure>
+    <volume name="volTPCActive">
+      <materialref ref="LAr"/>
+      <solidref ref="CRMActive"/>
+      <auxiliary auxtype="SensDet" auxvalue="SimEnergyDeposit"/>
+      <auxiliary auxtype="StepLimit" auxunit="cm" auxvalue="0.5208*cm"/>
+      <auxiliary auxtype="Efield" auxunit="V/cm" auxvalue="500*V/cm"/>
+      <colorref ref="blue"/>
+    </volume>
+EOF
+
+if($wires_on==1) 
+{
+    foreach my $wire (@winfoU) 
+    {
+	my $wid = $wire->[0];
+print TPC <<EOF;
+    <volume name="volTPCWireU$wid">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU$wid"/>
+    </volume>
+EOF
+    }
+
+    foreach my $wire (@winfoV) 
+    {
+	my $wid = $wire->[0];
+print TPC <<EOF;
+    <volume name="volTPCWireV$wid">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV$wid"/>
+    </volume>
+EOF
+    }
+
+print TPC <<EOF;
+    <volume name="volTPCWireZ">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireZ"/>
+    </volume>
+EOF
+}
+    # 1st induction plane
+print TPC <<EOF;
+   <volume name="volTPCPlaneU">
+     <materialref ref="LAr"/>
+     <solidref ref="CRMUPlane"/>
+EOF
+if ($wires_on==1) # add wires to U plane 
+{
+    # the coordinates were computed with a corner at (0,0)
+    # so we need to move to plane coordinates
+    my $offsetZ = 0; #-0.5 * $TPCActive_z;
+    my $offsetY = 0; #-0.5 * $TPCActive_y;
+
+    foreach my $wire (@winfoU) {
+	my $wid  = $wire->[0];
+	my $zpos = $wire->[1] + $offsetZ;
+	my $ypos = $wire->[2] + $offsetY;
+print TPC <<EOF;
+     <physvol>
+       <volumeref ref="volTPCWireU$wid"/> 
+       <position name="posWireU$wid" unit="cm" x="0" y="$ypos" z="$zpos"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+EOF
+    }
+}
+print TPC <<EOF;
+   </volume>
+EOF
+
+# 2nd induction plane
+print TPC <<EOF;
+  <volume name="volTPCPlaneV">
+    <materialref ref="LAr"/>
+    <solidref ref="CRMVPlane"/>
+EOF
+
+if ($wires_on==1) # add wires to V plane (plane with wires reading y position)
+  {
+          # the coordinates were computed with a corner at (0,0)
+    # so we need to move to plane coordinates
+    my $offsetZ = 0; #-0.5 * $TPCActive_z;
+    my $offsetY = 0; #-0.5 * $TPCActive_y;
+
+    foreach my $wire (@winfoV) {
+	my $wid  = $wire->[0];
+	my $zpos = $wire->[1] + $offsetZ;
+	my $ypos = $wire->[2] + $offsetY;
+print TPC <<EOF;
+     <physvol>
+       <volumeref ref="volTPCWireV$wid"/> 
+       <position name="posWireV$wid" unit="cm" x="0" y="$ypos" z="$zpos"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+EOF
+    }
+}
+print TPC <<EOF;
+  </volume>
+EOF
+
+# collection plane
+print TPC <<EOF;
+  <volume name="volTPCPlaneZ">
+    <materialref ref="LAr"/>
+    <solidref ref="CRMZPlane"/>
+EOF
+if ($wires_on==1) # add wires to Z plane (plane with wires reading z position)
+   {
+       for($i=0;$i<$nChans{'Col'};++$i)
+       {
+	  #my $zpos = -0.5 * $TPCActive_z + ($i+0.5)*$wirePitchZ + 0.5*$padWidth;
+	   my $zpos = ($i + 0.5 - $nChans{'Col'}/2)*$wirePitchZ;
+	   if( (0.5 * $TPCActive_z - abs($zpos)) < 0 ){
+	       die "Cannot place wire $i in view Z, as plane is too small\n";
+	   }
+print TPC <<EOF;
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ$i" unit="cm" x="0" y="0" z="$zpos"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+EOF
+       }
+}
+print TPC <<EOF;
+  </volume>
+EOF
+
+$posUplane[0] = 0.5*$TPC_x - 2.5*$padWidth; 
+$posUplane[1] = 0;
+$posUplane[2] = 0;
+
+$posVplane[0] = 0.5*$TPC_x - 1.5*$padWidth;
+$posVplane[1] = 0;
+$posVplane[2] = 0;
+
+$posZplane[0] = 0.5*$TPC_x - 0.5*$padWidth;
+$posZplane[1] = 0; 
+$posZplane[2] = 0;
+
+$posTPCActive[0] = -$ReadoutPlane/2;
+$posTPCActive[1] = 0;
+$posTPCActive[2] = 0;
+
+#wrap up the TPC file
+print TPC <<EOF;
+   <volume name="volTPC">
+     <materialref ref="LAr"/>
+       <solidref ref="CRM"/>
+       <physvol>
+       <volumeref ref="volTPCPlaneU"/>
+       <position name="posPlaneU" unit="cm" 
+         x="$posUplane[0]" y="$posUplane[1]" z="$posUplane[2]"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCPlaneV"/>
+       <position name="posPlaneY" unit="cm" 
+         x="$posVplane[0]" y="$posVplane[1]" z="$posVplane[2]"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCPlaneZ"/>
+       <position name="posPlaneZ" unit="cm" 
+         x="$posZplane[0]" y="$posZplane[1]" z="$posZplane[2]"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCActive"/>
+       <position name="posActive" unit="cm" 
+        x="$posTPCActive[0]" y="$posTPCAtive[1]" z="$posTPCActive[2]"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+   </volume>
+EOF
+print TPC <<EOF;
+ </structure>
+ </gdml>
+EOF
+
+    close(TPC);
+}
+
+#+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+#++++++++++++++++++++++++++++++++++++++ gen_FieldCage ++++++++++++++++++++++++++++++++++++
+#+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+sub gen_FieldCage {
+
+    $FieldCage = $basename."_FieldCage" . $suffix . ".gdml";
+    push (@gdmlFiles, $FieldCage);
+    $FieldCage = ">" . $FieldCage;
+    open(FieldCage) or die("Could not open file $FieldCage for writing");
+
+# The standard XML prefix and starting the gdml
+print FieldCage <<EOF;
+   <?xml version='1.0'?>
+   <gdml>
+EOF
+# The printing solids used in the Field Cage
+#print "lengthTPCActive      : $lengthTPCActive \n";
+#print "widthTPCActive       : $widthTPCActive \n";
+
+
+print FieldCage <<EOF;
+<solids>
+     <torus name="FieldShaperCorner" rmin="$FieldShaperInnerRadius" rmax="$FieldShaperOuterRadius" rtor="$FieldShaperTorRad" deltaphi="90" startphi="0" aunit="deg" lunit="cm"/>
+     <tube name="FieldShaperLongtube" rmin="$FieldShaperInnerRadius" rmax="$FieldShaperOuterRadius" z="$FieldShaperLongTubeLength" deltaphi="360" startphi="0" aunit="deg" lunit="cm"/>
+     <tube name="FieldShaperLongtubeSlim" rmin="$FieldShaperInnerRadius" rmax="$FieldShaperOuterRadiusSlim" z="$FieldShaperLongTubeLength" deltaphi="360" startphi="0" aunit="deg" lunit="cm"/>
+     <tube name="FieldShaperShorttube" rmin="$FieldShaperInnerRadius" rmax="$FieldShaperOuterRadius" z="$FieldShaperShortTubeLength" deltaphi="360" startphi="0" aunit="deg" lunit="cm"/>
+
+    <union name="FSunion1">
+      <first ref="FieldShaperLongtube"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos1" unit="cm" x="@{[-$FieldShaperTorRad]}" y="0" z="@{[0.5*$FieldShaperLongTubeLength]}"/>
+		<rotation name="rot1" unit="deg" x="90" y="0" z="0" />
+    </union>
+
+    <union name="FSunion2">
+      <first ref="FSunion1"/>
+      <second ref="FieldShaperShorttube"/>
+   		<position name="esquinapos2" unit="cm" x="@{[-0.5*$FieldShaperShortTubeLength-$FieldShaperTorRad]}" y="0" z="@{[+0.5*$FieldShaperLongTubeLength+$FieldShaperTorRad]}"/>
+   		<rotation name="rot2" unit="deg" x="0" y="90" z="0" />
+    </union>
+
+    <union name="FSunion3">
+      <first ref="FSunion2"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos3" unit="cm" x="@{[-$FieldShaperShortTubeLength-$FieldShaperTorRad]}" y="0" z="@{[0.5*$FieldShaperLongTubeLength]}"/>
+		<rotation name="rot3" unit="deg" x="90" y="270" z="0" />
+    </union>
+
+    <union name="FSunion4">
+      <first ref="FSunion3"/>
+      <second ref="FieldShaperLongtube"/>
+   		<position name="esquinapos4" unit="cm" x="@{[-$FieldShaperShortTubeLength-2*$FieldShaperTorRad]}" y="0" z="0"/>
+    </union>
+
+    <union name="FSunion5">
+      <first ref="FSunion4"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos5" unit="cm" x="@{[-$FieldShaperShortTubeLength-$FieldShaperTorRad]}" y="0" z="@{[-0.5*$FieldShaperLongTubeLength]}"/>
+		<rotation name="rot5" unit="deg" x="90" y="180" z="0" />
+    </union>
+
+    <union name="FSunion6">
+      <first ref="FSunion5"/>
+      <second ref="FieldShaperShorttube"/>
+   		<position name="esquinapos6" unit="cm" x="@{[-0.5*$FieldShaperShortTubeLength-$FieldShaperTorRad]}" y="0" z="@{[-0.5*$FieldShaperLongTubeLength-$FieldShaperTorRad]}"/>
+		<rotation name="rot6" unit="deg" x="0" y="90" z="0" />
+    </union>
+
+    <union name="FieldShaperSolid">
+      <first ref="FSunion6"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos7" unit="cm" x="@{[-$FieldShaperTorRad]}" y="0" z="@{[-0.5*$FieldShaperLongTubeLength]}"/>
+		<rotation name="rot7" unit="deg" x="90" y="90" z="0" />
+    </union>
+    
+    <union name="FSunionSlim1">
+      <first ref="FieldShaperLongtubeSlim"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos1" unit="cm" x="@{[-$FieldShaperTorRad]}" y="0" z="@{[0.5*$FieldShaperLongTubeLength]}"/>
+		<rotation name="rot1" unit="deg" x="90" y="0" z="0" />
+    </union>
+
+    <union name="FSunionSlim2">
+      <first ref="FSunionSlim1"/>
+      <second ref="FieldShaperShorttube"/>
+   		<position name="esquinapos2" unit="cm" x="@{[-0.5*$FieldShaperShortTubeLength-$FieldShaperTorRad]}" y="0" z="@{[+0.5*$FieldShaperLongTubeLength+$FieldShaperTorRad]}"/>
+   		<rotation name="rot2" unit="deg" x="0" y="90" z="0" />
+    </union>
+
+    <union name="FSunionSlim3">
+      <first ref="FSunionSlim2"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos3" unit="cm" x="@{[-$FieldShaperShortTubeLength-$FieldShaperTorRad]}" y="0" z="@{[0.5*$FieldShaperLongTubeLength]}"/>
+		<rotation name="rot3" unit="deg" x="90" y="270" z="0" />
+    </union>
+
+    <union name="FSunionSlim4">
+      <first ref="FSunionSlim3"/>
+      <second ref="FieldShaperLongtubeSlim"/>
+   		<position name="esquinapos4" unit="cm" x="@{[-$FieldShaperShortTubeLength-2*$FieldShaperTorRad]}" y="0" z="0"/>
+    </union>
+
+    <union name="FSunionSlim5">
+      <first ref="FSunionSlim4"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos5" unit="cm" x="@{[-$FieldShaperShortTubeLength-$FieldShaperTorRad]}" y="0" z="@{[-0.5*$FieldShaperLongTubeLength]}"/>
+		<rotation name="rot5" unit="deg" x="90" y="180" z="0" />
+    </union>
+
+    <union name="FSunionSlim6">
+      <first ref="FSunionSlim5"/>
+      <second ref="FieldShaperShorttube"/>
+   		<position name="esquinapos6" unit="cm" x="@{[-0.5*$FieldShaperShortTubeLength-$FieldShaperTorRad]}" y="0" z="@{[-0.5*$FieldShaperLongTubeLength-$FieldShaperTorRad]}"/>
+		<rotation name="rot6" unit="deg" x="0" y="90" z="0" />
+    </union>
+
+    <union name="FieldShaperSolidSlim">
+      <first ref="FSunionSlim6"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos7" unit="cm" x="@{[-$FieldShaperTorRad]}" y="0" z="@{[-0.5*$FieldShaperLongTubeLength]}"/>
+		<rotation name="rot7" unit="deg" x="90" y="90" z="0" />
+    </union>
+    
+</solids>
+
+EOF
+
+print FieldCage <<EOF;
+
+<structure>
+<volume name="volFieldShaper">
+  <materialref ref="Al2O3"/>
+  <solidref ref="FieldShaperSolid"/>
+</volume>
+<volume name="volFieldShaperSlim">
+  <materialref ref="Al2O3"/>
+  <solidref ref="FieldShaperSolidSlim"/>
+</volume>
+
+</structure>
+
+EOF
+
+print FieldCage <<EOF;
+
+</gdml>
+EOF
+close(FieldCage);
+}
+
+
+
+#+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+#++++++++++++++++++++++++++++++++++++++ gen_Cryostat +++++++++++++++++++++++++++++++++++++
+#+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+sub gen_Cryostat()
+{
+
+# Create the cryostat fragment file name,
+# add file to list of output GDML fragments,
+# and open it
+    $CRYO = $basename."_Cryostat" . $suffix . ".gdml";
+    push (@gdmlFiles, $CRYO);
+    $CRYO = ">" . $CRYO;
+    open(CRYO) or die("Could not open file $CRYO for writing");
+
+
+# The standard XML prefix and starting the gdml
+    print CRYO <<EOF;
+<?xml version='1.0'?>
+<gdml>
+EOF
+
+# All the cryostat solids.
+# External active are two side volumes for generating light outside the field cage (no top or bottom buffers included)
+print CRYO <<EOF;
+<solids>
+    <box name="Cryostat" lunit="cm" 
+      x="$Cryostat_x" 
+      y="$Cryostat_y" 
+      z="$Cryostat_z"/>
+
+    <box name="ArgonInterior" lunit="cm" 
+      x="$Argon_x"
+      y="$Argon_y"
+      z="$Argon_z"/>
+
+    <box name="GaseousArgon" lunit="cm" 
+      x="$HeightGaseousAr - $anodePlateWidth"
+      y="$Argon_y"
+      z="$Argon_z"/>
+
+    <box name="ExternalAuxOut" lunit="cm" 
+      x="$Argon_x - $xLArBuffer"
+      y="$Argon_y - 2*$ArapucaOut_y - 2*$FrameToArapucaSpaceLat"
+      z="$Argon_z"/>
+
+    <box name="ExternalAuxIn" lunit="cm" 
+      x="$Argon_x"
+      y="$FieldCageSizeY"
+      z="$Argon_z + 1"/>
+
+   <subtraction name="ExternalActive">
+      <first ref="ExternalAuxOut"/>
+      <second ref="ExternalAuxIn"/>
+    </subtraction>
+
+    <subtraction name="SteelShell">
+      <first ref="Cryostat"/>
+      <second ref="ArgonInterior"/>
+    </subtraction>
+
+</solids>
+EOF
+
+#PDS
+#Double sided detectors should only be included when both top and bottom volumes become available
+#Optical sensitive volumes cannot be rotated because Larsoft cannot pick up the rotation when obtinaing the lengths needed for the semi-analytic model --> two acceptance windows for single sided lateral and cathode
+print CRYO <<EOF;
+<solids>
+    <box name="ArapucaOut" lunit="cm"
+      x="@{[$ArapucaOut_x]}"
+      y="@{[$ArapucaOut_y]}"
+      z="@{[$ArapucaOut_z]}"/>
+
+    <box name="ArapucaIn" lunit="cm"
+      x="@{[$ArapucaIn_x]}"
+      y="@{[$ArapucaOut_y]}"
+      z="@{[$ArapucaIn_z]}"/>
+
+     <subtraction name="ArapucaWalls">
+      <first  ref="ArapucaOut"/>
+      <second ref="ArapucaIn"/>
+      <position name="posArapucaSub" x="0" y="@{[$ArapucaOut_y/2.0]}" z="0." unit="cm"/>
+      </subtraction>
+
+    <box name="ArapucaAcceptanceWindow" lunit="cm"
+      x="@{[$ArapucaAcceptanceWindow_x]}"
+      y="@{[$ArapucaAcceptanceWindow_y]}"
+      z="@{[$ArapucaAcceptanceWindow_z]}"/>
+
+    <box name="ArapucaDoubleIn" lunit="cm"
+      x="@{[$ArapucaIn_x]}"
+      y="@{[$ArapucaOut_y+1.0]}"
+      z="@{[$ArapucaIn_z]}"/>
+
+     <subtraction name="ArapucaDoubleWalls">
+      <first  ref="ArapucaOut"/>
+      <second ref="ArapucaDoubleIn"/>
+      <position name="posArapucaDoubleSub" x="0" y="0" z="0" unit="cm"/>
+      </subtraction>
+
+    <box name="ArapucaDoubleAcceptanceWindow" lunit="cm"
+      x="@{[$ArapucaOut_y-0.02]}"
+      y="@{[$ArapucaAcceptanceWindow_x]}"
+      z="@{[$ArapucaAcceptanceWindow_z]}"/>
+
+    <box name="ArapucaCathodeAcceptanceWindow" lunit="cm"
+      x="@{[$ArapucaAcceptanceWindow_y]}"
+      y="@{[$ArapucaAcceptanceWindow_x]}"
+      z="@{[$ArapucaAcceptanceWindow_z]}"/>
+
+</solids>
+EOF
+
+# Cryostat structure
+print CRYO <<EOF;
+<structure>
+    <volume name="volSteelShell">
+      <materialref ref="STEEL_STAINLESS_Fe7Cr2Ni" />
+      <solidref ref="SteelShell" />
+    </volume>
+    <volume name="volGroundGrid">
+      <materialref ref="STEEL_STAINLESS_Fe7Cr2Ni" />
+      <solidref ref="CathodeGrid" />
+    </volume>
+    <volume name="volAnodePlate">
+     <materialref ref="vm2000"/>
+     <solidref ref="AnodePlate"/>
+    </volume>
+    <volume name="volGaseousArgon">
+      <materialref ref="ArGas"/>
+      <solidref ref="GaseousArgon"/>
+    </volume>
+    <volume name="volExternalActive">
+      <materialref ref="LAr"/>
+      <solidref ref="ExternalActive"/>
+      <auxiliary auxtype="SensDet" auxvalue="SimEnergyDeposit"/>
+      <auxiliary auxtype="StepLimit" auxunit="cm" auxvalue="0.5208*cm"/>
+      <auxiliary auxtype="Efield" auxunit="V/cm" auxvalue="0*V/cm"/>
+      <colorref ref="green"/>
+    </volume>
+EOF
+#including single sided arapucas over the cathode while there is only the top volume
+#if double sided, use
+#    <volume name="volArapucaDouble_$i\-$j\-$p">
+#      <materialref ref="G10" />
+#      <solidref ref="ArapucaDoubleWalls" />
+#    </volume>
+#    <volume name="volOpDetSensitive_ArapucaDouble_$i\-$j\-$p">
+#      <materialref ref="LAr"/>
+#      <solidref ref="ArapucaDoubleAcceptanceWindow"/>
+#    </volume>
+if ($pdsconfig == 0){  #4-pi PDS converage
+for($i=0 ; $i<$nCRM_x/2 ; $i++){ #arapucas over the cathode
+for($j=0 ; $j<$nCRM_z/2 ; $j++){
+for($p=0 ; $p<4 ; $p++){
+  print CRYO <<EOF;
+    <volume name="volArapucaDouble_$i\-$j\-$p">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_$i\-$j\-$p">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+EOF
+}
+}
+}
+}
+
+if ($nCRM_x==8){ #arapucas on the laterals
+for($j=0 ; $j<$nCRM_z/2 ; $j++){
+for($p=0 ; $p<8 ; $p++){
+  print CRYO <<EOF;
+    <volume name="volArapucaLat_$j\-$p">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_$j\-$p">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+EOF
+}
+}
+}
+
+if ($pdsconfig == 1){  #Membrane PDS converage
+if ($nCRM_x==8) { #arapucas on the laterals
+for($j=0 ; $j<$nCRM_z/2 ; $j++){
+for($p=8 ; $p<18 ; $p++){
+  print CRYO <<EOF;
+    <volume name="volArapucaLat_$j\-$p">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_$j\-$p">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+EOF
+}
+}
+}
+}
+
+      print CRYO <<EOF;
+
+    <volume name="volCryostat">
+      <materialref ref="LAr" />
+      <solidref ref="Cryostat" />
+      <physvol>
+        <volumeref ref="volGaseousArgon"/>
+        <position name="posGaseousArgon" unit="cm" x="@{[$Argon_x/2-$HeightGaseousAr/2+$anodePlateWidth/2]}" y="0" z="0"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volSteelShell"/>
+        <position name="posSteelShell" unit="cm" x="0" y="0" z="0"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volExternalActive"/>
+        <position name="posExternalActive" unit="cm" x="-$xLArBuffer/2" y="0" z="0"/>
+      </physvol>
+EOF
+
+if ($tpc_on==1) # place TPC inside croysotat offsetting each pair of CRMs by borderCRP
+{
+  $posX =  $Argon_x/2 - $HeightGaseousAr - 0.5*($driftTPCActive + $ReadoutPlane); 
+  $idx = 0;
+  my $posZ = -0.5*$Argon_z + $zLArBuffer + 0.5*$lengthCRM;
+  for(my $ii=0;$ii<$nCRM_z;$ii++)
+  {
+    if( $ii % 2 == 0 ){
+	$posZ += $borderCRP;
+	if( $ii>0 ){
+	    $posZ += $borderCRP;
+	}
+    }
+    my $posY = -0.5*$Argon_y + $yLArBuffer + 0.5*$widthCRM;
+    for(my $jj=0;$jj<$nCRM_x;$jj++)
+    {
+	if( $jj % 2 == 0 ){
+	    $posY += $borderCRP;
+	    if( $jj>0 ){
+		$posY += $borderCRP;
+	    }
+	}
+	print CRYO <<EOF;
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC\-$idx" unit="cm"
+           x="$posX" y="$posY" z="$posZ"/>
+      </physvol>
+EOF
+       $idx++;
+       $posY += $widthCRM;
+    }
+
+    $posZ += $lengthCRM;
+  }
+}
+
+#The +50 in the x positions must depend on some other parameter
+  if ( $FieldCage_switch eq "on" ) {
+    for ( $i=0; $i<$NFieldShapers; $i=$i+1 ) {
+    $dist=$i*$FieldShaperSeparation;
+$posX =  $Argon_x/2 - $HeightGaseousAr - 0.5*($driftTPCActive + $ReadoutPlane); 
+	if ($pdsconfig==0){
+		if ($dist>250){
+	print CRYO <<EOF;
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper$i" unit="cm"  x="@{[-$OriginXSet+50+($i-$NFieldShapers*0.5)*$FieldShaperSeparation]}" y="@{[-0.5*$FieldShaperShortTubeLength-$FieldShaperTorRad]}" z="0" />
+     <rotation name="rotFS$i" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+EOF
+		}else{
+	print CRYO <<EOF;
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper$i" unit="cm"  x="@{[-$OriginXSet+50+($i-$NFieldShapers*0.5)*$FieldShaperSeparation]}" y="@{[-0.5*$FieldShaperShortTubeLength-$FieldShaperTorRad]}" z="0" />
+     <rotation name="rotFS$i" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+EOF
+		}
+	}else{
+	print CRYO <<EOF;
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper$i" unit="cm"  x="@{[-$OriginXSet+50+($i-$NFieldShapers*0.5)*$FieldShaperSeparation]}" y="@{[-0.5*$FieldShaperShortTubeLength-$FieldShaperTorRad]}" z="0" />
+     <rotation name="rotFS$i" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+EOF
+	}
+    }
+  }
+
+
+$CathodePosX =-$OriginXSet+50+(-1-$NFieldShapers*0.5)*$FieldShaperSeparation + $tpc_x_disp;
+$CathodePosY = -0.5*$Argon_y + $yLArBuffer + 0.5*$widthCathode;
+$CathodePosZ = -0.5*$Argon_z + $zLArBuffer + 0.5*$lengthCathode;
+$posAnodePlate = 0.5*($driftTPCActive + $nViews*$padWidth) + $anodePlateWidth/2;#right above TPC vol
+
+$idx = 0;
+  if ( $Cathode_switch eq "on" )
+  {
+  for(my $ii=0;$ii<$nCRM_z/2;$ii++)
+  {
+    for(my $jj=0;$jj<$nCRM_x/2;$jj++)
+    {
+	print CRYO <<EOF;
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid\-$idx" unit="cm" x="$CathodePosX" y="@{[$CathodePosY]}" z="@{[$CathodePosZ]}"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate\-$idx" unit="cm" x="$posAnodePlate" y="@{[$CathodePosY]}" z="@{[$CathodePosZ]}"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+EOF
+       $idx++;
+       $CathodePosY += $widthCathode;
+    }
+       $CathodePosZ += $lengthCathode;
+       $CathodePosY = -0.5*$Argon_y + $yLArBuffer + 0.5*$widthCathode;
+  }
+  }
+
+if ($pdsconfig == 0) {  #4-pi PDS converage
+
+#for placing the Arapucas over the cathode
+  $FrameCenter_x=-0.5*$Argon_y + $yLArBuffer + 0.5*$widthCathode;#-1.5*$FrameLenght_x+(4-$nCRM_x/2)/2*$FrameLenght_x;
+  $FrameCenter_y=$CathodePosX;
+  $FrameCenter_z=-0.5*$Argon_z + $zLArBuffer + 0.5*$lengthCathode;#-9.5*$FrameLenght_z+(20-$nCRM_z/2)/2*$FrameLenght_z;
+for($i=0;$i<$nCRM_x/2;$i++){
+for($j=0;$j<$nCRM_z/2;$j++){
+  place_OpDetsCathode($FrameCenter_x, $FrameCenter_y, $FrameCenter_z, $i, $j);
+  $FrameCenter_z+=$lengthCathode;
+}
+  $FrameCenter_x+=$widthCathode;
+  $FrameCenter_z=-0.5*$Argon_z + $zLArBuffer + 0.5*$lengthCathode;
+}
+}
+
+if ($pdsconfig == 0) {  #4-pi PDS converage
+#for placing the Arapucas on laterals
+if ($nCRM_x==8) {
+  $FrameCenter_y=$posZplane[0]; #anode position
+  $FrameCenter_z=-19*$lengthCathode/2+(40-$nCRM_z)/2*$lengthCathode/2;
+for($j=0;$j<$nCRM_z/2;$j++){#nCRM will give the collumn number (1 collumn per frame)
+  place_OpDetsLateral($FrameCenter_y, $FrameCenter_z, $j);
+  $FrameCenter_z+=$lengthCathode;
+}
+}
+
+} else {  #membrane only PDS converage
+
+if($pdsconfig == 1){
+if ($nCRM_x==8) {
+  $FrameCenter_y=$posZplane[0]; #anode position
+  $FrameCenter_z=-19*$lengthCathode/2+(40-$nCRM_z)/2*$lengthCathode/2;
+for($j=0;$j<$nCRM_z/2;$j++){#nCRM will give the collumn number (1 collumn per frame)
+  place_OpDetsMembOnly($FrameCenter_y, $FrameCenter_z, $j);
+  $FrameCenter_z+=$lengthCathode;
+}
+}
+}
+
+}
+  
+ print CRYO <<EOF;
+    </volume>
+</structure>
+</gdml>
+EOF
+
+close(CRYO);
+}
+
+#+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+#++++++++++++++++++++++++++++++++++++ place_OpDets +++++++++++++++++++++++++++++++++++++++
+#+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+sub place_OpDetsCathode()
+{
+
+    $FrameCenter_x = $_[0];
+    $FrameCenter_y = $_[1];
+    $FrameCenter_z = $_[2];
+    $Frame_x = $_[3];
+    $Frame_z = $_[4];
+
+#Placing Arapucas over the Cathode 
+#If there are both top and bottom volumes --> use double-sided:
+#     <physvol>
+#       <volumeref ref="volOpDetSensitive_ArapucaDouble_$Frame_x\-$Frame_z\-$ara"/>
+#       <position name="posOpArapucaDouble$ara-Frame\-$Frame_x\-$Frame_z" unit="cm" 
+#         x="@{[$Ara_X]}"
+#	 y="@{[$Ara_Y]}" 
+#	 z="@{[$Ara_Z]}"/>
+#     </physvol>
+#else
+for ($ara = 0; $ara<4; $ara++)
+{
+             # All Arapuca centers will have the same Y coordinate
+             # X and Z coordinates are defined with respect to the center of the current Frame
+
+ 	     $Ara_Y = $FrameCenter_x+$list_posx_bot[$ara]; #GEOMETRY IS ROTATED: X--> Y AND Y--> X
+             $Ara_X = $FrameCenter_y;
+ 	     $Ara_Z = $FrameCenter_z+$list_posz_bot[$ara];
+
+	print CRYO <<EOF;
+     <physvol>
+       <volumeref ref="volArapucaDouble_$Frame_x\-$Frame_z\-$ara"/>
+       <position name="posArapucaDouble$ara-Frame\-$Frame_x\-$Frame_z" unit="cm" 
+         x="@{[$Ara_X]}"
+	 y="@{[$Ara_Y]}" 
+	 z="@{[$Ara_Z]}"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_$Frame_x\-$Frame_z\-$ara"/>
+       <position name="posOpArapucaDouble$ara-Frame\-$Frame_x\-$Frame_z" unit="cm" 
+         x="@{[$Ara_X+0.5*$ArapucaOut_y-0.5*$ArapucaAcceptanceWindow_y-0.01]}"
+	 y="@{[$Ara_Y]}" 
+	 z="@{[$Ara_Z]}"/>
+     </physvol>
+EOF
+
+}#end Ara for-loop
+
+}
+
+
+sub place_OpDetsLateral()
+{
+
+    $FrameCenter_y = $_[0];
+    $FrameCenter_z = $_[1];
+    $Lat_z = $_[2];
+
+#Placing Arapucas on the laterals if nCRM_x=8 -- Single Sided
+for ($ara = 0; $ara<8; $ara++)
+{
+             # Arapucas on laterals
+             # All Arapuca centers on a given collumn will have the same Z coordinate
+             # X coordinates are on the left and right laterals
+             # Y coordinates are defined with respect to the cathode position
+             # There are two collumns per frame on each side.
+
+             if ($ara<4) {$Ara_Y = -0.5*$Argon_y + $FrameToArapucaSpaceLat;
+                         $Ara_YSens = ($Ara_Y+0.5*$ArapucaOut_y-0.5*$ArapucaAcceptanceWindow_y-0.01);
+                         $rot= "rIdentity"; }
+             else {$Ara_Y = 0.5*$Argon_y - $FrameToArapucaSpaceLat;
+                         $Ara_YSens = ($Ara_Y-0.5*$ArapucaOut_y+0.5*$ArapucaAcceptanceWindow_y+0.01);
+                         $rot = "rPlus180AboutX";} #GEOMETRY IS ROTATED: X--> Y AND Y--> X
+             if ($ara==0||$ara==4) {$Ara_X = $FrameCenter_y-40.0;} #first tile's center 40 cm bellow anode
+             else {$Ara_X-=$VerticalPDdist;} #other tiles separated by VerticalPDdist
+             $Ara_Z = $FrameCenter_z;
+
+        
+	print CRYO <<EOF;
+     <physvol>
+       <volumeref ref="volArapucaLat_$Lat_z\-$ara"/>
+       <position name="posArapuca$ara-Lat\-$Lat_z" unit="cm" 
+         x="@{[$Ara_X]}"
+	 y="@{[$Ara_Y]}" 
+	 z="@{[$Ara_Z]}"/>
+       <rotationref ref="$rot"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_$Lat_z\-$ara"/>
+       <position name="posOpArapuca$ara-Lat\-$Lat_z" unit="cm" 
+         x="@{[$Ara_X]}"
+	 y="@{[$Ara_YSens]}" 
+	 z="@{[$Ara_Z]}"/>
+     </physvol>
+EOF
+        
+}#end Ara for-loop
+
+}
+
+
+sub place_OpDetsMembOnly()
+{
+
+    $FrameCenter_y = $_[0];
+    $FrameCenter_z = $_[1];
+    $Lat_z = $_[2];
+
+#Placing Arapucas on the laterals if nCRM_x=8 -- Single Sided
+for ($ara = 0; $ara<18; $ara++)
+{
+             # Arapucas on laterals
+             # All Arapuca centers on a given collumn will have the same Z coordinate
+             # X coordinates are on the left and right laterals
+             # Y coordinates are defined with respect to the cathode position
+             # There are two collumns per frame on each side.
+
+             if($ara<9) {$Ara_Y = -0.5*$Argon_y + $FrameToArapucaSpaceLat;
+                         $Ara_YSens = ($Ara_Y+0.5*$ArapucaOut_y-0.5*$ArapucaAcceptanceWindow_y-0.01);
+                         $rot= "rIdentity"; }
+             else {$Ara_Y = 0.5*$Argon_y - $FrameToArapucaSpaceLat;
+                         $Ara_YSens = ($Ara_Y-0.5*$ArapucaOut_y+0.5*$ArapucaAcceptanceWindow_y+0.01);
+                         $rot = "rPlus180AboutX";} #GEOMETRY IS ROTATED: X--> Y AND Y--> X
+             if($ara==0||$ara==9) {$Ara_X = $FrameCenter_y-$ArapucaOut_x/2;} #first tile's center right below anode
+             else {$Ara_X-=$ArapucaOut_x - $FrameToArapucaSpace;} #other tiles separated by minimal distance + buffer
+             $Ara_Z = $FrameCenter_z;
+
+#        print "lateral arapucas: $Ara_X, $Ara_Y, $Ara_Z \n";
+        
+	print CRYO <<EOF;
+     <physvol>
+       <volumeref ref="volArapucaLat_$Lat_z\-$ara"/>
+       <position name="posArapuca$ara-Lat\-$Lat_z" unit="cm" 
+         x="@{[$Ara_X]}"
+	 y="@{[$Ara_Y]}" 
+	 z="@{[$Ara_Z]}"/>
+       <rotationref ref="$rot"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_$Lat_z\-$ara"/>
+       <position name="posOpArapuca$ara-Lat\-$Lat_z" unit="cm" 
+         x="@{[$Ara_X]}"
+	 y="@{[$Ara_YSens]}" 
+	 z="@{[$Ara_Z]}"/>
+     </physvol>
+EOF
+        
+}#end Ara for-loop
+
+
+
+}
+
+
+#+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+#+++++++++++++++++++++++++++++++++++++ gen_Enclosure +++++++++++++++++++++++++++++++++++++
+#+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+sub gen_Enclosure()
+{
+
+# Create the detector enclosure fragment file name,
+# add file to list of output GDML fragments,
+# and open it
+    $ENCL = $basename."_DetEnclosure" . $suffix . ".gdml";
+    push (@gdmlFiles, $ENCL);
+    $ENCL = ">" . $ENCL;
+    open(ENCL) or die("Could not open file $ENCL for writing");
+
+
+# The standard XML prefix and starting the gdml
+    print ENCL <<EOF;
+<?xml version='1.0'?>
+<gdml>
+EOF
+
+
+# All the detector enclosure solids.
+print ENCL <<EOF;
+<solids>
+
+    <box name="CathodeBlock" lunit="cm"
+      x="@{[$heightCathode]}"
+      y="@{[$widthCathode]}"
+      z="@{[$lengthCathode]}" />
+
+    <box name="CathodeVoid" lunit="cm"
+      x="@{[$heightCathode+1.0]}"
+      y="@{[$widthCathodeVoid]}"
+      z="@{[$lengthCathodeVoid]}" />
+
+    <subtraction name="Cathode1">
+      <first ref="CathodeBlock"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub1" x="0" y="@{[-1.5*$widthCathodeVoid-2.0*$CathodeBorder]}" z="@{[-1.5*$lengthCathodeVoid-2.0*$CathodeBorder]}" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode2">
+      <first ref="Cathode1"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub2" x="0" y="@{[-1.5*$widthCathodeVoid-2.0*$CathodeBorder]}" z="@{[-0.5*$lengthCathodeVoid-1.0*$CathodeBorder]}" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode3">
+      <first ref="Cathode2"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub3" x="0" y="@{[-1.5*$widthCathodeVoid-2.0*$CathodeBorder]}" z="@{[0.5*$lengthCathodeVoid+1.0*$CathodeBorder]}" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode4">
+      <first ref="Cathode3"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub4" x="0" y="@{[-1.5*$widthCathodeVoid-2.0*$CathodeBorder]}" z="@{[1.5*$lengthCathodeVoid+2.0*$CathodeBorder]}" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode5">
+      <first ref="Cathode4"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub5" x="0" y="@{[-0.5*$widthCathodeVoid-1.0*$CathodeBorder]}" z="@{[-1.5*$lengthCathodeVoid-2.0*$CathodeBorder]}" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode6">
+      <first ref="Cathode5"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub6" x="0" y="@{[-0.5*$widthCathodeVoid-1.0*$CathodeBorder]}" z="@{[-0.5*$lengthCathodeVoid-1.0*$CathodeBorder]}" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode7">
+      <first ref="Cathode6"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub7" x="0" y="@{[-0.5*$widthCathodeVoid-1.0*$CathodeBorder]}" z="@{[0.5*$lengthCathodeVoid+1.0*$CathodeBorder]}" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode8">
+      <first ref="Cathode7"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub8" x="0" y="@{[-0.5*$widthCathodeVoid-1.0*$CathodeBorder]}" z="@{[1.5*$lengthCathodeVoid+2.0*$CathodeBorder]}" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode9">
+      <first ref="Cathode8"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub9" x="0" y="@{[0.5*$widthCathodeVoid+1.0*$CathodeBorder]}" z="@{[-1.5*$lengthCathodeVoid-2.0*$CathodeBorder]}" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode10">
+      <first ref="Cathode9"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub10" x="0" y="@{[0.5*$widthCathodeVoid+1.0*$CathodeBorder]}" z="@{[-0.5*$lengthCathodeVoid-1.0*$CathodeBorder]}" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode11">
+      <first ref="Cathode10"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub11" x="0" y="@{[0.5*$widthCathodeVoid+1.0*$CathodeBorder]}" z="@{[0.5*$lengthCathodeVoid+1.0*$CathodeBorder]}" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode12">
+      <first ref="Cathode11"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub12" x="0" y="@{[0.5*$widthCathodeVoid+1.0*$CathodeBorder]}" z="@{[1.5*$lengthCathodeVoid+2.0*$CathodeBorder]}" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode13">
+      <first ref="Cathode12"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub13" x="0" y="@{[1.5*$widthCathodeVoid+2.0*$CathodeBorder]}" z="@{[-1.5*$lengthCathodeVoid-2.0*$CathodeBorder]}" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode14">
+      <first ref="Cathode13"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub14" x="0" y="@{[1.5*$widthCathodeVoid+2.0*$CathodeBorder]}" z="@{[-0.5*$lengthCathodeVoid-1.0*$CathodeBorder]}" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode15">
+      <first ref="Cathode14"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub15" x="0" y="@{[1.5*$widthCathodeVoid+2.0*$CathodeBorder]}" z="@{[0.5*$lengthCathodeVoid+1.0*$CathodeBorder]}" unit="cm"/>
+    </subtraction>
+    <subtraction name="CathodeGrid">
+      <first ref="Cathode15"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub16" x="0" y="@{[1.5*$widthCathodeVoid+2.0*$CathodeBorder]}" z="@{[1.5*$lengthCathodeVoid+2.0*$CathodeBorder]}" unit="cm"/>
+    </subtraction>
+
+   <box name="AnodePlate" 
+      x="$anodePlateWidth"
+      y="$widthCathode"
+      z="$lengthCathode"
+      lunit="cm"/>
+
+    <box name="FoamPadBlock" lunit="cm"
+      x="@{[$Cryostat_x + 2*$FoamPadding]}"
+      y="@{[$Cryostat_y + 2*$FoamPadding]}"
+      z="@{[$Cryostat_z + 2*$FoamPadding]}" />
+
+    <subtraction name="FoamPadding">
+      <first ref="FoamPadBlock"/>
+      <second ref="Cryostat"/>
+      <positionref ref="posCenter"/>
+    </subtraction>
+
+    <box name="SteelSupportBlock" lunit="cm"
+      x="@{[$Cryostat_x + 2*$FoamPadding + 2*$SteelSupport_x]}"
+      y="@{[$Cryostat_y + 2*$FoamPadding + 2*$SteelSupport_y]}"
+      z="@{[$Cryostat_z + 2*$FoamPadding + 2*$SteelSupport_z]}" />
+
+    <subtraction name="SteelSupport">
+      <first ref="SteelSupportBlock"/>
+      <second ref="FoamPadBlock"/>
+      <positionref ref="posCenter"/>
+    </subtraction>
+
+    <box name="DetEnclosure" lunit="cm" 
+      x="$DetEncX"
+      y="$DetEncY"
+      z="$DetEncZ"/>
+
+</solids>
+EOF
+
+
+# Detector enclosure structure
+    print ENCL <<EOF;
+<structure>
+    <volume name="volFoamPadding">
+      <materialref ref="fibrous_glass"/>
+      <solidref ref="FoamPadding"/>
+    </volume>
+
+    <volume name="volSteelSupport">
+      <materialref ref="AirSteelMixture"/>
+      <solidref ref="SteelSupport"/>
+    </volume>
+
+    <volume name="volDetEnclosure">
+      <materialref ref="Air"/>
+      <solidref ref="DetEnclosure"/>
+
+       <physvol>
+           <volumeref ref="volFoamPadding"/>
+           <positionref ref="posCryoInDetEnc"/>
+       </physvol>
+       <physvol>
+           <volumeref ref="volSteelSupport"/>
+           <positionref ref="posCryoInDetEnc"/>
+       </physvol>
+       <physvol>
+           <volumeref ref="volCryostat"/>
+           <positionref ref="posCryoInDetEnc"/>
+       </physvol>
+EOF
+
+
+print ENCL <<EOF;
+    </volume>
+EOF
+
+print ENCL <<EOF;
+</structure>
+</gdml>
+EOF
+
+close(ENCL);
+}
+
+
+
+#+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+#+++++++++++++++++++++++++++++++++++++++ gen_World +++++++++++++++++++++++++++++++++++++++
+#+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+sub gen_World()
+{
+
+# Create the WORLD fragment file name,
+# add file to list of output GDML fragments,
+# and open it
+    $WORLD = $basename."_World" . $suffix . ".gdml";
+    push (@gdmlFiles, $WORLD);
+    $WORLD = ">" . $WORLD;
+    open(WORLD) or die("Could not open file $WORLD for writing");
+
+
+# The standard XML prefix and starting the gdml
+    print WORLD <<EOF;
+<?xml version='1.0'?>
+<gdml>
+EOF
+
+
+# All the World solids.
+print WORLD <<EOF;
+<solids>
+    <box name="World" lunit="cm" 
+      x="@{[$DetEncX+2*$RockThickness]}" 
+      y="@{[$DetEncY+2*$RockThickness]}" 
+      z="@{[$DetEncZ+2*$RockThickness]}"/>
+</solids>
+EOF
+
+# World structure
+print WORLD <<EOF;
+<structure>
+    <volume name="volWorld" >
+      <materialref ref="DUSEL_Rock"/>
+      <solidref ref="World"/>
+
+      <physvol>
+        <volumeref ref="volDetEnclosure"/>
+	<position name="posDetEnclosure" unit="cm" x="$OriginXSet" y="$OriginYSet" z="$OriginZSet"/>
+      </physvol>
+
+    </volume>
+</structure>
+</gdml>
+EOF
+
+# make_gdml.pl will take care of <setup/>
+
+close(WORLD);
+}
+
+
+
+#+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+#++++++++++++++++++++++++++++++++++++ write_fragments ++++++++++++++++++++++++++++++++++++
+#+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+sub write_fragments()
+{
+   # This subroutine creates an XML file that summarizes the the subfiles output
+   # by the other sub routines - it is the input file for make_gdml.pl which will
+   # give the final desired GDML file. Specify its name with the output option.
+   # (you can change the name when running make_gdml)
+
+   # This code is taken straigh from the similar MicroBooNE generate script, Thank you.
+
+    if ( ! defined $output )
+    {
+	$output = "-"; # write to STDOUT 
+    }
+
+    # Set up the output file.
+    $OUTPUT = ">" . $output;
+    open(OUTPUT) or die("Could not open file $OUTPUT");
+
+    print OUTPUT <<EOF;
+<?xml version='1.0'?>
+
+<!-- Input to Geometry/gdml/make_gdml.pl; define the GDML fragments
+     that will be zipped together to create a detector description. 
+     -->
+
+<config>
+
+   <constantfiles>
+
+      <!-- These files contain GDML <constant></constant>
+           blocks. They are read in separately, so they can be
+           interpreted into the remaining GDML. See make_gdml.pl for
+           more information. 
+	   -->
+	   
+EOF
+
+    foreach $filename (@defFiles)
+    {
+	print OUTPUT <<EOF;
+      <filename> $filename </filename>
+EOF
+    }
+
+    print OUTPUT <<EOF;
+
+   </constantfiles>
+
+   <gdmlfiles>
+
+      <!-- The GDML file fragments to be zipped together. -->
+
+EOF
+
+    foreach $filename (@gdmlFiles)
+    {
+	print OUTPUT <<EOF;
+      <filename> $filename </filename>
+EOF
+    }
+
+    print OUTPUT <<EOF;
+
+   </gdmlfiles>
+
+</config>
+EOF
+
+    close(OUTPUT);
+}
+
+
+print "Some of the principal parameters for this TPC geometry (unit cm unless noted otherwise)\n";
+print " CRM active area       : $widthCRM_active x $lengthCRM_active\n";
+print " CRM total area        : $widthCRM x $lengthCRM\n";
+print " Wire pitch in U, V, Z : $wirePitchU, $wirePitchV, $wirePitchZ\n";
+print " TPC active volume  : $driftTPCActive x $widthTPCActive x $lengthTPCActive\n";
+print " Argon volume       : ($Argon_x, $Argon_y, $Argon_z) \n"; 
+print " Argon buffer       : ($xLArBuffer, $yLArBuffer, $zLArBuffer) \n"; 
+print " Detector enclosure : $DetEncX x $DetEncY x $DetEncZ\n";
+print " TPC Origin         : ($OriginXSet, $OriginYSet, $OriginZSet) \n";
+print " Field Cage         : $FieldCage_switch \n";
+print " Cathode            : $Cathode_switch \n";
+print " Workspace          : $workspace \n";
+print " Wires              : $wires_on \n";
+
+# run the sub routines that generate the fragments
+if ( $FieldCage_switch eq "on" ) {  gen_FieldCage();	}
+#if ( $Cathode_switch eq "on" ) {  gen_Cathode();	} #Cathode for now has the same geometry as the Ground Grid
+
+gen_Extend();    # generates the GDML color extension for the refactored geometry 
+gen_Define(); 	 # generates definitions at beginning of GDML
+gen_Materials(); # generates materials to be used
+gen_TPC();       # generate TPC for a given unit CRM
+gen_Cryostat();  # 
+gen_Enclosure(); # 
+gen_World();	 # places the enclosure among DUSEL Rock
+write_fragments(); # writes the XML input for make_gdml.pl
+		   # which zips together the final GDML
+print "--- done\n\n\n";
+exit;

--- a/dunecore/Geometry/gdml/generate_dunevd10kt_3view_v4_refactored.pl
+++ b/dunecore/Geometry/gdml/generate_dunevd10kt_3view_v4_refactored.pl
@@ -1,0 +1,1960 @@
+#!/usr/bin/perl
+
+#
+#
+#  First attempt to make a GDML fragment generator for the DUNE vertical drift 
+#  10kt detector geometry with 3 views (2 orthogonal + induction at angle)
+#  The lower chamber is not added yet. 
+#  !!!NOTE!!!: the readout is on a positive Y plane (drift along horizontal X)
+#              due to current reco limitations)
+#  No photon detectors declared
+#  Simplified treatment of inter-module dead spaces
+#
+#  Created: Thu Oct  1 16:45:27 CEST 2020
+#           Vyacheslav Galymov <vgalymov@ipnl.in2p3.fr>
+#
+#  Modified:
+#           VG: Added defs to enable use in the refactored sim framework
+#           VG: 23.02.21 Adjust plane dimensions to fit a given number of ch per side
+#           VG: 23.02.21 Group CRUs in CRPs
+#    V2     Laura Paulucci (lpaulucc@fnal.gov): Sept 2021 PDS added. 
+#             Use option -pds=1 for backup design (membrane only coverage).
+#             Default (pds=0) is the reference design (~4-pi).
+#             This is linked with a larger geometry to account for photon propagation, generate it with -k=4.
+#             Field Cage is turned on with reference and backup designs to match PDS option.
+#	      For not including the pds, please use option -pds=-1
+#
+#    V3       Mar 2022: Cathode included
+#
+#    V4     May 2022: Inclusion of anode plate on top of the 3 wire planes as requested by the background TF.
+#           This is included together with the cathode switch on. In order to avoid overlaps, the gaseous argon
+#           was decreased and displaced by $anodePlateWidth = 0.01 cm. Currently the material of this plate is 
+#           set to vm2000 so that no additional geometry (ReflAnode) is needed to obtain optical fast simulation.
+#           TO DO: include perforated PCB in the gdml (see LEMs in dual phase gdml) 
+#
+#################################################################################
+
+# Each subroutine generates a fragment GDML file, and the last subroutine
+# creates an XML file that make_gdml.pl will use to appropriately arrange
+# the fragment GDML files to create the final desired DUNE GDML file, 
+# to be named by make_gdml output command
+
+##################################################################################
+
+
+#use warnings;
+use gdmlMaterials;
+use Math::Trig;
+use Getopt::Long;
+use Math::BigFloat;
+Math::BigFloat->precision(-16);
+
+###
+GetOptions( "help|h" => \$help,
+	    "suffix|s:s" => \$suffix,
+	    "output|o:s" => \$output,
+	    "wires|w:s" => \$wires,
+	    "workspace|k:s" => \$wkspc,
+            "pdsconfig|pds:s" => \$pdsconfig);
+
+my $FieldCage_switch="on";
+my $Cathode_switch="on";
+
+if ( defined $help )
+{
+    # If the user requested help, print the usage notes and exit.
+    usage();
+    exit;
+}
+
+if ( ! defined $suffix )
+{
+    # The user didn't supply a suffix, so append nothing to the file
+    # names.
+    $suffix = "";
+}
+else
+{
+    # Otherwise, stick a "-" before the suffix, so that a suffix of
+    # "test" applied to filename.gdml becomes "filename-test.gdml".
+    $suffix = "-" . $suffix;
+}
+
+
+$workspace = 0;
+if(defined $wkspc ) 
+{
+    $workspace = $wkspc;
+}
+elsif ( $workspace != 0 )
+{
+    print "\t\tCreating smaller workspace geometry.\n";
+}
+
+if ( ! defined $pdsconfig )
+{
+    $pdsconfig = 0;
+    print "\t\tCreating reference design: 4-pi PDS converage.\n";
+}
+elsif ( $pdsconfig == 1 )
+{
+    print "\t\tCreating backup design: membrane-only PDS coverage.\n";
+}
+
+# set wires on to be the default, unless given an input by the user
+$wires_on = 1; # 1=on, 0=off
+if (defined $wires)
+{
+    $wires_on = $wires;
+}
+
+$tpc_on = 1;
+$basename="_";
+
+
+##################################################################
+############## Parameters for One Readout Panel ##################
+
+# parameters for 1.5 x 1.7 sub-unit Charge Readout Module / Unit
+#$widthPCBActive   = 169.0; # cm 
+#$lengthPCBActive  = 150.0; # cm
+
+# views and channel counts
+%nChans = ('Ind1', 256, 'Ind1Bot', 128, 'Ind2', 320, 'Col', 288);
+$nViews = keys %nChans;
+#print "$nViews %nChans\n";
+
+# first induction view
+$wirePitchU      = 0.8695;  # cm
+$wireAngleU      = 131.63;  #-48.37;  # deg
+
+# second induction view
+$wirePitchY      = 0.525;
+$widthPCBActive  = 168.00;   #$wirePitchY * $nChans{'Ind2'};
+
+# last collection view
+$wirePitchZ      = 0.517;
+$lengthPCBActive = 148.9009; #$wirePitchZ * $nChans{'Col'};
+
+#
+$borderCRM       = 0.0;      # border space aroud each CRM 
+
+$widthCRM_active  = $widthPCBActive;  
+$lengthCRM_active = $lengthPCBActive; 
+
+$widthCRM  = $widthPCBActive  + 2 * $borderCRM;
+$lengthCRM = $lengthPCBActive + 2 * $borderCRM;
+
+$borderCRP = 0.5; # cm
+
+# number of CRMs in y and z
+$nCRM_x   = 4 * 2;
+$nCRM_z   = 20 * 2;
+
+# create a smaller geometry
+if( $workspace == 1 )
+{
+    $nCRM_x = 1 * 2;
+    $nCRM_z = 1 * 2;
+}
+
+# create a smaller geometry
+if( $workspace == 2 )
+{
+    $nCRM_x = 2 * 2;
+    $nCRM_z = 2 * 2;
+}
+
+# create a smaller geometry
+if( $workspace == 3 )
+{
+    $nCRM_x = 4 * 2;
+    $nCRM_z = 3 * 2;
+}
+
+# create pds geometry
+if( $workspace == 4 )
+{
+    $nCRM_x = 4 * 2;
+    $nCRM_z = 7 * 2;
+}
+
+
+# calculate tpc area based on number of CRMs and their dimensions 
+# each CRP should have a 2x2 CRMs
+$widthTPCActive  = $nCRM_x * $widthCRM + $nCRM_x * $borderCRP;  # around 1200 for full module
+$lengthTPCActive = $nCRM_z * $lengthCRM + $nCRM_z * $borderCRP; # around 6000 for full module
+
+# active volume dimensions 
+$driftTPCActive  = 650.0;
+
+# model anode strips as wires of some diameter
+$padWidth          = 0.02;
+$ReadoutPlane      = $nViews * $padWidth; # 3 readout planes (no space b/w)!
+
+# anode plate definition
+$anodePlateWidth   = $padWidth/2.;
+
+##################################################################
+############## Parameters for TPC and inner volume ###############
+
+# inner volume dimensions of the cryostat
+$Argon_x = 1510;
+$Argon_y = 1510;
+$Argon_z = 6200;
+
+# width of gas argon layer on top
+$HeightGaseousAr = 100;
+
+if( $workspace != 0 )
+{
+    #active tpc + 1.0 m buffer on each side
+    $Argon_x = $driftTPCActive + $HeightGaseousAr + $ReadoutPlane + 100;
+    $Argon_y = $widthTPCActive + 200;
+    $Argon_z = $lengthTPCActive + 200;
+}
+
+
+# size of liquid argon buffer
+$xLArBuffer = $Argon_x - $driftTPCActive - $HeightGaseousAr - $ReadoutPlane;
+$yLArBuffer = 0.5 * ($Argon_y - $widthTPCActive);
+$zLArBuffer = 0.5 * ($Argon_z - $lengthTPCActive);
+
+# cryostat 
+$SteelThickness = 0.12; # membrane
+
+$Cryostat_x = $Argon_x + 2*$SteelThickness;
+$Cryostat_y = $Argon_y + 2*$SteelThickness;
+$Cryostat_z = $Argon_z + 2*$SteelThickness;
+
+##################################################################
+############## DetEnc and World relevant parameters  #############
+
+$SteelSupport_x  =  100;
+$SteelSupport_y  =  100;
+$SteelSupport_z  =  100; 
+$FoamPadding     =  80;  
+$FracMassOfSteel =  0.5; #The steel support is not a solid block, but a mixture of air and steel
+$FracMassOfAir   =  1 - $FracMassOfSteel;
+
+
+$SpaceSteelSupportToWall    = 100;
+$SpaceSteelSupportToCeiling = 100;
+
+$DetEncX  =    $Cryostat_x
+                  + 2*($SteelSupport_x + $FoamPadding) + $SpaceSteelSupportToCeiling;
+
+$DetEncY  =    $Cryostat_y
+                  + 2*($SteelSupport_y + $FoamPadding) + 2*$SpaceSteelSupportToWall;
+
+$DetEncZ  =    $Cryostat_z
+                  + 2*($SteelSupport_z + $FoamPadding) + 2*$SpaceSteelSupportToWall;
+
+$posCryoInDetEnc_x = - $DetEncX/2 + $SteelSupport_x + $FoamPadding + $Cryostat_x/2;
+
+
+$RockThickness = 4000;
+
+  # We want the world origin to be vertically centered on active TPC
+  # This is to be added to the x and y position of every volume in volWorld
+
+$OriginXSet =  $DetEncX/2.0
+             - $SteelSupport_x
+             - $FoamPadding
+             - $SteelThickness
+             - $xLArBuffer
+             - $driftTPCActive/2.0;
+
+$OriginYSet =   $DetEncY/2.0
+              - $SpaceSteelSupportToWall
+              - $SteelSupport_y
+              - $FoamPadding
+              - $SteelThickness
+              - $yLArBuffer
+              - $widthTPCActive/2.0;
+
+  # We want the world origin to be at the very front of the fiducial volume.
+  # move it to the front of the enclosure, then back it up through the concrete/foam, 
+  # then through the Cryostat shell, then through the upstream dead LAr (including the
+  # dead LAr on the edge of the TPC)
+  # This is to be added to the z position of every volume in volWorld
+
+$OriginZSet =   $DetEncZ/2.0 
+              - $SpaceSteelSupportToWall
+              - $SteelSupport_z
+              - $FoamPadding
+              - $SteelThickness
+              - $zLArBuffer
+              - $borderCRM;
+
+##################################################################
+############## Field Cage Parameters ###############
+$FieldShaperLongTubeLength  =  $lengthTPCActive;
+$FieldShaperShortTubeLength =  $widthTPCActive;
+#$FieldShaperInnerRadius = 1.485;
+#$FieldShaperOuterRadius = 1.685;
+#$FieldShaperTorRad = 1.69;
+$FieldShaperInnerRadius = 0.5; #cm
+$FieldShaperOuterRadius = 2.285; #cm
+$FieldShaperOuterRadiusSlim = 0.75; #cm
+$FieldShaperTorRad = 2.3; #cm
+
+$FieldShaperLength = $FieldShaperLongTubeLength + 2*$FieldShaperOuterRadius+ 2*$FieldShaperTorRad;
+$FieldShaperWidth =  $FieldShaperShortTubeLength + 2*$FieldShaperOuterRadius+ 2*$FieldShaperTorRad;
+
+$FieldShaperSeparation = 6.0; #cm
+$NFieldShapers = ($driftTPCActive/$FieldShaperSeparation) - 1;
+
+$FieldCageSizeX = $FieldShaperSeparation*$NFieldShapers+2;
+$FieldCageSizeY = $FieldShaperWidth+2;
+$FieldCageSizeZ = $FieldShaperLength+2;
+
+
+##################################################################
+############## Cathode Parameters ###############
+$heightCathode=4.0; #cm
+$CathodeBorder=4.0; #cm
+$widthCathode=2*$widthCRM;
+$lengthCathode=2*$lengthCRM;
+$widthCathodeVoid=76.35;
+$lengthCathodeVoid=67.0;
+
+
+####################################################################
+######################## ARAPUCA Dimensions ########################
+## in cm
+
+$ArapucaOut_x = 65.0; 
+$ArapucaOut_y = 2.5;
+$ArapucaOut_z = 65.0; 
+$ArapucaIn_x = 60.0;
+$ArapucaIn_y = 2.0;
+$ArapucaIn_z = 60.0;
+$ArapucaAcceptanceWindow_x = 60.0;
+$ArapucaAcceptanceWindow_y = 1.0;
+$ArapucaAcceptanceWindow_z = 60.0;
+$GapPD = 0.5; #Arapuca distance from Cathode Frame
+$FrameToArapucaSpace       =    1.0; #Small vertical gap over laterals to avoid overlap
+$FrameToArapucaSpaceLat    =   $yLArBuffer - 60.0; #Arapucas 60 cm behind FC. At this moment, should cover the thickness of Frame + small gap to prevent overlap. VALUE NEEDS TO BE CHECKED!!!
+$VerticalPDdist = 75.0; #distance of arapucas (center to center) in the y direction 
+$HorizontalPDdist = 150.0; #distance of arapucas (center to center) in the x direction
+
+#Positions of the 4 arapucas with respect to the Frame center --> arapucas over the cathode
+$list_posx_bot[0]=-2*$widthCathodeVoid - 2.0*$CathodeBorder + $GapPD + 0.5*$ArapucaOut_x;
+$list_posz_bot[0]= 0.5*$lengthCathodeVoid + $CathodeBorder;
+$list_posx_bot[1]= - $CathodeBorder - $GapPD - 0.5*$ArapucaOut_x;
+$list_posz_bot[1]=-1.5*$lengthCathodeVoid - 2.0*$CathodeBorder;
+$list_posx_bot[2]=-$list_posx_bot[1];
+$list_posz_bot[2]=-$list_posz_bot[1];
+$list_posx_bot[3]=-$list_posx_bot[0];
+$list_posz_bot[3]=-$list_posz_bot[0];
+
+
+#+++++++++++++++++++++++++ End defining variables ++++++++++++++++++++++++++
+
+
+#+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+#+++++++++++++++++++++++++++++++++++++++++ usage +++++++++++++++++++++++++++++++++++++++++
+#+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+sub usage()
+{
+    print "Usage: $0 [-h|--help] [-o|--output <fragments-file>] [-s|--suffix <string>]\n";
+    print "       if -o is omitted, output goes to STDOUT; <fragments-file> is input to make_gdml.pl\n";
+    print "       -s <string> appends the string to the file names; useful for multiple detector versions\n";
+    print "       -h prints this message, then quits\n";
+}
+
+
+sub gen_Extend()
+{
+
+# Create the <define> fragment file name, 
+# add file to list of fragments,
+# and open it
+    $DEF = $basename."_Ext" . $suffix . ".gdml";
+    push (@gdmlFiles, $DEF);
+    $DEF = ">" . $DEF;
+    open(DEF) or die("Could not open file $DEF for writing");
+
+print DEF <<EOF;
+<?xml version='1.0'?>
+<gdml>
+<extension>
+   <color name="magenta"     R="0.0"  G="1.0"  B="0.0"  A="1.0" />
+   <color name="green"       R="0.0"  G="1.0"  B="0.0"  A="1.0" />
+   <color name="red"         R="1.0"  G="0.0"  B="0.0"  A="1.0" />
+   <color name="blue"        R="0.0"  G="0.0"  B="1.0"  A="1.0" />
+   <color name="yellow"      R="1.0"  G="1.0"  B="0.0"  A="1.0" />    
+</extension>
+</gdml>
+EOF
+    close (DEF);
+}
+
+#+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+#++++++++++++++++++++++++++++++++++++++ gen_Define +++++++++++++++++++++++++++++++++++++++
+#+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+sub gen_Define()
+{
+
+# Create the <define> fragment file name, 
+# add file to list of fragments,
+# and open it
+    $DEF = $basename."_Def" . $suffix . ".gdml";
+    push (@gdmlFiles, $DEF);
+    $DEF = ">" . $DEF;
+    open(DEF) or die("Could not open file $DEF for writing");
+
+
+print DEF <<EOF;
+<?xml version='1.0'?>
+<gdml>
+<define>
+
+<!--
+
+
+
+-->
+
+   <position name="posCryoInDetEnc"     unit="cm" x="$posCryoInDetEnc_x" y="0" z="0"/>
+   <position name="posCenter"           unit="cm" x="0" y="0" z="0"/>
+   <rotation name="rUWireAboutX"        unit="deg" x="$wireAngleU" y="0" z="0"/>
+   <rotation name="rPlus90AboutX"       unit="deg" x="90" y="0" z="0"/>
+   <rotation name="rPlus90AboutY"       unit="deg" x="0" y="90" z="0"/>
+   <rotation name="rPlus90AboutXPlus90AboutY" unit="deg" x="90" y="90" z="0"/>
+   <rotation name="rMinus90AboutX"      unit="deg" x="270" y="0" z="0"/>
+   <rotation name="rMinus90AboutY"      unit="deg" x="0" y="270" z="0"/>
+   <rotation name="rMinus90AboutYMinus90AboutX"       unit="deg" x="270" y="270" z="0"/>
+   <rotation name="rPlus180AboutX"	unit="deg" x="180" y="0"   z="0"/>
+   <rotation name="rPlus180AboutY"	unit="deg" x="0" y="180"   z="0"/>
+   <rotation name="rPlus180AboutXPlus180AboutY"	unit="deg" x="180" y="180"   z="0"/>
+   <rotation name="rIdentity"		unit="deg" x="0" y="0"   z="0"/>
+</define>
+</gdml>
+EOF
+    close (DEF);
+}
+
+#+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+#+++++++++++++++++++++++++++++++++++++ gen_Materials +++++++++++++++++++++++++++++++++++++
+#+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+sub gen_Materials()
+{
+
+# Create the <materials> fragment file name,
+# add file to list of output GDML fragments,
+# and open it
+    $MAT = $basename."_Materials" . $suffix . ".gdml";
+    push (@gdmlFiles, $MAT);
+    $MAT = ">" . $MAT;
+
+    open(MAT) or die("Could not open file $MAT for writing");
+
+    # Add any materials special to this geometry by defining a mulitline string
+    # and passing it to the gdmlMaterials::gen_Materials() function.
+my $asmix = <<EOF;
+  <!-- preliminary values -->
+  <material name="AirSteelMixture" formula="AirSteelMixture">
+   <D value=" 0.001205*(1-$FracMassOfSteel) + 7.9300*$FracMassOfSteel " unit="g/cm3"/>
+   <fraction n="$FracMassOfSteel" ref="STEEL_STAINLESS_Fe7Cr2Ni"/>
+   <fraction n="$FracMassOfAir"   ref="Air"/>
+  </material>
+  <material name="vm2000" formula="vm2000">
+    <D value="1.2" unit="g/cm3"/>
+    <composite n="2" ref="carbon"/>
+    <composite n="4" ref="hydrogen"/>
+  </material>
+EOF
+
+    # add the general materials used anywere
+    print MAT gdmlMaterials::gen_Materials( $asmix );
+
+    close(MAT);
+}
+
+
+#+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+#++++++++++++++++++++++++++++++++++++++++ gen_TPC ++++++++++++++++++++++++++++++++++++++++
+#+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+# line clip on the rectangle boundary
+sub lineClip {
+    my $x0  = $_[0];
+    my $y0  = $_[1];
+    my $nx  = $_[2];
+    my $ny  = $_[3];
+    my $rcl = $_[4];
+    my $rcw = $_[5];
+
+    my $tol = 1.0E-4;
+    my @endpts = ();
+    if( abs( nx ) < tol ){
+	push( @endpts, ($x0, 0) );
+	push( @endpts, ($x0, $rcw) );
+	return @endpts;
+    }
+    if( abs( ny ) < tol ){
+	push( @endpts, (0, $y0) );
+	push( @endpts, ($rcl, $y0) );
+	return @endpts;
+    }
+    
+    # left border at x = 0
+    my $y = $y0 - $x0 * $ny/$nx;
+    if( $y >= 0 && $y <= $rcw ){
+	push( @endpts, (0, $y) );
+    }
+
+    # right border at x = l
+    $y = $y0 + ($rcl-$x0) * $ny/$nx;
+    if( $y >= 0 && $y <= $rcw ){
+	push( @endpts, ($rcl, $y) );
+	if( scalar(@endpts) == 4 ){
+	    return @endpts;
+	}
+    }
+
+    # bottom border at y = 0
+    my $x = $x0 - $y0 * $nx/$ny;
+    if( $x >= 0 && $x <= $rcl ){
+	push( @endpts, ($x, 0) );
+	if( scalar(@endpts) == 4 ){
+	    return @endpts;
+	}
+    }
+    
+    # top border at y = w
+    $x = $x0 + ($rcw-$y0)* $nx/$ny;
+    if( $x >= 0 && $x <= $rcl ){
+	push( @endpts, ($x, $rcw) );
+    }
+    
+    return @endpts;
+}
+
+sub gen_Wires
+{
+    my $length = $_[0];  # 
+    my $width  = $_[1];  # 
+    my $nch    = $_[2];  # 
+    my $nchb   = $_[3];  # nch per bottom side
+    my $pitch  = $_[4];  # 
+    my $theta  = $_[5];  # deg
+    my $dia    = $_[6];  #
+    
+    $theta  = $theta * pi()/180.0;
+    my @dirw   = (cos($theta), sin($theta));
+    my @dirp   = (cos($theta - pi()/2), sin($theta - pi()/2));
+
+    # calculate
+    my $alpha = $theta;
+    if( $alpha > pi()/2 ){
+	$alpha = pi() - $alpha;
+    }
+    my $dX = $pitch / sin( $alpha );
+    my $dY = $pitch / sin( pi()/2 - $alpha );
+    if( $length <= 0 ){
+        $length = $dX * $nchb;
+    }
+    if( $width <= 0 ){
+	$width = $dY * ($nch - $nchb);
+    }
+
+    my @orig   = (0, 0);
+    if( $dirp[0] < 0 ){
+	$orig[0] = $length;
+    }
+    if( $dirp[1] < 0 ){
+	$orig[1] = $width;
+    }
+  
+    #print "origin    : @orig\n";
+    #print "pitch dir : @dirp\n";
+    #print "wire dir  : @dirw\n";
+    #print "$length x $width cm2\n";
+    
+    # gen wires
+    my @winfo  = ();
+    my $offset = $pitch/2;
+    foreach my $ch (0..$nch-1){
+	#print "Processing $ch\n";
+
+	# calculate reference point for this strip
+	my @wcn = (0, 0);
+	$wcn[0] = $orig[0] + $offset * $dirp[0];
+	$wcn[1] = $orig[1] + $offset * $dirp[1];
+
+	# line clip on the rectangle boundary
+	@endpts = lineClip( $wcn[0], $wcn[1], $dirw[0], $dirw[1], $length, $width );
+
+	if( scalar(@endpts) != 4 ){
+	    print "Could not find end points for wire $ch : @endpts\n";
+	    $offset = $offset + $pitch;
+	    next;
+	}
+
+	# re-center on the mid-point
+	$endpts[0] -= $length/2;
+	$endpts[2] -= $length/2;
+	$endpts[1] -= $width/2;
+	$endpts[3] -= $width/2;
+
+	# calculate the strip center in the rectangle of CRU
+	$wcn[0] = ($endpts[0] + $endpts[2])/2;
+	$wcn[1] = ($endpts[1] + $endpts[3])/2;
+
+	# calculate the length
+	my $dx = $endpts[0] - $endpts[2];
+	my $dy = $endpts[1] - $endpts[3];
+	my $wlen = sqrt($dx**2 + $dy**2);
+
+	# put all info together
+	my @wire = ($ch, $wcn[0], $wcn[1], $wlen);
+	push( @wire, @endpts );
+	push( @winfo, \@wire);
+	$offset = $offset + $pitch;
+	#last;
+    }
+    return @winfo;
+}
+
+#
+sub gen_TPC()
+{
+    # CRM active volume
+    my $TPCActive_x = $driftTPCActive;
+    my $TPCActive_y = $widthCRM_active;
+    my $TPCActive_z = $lengthCRM_active;
+
+    # CRM total volume
+    my $TPC_x = $TPCActive_x + $ReadoutPlane;
+    my $TPC_y = $widthCRM;
+    my $TPC_z = $lengthCRM;
+
+    print " TPC dimensions     : $TPC_x x $TPC_y x $TPC_z\n";
+    
+    $TPC = $basename."_TPC" . $suffix . ".gdml";
+    push (@gdmlFiles, $TPC);
+    $TPC = ">" . $TPC;
+    open(TPC) or die("Could not open file $TPC for writing");
+
+    # The standard XML prefix and starting the gdml
+print TPC <<EOF;
+    <?xml version='1.0'?>
+	<gdml>
+EOF
+
+    # compute wires for 1st induction
+    my @winfo = ();
+    if( $wires_on == 1 ){
+	@winfo = gen_Wires( 0, 0, # $TPCActive_y,
+			    $nChans{'Ind1'}, $nChans{'Ind1Bot'}, 
+			    $wirePitchU, $wireAngleU, $padWidth );
+    }
+
+    # All the TPC solids save the wires.
+print TPC <<EOF;
+    <solids>
+EOF
+
+print TPC <<EOF;
+   <box name="CRM"
+      x="$TPC_x" 
+      y="$TPC_y" 
+      z="$TPC_z"
+      lunit="cm"/>
+   <box name="CRMUPlane" 
+      x="$padWidth" 
+      y="$TPCActive_y" 
+      z="$TPCActive_z"
+      lunit="cm"/>
+   <box name="CRMYPlane" 
+      x="$padWidth" 
+      y="$TPCActive_y" 
+      z="$TPCActive_z"
+      lunit="cm"/>
+   <box name="CRMZPlane" 
+      x="$padWidth"
+      y="$TPCActive_y"
+      z="$TPCActive_z"
+      lunit="cm"/>
+   <box name="CRMActive" 
+      x="$TPCActive_x"
+      y="$TPCActive_y"
+      z="$TPCActive_z"
+      lunit="cm"/>
+EOF
+
+#++++++++++++++++++++++++++++ Wire Solids ++++++++++++++++++++++++++++++
+if($wires_on==1){
+	    
+    foreach my $wire (@winfo) {
+	my $wid = $wire->[0];
+	my $wln = $wire->[3];
+print TPC <<EOF;
+   <tube name="CRMWireU$wid"
+      rmax="0.5*$padWidth"
+      z="$wln"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+EOF
+    }
+    
+print TPC <<EOF;
+   <tube name="CRMWireY"
+      rmax="0.5*$padWidth"
+      z="$TPCActive_z"               
+      deltaphi="360" 
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireZ"
+      rmax="0.5*$padWidth"
+      z="$TPCActive_y"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+EOF
+}
+print TPC <<EOF;
+</solids>
+EOF
+
+
+# Begin structure and create wire logical volumes
+print TPC <<EOF;
+<structure>
+    <volume name="volTPCActive">
+      <materialref ref="LAr"/>
+      <solidref ref="CRMActive"/>
+      <auxiliary auxtype="SensDet" auxvalue="SimEnergyDeposit"/>
+      <auxiliary auxtype="StepLimit" auxunit="cm" auxvalue="0.5208*cm"/>
+      <auxiliary auxtype="Efield" auxunit="V/cm" auxvalue="500*V/cm"/>
+      <colorref ref="blue"/>
+    </volume>
+EOF
+
+if($wires_on==1) 
+{
+    foreach my $wire (@winfo) 
+    {
+	my $wid = $wire->[0];
+print TPC <<EOF;
+    <volume name="volTPCWireU$wid">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU$wid"/>
+    </volume>
+EOF
+    }
+
+print TPC <<EOF;
+    <volume name="volTPCWireY">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireY"/>
+    </volume>
+    <volume name="volTPCWireZ">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireZ"/>
+    </volume>
+EOF
+}
+    # 1st induction plane
+print TPC <<EOF;
+   <volume name="volTPCPlaneU">
+     <materialref ref="LAr"/>
+     <solidref ref="CRMUPlane"/>
+EOF
+if ($wires_on==1) # add wires to U plane 
+{
+    # the coordinates were computed with a corner at (0,0)
+    # so we need to move to plane coordinates
+    my $offsetZ = 0; #-0.5 * $TPCActive_z;
+    my $offsetY = 0; #-0.5 * $TPCActive_y;
+
+    foreach my $wire (@winfo) {
+	my $wid  = $wire->[0];
+	my $zpos = $wire->[1] + $offsetZ;
+	my $ypos = $wire->[2] + $offsetY;
+print TPC <<EOF;
+     <physvol>
+       <volumeref ref="volTPCWireU$wid"/> 
+       <position name="posWireU$wid" unit="cm" x="0" y="$ypos" z="$zpos"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+EOF
+    }
+}
+print TPC <<EOF;
+   </volume>
+EOF
+
+# 2nd induction plane
+print TPC <<EOF;
+  <volume name="volTPCPlaneY">
+    <materialref ref="LAr"/>
+    <solidref ref="CRMYPlane"/>
+EOF
+
+if ($wires_on==1) # add wires to Y plane (plane with wires reading y position)
+{
+    for(my $i=0;$i<$nChans{'Ind2'};++$i)
+    {
+	#my $ypos = -0.5 * $TPCActive_y + ($i+0.5)*$wirePitchY + 0.5*$padWidth;
+	my $ypos = ($i + 0.5 - $nChans{'Ind2'}/2)*$wirePitchY;
+	if( (0.5 * $TPCActive_y - abs($ypos)) < 0 ){
+	    die "Cannot place wire $i in view Y, as plane is too small\n";
+	}
+print TPC <<EOF;
+      <physvol>
+        <volumeref ref="volTPCWireY"/> 
+        <position name="posWireY$i" unit="cm" x="0" y="$ypos" z="0"/>
+	<rotationref ref="rIdentity"/> 
+      </physvol>
+EOF
+   }
+}
+print TPC <<EOF;
+  </volume>
+EOF
+
+# collection plane
+print TPC <<EOF;
+  <volume name="volTPCPlaneZ">
+    <materialref ref="LAr"/>
+    <solidref ref="CRMZPlane"/>
+EOF
+if ($wires_on==1) # add wires to Z plane (plane with wires reading z position)
+   {
+       for(my $i=0;$i<$nChans{'Col'};++$i)
+       {
+	   #my $zpos = -0.5 * $TPCActive_z + ($i+0.5)*$wirePitchZ + 0.5*$padWidth;
+	   my $zpos = ($i + 0.5 - $nChans{'Col'}/2)*$wirePitchZ;
+	   if( (0.5 * $TPCActive_z - abs($zpos)) < 0 ){
+	       die "Cannot place wire $i in view Z, as plane is too small\n";
+	   }
+print TPC <<EOF;
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ$i" unit="cm" x="0" y="0" z="$zpos"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+EOF
+       }
+}
+print TPC <<EOF;
+  </volume>
+EOF
+       
+$posUplane[0] = 0.5*$TPC_x - 2.5*$padWidth;
+$posUplane[1] = 0;
+$posUplane[2] = 0;
+
+$posYplane[0] = 0.5*$TPC_x - 1.5*$padWidth;
+$posYplane[1] = 0;
+$posYplane[2] = 0;
+
+$posZplane[0] = 0.5*$TPC_x - 0.5*$padWidth;
+$posZplane[1] = 0; 
+$posZplane[2] = 0;
+
+$posTPCActive[0] = -$ReadoutPlane/2;
+$posTPCActive[1] = 0;
+$posTPCActive[2] = 0;
+
+
+#wrap up the TPC file
+print TPC <<EOF;
+   <volume name="volTPC">
+     <materialref ref="LAr"/>
+       <solidref ref="CRM"/>
+       <physvol>
+       <volumeref ref="volTPCPlaneU"/>
+       <position name="posPlaneU" unit="cm" 
+         x="$posUplane[0]" y="$posUplane[1]" z="$posUplane[2]"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCPlaneY"/>
+       <position name="posPlaneY" unit="cm" 
+         x="$posYplane[0]" y="$posYplane[1]" z="$posYplane[2]"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCPlaneZ"/>
+       <position name="posPlaneZ" unit="cm" 
+         x="$posZplane[0]" y="$posZplane[1]" z="$posZplane[2]"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCActive"/>
+       <position name="posActive" unit="cm" 
+        x="$posTPCActive[0]" y="$posTPCAtive[1]" z="$posTPCActive[2]"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+   </volume>
+EOF
+
+print TPC <<EOF;
+ </structure>
+ </gdml>
+EOF
+
+    close(TPC);
+}
+
+#+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+#++++++++++++++++++++++++++++++++++++++ gen_FieldCage ++++++++++++++++++++++++++++++++++++
+#+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+sub gen_FieldCage {
+
+    $FieldCage = $basename."_FieldCage" . $suffix . ".gdml";
+    push (@gdmlFiles, $FieldCage);
+    $FieldCage = ">" . $FieldCage;
+    open(FieldCage) or die("Could not open file $FieldCage for writing");
+
+# The standard XML prefix and starting the gdml
+print FieldCage <<EOF;
+   <?xml version='1.0'?>
+   <gdml>
+EOF
+# The printing solids used in the Field Cage
+#print "lengthTPCActive      : $lengthTPCActive \n";
+#print "widthTPCActive       : $widthTPCActive \n";
+
+
+print FieldCage <<EOF;
+<solids>
+     <torus name="FieldShaperCorner" rmin="$FieldShaperInnerRadius" rmax="$FieldShaperOuterRadius" rtor="$FieldShaperTorRad" deltaphi="90" startphi="0" aunit="deg" lunit="cm"/>
+     <tube name="FieldShaperLongtube" rmin="$FieldShaperInnerRadius" rmax="$FieldShaperOuterRadius" z="$FieldShaperLongTubeLength" deltaphi="360" startphi="0" aunit="deg" lunit="cm"/>
+     <tube name="FieldShaperLongtubeSlim" rmin="$FieldShaperInnerRadius" rmax="$FieldShaperOuterRadiusSlim" z="$FieldShaperLongTubeLength" deltaphi="360" startphi="0" aunit="deg" lunit="cm"/>
+     <tube name="FieldShaperShorttube" rmin="$FieldShaperInnerRadius" rmax="$FieldShaperOuterRadius" z="$FieldShaperShortTubeLength" deltaphi="360" startphi="0" aunit="deg" lunit="cm"/>
+
+    <union name="FSunion1">
+      <first ref="FieldShaperLongtube"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos1" unit="cm" x="@{[-$FieldShaperTorRad]}" y="0" z="@{[0.5*$FieldShaperLongTubeLength]}"/>
+		<rotation name="rot1" unit="deg" x="90" y="0" z="0" />
+    </union>
+
+    <union name="FSunion2">
+      <first ref="FSunion1"/>
+      <second ref="FieldShaperShorttube"/>
+   		<position name="esquinapos2" unit="cm" x="@{[-0.5*$FieldShaperShortTubeLength-$FieldShaperTorRad]}" y="0" z="@{[+0.5*$FieldShaperLongTubeLength+$FieldShaperTorRad]}"/>
+   		<rotation name="rot2" unit="deg" x="0" y="90" z="0" />
+    </union>
+
+    <union name="FSunion3">
+      <first ref="FSunion2"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos3" unit="cm" x="@{[-$FieldShaperShortTubeLength-$FieldShaperTorRad]}" y="0" z="@{[0.5*$FieldShaperLongTubeLength]}"/>
+		<rotation name="rot3" unit="deg" x="90" y="270" z="0" />
+    </union>
+
+    <union name="FSunion4">
+      <first ref="FSunion3"/>
+      <second ref="FieldShaperLongtube"/>
+   		<position name="esquinapos4" unit="cm" x="@{[-$FieldShaperShortTubeLength-2*$FieldShaperTorRad]}" y="0" z="0"/>
+    </union>
+
+    <union name="FSunion5">
+      <first ref="FSunion4"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos5" unit="cm" x="@{[-$FieldShaperShortTubeLength-$FieldShaperTorRad]}" y="0" z="@{[-0.5*$FieldShaperLongTubeLength]}"/>
+		<rotation name="rot5" unit="deg" x="90" y="180" z="0" />
+    </union>
+
+    <union name="FSunion6">
+      <first ref="FSunion5"/>
+      <second ref="FieldShaperShorttube"/>
+   		<position name="esquinapos6" unit="cm" x="@{[-0.5*$FieldShaperShortTubeLength-$FieldShaperTorRad]}" y="0" z="@{[-0.5*$FieldShaperLongTubeLength-$FieldShaperTorRad]}"/>
+		<rotation name="rot6" unit="deg" x="0" y="90" z="0" />
+    </union>
+
+    <union name="FieldShaperSolid">
+      <first ref="FSunion6"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos7" unit="cm" x="@{[-$FieldShaperTorRad]}" y="0" z="@{[-0.5*$FieldShaperLongTubeLength]}"/>
+		<rotation name="rot7" unit="deg" x="90" y="90" z="0" />
+    </union>
+    
+    <union name="FSunionSlim1">
+      <first ref="FieldShaperLongtubeSlim"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos1" unit="cm" x="@{[-$FieldShaperTorRad]}" y="0" z="@{[0.5*$FieldShaperLongTubeLength]}"/>
+		<rotation name="rot1" unit="deg" x="90" y="0" z="0" />
+    </union>
+
+    <union name="FSunionSlim2">
+      <first ref="FSunionSlim1"/>
+      <second ref="FieldShaperShorttube"/>
+   		<position name="esquinapos2" unit="cm" x="@{[-0.5*$FieldShaperShortTubeLength-$FieldShaperTorRad]}" y="0" z="@{[+0.5*$FieldShaperLongTubeLength+$FieldShaperTorRad]}"/>
+   		<rotation name="rot2" unit="deg" x="0" y="90" z="0" />
+    </union>
+
+    <union name="FSunionSlim3">
+      <first ref="FSunionSlim2"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos3" unit="cm" x="@{[-$FieldShaperShortTubeLength-$FieldShaperTorRad]}" y="0" z="@{[0.5*$FieldShaperLongTubeLength]}"/>
+		<rotation name="rot3" unit="deg" x="90" y="270" z="0" />
+    </union>
+
+    <union name="FSunionSlim4">
+      <first ref="FSunionSlim3"/>
+      <second ref="FieldShaperLongtubeSlim"/>
+   		<position name="esquinapos4" unit="cm" x="@{[-$FieldShaperShortTubeLength-2*$FieldShaperTorRad]}" y="0" z="0"/>
+    </union>
+
+    <union name="FSunionSlim5">
+      <first ref="FSunionSlim4"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos5" unit="cm" x="@{[-$FieldShaperShortTubeLength-$FieldShaperTorRad]}" y="0" z="@{[-0.5*$FieldShaperLongTubeLength]}"/>
+		<rotation name="rot5" unit="deg" x="90" y="180" z="0" />
+    </union>
+
+    <union name="FSunionSlim6">
+      <first ref="FSunionSlim5"/>
+      <second ref="FieldShaperShorttube"/>
+   		<position name="esquinapos6" unit="cm" x="@{[-0.5*$FieldShaperShortTubeLength-$FieldShaperTorRad]}" y="0" z="@{[-0.5*$FieldShaperLongTubeLength-$FieldShaperTorRad]}"/>
+		<rotation name="rot6" unit="deg" x="0" y="90" z="0" />
+    </union>
+
+    <union name="FieldShaperSolidSlim">
+      <first ref="FSunionSlim6"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos7" unit="cm" x="@{[-$FieldShaperTorRad]}" y="0" z="@{[-0.5*$FieldShaperLongTubeLength]}"/>
+		<rotation name="rot7" unit="deg" x="90" y="90" z="0" />
+    </union>
+    
+</solids>
+
+EOF
+
+print FieldCage <<EOF;
+
+<structure>
+<volume name="volFieldShaper">
+  <materialref ref="Al2O3"/>
+  <solidref ref="FieldShaperSolid"/>
+</volume>
+<volume name="volFieldShaperSlim">
+  <materialref ref="Al2O3"/>
+  <solidref ref="FieldShaperSolidSlim"/>
+</volume>
+
+</structure>
+
+EOF
+
+print FieldCage <<EOF;
+
+</gdml>
+EOF
+close(FieldCage);
+}
+
+
+
+#+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+#++++++++++++++++++++++++++++++++++++++ gen_Cryostat +++++++++++++++++++++++++++++++++++++
+#+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+sub gen_Cryostat()
+{
+
+# Create the cryostat fragment file name,
+# add file to list of output GDML fragments,
+# and open it
+    $CRYO = $basename."_Cryostat" . $suffix . ".gdml";
+    push (@gdmlFiles, $CRYO);
+    $CRYO = ">" . $CRYO;
+    open(CRYO) or die("Could not open file $CRYO for writing");
+
+
+# The standard XML prefix and starting the gdml
+    print CRYO <<EOF;
+<?xml version='1.0'?>
+<gdml>
+EOF
+
+# All the cryostat solids.
+# External active are two side volumes for generating light outside the field cage (no top or bottom buffers included)
+print CRYO <<EOF;
+<solids>
+    <box name="Cryostat" lunit="cm" 
+      x="$Cryostat_x" 
+      y="$Cryostat_y" 
+      z="$Cryostat_z"/>
+
+    <box name="ArgonInterior" lunit="cm" 
+      x="$Argon_x"
+      y="$Argon_y"
+      z="$Argon_z"/>
+
+    <box name="GaseousArgon" lunit="cm" 
+      x="$HeightGaseousAr - $anodePlateWidth"
+      y="$Argon_y"
+      z="$Argon_z"/>
+
+    <box name="ExternalAuxOut" lunit="cm" 
+      x="$Argon_x - $xLArBuffer"
+      y="$Argon_y - 2*$ArapucaOut_y - 2*$FrameToArapucaSpaceLat"
+      z="$Argon_z"/>
+
+    <box name="ExternalAuxIn" lunit="cm" 
+      x="$Argon_x"
+      y="$FieldCageSizeY"
+      z="$Argon_z + 1"/>
+
+   <subtraction name="ExternalActive">
+      <first ref="ExternalAuxOut"/>
+      <second ref="ExternalAuxIn"/>
+    </subtraction>
+
+    <subtraction name="SteelShell">
+      <first ref="Cryostat"/>
+      <second ref="ArgonInterior"/>
+    </subtraction>
+
+</solids>
+EOF
+    
+#PDS
+#Double sided detectors should only be included when both top and bottom volumes become available
+#Optical sensitive volumes cannot be rotated because Larsoft cannot pick up the rotation when obtinaing the lengths needed for the semi-analytic model --> two acceptance windows for single sided lateral and cathode
+print CRYO <<EOF;
+<solids>
+    <box name="ArapucaOut" lunit="cm"
+      x="@{[$ArapucaOut_x]}"
+      y="@{[$ArapucaOut_y]}"
+      z="@{[$ArapucaOut_z]}"/>
+
+    <box name="ArapucaIn" lunit="cm"
+      x="@{[$ArapucaIn_x]}"
+      y="@{[$ArapucaOut_y]}"
+      z="@{[$ArapucaIn_z]}"/>
+
+     <subtraction name="ArapucaWalls">
+      <first  ref="ArapucaOut"/>
+      <second ref="ArapucaIn"/>
+      <position name="posArapucaSub" x="0" y="@{[$ArapucaOut_y/2.0]}" z="0." unit="cm"/>
+      </subtraction>
+
+    <box name="ArapucaAcceptanceWindow" lunit="cm"
+      x="@{[$ArapucaAcceptanceWindow_x]}"
+      y="@{[$ArapucaAcceptanceWindow_y]}"
+      z="@{[$ArapucaAcceptanceWindow_z]}"/>
+
+    <box name="ArapucaDoubleIn" lunit="cm"
+      x="@{[$ArapucaIn_x]}"
+      y="@{[$ArapucaOut_y+1.0]}"
+      z="@{[$ArapucaIn_z]}"/>
+
+     <subtraction name="ArapucaDoubleWalls">
+      <first  ref="ArapucaOut"/>
+      <second ref="ArapucaDoubleIn"/>
+      <position name="posArapucaDoubleSub" x="0" y="0" z="0" unit="cm"/>
+      </subtraction>
+
+    <box name="ArapucaDoubleAcceptanceWindow" lunit="cm"
+      x="@{[$ArapucaOut_y-0.02]}"
+      y="@{[$ArapucaAcceptanceWindow_x]}"
+      z="@{[$ArapucaAcceptanceWindow_z]}"/>
+
+    <box name="ArapucaCathodeAcceptanceWindow" lunit="cm"
+      x="@{[$ArapucaAcceptanceWindow_y]}"
+      y="@{[$ArapucaAcceptanceWindow_x]}"
+      z="@{[$ArapucaAcceptanceWindow_z]}"/>
+
+</solids>
+EOF
+
+# Cryostat structure
+print CRYO <<EOF;
+<structure>
+    <volume name="volSteelShell">
+      <materialref ref="STEEL_STAINLESS_Fe7Cr2Ni" />
+      <solidref ref="SteelShell" />
+    </volume>
+    <volume name="volGroundGrid">
+      <materialref ref="STEEL_STAINLESS_Fe7Cr2Ni" />
+      <solidref ref="CathodeGrid" />
+    </volume>    
+    <volume name="volAnodePlate">
+     <materialref ref="vm2000"/>
+     <solidref ref="AnodePlate"/>
+    </volume>
+    <volume name="volGaseousArgon">
+      <materialref ref="ArGas"/>
+      <solidref ref="GaseousArgon"/>
+    </volume>
+    <volume name="volExternalActive">
+      <materialref ref="LAr"/>
+      <solidref ref="ExternalActive"/>
+      <auxiliary auxtype="SensDet" auxvalue="SimEnergyDeposit"/>
+      <auxiliary auxtype="StepLimit" auxunit="cm" auxvalue="0.5208*cm"/>
+      <auxiliary auxtype="Efield" auxunit="V/cm" auxvalue="0*V/cm"/>
+      <colorref ref="green"/>
+    </volume>
+EOF
+#including single sided arapucas over the cathode while there is only the top volume
+#if double sided, use
+#    <volume name="volArapucaDouble_$i\-$j\-$p">
+#      <materialref ref="G10" />
+#      <solidref ref="ArapucaDoubleWalls" />
+#    </volume>
+#    <volume name="volOpDetSensitive_ArapucaDouble_$i\-$j\-$p">
+#      <materialref ref="LAr"/>
+#      <solidref ref="ArapucaDoubleAcceptanceWindow"/>
+#    </volume>
+if ($pdsconfig == 0){  #4-pi PDS converage
+for($i=0 ; $i<$nCRM_x/2 ; $i++){ #arapucas over the cathode
+for($j=0 ; $j<$nCRM_z/2 ; $j++){
+for($p=0 ; $p<4 ; $p++){
+  print CRYO <<EOF;
+    <volume name="volArapucaDouble_$i\-$j\-$p">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_$i\-$j\-$p">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+EOF
+}
+}
+}
+}
+
+if ($nCRM_x==8){ #arapucas on the laterals
+for($j=0 ; $j<$nCRM_z/2 ; $j++){
+for($p=0 ; $p<8 ; $p++){
+  print CRYO <<EOF;
+    <volume name="volArapucaLat_$j\-$p">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_$j\-$p">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+EOF
+}
+}
+}
+
+if ($pdsconfig == 1){  #Membrane PDS converage
+if ($nCRM_x==8) { #arapucas on the laterals
+for($j=0 ; $j<$nCRM_z/2 ; $j++){
+for($p=8 ; $p<18 ; $p++){
+  print CRYO <<EOF;
+    <volume name="volArapucaLat_$j\-$p">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_$j\-$p">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+EOF
+}
+}
+}
+}
+
+      print CRYO <<EOF;
+
+    <volume name="volCryostat">
+      <materialref ref="LAr" />
+      <solidref ref="Cryostat" />
+      <physvol>
+        <volumeref ref="volGaseousArgon"/>
+        <position name="posGaseousArgon" unit="cm" x="@{[$Argon_x/2-$HeightGaseousAr/2+$anodePlateWidth/2]}" y="0" z="0"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volSteelShell"/>
+        <position name="posSteelShell" unit="cm" x="0" y="0" z="0"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volExternalActive"/>
+        <position name="posExternalActive" unit="cm" x="-$xLArBuffer/2" y="0" z="0"/>
+      </physvol>
+EOF
+
+if ($tpc_on==1) # place TPC inside cryostat offsetting each pair of CRMs by borderCRP
+{
+  $posX =  $Argon_x/2 - $HeightGaseousAr - 0.5*($driftTPCActive + $ReadoutPlane); 
+  $idx = 0;
+  my $posZ = -0.5*$Argon_z + $zLArBuffer + 0.5*$lengthCRM;
+  for(my $ii=0;$ii<$nCRM_z;$ii++)
+  {
+    if( $ii % 2 == 0 ){
+	$posZ += $borderCRP;
+	if( $ii>0 ){
+	    $posZ += $borderCRP;
+	}
+    }
+    my $posY = -0.5*$Argon_y + $yLArBuffer + 0.5*$widthCRM;
+    for(my $jj=0;$jj<$nCRM_x;$jj++)
+    {
+	if( $jj % 2 == 0 ){
+	    $posY += $borderCRP;
+	    if( $jj>0 ){
+		$posY += $borderCRP;
+	    }
+	}
+	print CRYO <<EOF;
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC\-$idx" unit="cm"
+           x="$posX" y="$posY" z="$posZ"/>
+      </physvol>
+EOF
+       $idx++;
+       $posY += $widthCRM;
+    }
+
+    $posZ += $lengthCRM;
+  }
+}
+
+#The +50 in the x positions must depend on some other parameter
+  if ( $FieldCage_switch eq "on" ) {
+    for ( $i=0; $i<$NFieldShapers; $i=$i+1 ) {
+    $dist=$i*$FieldShaperSeparation;
+$posX =  $Argon_x/2 - $HeightGaseousAr - 0.5*($driftTPCActive + $ReadoutPlane); 
+	if ($pdsconfig==0){
+		if ($dist>250){
+	print CRYO <<EOF;
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper$i" unit="cm"  x="@{[-$OriginXSet+50+($i-$NFieldShapers*0.5)*$FieldShaperSeparation]}" y="@{[-0.5*$FieldShaperShortTubeLength-$FieldShaperTorRad]}" z="0" />
+     <rotation name="rotFS$i" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+EOF
+		}else{
+	print CRYO <<EOF;
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper$i" unit="cm"  x="@{[-$OriginXSet+50+($i-$NFieldShapers*0.5)*$FieldShaperSeparation]}" y="@{[-0.5*$FieldShaperShortTubeLength-$FieldShaperTorRad]}" z="0" />
+     <rotation name="rotFS$i" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+EOF
+		}
+	}else{
+	print CRYO <<EOF;
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper$i" unit="cm"  x="@{[-$OriginXSet+50+($i-$NFieldShapers*0.5)*$FieldShaperSeparation]}" y="@{[-0.5*$FieldShaperShortTubeLength-$FieldShaperTorRad]}" z="0" />
+     <rotation name="rotFS$i" unit="deg" x="0" y="0" z="90" />
+  </physvol>
+EOF
+	}
+    }
+  }
+
+
+$CathodePosX =-$OriginXSet+50+(-1-$NFieldShapers*0.5)*$FieldShaperSeparation;
+$CathodePosY = -0.5*$Argon_y + $yLArBuffer + 0.5*$widthCathode;
+$CathodePosZ = -0.5*$Argon_z + $zLArBuffer + 0.5*$lengthCathode;
+$posAnodePlate = 0.5*($driftTPCActive + $nViews*$padWidth) + $anodePlateWidth/2;#right above TPC vol
+
+$idx = 0;
+  if ( $Cathode_switch eq "on" )
+  {
+  for(my $ii=0;$ii<$nCRM_z/2;$ii++)
+  {
+    for(my $jj=0;$jj<$nCRM_x/2;$jj++)
+    {
+	print CRYO <<EOF;
+      <physvol>
+   <volumeref ref="volGroundGrid"/>
+   <position name="posGroundGrid\-$idx" unit="cm" x="$CathodePosX" y="@{[$CathodePosY]}" z="@{[$CathodePosZ]}"/>
+      </physvol>
+     <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate\-$idx" unit="cm" 
+         x="$posAnodePlate" y="@{[$CathodePosY]}" z="@{[$CathodePosZ]}"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+EOF
+       $idx++;
+       $CathodePosY += $widthCathode;
+    }
+       $CathodePosZ += $lengthCathode;
+       $CathodePosY = -0.5*$Argon_y + $yLArBuffer + 0.5*$widthCathode;
+  }
+  }
+  
+if ($pdsconfig == 0) {  #4-pi PDS converage
+
+#for placing the Arapucas over the cathode
+  $FrameCenter_x=-0.5*$Argon_y + $yLArBuffer + 0.5*$widthCathode;#-1.5*$FrameLenght_x+(4-$nCRM_x/2)/2*$FrameLenght_x;
+  $FrameCenter_y=$CathodePosX;
+  $FrameCenter_z=-0.5*$Argon_z + $zLArBuffer + 0.5*$lengthCathode;#-9.5*$FrameLenght_z+(20-$nCRM_z/2)/2*$FrameLenght_z;
+for($i=0;$i<$nCRM_x/2;$i++){
+for($j=0;$j<$nCRM_z/2;$j++){
+  place_OpDetsCathode($FrameCenter_x, $FrameCenter_y, $FrameCenter_z, $i, $j);
+  $FrameCenter_z+=$lengthCathode;
+}
+  $FrameCenter_x+=$widthCathode;
+  $FrameCenter_z=-0.5*$Argon_z + $zLArBuffer + 0.5*$lengthCathode;
+}
+}
+
+if ($pdsconfig == 0) {  #4-pi PDS converage
+#for placing the Arapucas on laterals
+if ($nCRM_x==8) {
+  $FrameCenter_y=$posZplane[0]; #anode position
+  $FrameCenter_z=-19*$lengthCathode/2+(40-$nCRM_z)/2*$lengthCathode/2;
+for($j=0;$j<$nCRM_z/2;$j++){#nCRM will give the collumn number (1 collumn per frame)
+  place_OpDetsLateral($FrameCenter_y, $FrameCenter_z, $j);
+  $FrameCenter_z+=$lengthCathode;
+}
+}
+
+} else {  #membrane only PDS converage
+
+if($pdsconfig == 1){
+if ($nCRM_x==8) {
+  $FrameCenter_y=$posZplane[0]; #anode position
+  $FrameCenter_z=-19*$lengthCathode/2+(40-$nCRM_z)/2*$lengthCathode/2;
+for($j=0;$j<$nCRM_z/2;$j++){#nCRM will give the collumn number (1 collumn per frame)
+  place_OpDetsMembOnly($FrameCenter_y, $FrameCenter_z, $j);
+  $FrameCenter_z+=$lengthCathode;
+}
+}
+}
+
+}
+
+ print CRYO <<EOF;
+    </volume>
+</structure>
+</gdml>
+EOF
+
+close(CRYO);
+}
+
+#+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+#++++++++++++++++++++++++++++++++++++ place_OpDets +++++++++++++++++++++++++++++++++++++++
+#+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+sub place_OpDetsCathode()
+{
+
+    $FrameCenter_x = $_[0];
+    $FrameCenter_y = $_[1];
+    $FrameCenter_z = $_[2];
+    $Frame_x = $_[3];
+    $Frame_z = $_[4];
+
+#Placing Arapucas over the Cathode 
+#If there are both top and bottom volumes --> use double-sided:
+#     <physvol>
+#       <volumeref ref="volOpDetSensitive_ArapucaDouble_$Frame_x\-$Frame_z\-$ara"/>
+#       <position name="posOpArapucaDouble$ara-Frame\-$Frame_x\-$Frame_z" unit="cm" 
+#         x="@{[$Ara_X]}"
+#	 y="@{[$Ara_Y]}" 
+#	 z="@{[$Ara_Z]}"/>
+#     </physvol>
+#else
+for ($ara = 0; $ara<4; $ara++)
+{
+             # All Arapuca centers will have the same Y coordinate
+             # X and Z coordinates are defined with respect to the center of the current Frame
+
+ 	     $Ara_Y = $FrameCenter_x+$list_posx_bot[$ara]; #GEOMETRY IS ROTATED: X--> Y AND Y--> X
+             $Ara_X = $FrameCenter_y;
+ 	     $Ara_Z = $FrameCenter_z+$list_posz_bot[$ara];
+
+	print CRYO <<EOF;
+     <physvol>
+       <volumeref ref="volArapucaDouble_$Frame_x\-$Frame_z\-$ara"/>
+       <position name="posArapucaDouble$ara-Frame\-$Frame_x\-$Frame_z" unit="cm" 
+         x="@{[$Ara_X]}"
+	 y="@{[$Ara_Y]}" 
+	 z="@{[$Ara_Z]}"/>
+       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_$Frame_x\-$Frame_z\-$ara"/>
+       <position name="posOpArapucaDouble$ara-Frame\-$Frame_x\-$Frame_z" unit="cm" 
+         x="@{[$Ara_X+0.5*$ArapucaOut_y-0.5*$ArapucaAcceptanceWindow_y-0.01]}"
+	 y="@{[$Ara_Y]}" 
+	 z="@{[$Ara_Z]}"/>
+     </physvol>
+EOF
+
+}#end Ara for-loop
+
+}
+
+
+sub place_OpDetsLateral()
+{
+
+    $FrameCenter_y = $_[0];
+    $FrameCenter_z = $_[1];
+    $Lat_z = $_[2];
+
+#Placing Arapucas on the laterals if nCRM_x=8 -- Single Sided
+for ($ara = 0; $ara<8; $ara++)
+{
+             # Arapucas on laterals
+             # All Arapuca centers on a given collumn will have the same Z coordinate
+             # X coordinates are on the left and right laterals
+             # Y coordinates are defined with respect to the cathode position
+             # There are two collumns per frame on each side.
+
+             if ($ara<4) {$Ara_Y = -0.5*$Argon_y + $FrameToArapucaSpaceLat;
+                         $Ara_YSens = ($Ara_Y+0.5*$ArapucaOut_y-0.5*$ArapucaAcceptanceWindow_y-0.01);
+                         $rot= "rIdentity"; }
+             else {$Ara_Y = 0.5*$Argon_y - $FrameToArapucaSpaceLat;
+                         $Ara_YSens = ($Ara_Y-0.5*$ArapucaOut_y+0.5*$ArapucaAcceptanceWindow_y+0.01);
+                         $rot = "rPlus180AboutX";} #GEOMETRY IS ROTATED: X--> Y AND Y--> X
+             if ($ara==0||$ara==4) {$Ara_X = $FrameCenter_y-40.0;} #first tile's center 40 cm bellow anode
+             else {$Ara_X-=$VerticalPDdist;} #other tiles separated by VerticalPDdist
+             $Ara_Z = $FrameCenter_z;
+
+        
+	print CRYO <<EOF;
+     <physvol>
+       <volumeref ref="volArapucaLat_$Lat_z\-$ara"/>
+       <position name="posArapuca$ara-Lat\-$Lat_z" unit="cm" 
+         x="@{[$Ara_X]}"
+	 y="@{[$Ara_Y]}" 
+	 z="@{[$Ara_Z]}"/>
+       <rotationref ref="$rot"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_$Lat_z\-$ara"/>
+       <position name="posOpArapuca$ara-Lat\-$Lat_z" unit="cm" 
+         x="@{[$Ara_X]}"
+	 y="@{[$Ara_YSens]}" 
+	 z="@{[$Ara_Z]}"/>
+     </physvol>
+EOF
+        
+}#end Ara for-loop
+
+}
+
+
+sub place_OpDetsMembOnly()
+{
+
+    $FrameCenter_y = $_[0];
+    $FrameCenter_z = $_[1];
+    $Lat_z = $_[2];
+
+#Placing Arapucas on the laterals if nCRM_x=8 -- Single Sided
+for ($ara = 0; $ara<18; $ara++)
+{
+             # Arapucas on laterals
+             # All Arapuca centers on a given collumn will have the same Z coordinate
+             # X coordinates are on the left and right laterals
+             # Y coordinates are defined with respect to the cathode position
+             # There are two collumns per frame on each side.
+
+             if($ara<9) {$Ara_Y = -0.5*$Argon_y + $FrameToArapucaSpaceLat;
+                         $Ara_YSens = ($Ara_Y+0.5*$ArapucaOut_y-0.5*$ArapucaAcceptanceWindow_y-0.01);
+                         $rot= "rIdentity"; }
+             else {$Ara_Y = 0.5*$Argon_y - $FrameToArapucaSpaceLat;
+                         $Ara_YSens = ($Ara_Y-0.5*$ArapucaOut_y+0.5*$ArapucaAcceptanceWindow_y+0.01);
+                         $rot = "rPlus180AboutX";} #GEOMETRY IS ROTATED: X--> Y AND Y--> X
+             if($ara==0||$ara==9) {$Ara_X = $FrameCenter_y-$ArapucaOut_x/2;} #first tile's center right below anode
+             else {$Ara_X-=$ArapucaOut_x - $FrameToArapucaSpace;} #other tiles separated by minimal distance + buffer
+             $Ara_Z = $FrameCenter_z;
+
+#        print "lateral arapucas: $Ara_X, $Ara_Y, $Ara_Z \n";
+        
+	print CRYO <<EOF;
+     <physvol>
+       <volumeref ref="volArapucaLat_$Lat_z\-$ara"/>
+       <position name="posArapuca$ara-Lat\-$Lat_z" unit="cm" 
+         x="@{[$Ara_X]}"
+	 y="@{[$Ara_Y]}" 
+	 z="@{[$Ara_Z]}"/>
+       <rotationref ref="$rot"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_$Lat_z\-$ara"/>
+       <position name="posOpArapuca$ara-Lat\-$Lat_z" unit="cm" 
+         x="@{[$Ara_X]}"
+	 y="@{[$Ara_YSens]}" 
+	 z="@{[$Ara_Z]}"/>
+     </physvol>
+EOF
+        
+}#end Ara for-loop
+
+
+
+}
+
+
+#+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+#+++++++++++++++++++++++++++++++++++++ gen_Enclosure +++++++++++++++++++++++++++++++++++++
+#+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+sub gen_Enclosure()
+{
+
+# Create the detector enclosure fragment file name,
+# add file to list of output GDML fragments,
+# and open it
+    $ENCL = $basename."_DetEnclosure" . $suffix . ".gdml";
+    push (@gdmlFiles, $ENCL);
+    $ENCL = ">" . $ENCL;
+    open(ENCL) or die("Could not open file $ENCL for writing");
+
+
+# The standard XML prefix and starting the gdml
+    print ENCL <<EOF;
+<?xml version='1.0'?>
+<gdml>
+EOF
+
+
+# All the detector enclosure solids.
+print ENCL <<EOF;
+<solids>
+
+    <box name="CathodeBlock" lunit="cm"
+      x="@{[$heightCathode]}"
+      y="@{[$widthCathode]}"
+      z="@{[$lengthCathode]}" />
+
+    <box name="CathodeVoid" lunit="cm"
+      x="@{[$heightCathode+1.0]}"
+      y="@{[$widthCathodeVoid]}"
+      z="@{[$lengthCathodeVoid]}" />
+
+    <subtraction name="Cathode1">
+      <first ref="CathodeBlock"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub1" x="0" y="@{[-1.5*$widthCathodeVoid-2.0*$CathodeBorder]}" z="@{[-1.5*$lengthCathodeVoid-2.0*$CathodeBorder]}" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode2">
+      <first ref="Cathode1"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub2" x="0" y="@{[-1.5*$widthCathodeVoid-2.0*$CathodeBorder]}" z="@{[-0.5*$lengthCathodeVoid-1.0*$CathodeBorder]}" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode3">
+      <first ref="Cathode2"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub3" x="0" y="@{[-1.5*$widthCathodeVoid-2.0*$CathodeBorder]}" z="@{[0.5*$lengthCathodeVoid+1.0*$CathodeBorder]}" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode4">
+      <first ref="Cathode3"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub4" x="0" y="@{[-1.5*$widthCathodeVoid-2.0*$CathodeBorder]}" z="@{[1.5*$lengthCathodeVoid+2.0*$CathodeBorder]}" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode5">
+      <first ref="Cathode4"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub5" x="0" y="@{[-0.5*$widthCathodeVoid-1.0*$CathodeBorder]}" z="@{[-1.5*$lengthCathodeVoid-2.0*$CathodeBorder]}" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode6">
+      <first ref="Cathode5"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub6" x="0" y="@{[-0.5*$widthCathodeVoid-1.0*$CathodeBorder]}" z="@{[-0.5*$lengthCathodeVoid-1.0*$CathodeBorder]}" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode7">
+      <first ref="Cathode6"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub7" x="0" y="@{[-0.5*$widthCathodeVoid-1.0*$CathodeBorder]}" z="@{[0.5*$lengthCathodeVoid+1.0*$CathodeBorder]}" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode8">
+      <first ref="Cathode7"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub8" x="0" y="@{[-0.5*$widthCathodeVoid-1.0*$CathodeBorder]}" z="@{[1.5*$lengthCathodeVoid+2.0*$CathodeBorder]}" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode9">
+      <first ref="Cathode8"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub9" x="0" y="@{[0.5*$widthCathodeVoid+1.0*$CathodeBorder]}" z="@{[-1.5*$lengthCathodeVoid-2.0*$CathodeBorder]}" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode10">
+      <first ref="Cathode9"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub10" x="0" y="@{[0.5*$widthCathodeVoid+1.0*$CathodeBorder]}" z="@{[-0.5*$lengthCathodeVoid-1.0*$CathodeBorder]}" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode11">
+      <first ref="Cathode10"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub11" x="0" y="@{[0.5*$widthCathodeVoid+1.0*$CathodeBorder]}" z="@{[0.5*$lengthCathodeVoid+1.0*$CathodeBorder]}" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode12">
+      <first ref="Cathode11"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub12" x="0" y="@{[0.5*$widthCathodeVoid+1.0*$CathodeBorder]}" z="@{[1.5*$lengthCathodeVoid+2.0*$CathodeBorder]}" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode13">
+      <first ref="Cathode12"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub13" x="0" y="@{[1.5*$widthCathodeVoid+2.0*$CathodeBorder]}" z="@{[-1.5*$lengthCathodeVoid-2.0*$CathodeBorder]}" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode14">
+      <first ref="Cathode13"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub14" x="0" y="@{[1.5*$widthCathodeVoid+2.0*$CathodeBorder]}" z="@{[-0.5*$lengthCathodeVoid-1.0*$CathodeBorder]}" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode15">
+      <first ref="Cathode14"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub15" x="0" y="@{[1.5*$widthCathodeVoid+2.0*$CathodeBorder]}" z="@{[0.5*$lengthCathodeVoid+1.0*$CathodeBorder]}" unit="cm"/>
+    </subtraction>
+    <subtraction name="CathodeGrid">
+      <first ref="Cathode15"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub16" x="0" y="@{[1.5*$widthCathodeVoid+2.0*$CathodeBorder]}" z="@{[1.5*$lengthCathodeVoid+2.0*$CathodeBorder]}" unit="cm"/>
+    </subtraction>
+
+   <box name="AnodePlate" 
+      x="$anodePlateWidth"
+      y="$widthCathode"
+      z="$lengthCathode"
+      lunit="cm"/>
+
+    <box name="FoamPadBlock" lunit="cm"
+      x="@{[$Cryostat_x + 2*$FoamPadding]}"
+      y="@{[$Cryostat_y + 2*$FoamPadding]}"
+      z="@{[$Cryostat_z + 2*$FoamPadding]}" />
+
+    <subtraction name="FoamPadding">
+      <first ref="FoamPadBlock"/>
+      <second ref="Cryostat"/>
+      <positionref ref="posCenter"/>
+    </subtraction>
+
+    <box name="SteelSupportBlock" lunit="cm"
+      x="@{[$Cryostat_x + 2*$FoamPadding + 2*$SteelSupport_x]}"
+      y="@{[$Cryostat_y + 2*$FoamPadding + 2*$SteelSupport_y]}"
+      z="@{[$Cryostat_z + 2*$FoamPadding + 2*$SteelSupport_z]}" />
+
+    <subtraction name="SteelSupport">
+      <first ref="SteelSupportBlock"/>
+      <second ref="FoamPadBlock"/>
+      <positionref ref="posCenter"/>
+    </subtraction>
+
+    <box name="DetEnclosure" lunit="cm" 
+      x="$DetEncX"
+      y="$DetEncY"
+      z="$DetEncZ"/>
+
+</solids>
+EOF
+
+
+# Detector enclosure structure
+    print ENCL <<EOF;
+<structure>
+    <volume name="volFoamPadding">
+      <materialref ref="fibrous_glass"/>
+      <solidref ref="FoamPadding"/>
+    </volume>
+
+    <volume name="volSteelSupport">
+      <materialref ref="AirSteelMixture"/>
+      <solidref ref="SteelSupport"/>
+    </volume>
+
+    <volume name="volDetEnclosure">
+      <materialref ref="Air"/>
+      <solidref ref="DetEnclosure"/>
+
+       <physvol>
+           <volumeref ref="volFoamPadding"/>
+           <positionref ref="posCryoInDetEnc"/>
+       </physvol>
+       <physvol>
+           <volumeref ref="volSteelSupport"/>
+           <positionref ref="posCryoInDetEnc"/>
+       </physvol>
+       <physvol>
+           <volumeref ref="volCryostat"/>
+           <positionref ref="posCryoInDetEnc"/>
+       </physvol>
+EOF
+
+
+print ENCL <<EOF;
+    </volume>
+EOF
+
+print ENCL <<EOF;
+</structure>
+</gdml>
+EOF
+
+close(ENCL);
+}
+
+
+
+#+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+#+++++++++++++++++++++++++++++++++++++++ gen_World +++++++++++++++++++++++++++++++++++++++
+#+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+sub gen_World()
+{
+
+# Create the WORLD fragment file name,
+# add file to list of output GDML fragments,
+# and open it
+    $WORLD = $basename."_World" . $suffix . ".gdml";
+    push (@gdmlFiles, $WORLD);
+    $WORLD = ">" . $WORLD;
+    open(WORLD) or die("Could not open file $WORLD for writing");
+
+
+# The standard XML prefix and starting the gdml
+    print WORLD <<EOF;
+<?xml version='1.0'?>
+<gdml>
+EOF
+
+
+# All the World solids.
+print WORLD <<EOF;
+<solids>
+    <box name="World" lunit="cm" 
+      x="@{[$DetEncX+2*$RockThickness]}" 
+      y="@{[$DetEncY+2*$RockThickness]}" 
+      z="@{[$DetEncZ+2*$RockThickness]}"/>
+</solids>
+EOF
+
+# World structure
+print WORLD <<EOF;
+<structure>
+    <volume name="volWorld" >
+      <materialref ref="DUSEL_Rock"/>
+      <solidref ref="World"/>
+
+      <physvol>
+        <volumeref ref="volDetEnclosure"/>
+	<position name="posDetEnclosure" unit="cm" x="$OriginXSet" y="$OriginYSet" z="$OriginZSet"/>
+      </physvol>
+
+    </volume>
+</structure>
+</gdml>
+EOF
+
+# make_gdml.pl will take care of <setup/>
+
+close(WORLD);
+}
+
+
+
+#+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+#++++++++++++++++++++++++++++++++++++ write_fragments ++++++++++++++++++++++++++++++++++++
+#+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+sub write_fragments()
+{
+   # This subroutine creates an XML file that summarizes the the subfiles output
+   # by the other sub routines - it is the input file for make_gdml.pl which will
+   # give the final desired GDML file. Specify its name with the output option.
+   # (you can change the name when running make_gdml)
+
+   # This code is taken straigh from the similar MicroBooNE generate script, Thank you.
+
+    if ( ! defined $output )
+    {
+	$output = "-"; # write to STDOUT 
+    }
+
+    # Set up the output file.
+    $OUTPUT = ">" . $output;
+    open(OUTPUT) or die("Could not open file $OUTPUT");
+
+    print OUTPUT <<EOF;
+<?xml version='1.0'?>
+
+<!-- Input to Geometry/gdml/make_gdml.pl; define the GDML fragments
+     that will be zipped together to create a detector description. 
+     -->
+
+<config>
+
+   <constantfiles>
+
+      <!-- These files contain GDML <constant></constant>
+           blocks. They are read in separately, so they can be
+           interpreted into the remaining GDML. See make_gdml.pl for
+           more information. 
+	   -->
+	   
+EOF
+
+    foreach $filename (@defFiles)
+    {
+	print OUTPUT <<EOF;
+      <filename> $filename </filename>
+EOF
+    }
+
+    print OUTPUT <<EOF;
+
+   </constantfiles>
+
+   <gdmlfiles>
+
+      <!-- The GDML file fragments to be zipped together. -->
+
+EOF
+
+    foreach $filename (@gdmlFiles)
+    {
+	print OUTPUT <<EOF;
+      <filename> $filename </filename>
+EOF
+    }
+
+    print OUTPUT <<EOF;
+
+   </gdmlfiles>
+
+</config>
+EOF
+
+    close(OUTPUT);
+}
+
+
+print "Some of the principal parameters for this TPC geometry (unit cm unless noted otherwise)\n";
+print " CRM active area       : $widthCRM_active x $lengthCRM_active\n";
+print " CRM total area        : $widthCRM x $lengthCRM\n";
+print " Wire pitch in U, Y, Z : $wirePitchU, $wirePitchY, $wirePitchZ\n";
+print " TPC active volume  : $driftTPCActive x $widthTPCActive x $lengthTPCActive\n";
+print " Argon volume       : ($Argon_x, $Argon_y, $Argon_z) \n"; 
+print " Argon buffer       : ($xLArBuffer, $yLArBuffer, $zLArBuffer) \n"; 
+print " Detector enclosure : $DetEncX x $DetEncY x $DetEncZ\n";
+print " TPC Origin         : ($OriginXSet, $OriginYSet, $OriginZSet) \n";
+print " Field Cage         : $FieldCage_switch \n";
+print " Cathode            : $Cathode_switch \n";
+print " Workspace          : $workspace \n";
+print " Wires              : $wires_on \n";
+
+# run the sub routines that generate the fragments
+if ( $FieldCage_switch eq "on" ) {  gen_FieldCage();	}
+#if ( $Cathode_switch eq "on" ) {  gen_Cathode();	} #Cathode for now has the same geometry as the Ground Grid
+
+gen_Extend();    # generates the GDML color extension for the refactored geometry 
+gen_Define(); 	 # generates definitions at beginning of GDML
+gen_Materials(); # generates materials to be used
+gen_TPC();       # generate TPC for a given unit CRM
+gen_Cryostat();  # 
+gen_Enclosure(); # 
+gen_World();	 # places the enclosure among DUSEL Rock
+write_fragments(); # writes the XML input for make_gdml.pl
+		   # which zips together the final GDML
+print "--- done\n\n\n";
+exit;

--- a/dunecore/Geometry/geometry_dune.fcl
+++ b/dunecore/Geometry/geometry_dune.fcl
@@ -264,11 +264,6 @@ dunevd10kt_1x8x6_3view_30deg_v2_geo.Name: "dunevd10kt_3view_30deg_v2_refactored_
 dunevd10kt_1x8x6_3view_30deg_v2_geo.GDML: "dunevd10kt_3view_30deg_v2_refactored_1x8x6ref.gdml"
 dunevd10kt_1x8x6_3view_30deg_v2_geo.ROOT: "dunevd10kt_3view_30deg_v2_refactored_1x8x6ref.gdml"
 
-dunevd10kt_1x8x6_3view_v3_geo: @local::dune10kt_geo
-dunevd10kt_1x8x6_3view_v3_geo.Name: "dunevd10kt_3view_v3_refactored_1x8x6ref"
-dunevd10kt_1x8x6_3view_v3_geo.GDML: "dunevd10kt_3view_v3_refactored_1x8x6ref.gdml"
-dunevd10kt_1x8x6_3view_v3_geo.ROOT: "dunevd10kt_3view_v3_refactored_1x8x6ref.gdml"
-
 dunevd10kt_1x8x6_3view_30deg_v3_geo: @local::dune10kt_geo
 dunevd10kt_1x8x6_3view_30deg_v3_geo.Name: "dunevd10kt_3view_30deg_v3_refactored_1x8x6ref"
 dunevd10kt_1x8x6_3view_30deg_v3_geo.GDML: "dunevd10kt_3view_30deg_v3_refactored_1x8x6ref.gdml"
@@ -285,7 +280,7 @@ dunevd10kt_1x8x6_3view_30deg_v4_geo.GDML: "dunevd10kt_3view_30deg_v4_refactored_
 dunevd10kt_1x8x6_3view_30deg_v4_geo.ROOT: "dunevd10kt_3view_30deg_v4_refactored_1x8x6ref.gdml"
 
 #Default 1x8x6 VD geometry
-dunevd10kt_1x8x6_3view_geo: @local::dunevd10kt_1x8x14_3view_v3_geo
+dunevd10kt_1x8x6_3view_geo: @local::dunevd10kt_1x8x14_3view_v4_geo
 dunevd10kt_1x8x6_3view_30deg_geo: @local::dunevd10kt_1x8x14_3view_30deg_v3_geo
 
 # temporarily assign workspace geometry

--- a/dunecore/Geometry/geometry_dune.fcl
+++ b/dunecore/Geometry/geometry_dune.fcl
@@ -187,6 +187,8 @@ dune10kt_1x2x6_v4_refactored_geo.ROOT: "dune10kt_v4_refactored_1x2x6.gdml"
 dune10kt_1x2x6_geo:              @local::dune10kt_1x2x6_v4_geo
 dune10kt_1x2x6_refactored_geo:   @local::dune10kt_1x2x6_v4_refactored_geo
 
+#VD 1x6x6 geo
+
 dunevd10kt_1x6x6_2view_v1_geo: @local::dune10kt_geo
 dunevd10kt_1x6x6_2view_v1_geo.Name: "dunevd10kt_2view_v1_refactored_1x6x6"
 dunevd10kt_1x6x6_2view_v1_geo.GDML: "dunevd10kt_2view_v1_refactored_1x6x6.gdml"
@@ -207,53 +209,84 @@ dunevd10kt_1x6x6_3view_30deg_geo: @local::dunevd10kt_1x6x6_3view_30deg_v1_geo
 
 dunevd10kt_1x6x6_geo: @local::dunevd10kt_1x6x6_2view_geo
 
+#VD 1x8x14 geo
 
 dunevd10kt_1x8x14_3view_v2_geo: @local::dune10kt_geo
 dunevd10kt_1x8x14_3view_v2_geo.Name: "dunevd10kt_3view_v2_refactored_1x8x14ref"
 dunevd10kt_1x8x14_3view_v2_geo.GDML: "dunevd10kt_3view_v2_refactored_1x8x14ref.gdml"
 dunevd10kt_1x8x14_3view_v2_geo.ROOT: "dunevd10kt_3view_v2_refactored_1x8x14ref.gdml"
 
-dunevd10kt_1x8x14_3view_geo: @local::dunevd10kt_1x8x14_3view_v2_geo
-
-
 dunevd10kt_1x8x14_3view_30deg_v2_geo: @local::dune10kt_geo
 dunevd10kt_1x8x14_3view_30deg_v2_geo.Name: "dunevd10kt_3view_30deg_v2_refactored_1x8x14ref"
 dunevd10kt_1x8x14_3view_30deg_v2_geo.GDML: "dunevd10kt_3view_30deg_v2_refactored_1x8x14ref.gdml"
 dunevd10kt_1x8x14_3view_30deg_v2_geo.ROOT: "dunevd10kt_3view_30deg_v2_refactored_1x8x14ref.gdml"
-
-dunevd10kt_1x8x14_3view_30deg_geo: @local::dunevd10kt_1x8x14_3view_30deg_v2_geo
-
 
 dunevd10kt_1x8x14_2view_v2_geo: @local::dune10kt_geo
 dunevd10kt_1x8x14_2view_v2_geo.Name: "dunevd10kt_2view_v2_refactored_1x8x14ref"
 dunevd10kt_1x8x14_2view_v2_geo.GDML: "dunevd10kt_2view_v2_refactored_1x8x14ref.gdml"
 dunevd10kt_1x8x14_2view_v2_geo.ROOT: "dunevd10kt_2view_v2_refactored_1x8x14ref.gdml"
 
-dunevd10kt_1x8x14_2view_geo: @local::dunevd10kt_1x8x14_2view_v2_geo
-
-
 dunevd10kt_1x8x14backup_3view_v2_geo: @local::dune10kt_geo
 dunevd10kt_1x8x14backup_3view_v2_geo.Name: "dunevd10kt_3view_v2_refactored_1x8x14backup"
 dunevd10kt_1x8x14backup_3view_v2_geo.GDML: "dunevd10kt_3view_v2_refactored_1x8x14backup.gdml"
 dunevd10kt_1x8x14backup_3view_v2_geo.ROOT: "dunevd10kt_3view_v2_refactored_1x8x14backup.gdml"
 
-dunevd10kt_1x8x14backup_3view_geo: @local::dunevd10kt_1x8x14backup_3view_v2_geo
+dunevd10kt_1x8x14_3view_v4_geo: @local::dune10kt_geo
+dunevd10kt_1x8x14_3view_v4_geo.Name: "dunevd10kt_3view_v4_refactored_1x8x14ref"
+dunevd10kt_1x8x14_3view_v4_geo.GDML: "dunevd10kt_3view_v4_refactored_1x8x14ref.gdml"
+dunevd10kt_1x8x14_3view_v4_geo.ROOT: "dunevd10kt_3view_v4_refactored_1x8x14ref.gdml"
 
+dunevd10kt_1x8x14_3view_30deg_v4_geo: @local::dune10kt_geo
+dunevd10kt_1x8x14_3view_30deg_v4_geo.Name: "dunevd10kt_3view_30deg_v4_refactored_1x8x14ref"
+dunevd10kt_1x8x14_3view_30deg_v4_geo.GDML: "dunevd10kt_3view_30deg_v4_refactored_1x8x14ref.gdml"
+dunevd10kt_1x8x14_3view_30deg_v4_geo.ROOT: "dunevd10kt_3view_30deg_v4_refactored_1x8x14ref.gdml"
+
+#VD 1x8x14 default geo
+dunevd10kt_1x8x14_2view_geo: @local::dunevd10kt_1x8x14_2view_v2_geo
+dunevd10kt_1x8x14backup_3view_geo: @local::dunevd10kt_1x8x14backup_3view_v2_geo
+dunevd10kt_1x8x14_3view_geo: @local::dunevd10kt_1x8x14_3view_v4_geo
+dunevd10kt_1x8x14_3view_30deg_geo: @local::dunevd10kt_1x8x14_3view_30deg_v4_geo
+
+#VD 1x8x6 geo
 
 dunevd10kt_1x8x6_2view_geo: @local::dune10kt_geo
 dunevd10kt_1x8x6_2view_geo.Name: "dunevd10kt_2view_v2_refactored_1x8x6ref"
 dunevd10kt_1x8x6_2view_geo.GDML: "dunevd10kt_2view_v2_refactored_1x8x6ref.gdml" 
 dunevd10kt_1x8x6_2view_geo.ROOT: "dunevd10kt_2view_v2_refactored_1x8x6ref.gdml"
 
-dunevd10kt_1x8x6_3view_geo: @local::dune10kt_geo
-dunevd10kt_1x8x6_3view_geo.Name: "dunevd10kt_3view_v2_refactored_1x8x6ref"
-dunevd10kt_1x8x6_3view_geo.GDML: "dunevd10kt_3view_v2_refactored_1x8x6ref.gdml"
-dunevd10kt_1x8x6_3view_geo.ROOT: "dunevd10kt_3view_v2_refactored_1x8x6ref.gdml"
+dunevd10kt_1x8x6_3view_v2_geo: @local::dune10kt_geo
+dunevd10kt_1x8x6_3view_v2_geo.Name: "dunevd10kt_3view_v2_refactored_1x8x6ref"
+dunevd10kt_1x8x6_3view_v2_geo.GDML: "dunevd10kt_3view_v2_refactored_1x8x6ref.gdml"
+dunevd10kt_1x8x6_3view_v2_geo.ROOT: "dunevd10kt_3view_v2_refactored_1x8x6ref.gdml"
 
-dunevd10kt_1x8x6_3view_30deg_geo: @local::dune10kt_geo
-dunevd10kt_1x8x6_3view_30deg_geo.Name: "dunevd10kt_3view_30deg_v2_refactored_1x8x6ref"
-dunevd10kt_1x8x6_3view_30deg_geo.GDML: "dunevd10kt_3view_30deg_v2_refactored_1x8x6ref.gdml"
-dunevd10kt_1x8x6_3view_30deg_geo.ROOT: "dunevd10kt_3view_30deg_v2_refactored_1x8x6ref.gdml"
+dunevd10kt_1x8x6_3view_30deg_v2_geo: @local::dune10kt_geo
+dunevd10kt_1x8x6_3view_30deg_v2_geo.Name: "dunevd10kt_3view_30deg_v2_refactored_1x8x6ref"
+dunevd10kt_1x8x6_3view_30deg_v2_geo.GDML: "dunevd10kt_3view_30deg_v2_refactored_1x8x6ref.gdml"
+dunevd10kt_1x8x6_3view_30deg_v2_geo.ROOT: "dunevd10kt_3view_30deg_v2_refactored_1x8x6ref.gdml"
+
+dunevd10kt_1x8x6_3view_v3_geo: @local::dune10kt_geo
+dunevd10kt_1x8x6_3view_v3_geo.Name: "dunevd10kt_3view_v3_refactored_1x8x6ref"
+dunevd10kt_1x8x6_3view_v3_geo.GDML: "dunevd10kt_3view_v3_refactored_1x8x6ref.gdml"
+dunevd10kt_1x8x6_3view_v3_geo.ROOT: "dunevd10kt_3view_v3_refactored_1x8x6ref.gdml"
+
+dunevd10kt_1x8x6_3view_30deg_v3_geo: @local::dune10kt_geo
+dunevd10kt_1x8x6_3view_30deg_v3_geo.Name: "dunevd10kt_3view_30deg_v3_refactored_1x8x6ref"
+dunevd10kt_1x8x6_3view_30deg_v3_geo.GDML: "dunevd10kt_3view_30deg_v3_refactored_1x8x6ref.gdml"
+dunevd10kt_1x8x6_3view_30deg_v3_geo.ROOT: "dunevd10kt_3view_30deg_v3_refactored_1x8x6ref.gdml"
+
+dunevd10kt_1x8x6_3view_v4_geo: @local::dune10kt_geo
+dunevd10kt_1x8x6_3view_v4_geo.Name: "dunevd10kt_3view_v4_refactored_1x8x6ref"
+dunevd10kt_1x8x6_3view_v4_geo.GDML: "dunevd10kt_3view_v4_refactored_1x8x6ref.gdml"
+dunevd10kt_1x8x6_3view_v4_geo.ROOT: "dunevd10kt_3view_v4_refactored_1x8x6ref.gdml"
+
+dunevd10kt_1x8x6_3view_30deg_v4_geo: @local::dune10kt_geo
+dunevd10kt_1x8x6_3view_30deg_v4_geo.Name: "dunevd10kt_3view_30deg_v4_refactored_1x8x6ref"
+dunevd10kt_1x8x6_3view_30deg_v4_geo.GDML: "dunevd10kt_3view_30deg_v4_refactored_1x8x6ref.gdml"
+dunevd10kt_1x8x6_3view_30deg_v4_geo.ROOT: "dunevd10kt_3view_30deg_v4_refactored_1x8x6ref.gdml"
+
+#Default 1x8x6 VD geometry
+dunevd10kt_1x8x6_3view_geo: @local::dunevd10kt_1x8x14_3view_v3_geo
+dunevd10kt_1x8x6_3view_30deg_geo: @local::dunevd10kt_1x8x14_3view_30deg_v3_geo
 
 # temporarily assign workspace geometry
 dunevd10kt_geo : @local::dunevd10kt_1x6x6_geo

--- a/dunecore/Geometry/geometry_dune.fcl
+++ b/dunecore/Geometry/geometry_dune.fcl
@@ -264,6 +264,11 @@ dunevd10kt_1x8x6_3view_30deg_v2_geo.Name: "dunevd10kt_3view_30deg_v2_refactored_
 dunevd10kt_1x8x6_3view_30deg_v2_geo.GDML: "dunevd10kt_3view_30deg_v2_refactored_1x8x6ref.gdml"
 dunevd10kt_1x8x6_3view_30deg_v2_geo.ROOT: "dunevd10kt_3view_30deg_v2_refactored_1x8x6ref.gdml"
 
+dunevd10kt_1x8x6_3view_v3_geo: @local::dune10kt_geo
+dunevd10kt_1x8x6_3view_v3_geo.Name: "dunevd10kt_3view_v3_refactored_1x8x6ref"
+dunevd10kt_1x8x6_3view_v3_geo.GDML: "dunevd10kt_3view_v3_refactored_1x8x6ref.gdml"
+dunevd10kt_1x8x6_3view_v3_geo.ROOT: "dunevd10kt_3view_v3_refactored_1x8x6ref.gdml"
+
 dunevd10kt_1x8x6_3view_30deg_v3_geo: @local::dune10kt_geo
 dunevd10kt_1x8x6_3view_30deg_v3_geo.Name: "dunevd10kt_3view_30deg_v3_refactored_1x8x6ref"
 dunevd10kt_1x8x6_3view_30deg_v3_geo.GDML: "dunevd10kt_3view_30deg_v3_refactored_1x8x6ref.gdml"
@@ -280,8 +285,8 @@ dunevd10kt_1x8x6_3view_30deg_v4_geo.GDML: "dunevd10kt_3view_30deg_v4_refactored_
 dunevd10kt_1x8x6_3view_30deg_v4_geo.ROOT: "dunevd10kt_3view_30deg_v4_refactored_1x8x6ref.gdml"
 
 #Default 1x8x6 VD geometry
-dunevd10kt_1x8x6_3view_geo: @local::dunevd10kt_1x8x14_3view_v4_geo
-dunevd10kt_1x8x6_3view_30deg_geo: @local::dunevd10kt_1x8x14_3view_30deg_v3_geo
+dunevd10kt_1x8x6_3view_geo: @local::dunevd10kt_1x8x6_3view_v3_geo
+dunevd10kt_1x8x6_3view_30deg_geo: @local::dunevd10kt_1x8x6_3view_30deg_v3_geo
 
 # temporarily assign workspace geometry
 dunevd10kt_geo : @local::dunevd10kt_1x6x6_geo


### PR DESCRIPTION
@absolution1 @vgalymov 
Pull request to substitute https://github.com/DUNE/dunecore/pull/7 which was closed. Now VD geometry should follow this:
3view_v2: PDS added
3view_v3: cathode added (just the perl generator, not the gdmls, since those were not actually used anywhere but this would match the 3view and 3view_30deg number of versions)
3view_v4: anode plate added
3view_30deg_v2: PDS
3view_30deg_v3: cathode added + change in pitch angle
3view_30deg_v4: anode plate added
The geometry fhicl was updated and default geos are
1x8x14, 3view + 3view_30deg --> v4
1x8x6, 3view --> v4
1x8x6, 3view_30deg --> v3