### PR TITLE
Adjusting fast to slow ratio of Ar scintillation light in VD sim

### DIFF
--- a/dunecore/Utilities/services_dunefd_vertdrift.fcl
+++ b/dunecore/Utilities/services_dunefd_vertdrift.fcl
@@ -24,6 +24,7 @@ dunefdvd_simulation_services: {
     ParticleListAction:        @local::dunefdvd_particle_list_action
     PhotonBackTrackerService:  @local::dunefdvd_photonbacktrackerservice
 }
+dunefdvd_simulation_services.LArPropertiesService.ScintYieldRatio: 0.23   
 
 dunefdvd_reco_services: {
     @table::dunefd_reco_services


### PR DESCRIPTION
According the ProtoDUNE-DP data, the ratio should be 0.23 (instead of 0.3 currently in the code).