### PR TITLE
Adding protodunevd detector properties

### DIFF
--- a/dunecore/Utilities/detectorproperties_dune.fcl
+++ b/dunecore/Utilities/detectorproperties_dune.fcl
@@ -91,6 +91,18 @@ protodune_detproperties.TimeOffsetU:       0.
 protodune_detproperties.TimeOffsetV:       0.
 protodune_detproperties.TimeOffsetZ:       0.
 
+protodunevd_detproperties:                   @local::standard_detproperties
+protodunevd_detproperties.Temperature:       87.68
+protodunevd_detproperties.Electronlifetime:  35.0e3
+protodunevd_detproperties.Efield:           [0.495, 4.0, 0.0]   #(predicted for microBooNE)
+protodunevd_detproperties.ElectronsToADC:    6.8906513e-3 # 1fC = 43.008 ADC counts for DUNE fd
+protodunevd_detproperties.NumberTimeSamples: 6000         # 1 drift window = 4492 = drift length/drift velocity*sampling rate = (359.4 cm)/(0.16 cm/us)*(2 MHz)
+protodunevd_detproperties.ReadOutWindowSize: 6000         # 1 drift window = 4492 = drift length/drift velocity*sampling rate = (359.4 cm)/(0.16 cm/us)*(2 MHz)
+protodunevd_detproperties.TimeOffsetU:       0.
+protodunevd_detproperties.TimeOffsetV:       0.
+protodunevd_detproperties.TimeOffsetZ:       0.
+
+
 
 
 


### PR DESCRIPTION
E-field is slightly different from ProtoDUNE-VD and the number of timesamples/readoutwindow size should be tunable (TDE and BDE different sampling rate)