### PR TITLE
Feature/lp vdopbacktrackerfix

### DIFF
--- a/dunecore/Geometry/geometry_dune.fcl
+++ b/dunecore/Geometry/geometry_dune.fcl
@@ -394,6 +394,11 @@ dunevdcb_geo.Name: "dunevdcb1"
 dunevdcb_geo.GDML: "dunevdcb1_refactored.gdml"
 dunevdcb_geo.ROOT: "dunevdcb1_refactored.gdml"
 
+dunevdcb1_v2_geo: @local::dune10kt_geo
+dunevdcb1_v2_geo.Name: "dunevdcb1_v2"
+dunevdcb1_v2_geo.GDML: "dunevdcb1_v2_refactored.gdml"
+dunevdcb1_v2_geo.ROOT: "dunevdcb1_v2_refactored.gdml"
+
 dune35t_geo:
 {
  Name:     "dune35t4apa_v6"

--- a/dunecore/Utilities/photonbacktrackerservice_dune.fcl
+++ b/dunecore/Utilities/photonbacktrackerservice_dune.fcl
@@ -16,7 +16,7 @@ dunefd_photonbacktrackerservice:
 }
 
 dunefdvd_photonbacktrackerservice: @local::standard_photonbacktrackerservice
-dunefdvd_photonbacktrackerservice.PhotonBackTracker.G4ModuleLabels: ["PDFastSimAr", "PDFastSimXe", "PDFastSimArExternal", "PDFastSimXeExternal"]
+dunefdvd_photonbacktrackerservice.PhotonBackTracker.G4ModuleLabels: ["PDFastSimAr", "PDFastSimXe", "PDFastSimExternal"]
 
 
 # Legacy definitions


### PR DESCRIPTION
After approval of PR [duneopdet #9](https://github.com/DUNE/duneopdet/pull/9), there was an update of the labels associated with the photon generation outside the field cage in PR [dunesw #30](https://github.com/DUNE/dunesw/pull/30) for the vertical drift detector but the Photon Backtracker change was missed. Correcting now.