### PR TITLE
A small modification to dunefdvd_simulation_services

### DIFF
--- a/dunecore/Utilities/services_dunefd_vertdrift.fcl
+++ b/dunecore/Utilities/services_dunefd_vertdrift.fcl
@@ -23,6 +23,7 @@ dunefdvd_simulation_services: {
     DetectorClocksService:     @local::dunefdvd_detectorclocks
     ParticleListAction:        @local::dunefdvd_particle_list_action
     PhotonBackTrackerService:  @local::dunefdvd_photonbacktrackerservice
+    PhotonVisibilityService: @local::dune10kt_vd_1x8x14_photonvisibilityservice_ArXe # The PhotonVisibilityService is used for the hybrid model for light simulation. 
 }
 
 dunefdvd_reco_services: {

--- a/dunecore/Utilities/services_dunefd_vertdrift.fcl
+++ b/dunecore/Utilities/services_dunefd_vertdrift.fcl
@@ -23,7 +23,7 @@ dunefdvd_simulation_services: {
     DetectorClocksService:     @local::dunefdvd_detectorclocks
     ParticleListAction:        @local::dunefdvd_particle_list_action
     PhotonBackTrackerService:  @local::dunefdvd_photonbacktrackerservice
-    PhotonVisibilityService: @local::dune10kt_vd_1x8x14_photonvisibilityservice_ArXe # The PhotonVisibilityService is used for the hybrid model for light simulation. 
+    PhotonVisibilityService:   @local::dune10kt_vd_1x8x14_photonvisibilityservice_ArXe # The PhotonVisibilityService is used for the hybrid model for light simulation. 
 }
 
 dunefdvd_reco_services: {


### PR DESCRIPTION
In this PR, I included PhotonVisibilityService in dunefdvd_simulation_services for the hybrid model implementation for fast light simulation. 