### PR TITLE
Jsoto dunevd photon geometry

### DIFF
--- a/dunecore/Geometry/gdml/dunevd10kt_3view_30deg_v5_refactored_1x8x14ref.gdml
+++ b/dunecore/Geometry/gdml/dunevd10kt_3view_30deg_v5_refactored_1x8x14ref.gdml
@@ -397,6 +397,24 @@
      <tube name="FieldShaperLongtube" rmin="0.5" rmax="2.285" z="2095.1" deltaphi="360" startphi="0" aunit="deg" lunit="cm"/>
      <tube name="FieldShaperLongtubeSlim" rmin="0.5" rmax="0.75" z="2095.1" deltaphi="360" startphi="0" aunit="deg" lunit="cm"/>
      <tube name="FieldShaperShorttube" rmin="0.5" rmax="2.285" z="1348" deltaphi="360" startphi="0" aunit="deg" lunit="cm"/>
+     <tube name="FieldShaperShorttubeWindowSlim" rmin="0.5" rmax="0.75" z="670" deltaphi="360" startphi="0" aunit="deg" lunit="cm"/>
+     <tube name="FieldShaperShorttubeWindowNotSlim" rmin="0.5" rmax="2.285" z="339" deltaphi="360" startphi="0" aunit="deg" lunit="cm"/>
+
+
+    <union name="FSunionWindow1">
+      <first ref="FieldShaperShorttubeWindowSlim"/>
+      <second ref="FieldShaperShorttubeWindowNotSlim"/>
+      <position name="posFieldShaperShortTube_shift1" unit="cm" x="0" y="0" z="504.5"/>
+    </union>
+
+    <union name="FieldShaperShorttubeSlim">
+      <first ref="FSunionWindow1"/>
+      <second ref="FieldShaperShorttubeWindowNotSlim"/>
+      <position name="posFieldShaperShortTube_shift2" unit="cm" x="0" y="0" z="-504.5"/>
+    </union>
+
+
+
 
     <union name="FSunion1">
       <first ref="FieldShaperLongtube"/>
@@ -455,7 +473,7 @@
 
     <union name="FSunionSlim2">
       <first ref="FSunionSlim1"/>
-      <second ref="FieldShaperShorttube"/>
+      <second ref="FieldShaperShorttubeSlim"/>
    		<position name="esquinapos9" unit="cm" x="-676.3" y="0" z="1049.85"/>
    		<rotationref ref="rPlus90AboutY"/>
     </union>
@@ -482,7 +500,7 @@
 
     <union name="FSunionSlim6">
       <first ref="FSunionSlim5"/>
-      <second ref="FieldShaperShorttube"/>
+      <second ref="FieldShaperShorttubeSlim"/>
    		<position name="esquinapos12" unit="cm" x="-676.3" y="0" z="-1049.85"/>
 		<rotationref ref="rPlus90AboutY"/>
     </union>
@@ -38906,10 +38924,6 @@
       <colorref ref="green"/>
     </volume>
 
-    <volume name="volArapucaShortLat">
-      <materialref ref="G10"/>
-      <solidref ref="ArapucaWalls"/>
-    </volume>
     <volume name="volOpDetSensitive">
       <materialref ref="LAr"/>
       <solidref ref="ArapucaAcceptanceWindow"/>
@@ -38933,1350 +38947,6 @@
       </physvol>
     </volume>
 
-    <volume name="volArapucaDouble_0-0-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-0-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-0-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-0-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-0-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-0-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-0-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-0-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-1-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-1-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-1-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-1-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-1-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-1-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-1-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-1-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-2-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-2-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-2-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-2-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-2-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-2-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-2-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-2-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-3-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-3-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-3-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-3-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-3-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-3-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-3-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-3-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-4-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-4-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-4-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-4-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-4-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-4-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-4-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-4-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-5-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-5-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-5-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-5-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-5-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-5-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-5-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-5-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-6-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-6-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-6-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-6-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-6-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-6-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-6-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-6-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-0-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-0-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-0-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-0-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-0-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-0-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-0-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-0-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-1-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-1-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-1-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-1-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-1-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-1-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-1-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-1-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-2-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-2-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-2-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-2-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-2-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-2-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-2-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-2-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-3-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-3-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-3-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-3-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-3-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-3-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-3-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-3-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-4-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-4-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-4-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-4-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-4-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-4-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-4-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-4-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-5-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-5-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-5-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-5-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-5-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-5-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-5-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-5-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-6-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-6-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-6-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-6-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-6-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-6-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-6-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-6-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-0-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-0-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-0-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-0-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-0-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-0-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-0-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-0-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-1-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-1-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-1-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-1-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-1-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-1-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-1-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-1-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-2-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-2-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-2-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-2-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-2-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-2-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-2-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-2-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-3-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-3-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-3-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-3-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-3-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-3-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-3-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-3-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-4-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-4-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-4-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-4-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-4-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-4-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-4-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-4-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-5-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-5-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-5-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-5-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-5-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-5-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-5-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-5-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-6-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-6-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-6-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-6-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-6-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-6-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-6-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-6-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-0-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-0-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-0-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-0-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-0-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-0-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-0-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-0-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-1-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-1-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-1-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-1-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-1-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-1-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-1-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-1-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-2-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-2-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-2-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-2-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-2-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-2-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-2-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-2-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-3-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-3-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-3-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-3-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-3-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-3-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-3-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-3-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-4-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-4-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-4-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-4-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-4-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-4-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-4-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-4-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-5-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-5-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-5-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-5-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-5-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-5-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-5-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-5-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-6-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-6-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-6-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-6-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-6-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-6-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-6-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-6-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_0-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_0-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_0-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_0-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_0-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_0-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_0-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_0-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_0-4">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_0-4">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_0-5">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_0-5">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_0-6">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_0-6">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_0-7">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_0-7">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_1-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_1-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_1-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_1-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_1-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_1-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_1-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_1-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_1-4">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_1-4">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_1-5">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_1-5">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_1-6">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_1-6">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_1-7">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_1-7">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_2-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_2-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_2-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_2-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_2-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_2-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_2-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_2-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_2-4">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_2-4">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_2-5">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_2-5">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_2-6">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_2-6">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_2-7">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_2-7">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_3-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_3-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_3-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_3-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_3-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_3-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_3-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_3-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_3-4">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_3-4">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_3-5">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_3-5">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_3-6">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_3-6">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_3-7">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_3-7">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_4-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_4-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_4-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_4-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_4-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_4-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_4-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_4-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_4-4">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_4-4">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_4-5">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_4-5">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_4-6">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_4-6">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_4-7">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_4-7">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_5-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_5-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_5-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_5-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_5-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_5-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_5-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_5-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_5-4">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_5-4">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_5-5">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_5-5">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_5-6">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_5-6">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_5-7">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_5-7">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_6-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_6-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_6-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_6-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_6-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_6-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_6-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_6-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_6-4">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_6-4">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_6-5">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_6-5">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_6-6">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_6-6">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_6-7">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_6-7">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
 
     <volume name="volCryostat">
       <materialref ref="LAr" />
@@ -41646,7 +40316,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>    
      <physvol>
-       <volumeref ref="volArapucaDouble_0-0-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-0-0" unit="cm" 
          x="-328.03"
 	 y="-633.2" 
@@ -41654,14 +40324,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-0"/>
-       <position name="posOpArapucaDouble0-Frame-0-0" unit="cm" 
-         x="-327.29"
-	 y="-633.2" 
-	 z="-860.4"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-0-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-0-0" unit="cm" 
          x="-328.03"
 	 y="-542.5" 
@@ -41669,14 +40332,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-1"/>
-       <position name="posOpArapucaDouble1-Frame-0-0" unit="cm" 
-         x="-327.29"
-	 y="-542.5" 
-	 z="-1006.4"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-0-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-0-0" unit="cm" 
          x="-328.03"
 	 y="-468.5" 
@@ -41684,14 +40340,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-2"/>
-       <position name="posOpArapucaDouble2-Frame-0-0" unit="cm" 
-         x="-327.29"
-	 y="-468.5" 
-	 z="-789.4"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-0-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-0-0" unit="cm" 
          x="-328.03"
 	 y="-377.8" 
@@ -41699,14 +40348,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-3"/>
-       <position name="posOpArapucaDouble3-Frame-0-0" unit="cm" 
-         x="-327.29"
-	 y="-377.8" 
-	 z="-935.4"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-1-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-0-1" unit="cm" 
          x="-328.03"
 	 y="-633.2" 
@@ -41714,14 +40356,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-0"/>
-       <position name="posOpArapucaDouble0-Frame-0-1" unit="cm" 
-         x="-327.29"
-	 y="-633.2" 
-	 z="-561.1"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-1-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-0-1" unit="cm" 
          x="-328.03"
 	 y="-542.5" 
@@ -41729,14 +40364,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-1"/>
-       <position name="posOpArapucaDouble1-Frame-0-1" unit="cm" 
-         x="-327.29"
-	 y="-542.5" 
-	 z="-707.1"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-1-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-0-1" unit="cm" 
          x="-328.03"
 	 y="-468.5" 
@@ -41744,14 +40372,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-2"/>
-       <position name="posOpArapucaDouble2-Frame-0-1" unit="cm" 
-         x="-327.29"
-	 y="-468.5" 
-	 z="-490.1"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-1-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-0-1" unit="cm" 
          x="-328.03"
 	 y="-377.8" 
@@ -41759,14 +40380,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-3"/>
-       <position name="posOpArapucaDouble3-Frame-0-1" unit="cm" 
-         x="-327.29"
-	 y="-377.8" 
-	 z="-636.1"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-2-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-0-2" unit="cm" 
          x="-328.03"
 	 y="-633.2" 
@@ -41774,14 +40388,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-0"/>
-       <position name="posOpArapucaDouble0-Frame-0-2" unit="cm" 
-         x="-327.29"
-	 y="-633.2" 
-	 z="-261.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-2-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-0-2" unit="cm" 
          x="-328.03"
 	 y="-542.5" 
@@ -41789,14 +40396,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-1"/>
-       <position name="posOpArapucaDouble1-Frame-0-2" unit="cm" 
-         x="-327.29"
-	 y="-542.5" 
-	 z="-407.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-2-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-0-2" unit="cm" 
          x="-328.03"
 	 y="-468.5" 
@@ -41804,14 +40404,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-2"/>
-       <position name="posOpArapucaDouble2-Frame-0-2" unit="cm" 
-         x="-327.29"
-	 y="-468.5" 
-	 z="-190.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-2-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-0-2" unit="cm" 
          x="-328.03"
 	 y="-377.8" 
@@ -41819,14 +40412,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-3"/>
-       <position name="posOpArapucaDouble3-Frame-0-2" unit="cm" 
-         x="-327.29"
-	 y="-377.8" 
-	 z="-336.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-3-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-0-3" unit="cm" 
          x="-328.03"
 	 y="-633.2" 
@@ -41834,14 +40420,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-3-0"/>
-       <position name="posOpArapucaDouble0-Frame-0-3" unit="cm" 
-         x="-327.29"
-	 y="-633.2" 
-	 z="37.5000000000001"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-3-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-0-3" unit="cm" 
          x="-328.03"
 	 y="-542.5" 
@@ -41849,14 +40428,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-3-1"/>
-       <position name="posOpArapucaDouble1-Frame-0-3" unit="cm" 
-         x="-327.29"
-	 y="-542.5" 
-	 z="-108.5"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-3-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-0-3" unit="cm" 
          x="-328.03"
 	 y="-468.5" 
@@ -41864,14 +40436,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-3-2"/>
-       <position name="posOpArapucaDouble2-Frame-0-3" unit="cm" 
-         x="-327.29"
-	 y="-468.5" 
-	 z="108.5"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-3-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-0-3" unit="cm" 
          x="-328.03"
 	 y="-377.8" 
@@ -41879,14 +40444,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-3-3"/>
-       <position name="posOpArapucaDouble3-Frame-0-3" unit="cm" 
-         x="-327.29"
-	 y="-377.8" 
-	 z="-37.4999999999999"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-4-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-0-4" unit="cm" 
          x="-328.03"
 	 y="-633.2" 
@@ -41894,14 +40452,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-4-0"/>
-       <position name="posOpArapucaDouble0-Frame-0-4" unit="cm" 
-         x="-327.29"
-	 y="-633.2" 
-	 z="336.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-4-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-0-4" unit="cm" 
          x="-328.03"
 	 y="-542.5" 
@@ -41909,14 +40460,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-4-1"/>
-       <position name="posOpArapucaDouble1-Frame-0-4" unit="cm" 
-         x="-327.29"
-	 y="-542.5" 
-	 z="190.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-4-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-0-4" unit="cm" 
          x="-328.03"
 	 y="-468.5" 
@@ -41924,14 +40468,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-4-2"/>
-       <position name="posOpArapucaDouble2-Frame-0-4" unit="cm" 
-         x="-327.29"
-	 y="-468.5" 
-	 z="407.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-4-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-0-4" unit="cm" 
          x="-328.03"
 	 y="-377.8" 
@@ -41939,14 +40476,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-4-3"/>
-       <position name="posOpArapucaDouble3-Frame-0-4" unit="cm" 
-         x="-327.29"
-	 y="-377.8" 
-	 z="261.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-5-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-0-5" unit="cm" 
          x="-328.03"
 	 y="-633.2" 
@@ -41954,14 +40484,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-5-0"/>
-       <position name="posOpArapucaDouble0-Frame-0-5" unit="cm" 
-         x="-327.29"
-	 y="-633.2" 
-	 z="636.1"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-5-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-0-5" unit="cm" 
          x="-328.03"
 	 y="-542.5" 
@@ -41969,14 +40492,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-5-1"/>
-       <position name="posOpArapucaDouble1-Frame-0-5" unit="cm" 
-         x="-327.29"
-	 y="-542.5" 
-	 z="490.1"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-5-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-0-5" unit="cm" 
          x="-328.03"
 	 y="-468.5" 
@@ -41984,14 +40500,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-5-2"/>
-       <position name="posOpArapucaDouble2-Frame-0-5" unit="cm" 
-         x="-327.29"
-	 y="-468.5" 
-	 z="707.1"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-5-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-0-5" unit="cm" 
          x="-328.03"
 	 y="-377.8" 
@@ -41999,14 +40508,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-5-3"/>
-       <position name="posOpArapucaDouble3-Frame-0-5" unit="cm" 
-         x="-327.29"
-	 y="-377.8" 
-	 z="561.1"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-6-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-0-6" unit="cm" 
          x="-328.03"
 	 y="-633.2" 
@@ -42014,14 +40516,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-6-0"/>
-       <position name="posOpArapucaDouble0-Frame-0-6" unit="cm" 
-         x="-327.29"
-	 y="-633.2" 
-	 z="935.4"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-6-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-0-6" unit="cm" 
          x="-328.03"
 	 y="-542.5" 
@@ -42029,14 +40524,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-6-1"/>
-       <position name="posOpArapucaDouble1-Frame-0-6" unit="cm" 
-         x="-327.29"
-	 y="-542.5" 
-	 z="789.4"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-6-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-0-6" unit="cm" 
          x="-328.03"
 	 y="-468.5" 
@@ -42044,14 +40532,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-6-2"/>
-       <position name="posOpArapucaDouble2-Frame-0-6" unit="cm" 
-         x="-327.29"
-	 y="-468.5" 
-	 z="1006.4"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-6-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-0-6" unit="cm" 
          x="-328.03"
 	 y="-377.8" 
@@ -42059,14 +40540,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-6-3"/>
-       <position name="posOpArapucaDouble3-Frame-0-6" unit="cm" 
-         x="-327.29"
-	 y="-377.8" 
-	 z="860.4"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-0-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-1-0" unit="cm" 
          x="-328.03"
 	 y="-296.2" 
@@ -42074,14 +40548,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-0"/>
-       <position name="posOpArapucaDouble0-Frame-1-0" unit="cm" 
-         x="-327.29"
-	 y="-296.2" 
-	 z="-860.4"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-0-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-1-0" unit="cm" 
          x="-328.03"
 	 y="-205.5" 
@@ -42089,14 +40556,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-1"/>
-       <position name="posOpArapucaDouble1-Frame-1-0" unit="cm" 
-         x="-327.29"
-	 y="-205.5" 
-	 z="-1006.4"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-0-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-1-0" unit="cm" 
          x="-328.03"
 	 y="-131.5" 
@@ -42104,14 +40564,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-2"/>
-       <position name="posOpArapucaDouble2-Frame-1-0" unit="cm" 
-         x="-327.29"
-	 y="-131.5" 
-	 z="-789.4"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-0-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-1-0" unit="cm" 
          x="-328.03"
 	 y="-40.8" 
@@ -42119,14 +40572,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-3"/>
-       <position name="posOpArapucaDouble3-Frame-1-0" unit="cm" 
-         x="-327.29"
-	 y="-40.8" 
-	 z="-935.4"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-1-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-1-1" unit="cm" 
          x="-328.03"
 	 y="-296.2" 
@@ -42134,14 +40580,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-0"/>
-       <position name="posOpArapucaDouble0-Frame-1-1" unit="cm" 
-         x="-327.29"
-	 y="-296.2" 
-	 z="-561.1"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-1-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-1-1" unit="cm" 
          x="-328.03"
 	 y="-205.5" 
@@ -42149,14 +40588,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-1"/>
-       <position name="posOpArapucaDouble1-Frame-1-1" unit="cm" 
-         x="-327.29"
-	 y="-205.5" 
-	 z="-707.1"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-1-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-1-1" unit="cm" 
          x="-328.03"
 	 y="-131.5" 
@@ -42164,14 +40596,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-2"/>
-       <position name="posOpArapucaDouble2-Frame-1-1" unit="cm" 
-         x="-327.29"
-	 y="-131.5" 
-	 z="-490.1"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-1-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-1-1" unit="cm" 
          x="-328.03"
 	 y="-40.8" 
@@ -42179,14 +40604,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-3"/>
-       <position name="posOpArapucaDouble3-Frame-1-1" unit="cm" 
-         x="-327.29"
-	 y="-40.8" 
-	 z="-636.1"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-2-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-1-2" unit="cm" 
          x="-328.03"
 	 y="-296.2" 
@@ -42194,14 +40612,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-0"/>
-       <position name="posOpArapucaDouble0-Frame-1-2" unit="cm" 
-         x="-327.29"
-	 y="-296.2" 
-	 z="-261.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-2-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-1-2" unit="cm" 
          x="-328.03"
 	 y="-205.5" 
@@ -42209,14 +40620,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-1"/>
-       <position name="posOpArapucaDouble1-Frame-1-2" unit="cm" 
-         x="-327.29"
-	 y="-205.5" 
-	 z="-407.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-2-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-1-2" unit="cm" 
          x="-328.03"
 	 y="-131.5" 
@@ -42224,14 +40628,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-2"/>
-       <position name="posOpArapucaDouble2-Frame-1-2" unit="cm" 
-         x="-327.29"
-	 y="-131.5" 
-	 z="-190.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-2-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-1-2" unit="cm" 
          x="-328.03"
 	 y="-40.8" 
@@ -42239,14 +40636,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-3"/>
-       <position name="posOpArapucaDouble3-Frame-1-2" unit="cm" 
-         x="-327.29"
-	 y="-40.8" 
-	 z="-336.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-3-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-1-3" unit="cm" 
          x="-328.03"
 	 y="-296.2" 
@@ -42254,14 +40644,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-3-0"/>
-       <position name="posOpArapucaDouble0-Frame-1-3" unit="cm" 
-         x="-327.29"
-	 y="-296.2" 
-	 z="37.5000000000001"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-3-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-1-3" unit="cm" 
          x="-328.03"
 	 y="-205.5" 
@@ -42269,14 +40652,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-3-1"/>
-       <position name="posOpArapucaDouble1-Frame-1-3" unit="cm" 
-         x="-327.29"
-	 y="-205.5" 
-	 z="-108.5"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-3-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-1-3" unit="cm" 
          x="-328.03"
 	 y="-131.5" 
@@ -42284,14 +40660,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-3-2"/>
-       <position name="posOpArapucaDouble2-Frame-1-3" unit="cm" 
-         x="-327.29"
-	 y="-131.5" 
-	 z="108.5"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-3-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-1-3" unit="cm" 
          x="-328.03"
 	 y="-40.8" 
@@ -42299,14 +40668,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-3-3"/>
-       <position name="posOpArapucaDouble3-Frame-1-3" unit="cm" 
-         x="-327.29"
-	 y="-40.8" 
-	 z="-37.4999999999999"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-4-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-1-4" unit="cm" 
          x="-328.03"
 	 y="-296.2" 
@@ -42314,14 +40676,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-4-0"/>
-       <position name="posOpArapucaDouble0-Frame-1-4" unit="cm" 
-         x="-327.29"
-	 y="-296.2" 
-	 z="336.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-4-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-1-4" unit="cm" 
          x="-328.03"
 	 y="-205.5" 
@@ -42329,14 +40684,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-4-1"/>
-       <position name="posOpArapucaDouble1-Frame-1-4" unit="cm" 
-         x="-327.29"
-	 y="-205.5" 
-	 z="190.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-4-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-1-4" unit="cm" 
          x="-328.03"
 	 y="-131.5" 
@@ -42344,14 +40692,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-4-2"/>
-       <position name="posOpArapucaDouble2-Frame-1-4" unit="cm" 
-         x="-327.29"
-	 y="-131.5" 
-	 z="407.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-4-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-1-4" unit="cm" 
          x="-328.03"
 	 y="-40.8" 
@@ -42359,14 +40700,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-4-3"/>
-       <position name="posOpArapucaDouble3-Frame-1-4" unit="cm" 
-         x="-327.29"
-	 y="-40.8" 
-	 z="261.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-5-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-1-5" unit="cm" 
          x="-328.03"
 	 y="-296.2" 
@@ -42374,14 +40708,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-5-0"/>
-       <position name="posOpArapucaDouble0-Frame-1-5" unit="cm" 
-         x="-327.29"
-	 y="-296.2" 
-	 z="636.1"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-5-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-1-5" unit="cm" 
          x="-328.03"
 	 y="-205.5" 
@@ -42389,14 +40716,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-5-1"/>
-       <position name="posOpArapucaDouble1-Frame-1-5" unit="cm" 
-         x="-327.29"
-	 y="-205.5" 
-	 z="490.1"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-5-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-1-5" unit="cm" 
          x="-328.03"
 	 y="-131.5" 
@@ -42404,14 +40724,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-5-2"/>
-       <position name="posOpArapucaDouble2-Frame-1-5" unit="cm" 
-         x="-327.29"
-	 y="-131.5" 
-	 z="707.1"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-5-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-1-5" unit="cm" 
          x="-328.03"
 	 y="-40.8" 
@@ -42419,14 +40732,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-5-3"/>
-       <position name="posOpArapucaDouble3-Frame-1-5" unit="cm" 
-         x="-327.29"
-	 y="-40.8" 
-	 z="561.1"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-6-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-1-6" unit="cm" 
          x="-328.03"
 	 y="-296.2" 
@@ -42434,14 +40740,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-6-0"/>
-       <position name="posOpArapucaDouble0-Frame-1-6" unit="cm" 
-         x="-327.29"
-	 y="-296.2" 
-	 z="935.4"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-6-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-1-6" unit="cm" 
          x="-328.03"
 	 y="-205.5" 
@@ -42449,14 +40748,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-6-1"/>
-       <position name="posOpArapucaDouble1-Frame-1-6" unit="cm" 
-         x="-327.29"
-	 y="-205.5" 
-	 z="789.4"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-6-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-1-6" unit="cm" 
          x="-328.03"
 	 y="-131.5" 
@@ -42464,14 +40756,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-6-2"/>
-       <position name="posOpArapucaDouble2-Frame-1-6" unit="cm" 
-         x="-327.29"
-	 y="-131.5" 
-	 z="1006.4"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-6-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-1-6" unit="cm" 
          x="-328.03"
 	 y="-40.8" 
@@ -42479,14 +40764,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-6-3"/>
-       <position name="posOpArapucaDouble3-Frame-1-6" unit="cm" 
-         x="-327.29"
-	 y="-40.8" 
-	 z="860.4"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-0-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-2-0" unit="cm" 
          x="-328.03"
 	 y="40.8" 
@@ -42494,14 +40772,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-0"/>
-       <position name="posOpArapucaDouble0-Frame-2-0" unit="cm" 
-         x="-327.29"
-	 y="40.8" 
-	 z="-860.4"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-0-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-2-0" unit="cm" 
          x="-328.03"
 	 y="131.5" 
@@ -42509,14 +40780,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-1"/>
-       <position name="posOpArapucaDouble1-Frame-2-0" unit="cm" 
-         x="-327.29"
-	 y="131.5" 
-	 z="-1006.4"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-0-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-2-0" unit="cm" 
          x="-328.03"
 	 y="205.5" 
@@ -42524,14 +40788,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-2"/>
-       <position name="posOpArapucaDouble2-Frame-2-0" unit="cm" 
-         x="-327.29"
-	 y="205.5" 
-	 z="-789.4"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-0-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-2-0" unit="cm" 
          x="-328.03"
 	 y="296.2" 
@@ -42539,14 +40796,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-3"/>
-       <position name="posOpArapucaDouble3-Frame-2-0" unit="cm" 
-         x="-327.29"
-	 y="296.2" 
-	 z="-935.4"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-1-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-2-1" unit="cm" 
          x="-328.03"
 	 y="40.8" 
@@ -42554,14 +40804,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-0"/>
-       <position name="posOpArapucaDouble0-Frame-2-1" unit="cm" 
-         x="-327.29"
-	 y="40.8" 
-	 z="-561.1"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-1-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-2-1" unit="cm" 
          x="-328.03"
 	 y="131.5" 
@@ -42569,14 +40812,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-1"/>
-       <position name="posOpArapucaDouble1-Frame-2-1" unit="cm" 
-         x="-327.29"
-	 y="131.5" 
-	 z="-707.1"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-1-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-2-1" unit="cm" 
          x="-328.03"
 	 y="205.5" 
@@ -42584,14 +40820,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-2"/>
-       <position name="posOpArapucaDouble2-Frame-2-1" unit="cm" 
-         x="-327.29"
-	 y="205.5" 
-	 z="-490.1"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-1-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-2-1" unit="cm" 
          x="-328.03"
 	 y="296.2" 
@@ -42599,14 +40828,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-3"/>
-       <position name="posOpArapucaDouble3-Frame-2-1" unit="cm" 
-         x="-327.29"
-	 y="296.2" 
-	 z="-636.1"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-2-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-2-2" unit="cm" 
          x="-328.03"
 	 y="40.8" 
@@ -42614,14 +40836,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-0"/>
-       <position name="posOpArapucaDouble0-Frame-2-2" unit="cm" 
-         x="-327.29"
-	 y="40.8" 
-	 z="-261.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-2-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-2-2" unit="cm" 
          x="-328.03"
 	 y="131.5" 
@@ -42629,14 +40844,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-1"/>
-       <position name="posOpArapucaDouble1-Frame-2-2" unit="cm" 
-         x="-327.29"
-	 y="131.5" 
-	 z="-407.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-2-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-2-2" unit="cm" 
          x="-328.03"
 	 y="205.5" 
@@ -42644,14 +40852,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-2"/>
-       <position name="posOpArapucaDouble2-Frame-2-2" unit="cm" 
-         x="-327.29"
-	 y="205.5" 
-	 z="-190.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-2-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-2-2" unit="cm" 
          x="-328.03"
 	 y="296.2" 
@@ -42659,14 +40860,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-3"/>
-       <position name="posOpArapucaDouble3-Frame-2-2" unit="cm" 
-         x="-327.29"
-	 y="296.2" 
-	 z="-336.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-3-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-2-3" unit="cm" 
          x="-328.03"
 	 y="40.8" 
@@ -42674,14 +40868,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-3-0"/>
-       <position name="posOpArapucaDouble0-Frame-2-3" unit="cm" 
-         x="-327.29"
-	 y="40.8" 
-	 z="37.5000000000001"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-3-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-2-3" unit="cm" 
          x="-328.03"
 	 y="131.5" 
@@ -42689,14 +40876,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-3-1"/>
-       <position name="posOpArapucaDouble1-Frame-2-3" unit="cm" 
-         x="-327.29"
-	 y="131.5" 
-	 z="-108.5"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-3-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-2-3" unit="cm" 
          x="-328.03"
 	 y="205.5" 
@@ -42704,14 +40884,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-3-2"/>
-       <position name="posOpArapucaDouble2-Frame-2-3" unit="cm" 
-         x="-327.29"
-	 y="205.5" 
-	 z="108.5"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-3-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-2-3" unit="cm" 
          x="-328.03"
 	 y="296.2" 
@@ -42719,14 +40892,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-3-3"/>
-       <position name="posOpArapucaDouble3-Frame-2-3" unit="cm" 
-         x="-327.29"
-	 y="296.2" 
-	 z="-37.4999999999999"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-4-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-2-4" unit="cm" 
          x="-328.03"
 	 y="40.8" 
@@ -42734,14 +40900,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-4-0"/>
-       <position name="posOpArapucaDouble0-Frame-2-4" unit="cm" 
-         x="-327.29"
-	 y="40.8" 
-	 z="336.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-4-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-2-4" unit="cm" 
          x="-328.03"
 	 y="131.5" 
@@ -42749,14 +40908,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-4-1"/>
-       <position name="posOpArapucaDouble1-Frame-2-4" unit="cm" 
-         x="-327.29"
-	 y="131.5" 
-	 z="190.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-4-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-2-4" unit="cm" 
          x="-328.03"
 	 y="205.5" 
@@ -42764,14 +40916,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-4-2"/>
-       <position name="posOpArapucaDouble2-Frame-2-4" unit="cm" 
-         x="-327.29"
-	 y="205.5" 
-	 z="407.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-4-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-2-4" unit="cm" 
          x="-328.03"
 	 y="296.2" 
@@ -42779,14 +40924,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-4-3"/>
-       <position name="posOpArapucaDouble3-Frame-2-4" unit="cm" 
-         x="-327.29"
-	 y="296.2" 
-	 z="261.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-5-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-2-5" unit="cm" 
          x="-328.03"
 	 y="40.8" 
@@ -42794,14 +40932,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-5-0"/>
-       <position name="posOpArapucaDouble0-Frame-2-5" unit="cm" 
-         x="-327.29"
-	 y="40.8" 
-	 z="636.1"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-5-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-2-5" unit="cm" 
          x="-328.03"
 	 y="131.5" 
@@ -42809,14 +40940,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-5-1"/>
-       <position name="posOpArapucaDouble1-Frame-2-5" unit="cm" 
-         x="-327.29"
-	 y="131.5" 
-	 z="490.1"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-5-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-2-5" unit="cm" 
          x="-328.03"
 	 y="205.5" 
@@ -42824,14 +40948,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-5-2"/>
-       <position name="posOpArapucaDouble2-Frame-2-5" unit="cm" 
-         x="-327.29"
-	 y="205.5" 
-	 z="707.1"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-5-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-2-5" unit="cm" 
          x="-328.03"
 	 y="296.2" 
@@ -42839,14 +40956,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-5-3"/>
-       <position name="posOpArapucaDouble3-Frame-2-5" unit="cm" 
-         x="-327.29"
-	 y="296.2" 
-	 z="561.1"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-6-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-2-6" unit="cm" 
          x="-328.03"
 	 y="40.8" 
@@ -42854,14 +40964,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-6-0"/>
-       <position name="posOpArapucaDouble0-Frame-2-6" unit="cm" 
-         x="-327.29"
-	 y="40.8" 
-	 z="935.4"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-6-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-2-6" unit="cm" 
          x="-328.03"
 	 y="131.5" 
@@ -42869,14 +40972,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-6-1"/>
-       <position name="posOpArapucaDouble1-Frame-2-6" unit="cm" 
-         x="-327.29"
-	 y="131.5" 
-	 z="789.4"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-6-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-2-6" unit="cm" 
          x="-328.03"
 	 y="205.5" 
@@ -42884,14 +40980,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-6-2"/>
-       <position name="posOpArapucaDouble2-Frame-2-6" unit="cm" 
-         x="-327.29"
-	 y="205.5" 
-	 z="1006.4"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-6-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-2-6" unit="cm" 
          x="-328.03"
 	 y="296.2" 
@@ -42899,14 +40988,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-6-3"/>
-       <position name="posOpArapucaDouble3-Frame-2-6" unit="cm" 
-         x="-327.29"
-	 y="296.2" 
-	 z="860.4"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-0-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-3-0" unit="cm" 
          x="-328.03"
 	 y="377.8" 
@@ -42914,14 +40996,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-0"/>
-       <position name="posOpArapucaDouble0-Frame-3-0" unit="cm" 
-         x="-327.29"
-	 y="377.8" 
-	 z="-860.4"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-0-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-3-0" unit="cm" 
          x="-328.03"
 	 y="468.5" 
@@ -42929,14 +41004,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-1"/>
-       <position name="posOpArapucaDouble1-Frame-3-0" unit="cm" 
-         x="-327.29"
-	 y="468.5" 
-	 z="-1006.4"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-0-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-3-0" unit="cm" 
          x="-328.03"
 	 y="542.5" 
@@ -42944,14 +41012,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-2"/>
-       <position name="posOpArapucaDouble2-Frame-3-0" unit="cm" 
-         x="-327.29"
-	 y="542.5" 
-	 z="-789.4"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-0-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-3-0" unit="cm" 
          x="-328.03"
 	 y="633.2" 
@@ -42959,14 +41020,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-3"/>
-       <position name="posOpArapucaDouble3-Frame-3-0" unit="cm" 
-         x="-327.29"
-	 y="633.2" 
-	 z="-935.4"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-1-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-3-1" unit="cm" 
          x="-328.03"
 	 y="377.8" 
@@ -42974,14 +41028,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-0"/>
-       <position name="posOpArapucaDouble0-Frame-3-1" unit="cm" 
-         x="-327.29"
-	 y="377.8" 
-	 z="-561.1"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-1-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-3-1" unit="cm" 
          x="-328.03"
 	 y="468.5" 
@@ -42989,14 +41036,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-1"/>
-       <position name="posOpArapucaDouble1-Frame-3-1" unit="cm" 
-         x="-327.29"
-	 y="468.5" 
-	 z="-707.1"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-1-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-3-1" unit="cm" 
          x="-328.03"
 	 y="542.5" 
@@ -43004,14 +41044,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-2"/>
-       <position name="posOpArapucaDouble2-Frame-3-1" unit="cm" 
-         x="-327.29"
-	 y="542.5" 
-	 z="-490.1"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-1-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-3-1" unit="cm" 
          x="-328.03"
 	 y="633.2" 
@@ -43019,14 +41052,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-3"/>
-       <position name="posOpArapucaDouble3-Frame-3-1" unit="cm" 
-         x="-327.29"
-	 y="633.2" 
-	 z="-636.1"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-2-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-3-2" unit="cm" 
          x="-328.03"
 	 y="377.8" 
@@ -43034,14 +41060,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-0"/>
-       <position name="posOpArapucaDouble0-Frame-3-2" unit="cm" 
-         x="-327.29"
-	 y="377.8" 
-	 z="-261.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-2-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-3-2" unit="cm" 
          x="-328.03"
 	 y="468.5" 
@@ -43049,14 +41068,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-1"/>
-       <position name="posOpArapucaDouble1-Frame-3-2" unit="cm" 
-         x="-327.29"
-	 y="468.5" 
-	 z="-407.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-2-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-3-2" unit="cm" 
          x="-328.03"
 	 y="542.5" 
@@ -43064,14 +41076,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-2"/>
-       <position name="posOpArapucaDouble2-Frame-3-2" unit="cm" 
-         x="-327.29"
-	 y="542.5" 
-	 z="-190.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-2-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-3-2" unit="cm" 
          x="-328.03"
 	 y="633.2" 
@@ -43079,14 +41084,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-3"/>
-       <position name="posOpArapucaDouble3-Frame-3-2" unit="cm" 
-         x="-327.29"
-	 y="633.2" 
-	 z="-336.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-3-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-3-3" unit="cm" 
          x="-328.03"
 	 y="377.8" 
@@ -43094,14 +41092,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-3-0"/>
-       <position name="posOpArapucaDouble0-Frame-3-3" unit="cm" 
-         x="-327.29"
-	 y="377.8" 
-	 z="37.5000000000001"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-3-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-3-3" unit="cm" 
          x="-328.03"
 	 y="468.5" 
@@ -43109,14 +41100,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-3-1"/>
-       <position name="posOpArapucaDouble1-Frame-3-3" unit="cm" 
-         x="-327.29"
-	 y="468.5" 
-	 z="-108.5"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-3-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-3-3" unit="cm" 
          x="-328.03"
 	 y="542.5" 
@@ -43124,14 +41108,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-3-2"/>
-       <position name="posOpArapucaDouble2-Frame-3-3" unit="cm" 
-         x="-327.29"
-	 y="542.5" 
-	 z="108.5"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-3-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-3-3" unit="cm" 
          x="-328.03"
 	 y="633.2" 
@@ -43139,14 +41116,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-3-3"/>
-       <position name="posOpArapucaDouble3-Frame-3-3" unit="cm" 
-         x="-327.29"
-	 y="633.2" 
-	 z="-37.4999999999999"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-4-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-3-4" unit="cm" 
          x="-328.03"
 	 y="377.8" 
@@ -43154,14 +41124,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-4-0"/>
-       <position name="posOpArapucaDouble0-Frame-3-4" unit="cm" 
-         x="-327.29"
-	 y="377.8" 
-	 z="336.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-4-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-3-4" unit="cm" 
          x="-328.03"
 	 y="468.5" 
@@ -43169,14 +41132,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-4-1"/>
-       <position name="posOpArapucaDouble1-Frame-3-4" unit="cm" 
-         x="-327.29"
-	 y="468.5" 
-	 z="190.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-4-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-3-4" unit="cm" 
          x="-328.03"
 	 y="542.5" 
@@ -43184,14 +41140,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-4-2"/>
-       <position name="posOpArapucaDouble2-Frame-3-4" unit="cm" 
-         x="-327.29"
-	 y="542.5" 
-	 z="407.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-4-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-3-4" unit="cm" 
          x="-328.03"
 	 y="633.2" 
@@ -43199,14 +41148,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-4-3"/>
-       <position name="posOpArapucaDouble3-Frame-3-4" unit="cm" 
-         x="-327.29"
-	 y="633.2" 
-	 z="261.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-5-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-3-5" unit="cm" 
          x="-328.03"
 	 y="377.8" 
@@ -43214,14 +41156,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-5-0"/>
-       <position name="posOpArapucaDouble0-Frame-3-5" unit="cm" 
-         x="-327.29"
-	 y="377.8" 
-	 z="636.1"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-5-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-3-5" unit="cm" 
          x="-328.03"
 	 y="468.5" 
@@ -43229,14 +41164,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-5-1"/>
-       <position name="posOpArapucaDouble1-Frame-3-5" unit="cm" 
-         x="-327.29"
-	 y="468.5" 
-	 z="490.1"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-5-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-3-5" unit="cm" 
          x="-328.03"
 	 y="542.5" 
@@ -43244,14 +41172,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-5-2"/>
-       <position name="posOpArapucaDouble2-Frame-3-5" unit="cm" 
-         x="-327.29"
-	 y="542.5" 
-	 z="707.1"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-5-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-3-5" unit="cm" 
          x="-328.03"
 	 y="633.2" 
@@ -43259,14 +41180,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-5-3"/>
-       <position name="posOpArapucaDouble3-Frame-3-5" unit="cm" 
-         x="-327.29"
-	 y="633.2" 
-	 z="561.1"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-6-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-3-6" unit="cm" 
          x="-328.03"
 	 y="377.8" 
@@ -43274,14 +41188,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-6-0"/>
-       <position name="posOpArapucaDouble0-Frame-3-6" unit="cm" 
-         x="-327.29"
-	 y="377.8" 
-	 z="935.4"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-6-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-3-6" unit="cm" 
          x="-328.03"
 	 y="468.5" 
@@ -43289,14 +41196,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-6-1"/>
-       <position name="posOpArapucaDouble1-Frame-3-6" unit="cm" 
-         x="-327.29"
-	 y="468.5" 
-	 z="789.4"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-6-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-3-6" unit="cm" 
          x="-328.03"
 	 y="542.5" 
@@ -43304,14 +41204,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-6-2"/>
-       <position name="posOpArapucaDouble2-Frame-3-6" unit="cm" 
-         x="-327.29"
-	 y="542.5" 
-	 z="1006.4"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-6-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-3-6" unit="cm" 
          x="-328.03"
 	 y="633.2" 
@@ -43319,14 +41212,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-6-3"/>
-       <position name="posOpArapucaDouble3-Frame-3-6" unit="cm" 
-         x="-327.29"
-	 y="633.2" 
-	 z="860.4"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_0-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca0-Lat-0" unit="cm" 
          x="285.02"
 	 y="-745" 
@@ -43334,14 +41220,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_0-0"/>
-       <position name="posOpArapuca0-Lat-0" unit="cm" 
-         x="285.02"
-	 y="-744.26" 
-	 z="-897.9"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_0-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca1-Lat-0" unit="cm" 
          x="210.02"
 	 y="-745" 
@@ -43349,14 +41228,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_0-1"/>
-       <position name="posOpArapuca1-Lat-0" unit="cm" 
-         x="210.02"
-	 y="-744.26" 
-	 z="-897.9"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_0-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca2-Lat-0" unit="cm" 
          x="135.02"
 	 y="-745" 
@@ -43364,14 +41236,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_0-2"/>
-       <position name="posOpArapuca2-Lat-0" unit="cm" 
-         x="135.02"
-	 y="-744.26" 
-	 z="-897.9"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_0-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca3-Lat-0" unit="cm" 
          x="60.02"
 	 y="-745" 
@@ -43379,14 +41244,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_0-3"/>
-       <position name="posOpArapuca3-Lat-0" unit="cm" 
-         x="60.02"
-	 y="-744.26" 
-	 z="-897.9"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_0-4"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca4-Lat-0" unit="cm" 
          x="285.02"
 	 y="745" 
@@ -43394,14 +41252,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_0-4"/>
-       <position name="posOpArapuca4-Lat-0" unit="cm" 
-         x="285.02"
-	 y="744.26" 
-	 z="-897.9"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_0-5"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca5-Lat-0" unit="cm" 
          x="210.02"
 	 y="745" 
@@ -43409,14 +41260,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_0-5"/>
-       <position name="posOpArapuca5-Lat-0" unit="cm" 
-         x="210.02"
-	 y="744.26" 
-	 z="-897.9"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_0-6"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca6-Lat-0" unit="cm" 
          x="135.02"
 	 y="745" 
@@ -43424,14 +41268,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_0-6"/>
-       <position name="posOpArapuca6-Lat-0" unit="cm" 
-         x="135.02"
-	 y="744.26" 
-	 z="-897.9"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_0-7"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca7-Lat-0" unit="cm" 
          x="60.02"
 	 y="745" 
@@ -43439,14 +41276,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_0-7"/>
-       <position name="posOpArapuca7-Lat-0" unit="cm" 
-         x="60.02"
-	 y="744.26" 
-	 z="-897.9"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_1-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca0-Lat-1" unit="cm" 
          x="285.02"
 	 y="-745" 
@@ -43454,14 +41284,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_1-0"/>
-       <position name="posOpArapuca0-Lat-1" unit="cm" 
-         x="285.02"
-	 y="-744.26" 
-	 z="-598.6"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_1-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca1-Lat-1" unit="cm" 
          x="210.02"
 	 y="-745" 
@@ -43469,14 +41292,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_1-1"/>
-       <position name="posOpArapuca1-Lat-1" unit="cm" 
-         x="210.02"
-	 y="-744.26" 
-	 z="-598.6"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_1-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca2-Lat-1" unit="cm" 
          x="135.02"
 	 y="-745" 
@@ -43484,14 +41300,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_1-2"/>
-       <position name="posOpArapuca2-Lat-1" unit="cm" 
-         x="135.02"
-	 y="-744.26" 
-	 z="-598.6"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_1-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca3-Lat-1" unit="cm" 
          x="60.02"
 	 y="-745" 
@@ -43499,14 +41308,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_1-3"/>
-       <position name="posOpArapuca3-Lat-1" unit="cm" 
-         x="60.02"
-	 y="-744.26" 
-	 z="-598.6"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_1-4"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca4-Lat-1" unit="cm" 
          x="285.02"
 	 y="745" 
@@ -43514,14 +41316,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_1-4"/>
-       <position name="posOpArapuca4-Lat-1" unit="cm" 
-         x="285.02"
-	 y="744.26" 
-	 z="-598.6"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_1-5"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca5-Lat-1" unit="cm" 
          x="210.02"
 	 y="745" 
@@ -43529,14 +41324,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_1-5"/>
-       <position name="posOpArapuca5-Lat-1" unit="cm" 
-         x="210.02"
-	 y="744.26" 
-	 z="-598.6"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_1-6"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca6-Lat-1" unit="cm" 
          x="135.02"
 	 y="745" 
@@ -43544,14 +41332,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_1-6"/>
-       <position name="posOpArapuca6-Lat-1" unit="cm" 
-         x="135.02"
-	 y="744.26" 
-	 z="-598.6"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_1-7"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca7-Lat-1" unit="cm" 
          x="60.02"
 	 y="745" 
@@ -43559,14 +41340,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_1-7"/>
-       <position name="posOpArapuca7-Lat-1" unit="cm" 
-         x="60.02"
-	 y="744.26" 
-	 z="-598.6"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_2-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca0-Lat-2" unit="cm" 
          x="285.02"
 	 y="-745" 
@@ -43574,14 +41348,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_2-0"/>
-       <position name="posOpArapuca0-Lat-2" unit="cm" 
-         x="285.02"
-	 y="-744.26" 
-	 z="-299.3"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_2-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca1-Lat-2" unit="cm" 
          x="210.02"
 	 y="-745" 
@@ -43589,14 +41356,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_2-1"/>
-       <position name="posOpArapuca1-Lat-2" unit="cm" 
-         x="210.02"
-	 y="-744.26" 
-	 z="-299.3"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_2-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca2-Lat-2" unit="cm" 
          x="135.02"
 	 y="-745" 
@@ -43604,14 +41364,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_2-2"/>
-       <position name="posOpArapuca2-Lat-2" unit="cm" 
-         x="135.02"
-	 y="-744.26" 
-	 z="-299.3"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_2-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca3-Lat-2" unit="cm" 
          x="60.02"
 	 y="-745" 
@@ -43619,14 +41372,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_2-3"/>
-       <position name="posOpArapuca3-Lat-2" unit="cm" 
-         x="60.02"
-	 y="-744.26" 
-	 z="-299.3"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_2-4"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca4-Lat-2" unit="cm" 
          x="285.02"
 	 y="745" 
@@ -43634,14 +41380,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_2-4"/>
-       <position name="posOpArapuca4-Lat-2" unit="cm" 
-         x="285.02"
-	 y="744.26" 
-	 z="-299.3"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_2-5"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca5-Lat-2" unit="cm" 
          x="210.02"
 	 y="745" 
@@ -43649,14 +41388,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_2-5"/>
-       <position name="posOpArapuca5-Lat-2" unit="cm" 
-         x="210.02"
-	 y="744.26" 
-	 z="-299.3"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_2-6"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca6-Lat-2" unit="cm" 
          x="135.02"
 	 y="745" 
@@ -43664,14 +41396,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_2-6"/>
-       <position name="posOpArapuca6-Lat-2" unit="cm" 
-         x="135.02"
-	 y="744.26" 
-	 z="-299.3"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_2-7"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca7-Lat-2" unit="cm" 
          x="60.02"
 	 y="745" 
@@ -43679,14 +41404,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_2-7"/>
-       <position name="posOpArapuca7-Lat-2" unit="cm" 
-         x="60.02"
-	 y="744.26" 
-	 z="-299.3"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_3-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca0-Lat-3" unit="cm" 
          x="285.02"
 	 y="-745" 
@@ -43694,14 +41412,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_3-0"/>
-       <position name="posOpArapuca0-Lat-3" unit="cm" 
-         x="285.02"
-	 y="-744.26" 
-	 z="1.13686837721616e-13"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_3-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca1-Lat-3" unit="cm" 
          x="210.02"
 	 y="-745" 
@@ -43709,14 +41420,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_3-1"/>
-       <position name="posOpArapuca1-Lat-3" unit="cm" 
-         x="210.02"
-	 y="-744.26" 
-	 z="1.13686837721616e-13"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_3-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca2-Lat-3" unit="cm" 
          x="135.02"
 	 y="-745" 
@@ -43724,14 +41428,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_3-2"/>
-       <position name="posOpArapuca2-Lat-3" unit="cm" 
-         x="135.02"
-	 y="-744.26" 
-	 z="1.13686837721616e-13"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_3-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca3-Lat-3" unit="cm" 
          x="60.02"
 	 y="-745" 
@@ -43739,14 +41436,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_3-3"/>
-       <position name="posOpArapuca3-Lat-3" unit="cm" 
-         x="60.02"
-	 y="-744.26" 
-	 z="1.13686837721616e-13"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_3-4"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca4-Lat-3" unit="cm" 
          x="285.02"
 	 y="745" 
@@ -43754,14 +41444,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_3-4"/>
-       <position name="posOpArapuca4-Lat-3" unit="cm" 
-         x="285.02"
-	 y="744.26" 
-	 z="1.13686837721616e-13"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_3-5"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca5-Lat-3" unit="cm" 
          x="210.02"
 	 y="745" 
@@ -43769,14 +41452,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_3-5"/>
-       <position name="posOpArapuca5-Lat-3" unit="cm" 
-         x="210.02"
-	 y="744.26" 
-	 z="1.13686837721616e-13"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_3-6"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca6-Lat-3" unit="cm" 
          x="135.02"
 	 y="745" 
@@ -43784,14 +41460,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_3-6"/>
-       <position name="posOpArapuca6-Lat-3" unit="cm" 
-         x="135.02"
-	 y="744.26" 
-	 z="1.13686837721616e-13"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_3-7"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca7-Lat-3" unit="cm" 
          x="60.02"
 	 y="745" 
@@ -43799,14 +41468,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_3-7"/>
-       <position name="posOpArapuca7-Lat-3" unit="cm" 
-         x="60.02"
-	 y="744.26" 
-	 z="1.13686837721616e-13"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_4-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca0-Lat-4" unit="cm" 
          x="285.02"
 	 y="-745" 
@@ -43814,14 +41476,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_4-0"/>
-       <position name="posOpArapuca0-Lat-4" unit="cm" 
-         x="285.02"
-	 y="-744.26" 
-	 z="299.3"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_4-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca1-Lat-4" unit="cm" 
          x="210.02"
 	 y="-745" 
@@ -43829,14 +41484,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_4-1"/>
-       <position name="posOpArapuca1-Lat-4" unit="cm" 
-         x="210.02"
-	 y="-744.26" 
-	 z="299.3"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_4-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca2-Lat-4" unit="cm" 
          x="135.02"
 	 y="-745" 
@@ -43844,14 +41492,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_4-2"/>
-       <position name="posOpArapuca2-Lat-4" unit="cm" 
-         x="135.02"
-	 y="-744.26" 
-	 z="299.3"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_4-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca3-Lat-4" unit="cm" 
          x="60.02"
 	 y="-745" 
@@ -43859,14 +41500,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_4-3"/>
-       <position name="posOpArapuca3-Lat-4" unit="cm" 
-         x="60.02"
-	 y="-744.26" 
-	 z="299.3"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_4-4"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca4-Lat-4" unit="cm" 
          x="285.02"
 	 y="745" 
@@ -43874,14 +41508,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_4-4"/>
-       <position name="posOpArapuca4-Lat-4" unit="cm" 
-         x="285.02"
-	 y="744.26" 
-	 z="299.3"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_4-5"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca5-Lat-4" unit="cm" 
          x="210.02"
 	 y="745" 
@@ -43889,14 +41516,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_4-5"/>
-       <position name="posOpArapuca5-Lat-4" unit="cm" 
-         x="210.02"
-	 y="744.26" 
-	 z="299.3"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_4-6"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca6-Lat-4" unit="cm" 
          x="135.02"
 	 y="745" 
@@ -43904,14 +41524,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_4-6"/>
-       <position name="posOpArapuca6-Lat-4" unit="cm" 
-         x="135.02"
-	 y="744.26" 
-	 z="299.3"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_4-7"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca7-Lat-4" unit="cm" 
          x="60.02"
 	 y="745" 
@@ -43919,14 +41532,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_4-7"/>
-       <position name="posOpArapuca7-Lat-4" unit="cm" 
-         x="60.02"
-	 y="744.26" 
-	 z="299.3"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_5-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca0-Lat-5" unit="cm" 
          x="285.02"
 	 y="-745" 
@@ -43934,14 +41540,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_5-0"/>
-       <position name="posOpArapuca0-Lat-5" unit="cm" 
-         x="285.02"
-	 y="-744.26" 
-	 z="598.6"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_5-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca1-Lat-5" unit="cm" 
          x="210.02"
 	 y="-745" 
@@ -43949,14 +41548,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_5-1"/>
-       <position name="posOpArapuca1-Lat-5" unit="cm" 
-         x="210.02"
-	 y="-744.26" 
-	 z="598.6"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_5-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca2-Lat-5" unit="cm" 
          x="135.02"
 	 y="-745" 
@@ -43964,14 +41556,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_5-2"/>
-       <position name="posOpArapuca2-Lat-5" unit="cm" 
-         x="135.02"
-	 y="-744.26" 
-	 z="598.6"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_5-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca3-Lat-5" unit="cm" 
          x="60.02"
 	 y="-745" 
@@ -43979,14 +41564,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_5-3"/>
-       <position name="posOpArapuca3-Lat-5" unit="cm" 
-         x="60.02"
-	 y="-744.26" 
-	 z="598.6"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_5-4"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca4-Lat-5" unit="cm" 
          x="285.02"
 	 y="745" 
@@ -43994,14 +41572,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_5-4"/>
-       <position name="posOpArapuca4-Lat-5" unit="cm" 
-         x="285.02"
-	 y="744.26" 
-	 z="598.6"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_5-5"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca5-Lat-5" unit="cm" 
          x="210.02"
 	 y="745" 
@@ -44009,14 +41580,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_5-5"/>
-       <position name="posOpArapuca5-Lat-5" unit="cm" 
-         x="210.02"
-	 y="744.26" 
-	 z="598.6"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_5-6"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca6-Lat-5" unit="cm" 
          x="135.02"
 	 y="745" 
@@ -44024,14 +41588,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_5-6"/>
-       <position name="posOpArapuca6-Lat-5" unit="cm" 
-         x="135.02"
-	 y="744.26" 
-	 z="598.6"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_5-7"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca7-Lat-5" unit="cm" 
          x="60.02"
 	 y="745" 
@@ -44039,14 +41596,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_5-7"/>
-       <position name="posOpArapuca7-Lat-5" unit="cm" 
-         x="60.02"
-	 y="744.26" 
-	 z="598.6"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_6-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca0-Lat-6" unit="cm" 
          x="285.02"
 	 y="-745" 
@@ -44054,14 +41604,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_6-0"/>
-       <position name="posOpArapuca0-Lat-6" unit="cm" 
-         x="285.02"
-	 y="-744.26" 
-	 z="897.9"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_6-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca1-Lat-6" unit="cm" 
          x="210.02"
 	 y="-745" 
@@ -44069,14 +41612,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_6-1"/>
-       <position name="posOpArapuca1-Lat-6" unit="cm" 
-         x="210.02"
-	 y="-744.26" 
-	 z="897.9"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_6-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca2-Lat-6" unit="cm" 
          x="135.02"
 	 y="-745" 
@@ -44084,14 +41620,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_6-2"/>
-       <position name="posOpArapuca2-Lat-6" unit="cm" 
-         x="135.02"
-	 y="-744.26" 
-	 z="897.9"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_6-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca3-Lat-6" unit="cm" 
          x="60.02"
 	 y="-745" 
@@ -44099,14 +41628,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_6-3"/>
-       <position name="posOpArapuca3-Lat-6" unit="cm" 
-         x="60.02"
-	 y="-744.26" 
-	 z="897.9"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_6-4"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca4-Lat-6" unit="cm" 
          x="285.02"
 	 y="745" 
@@ -44114,14 +41636,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_6-4"/>
-       <position name="posOpArapuca4-Lat-6" unit="cm" 
-         x="285.02"
-	 y="744.26" 
-	 z="897.9"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_6-5"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca5-Lat-6" unit="cm" 
          x="210.02"
 	 y="745" 
@@ -44129,14 +41644,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_6-5"/>
-       <position name="posOpArapuca5-Lat-6" unit="cm" 
-         x="210.02"
-	 y="744.26" 
-	 z="897.9"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_6-6"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca6-Lat-6" unit="cm" 
          x="135.02"
 	 y="745" 
@@ -44144,14 +41652,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_6-6"/>
-       <position name="posOpArapuca6-Lat-6" unit="cm" 
-         x="135.02"
-	 y="744.26" 
-	 z="897.9"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_6-7"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca7-Lat-6" unit="cm" 
          x="60.02"
 	 y="745" 
@@ -44159,15 +41660,8 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_6-7"/>
-       <position name="posOpArapuca7-Lat-6" unit="cm" 
-         x="60.02"
-	 y="744.26" 
-	 z="897.9"/>
-     </physvol>
-     <physvol>
        <volumeref ref="volArapuca"/>
-       <position name="posArapuca0-ShortLat-6" unit="cm" 
+       <position name="posArapuca0-ShortLat-220" unit="cm" 
          x="285.02"
 	 y="-220" 
 	 z="-1144.55"/>
@@ -44175,7 +41669,7 @@
      </physvol>
      <physvol>
        <volumeref ref="volArapuca"/>
-       <position name="posArapuca1-ShortLat-6" unit="cm" 
+       <position name="posArapuca1-ShortLat-220" unit="cm" 
          x="210.02"
 	 y="-220" 
 	 z="-1144.55"/>
@@ -44183,7 +41677,7 @@
      </physvol>
      <physvol>
        <volumeref ref="volArapuca"/>
-       <position name="posArapuca2-ShortLat-6" unit="cm" 
+       <position name="posArapuca2-ShortLat-220" unit="cm" 
          x="135.02"
 	 y="-220" 
 	 z="-1144.55"/>
@@ -44191,7 +41685,7 @@
      </physvol>
      <physvol>
        <volumeref ref="volArapuca"/>
-       <position name="posArapuca3-ShortLat-6" unit="cm" 
+       <position name="posArapuca3-ShortLat-220" unit="cm" 
          x="60.02"
 	 y="-220" 
 	 z="-1144.55"/>
@@ -44199,7 +41693,7 @@
      </physvol>
      <physvol>
        <volumeref ref="volArapuca"/>
-       <position name="posArapuca4-ShortLat-6" unit="cm" 
+       <position name="posArapuca4-ShortLat-220" unit="cm" 
          x="285.02"
 	 y="-220" 
 	 z="1144.55"/>
@@ -44207,7 +41701,7 @@
      </physvol>
      <physvol>
        <volumeref ref="volArapuca"/>
-       <position name="posArapuca5-ShortLat-6" unit="cm" 
+       <position name="posArapuca5-ShortLat-220" unit="cm" 
          x="210.02"
 	 y="-220" 
 	 z="1144.55"/>
@@ -44215,7 +41709,7 @@
      </physvol>
      <physvol>
        <volumeref ref="volArapuca"/>
-       <position name="posArapuca6-ShortLat-6" unit="cm" 
+       <position name="posArapuca6-ShortLat-220" unit="cm" 
          x="135.02"
 	 y="-220" 
 	 z="1144.55"/>
@@ -44223,7 +41717,7 @@
      </physvol>
      <physvol>
        <volumeref ref="volArapuca"/>
-       <position name="posArapuca7-ShortLat-6" unit="cm" 
+       <position name="posArapuca7-ShortLat-220" unit="cm" 
          x="60.02"
 	 y="-220" 
 	 z="1144.55"/>
@@ -44231,7 +41725,7 @@
      </physvol>
      <physvol>
        <volumeref ref="volArapuca"/>
-       <position name="posArapuca0-ShortLat-6" unit="cm" 
+       <position name="posArapuca0-ShortLat220" unit="cm" 
          x="285.02"
 	 y="220" 
 	 z="-1144.55"/>
@@ -44239,7 +41733,7 @@
      </physvol>
      <physvol>
        <volumeref ref="volArapuca"/>
-       <position name="posArapuca1-ShortLat-6" unit="cm" 
+       <position name="posArapuca1-ShortLat220" unit="cm" 
          x="210.02"
 	 y="220" 
 	 z="-1144.55"/>
@@ -44247,7 +41741,7 @@
      </physvol>
      <physvol>
        <volumeref ref="volArapuca"/>
-       <position name="posArapuca2-ShortLat-6" unit="cm" 
+       <position name="posArapuca2-ShortLat220" unit="cm" 
          x="135.02"
 	 y="220" 
 	 z="-1144.55"/>
@@ -44255,7 +41749,7 @@
      </physvol>
      <physvol>
        <volumeref ref="volArapuca"/>
-       <position name="posArapuca3-ShortLat-6" unit="cm" 
+       <position name="posArapuca3-ShortLat220" unit="cm" 
          x="60.02"
 	 y="220" 
 	 z="-1144.55"/>
@@ -44263,7 +41757,7 @@
      </physvol>
      <physvol>
        <volumeref ref="volArapuca"/>
-       <position name="posArapuca4-ShortLat-6" unit="cm" 
+       <position name="posArapuca4-ShortLat220" unit="cm" 
          x="285.02"
 	 y="220" 
 	 z="1144.55"/>
@@ -44271,7 +41765,7 @@
      </physvol>
      <physvol>
        <volumeref ref="volArapuca"/>
-       <position name="posArapuca5-ShortLat-6" unit="cm" 
+       <position name="posArapuca5-ShortLat220" unit="cm" 
          x="210.02"
 	 y="220" 
 	 z="1144.55"/>
@@ -44279,7 +41773,7 @@
      </physvol>
      <physvol>
        <volumeref ref="volArapuca"/>
-       <position name="posArapuca6-ShortLat-6" unit="cm" 
+       <position name="posArapuca6-ShortLat220" unit="cm" 
          x="135.02"
 	 y="220" 
 	 z="1144.55"/>
@@ -44287,7 +41781,7 @@
      </physvol>
      <physvol>
        <volumeref ref="volArapuca"/>
-       <position name="posArapuca7-ShortLat-6" unit="cm" 
+       <position name="posArapuca7-ShortLat220" unit="cm" 
          x="60.02"
 	 y="220" 
 	 z="1144.55"/>

--- a/dunecore/Geometry/gdml/dunevd10kt_3view_30deg_v5_refactored_1x8x14ref.gdml
+++ b/dunecore/Geometry/gdml/dunevd10kt_3view_30deg_v5_refactored_1x8x14ref.gdml
@@ -2,6 +2,8 @@
 <gdml_simple_extension xmlns:gdml_simple_extension="http://www.example.org"
                        xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"          
                        xs:noNamespaceSchemaLocation="RefactoredGDMLSchema/SimpleExtension.xsd"> 
+
+
 <extension>
    <color name="magenta"     R="0.0"  G="1.0"  B="0.0"  A="1.0" />
    <color name="green"       R="0.0"  G="1.0"  B="0.0"  A="1.0" />
@@ -31,6 +33,10 @@
    <rotation name="rPlus180AboutY"	unit="deg" x="0" y="180"   z="0"/>
    <rotation name="rPlus180AboutXPlus180AboutY"	unit="deg" x="180" y="180"   z="0"/>
    <rotation name="rIdentity"		unit="deg" x="0" y="0"   z="0"/>
+   <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+   <rotation name="rPlus90AboutXPlus180AboutY" unit="deg" x="90" y="180" z="0" />
+   <rotation name="rPlus90AboutXMinux90AboutY" unit="deg" x="90" y="270" z="0" />
+   <rotation name="rPlus90AboutZ" unit="deg" x="0" y="0" z="90" />
 </define>
 <materials>
   <element name="videRef" formula="VACUUM" Z="1">  <atom value="1"/> </element>
@@ -396,21 +402,21 @@
       <first ref="FieldShaperLongtube"/>
       <second ref="FieldShaperCorner"/>
    		<position name="esquinapos1" unit="cm" x="-2.3" y="0" z="1047.55"/>
-		<rotation name="rot1" unit="deg" x="90" y="0" z="0" />
+		<rotationref ref="rPlus90AboutX"/>
     </union>
 
     <union name="FSunion2">
       <first ref="FSunion1"/>
       <second ref="FieldShaperShorttube"/>
    		<position name="esquinapos2" unit="cm" x="-676.3" y="0" z="1049.85"/>
-   		<rotation name="rot2" unit="deg" x="0" y="90" z="0" />
+   		<rotationref ref="rPlus90AboutY"/>
     </union>
 
     <union name="FSunion3">
       <first ref="FSunion2"/>
       <second ref="FieldShaperCorner"/>
    		<position name="esquinapos3" unit="cm" x="-1350.3" y="0" z="1047.55"/>
-		<rotation name="rot3" unit="deg" x="90" y="270" z="0" />
+		<rotationref ref="rPlus90AboutXMinux90AboutY"/>
     </union>
 
     <union name="FSunion4">
@@ -423,42 +429,42 @@
       <first ref="FSunion4"/>
       <second ref="FieldShaperCorner"/>
    		<position name="esquinapos5" unit="cm" x="-1350.3" y="0" z="-1047.55"/>
-		<rotation name="rot5" unit="deg" x="90" y="180" z="0" />
+		<rotationref ref="rPlus90AboutXPlus180AboutY"/>
     </union>
 
     <union name="FSunion6">
       <first ref="FSunion5"/>
       <second ref="FieldShaperShorttube"/>
    		<position name="esquinapos6" unit="cm" x="-676.3" y="0" z="-1049.85"/>
-		<rotation name="rot6" unit="deg" x="0" y="90" z="0" />
+		<rotationref ref="rPlus90AboutY"/>
     </union>
 
     <union name="FieldShaperSolid">
       <first ref="FSunion6"/>
       <second ref="FieldShaperCorner"/>
    		<position name="esquinapos7" unit="cm" x="-2.3" y="0" z="-1047.55"/>
-		<rotation name="rot7" unit="deg" x="90" y="90" z="0" />
+		<rotationref ref="rPlus90AboutXPlus90AboutY"/>
     </union>
     
     <union name="FSunionSlim1">
       <first ref="FieldShaperLongtubeSlim"/>
       <second ref="FieldShaperCorner"/>
-   		<position name="esquinapos1" unit="cm" x="-2.3" y="0" z="1047.55"/>
-		<rotation name="rot1" unit="deg" x="90" y="0" z="0" />
+   		<position name="esquinapos8" unit="cm" x="-2.3" y="0" z="1047.55"/>
+		<rotationref ref="rPlus90AboutX"/>
     </union>
 
     <union name="FSunionSlim2">
       <first ref="FSunionSlim1"/>
       <second ref="FieldShaperShorttube"/>
-   		<position name="esquinapos2" unit="cm" x="-676.3" y="0" z="1049.85"/>
-   		<rotation name="rot2" unit="deg" x="0" y="90" z="0" />
+   		<position name="esquinapos9" unit="cm" x="-676.3" y="0" z="1049.85"/>
+   		<rotationref ref="rPlus90AboutY"/>
     </union>
 
     <union name="FSunionSlim3">
       <first ref="FSunionSlim2"/>
       <second ref="FieldShaperCorner"/>
-   		<position name="esquinapos3" unit="cm" x="-1350.3" y="0" z="1047.55"/>
-		<rotation name="rot3" unit="deg" x="90" y="270" z="0" />
+   		<position name="esquinapos10" unit="cm" x="-1350.3" y="0" z="1047.55"/>
+		<rotationref ref="rPlus90AboutXMinux90AboutY"/>
     </union>
 
     <union name="FSunionSlim4">
@@ -470,22 +476,22 @@
     <union name="FSunionSlim5">
       <first ref="FSunionSlim4"/>
       <second ref="FieldShaperCorner"/>
-   		<position name="esquinapos5" unit="cm" x="-1350.3" y="0" z="-1047.55"/>
-		<rotation name="rot5" unit="deg" x="90" y="180" z="0" />
+   		<position name="esquinapos11" unit="cm" x="-1350.3" y="0" z="-1047.55"/>
+		<rotationref ref="rPlus90AboutXPlus180AboutY"/>
     </union>
 
     <union name="FSunionSlim6">
       <first ref="FSunionSlim5"/>
       <second ref="FieldShaperShorttube"/>
-   		<position name="esquinapos6" unit="cm" x="-676.3" y="0" z="-1049.85"/>
-		<rotation name="rot6" unit="deg" x="0" y="90" z="0" />
+   		<position name="esquinapos12" unit="cm" x="-676.3" y="0" z="-1049.85"/>
+		<rotationref ref="rPlus90AboutY"/>
     </union>
 
     <union name="FieldShaperSolidSlim">
       <first ref="FSunionSlim6"/>
       <second ref="FieldShaperCorner"/>
-   		<position name="esquinapos7" unit="cm" x="-2.3" y="0" z="-1047.55"/>
-		<rotation name="rot7" unit="deg" x="90" y="90" z="0" />
+   		<position name="esquinapos13" unit="cm" x="-2.3" y="0" z="-1047.55"/>
+		<rotationref ref="rPlus90AboutXPlus90AboutY"/>
     </union>
     
 
@@ -12043,28 +12049,28 @@
 
     <box name="Cryostat" lunit="cm" 
       x="850.3" 
-      y="1548.24" 
-      z="2295.34"/>
+      y="1510.24" 
+      z="2309.34"/>
 
     <box name="ArgonInterior" lunit="cm" 
       x="850.06"
-      y="1548"
-      z="2295.1"/>
+      y="1510"
+      z="2309.1"/>
 
     <box name="GaseousArgon" lunit="cm" 
       x="100 - 0.01"
-      y="1548"
-      z="2295.1"/>
+      y="1510"
+      z="2309.1"/>
 
     <box name="ExternalAuxOut" lunit="cm" 
       x="850.06 - 99.9999999999999"
-      y="1548 - 2*2.5 - 2*40"
-      z="2295.1"/>
+      y="1510 - 2*2.5 - 2*10"
+      z="2309.1"/>
 
     <box name="ExternalAuxIn" lunit="cm" 
       x="850.06"
       y="1359.17"
-      z="2295.1 + 1"/>
+      z="2309.1 + 1"/>
 
    <subtraction name="ExternalActive">
       <first ref="ExternalAuxOut"/>
@@ -12177,8 +12183,8 @@
 
     <box name="FoamPadBlock" lunit="cm"
       x="1010.3"
-      y="1708.24"
-      z="2455.34" />
+      y="1670.24"
+      z="2469.34" />
 
     <subtraction name="FoamPadding">
       <first ref="FoamPadBlock"/>
@@ -12188,8 +12194,8 @@
 
     <box name="SteelSupportBlock" lunit="cm"
       x="1210.3"
-      y="1908.24"
-      z="2655.34" />
+      y="1870.24"
+      z="2669.34" />
 
     <subtraction name="SteelSupport">
       <first ref="SteelSupportBlock"/>
@@ -12199,22 +12205,22 @@
 
     <box name="DetEnclosure" lunit="cm" 
       x="1310.3"
-      y="2108.24"
-      z="2855.34"/>
+      y="2070.24"
+      z="2869.34"/>
 
 
     <box name="World" lunit="cm" 
       x="9310.3" 
-      y="10108.24" 
-      z="10855.34"/>
+      y="10070.24" 
+      z="10869.34"/>
 </solids>
 <structure>
 <volume name="volFieldShaper">
-  <materialref ref="Al2O3"/>
+  <materialref ref="ALUMINUM_Al"/>
   <solidref ref="FieldShaperSolid"/>
 </volume>
 <volume name="volFieldShaperSlim">
-  <materialref ref="Al2O3"/>
+  <materialref ref="ALUMINUM_Al"/>
   <solidref ref="FieldShaperSolidSlim"/>
 </volume>
 
@@ -38879,8 +38885,8 @@
       <materialref ref="STEEL_STAINLESS_Fe7Cr2Ni" />
       <solidref ref="SteelShell" />
     </volume>
-    <volume name="volGroundGrid">
-      <materialref ref="STEEL_STAINLESS_Fe7Cr2Ni" />
+    <volume name="volCathodeGrid">
+      <materialref ref="G10" />
       <solidref ref="CathodeGrid" />
     </volume>
     <volume name="volAnodePlate">
@@ -38899,6 +38905,34 @@
       <auxiliary auxtype="Efield" auxunit="V/cm" auxvalue="0*V/cm"/>
       <colorref ref="green"/>
     </volume>
+
+    <volume name="volArapucaShortLat">
+      <materialref ref="G10"/>
+      <solidref ref="ArapucaWalls"/>
+    </volume>
+    <volume name="volOpDetSensitive">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+
+    <volume name="Arapuca">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+
+    <volume name="volArapuca">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaOut"/>
+      <physvol>
+        <volumeref ref="Arapuca"/>
+        <positionref ref="posCenter"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volOpDetSensitive"/>
+        <position name="opdetshift" unit="cm" x="0" y="0.5" z="0"/>
+      </physvol>
+    </volume>
+
     <volume name="volArapucaDouble_0-0-0">
       <materialref ref="G10" />
       <solidref ref="ArapucaWalls" />
@@ -40822,546 +40856,546 @@
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper0" unit="cm"  x="-322.03" y="-676.3" z="0" />
-     <rotation name="rotFS0" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper1" unit="cm"  x="-316.03" y="-676.3" z="0" />
-     <rotation name="rotFS1" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper2" unit="cm"  x="-310.03" y="-676.3" z="0" />
-     <rotation name="rotFS2" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper3" unit="cm"  x="-304.03" y="-676.3" z="0" />
-     <rotation name="rotFS3" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper4" unit="cm"  x="-298.03" y="-676.3" z="0" />
-     <rotation name="rotFS4" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper5" unit="cm"  x="-292.03" y="-676.3" z="0" />
-     <rotation name="rotFS5" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper6" unit="cm"  x="-286.03" y="-676.3" z="0" />
-     <rotation name="rotFS6" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper7" unit="cm"  x="-280.03" y="-676.3" z="0" />
-     <rotation name="rotFS7" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper8" unit="cm"  x="-274.03" y="-676.3" z="0" />
-     <rotation name="rotFS8" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper9" unit="cm"  x="-268.03" y="-676.3" z="0" />
-     <rotation name="rotFS9" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper10" unit="cm"  x="-262.03" y="-676.3" z="0" />
-     <rotation name="rotFS10" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper11" unit="cm"  x="-256.03" y="-676.3" z="0" />
-     <rotation name="rotFS11" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper12" unit="cm"  x="-250.03" y="-676.3" z="0" />
-     <rotation name="rotFS12" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper13" unit="cm"  x="-244.03" y="-676.3" z="0" />
-     <rotation name="rotFS13" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper14" unit="cm"  x="-238.03" y="-676.3" z="0" />
-     <rotation name="rotFS14" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper15" unit="cm"  x="-232.03" y="-676.3" z="0" />
-     <rotation name="rotFS15" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper16" unit="cm"  x="-226.03" y="-676.3" z="0" />
-     <rotation name="rotFS16" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper17" unit="cm"  x="-220.03" y="-676.3" z="0" />
-     <rotation name="rotFS17" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper18" unit="cm"  x="-214.03" y="-676.3" z="0" />
-     <rotation name="rotFS18" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper19" unit="cm"  x="-208.03" y="-676.3" z="0" />
-     <rotation name="rotFS19" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper20" unit="cm"  x="-202.03" y="-676.3" z="0" />
-     <rotation name="rotFS20" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper21" unit="cm"  x="-196.03" y="-676.3" z="0" />
-     <rotation name="rotFS21" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper22" unit="cm"  x="-190.03" y="-676.3" z="0" />
-     <rotation name="rotFS22" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper23" unit="cm"  x="-184.03" y="-676.3" z="0" />
-     <rotation name="rotFS23" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper24" unit="cm"  x="-178.03" y="-676.3" z="0" />
-     <rotation name="rotFS24" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper25" unit="cm"  x="-172.03" y="-676.3" z="0" />
-     <rotation name="rotFS25" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper26" unit="cm"  x="-166.03" y="-676.3" z="0" />
-     <rotation name="rotFS26" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper27" unit="cm"  x="-160.03" y="-676.3" z="0" />
-     <rotation name="rotFS27" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper28" unit="cm"  x="-154.03" y="-676.3" z="0" />
-     <rotation name="rotFS28" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper29" unit="cm"  x="-148.03" y="-676.3" z="0" />
-     <rotation name="rotFS29" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper30" unit="cm"  x="-142.03" y="-676.3" z="0" />
-     <rotation name="rotFS30" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper31" unit="cm"  x="-136.03" y="-676.3" z="0" />
-     <rotation name="rotFS31" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper32" unit="cm"  x="-130.03" y="-676.3" z="0" />
-     <rotation name="rotFS32" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper33" unit="cm"  x="-124.03" y="-676.3" z="0" />
-     <rotation name="rotFS33" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper34" unit="cm"  x="-118.03" y="-676.3" z="0" />
-     <rotation name="rotFS34" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper35" unit="cm"  x="-112.03" y="-676.3" z="0" />
-     <rotation name="rotFS35" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper36" unit="cm"  x="-106.03" y="-676.3" z="0" />
-     <rotation name="rotFS36" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper37" unit="cm"  x="-100.03" y="-676.3" z="0" />
-     <rotation name="rotFS37" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper38" unit="cm"  x="-94.03" y="-676.3" z="0" />
-     <rotation name="rotFS38" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper39" unit="cm"  x="-88.03" y="-676.3" z="0" />
-     <rotation name="rotFS39" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper40" unit="cm"  x="-82.03" y="-676.3" z="0" />
-     <rotation name="rotFS40" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper41" unit="cm"  x="-76.03" y="-676.3" z="0" />
-     <rotation name="rotFS41" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper42" unit="cm"  x="-70.03" y="-676.3" z="0" />
-     <rotation name="rotFS42" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper43" unit="cm"  x="-64.03" y="-676.3" z="0" />
-     <rotation name="rotFS43" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper44" unit="cm"  x="-58.03" y="-676.3" z="0" />
-     <rotation name="rotFS44" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper45" unit="cm"  x="-52.03" y="-676.3" z="0" />
-     <rotation name="rotFS45" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper46" unit="cm"  x="-46.03" y="-676.3" z="0" />
-     <rotation name="rotFS46" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper47" unit="cm"  x="-40.03" y="-676.3" z="0" />
-     <rotation name="rotFS47" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper48" unit="cm"  x="-34.03" y="-676.3" z="0" />
-     <rotation name="rotFS48" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper49" unit="cm"  x="-28.03" y="-676.3" z="0" />
-     <rotation name="rotFS49" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper50" unit="cm"  x="-22.03" y="-676.3" z="0" />
-     <rotation name="rotFS50" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper51" unit="cm"  x="-16.03" y="-676.3" z="0" />
-     <rotation name="rotFS51" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper52" unit="cm"  x="-10.03" y="-676.3" z="0" />
-     <rotation name="rotFS52" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper53" unit="cm"  x="-4.03000000000002" y="-676.3" z="0" />
-     <rotation name="rotFS53" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper54" unit="cm"  x="1.96999999999998" y="-676.3" z="0" />
-     <rotation name="rotFS54" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper55" unit="cm"  x="7.96999999999998" y="-676.3" z="0" />
-     <rotation name="rotFS55" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper56" unit="cm"  x="13.97" y="-676.3" z="0" />
-     <rotation name="rotFS56" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper57" unit="cm"  x="19.97" y="-676.3" z="0" />
-     <rotation name="rotFS57" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper58" unit="cm"  x="25.97" y="-676.3" z="0" />
-     <rotation name="rotFS58" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper59" unit="cm"  x="31.97" y="-676.3" z="0" />
-     <rotation name="rotFS59" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper60" unit="cm"  x="37.97" y="-676.3" z="0" />
-     <rotation name="rotFS60" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper61" unit="cm"  x="43.97" y="-676.3" z="0" />
-     <rotation name="rotFS61" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper62" unit="cm"  x="49.97" y="-676.3" z="0" />
-     <rotation name="rotFS62" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper63" unit="cm"  x="55.97" y="-676.3" z="0" />
-     <rotation name="rotFS63" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper64" unit="cm"  x="61.97" y="-676.3" z="0" />
-     <rotation name="rotFS64" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper65" unit="cm"  x="67.97" y="-676.3" z="0" />
-     <rotation name="rotFS65" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper66" unit="cm"  x="73.97" y="-676.3" z="0" />
-     <rotation name="rotFS66" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper67" unit="cm"  x="79.97" y="-676.3" z="0" />
-     <rotation name="rotFS67" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper68" unit="cm"  x="85.97" y="-676.3" z="0" />
-     <rotation name="rotFS68" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper69" unit="cm"  x="91.97" y="-676.3" z="0" />
-     <rotation name="rotFS69" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper70" unit="cm"  x="97.97" y="-676.3" z="0" />
-     <rotation name="rotFS70" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper71" unit="cm"  x="103.97" y="-676.3" z="0" />
-     <rotation name="rotFS71" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper72" unit="cm"  x="109.97" y="-676.3" z="0" />
-     <rotation name="rotFS72" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper73" unit="cm"  x="115.97" y="-676.3" z="0" />
-     <rotation name="rotFS73" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper74" unit="cm"  x="121.97" y="-676.3" z="0" />
-     <rotation name="rotFS74" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper75" unit="cm"  x="127.97" y="-676.3" z="0" />
-     <rotation name="rotFS75" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper76" unit="cm"  x="133.97" y="-676.3" z="0" />
-     <rotation name="rotFS76" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper77" unit="cm"  x="139.97" y="-676.3" z="0" />
-     <rotation name="rotFS77" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper78" unit="cm"  x="145.97" y="-676.3" z="0" />
-     <rotation name="rotFS78" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper79" unit="cm"  x="151.97" y="-676.3" z="0" />
-     <rotation name="rotFS79" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper80" unit="cm"  x="157.97" y="-676.3" z="0" />
-     <rotation name="rotFS80" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper81" unit="cm"  x="163.97" y="-676.3" z="0" />
-     <rotation name="rotFS81" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper82" unit="cm"  x="169.97" y="-676.3" z="0" />
-     <rotation name="rotFS82" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper83" unit="cm"  x="175.97" y="-676.3" z="0" />
-     <rotation name="rotFS83" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper84" unit="cm"  x="181.97" y="-676.3" z="0" />
-     <rotation name="rotFS84" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper85" unit="cm"  x="187.97" y="-676.3" z="0" />
-     <rotation name="rotFS85" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper86" unit="cm"  x="193.97" y="-676.3" z="0" />
-     <rotation name="rotFS86" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper87" unit="cm"  x="199.97" y="-676.3" z="0" />
-     <rotation name="rotFS87" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper88" unit="cm"  x="205.97" y="-676.3" z="0" />
-     <rotation name="rotFS88" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper89" unit="cm"  x="211.97" y="-676.3" z="0" />
-     <rotation name="rotFS89" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper90" unit="cm"  x="217.97" y="-676.3" z="0" />
-     <rotation name="rotFS90" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper91" unit="cm"  x="223.97" y="-676.3" z="0" />
-     <rotation name="rotFS91" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper92" unit="cm"  x="229.97" y="-676.3" z="0" />
-     <rotation name="rotFS92" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper93" unit="cm"  x="235.97" y="-676.3" z="0" />
-     <rotation name="rotFS93" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper94" unit="cm"  x="241.97" y="-676.3" z="0" />
-     <rotation name="rotFS94" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper95" unit="cm"  x="247.97" y="-676.3" z="0" />
-     <rotation name="rotFS95" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper96" unit="cm"  x="253.97" y="-676.3" z="0" />
-     <rotation name="rotFS96" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper97" unit="cm"  x="259.97" y="-676.3" z="0" />
-     <rotation name="rotFS97" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper98" unit="cm"  x="265.97" y="-676.3" z="0" />
-     <rotation name="rotFS98" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper99" unit="cm"  x="271.97" y="-676.3" z="0" />
-     <rotation name="rotFS99" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper100" unit="cm"  x="277.97" y="-676.3" z="0" />
-     <rotation name="rotFS100" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper101" unit="cm"  x="283.97" y="-676.3" z="0" />
-     <rotation name="rotFS101" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper102" unit="cm"  x="289.97" y="-676.3" z="0" />
-     <rotation name="rotFS102" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper103" unit="cm"  x="295.97" y="-676.3" z="0" />
-     <rotation name="rotFS103" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper104" unit="cm"  x="301.97" y="-676.3" z="0" />
-     <rotation name="rotFS104" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper105" unit="cm"  x="307.97" y="-676.3" z="0" />
-     <rotation name="rotFS105" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper106" unit="cm"  x="313.97" y="-676.3" z="0" />
-     <rotation name="rotFS106" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper107" unit="cm"  x="319.97" y="-676.3" z="0" />
-     <rotation name="rotFS107" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
       <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-0" unit="cm" x="-328.03" y="-505.5" z="-897.9"/>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-0" unit="cm" x="-328.03" y="-505.5" z="-897.9"/>
       </physvol>
       <physvol>
        <volumeref ref="volAnodePlate"/>
@@ -41369,8 +41403,8 @@
        <rotationref ref="rIdentity"/>
      </physvol>    
       <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-1" unit="cm" x="-328.03" y="-168.5" z="-897.9"/>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-1" unit="cm" x="-328.03" y="-168.5" z="-897.9"/>
       </physvol>
       <physvol>
        <volumeref ref="volAnodePlate"/>
@@ -41378,8 +41412,8 @@
        <rotationref ref="rIdentity"/>
      </physvol>    
       <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-2" unit="cm" x="-328.03" y="168.5" z="-897.9"/>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-2" unit="cm" x="-328.03" y="168.5" z="-897.9"/>
       </physvol>
       <physvol>
        <volumeref ref="volAnodePlate"/>
@@ -41387,8 +41421,8 @@
        <rotationref ref="rIdentity"/>
      </physvol>    
       <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-3" unit="cm" x="-328.03" y="505.5" z="-897.9"/>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-3" unit="cm" x="-328.03" y="505.5" z="-897.9"/>
       </physvol>
       <physvol>
        <volumeref ref="volAnodePlate"/>
@@ -41396,8 +41430,8 @@
        <rotationref ref="rIdentity"/>
      </physvol>    
       <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-4" unit="cm" x="-328.03" y="-505.5" z="-598.6"/>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-4" unit="cm" x="-328.03" y="-505.5" z="-598.6"/>
       </physvol>
       <physvol>
        <volumeref ref="volAnodePlate"/>
@@ -41405,8 +41439,8 @@
        <rotationref ref="rIdentity"/>
      </physvol>    
       <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-5" unit="cm" x="-328.03" y="-168.5" z="-598.6"/>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-5" unit="cm" x="-328.03" y="-168.5" z="-598.6"/>
       </physvol>
       <physvol>
        <volumeref ref="volAnodePlate"/>
@@ -41414,8 +41448,8 @@
        <rotationref ref="rIdentity"/>
      </physvol>    
       <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-6" unit="cm" x="-328.03" y="168.5" z="-598.6"/>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-6" unit="cm" x="-328.03" y="168.5" z="-598.6"/>
       </physvol>
       <physvol>
        <volumeref ref="volAnodePlate"/>
@@ -41423,8 +41457,8 @@
        <rotationref ref="rIdentity"/>
      </physvol>    
       <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-7" unit="cm" x="-328.03" y="505.5" z="-598.6"/>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-7" unit="cm" x="-328.03" y="505.5" z="-598.6"/>
       </physvol>
       <physvol>
        <volumeref ref="volAnodePlate"/>
@@ -41432,8 +41466,8 @@
        <rotationref ref="rIdentity"/>
      </physvol>    
       <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-8" unit="cm" x="-328.03" y="-505.5" z="-299.3"/>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-8" unit="cm" x="-328.03" y="-505.5" z="-299.3"/>
       </physvol>
       <physvol>
        <volumeref ref="volAnodePlate"/>
@@ -41441,8 +41475,8 @@
        <rotationref ref="rIdentity"/>
      </physvol>    
       <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-9" unit="cm" x="-328.03" y="-168.5" z="-299.3"/>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-9" unit="cm" x="-328.03" y="-168.5" z="-299.3"/>
       </physvol>
       <physvol>
        <volumeref ref="volAnodePlate"/>
@@ -41450,8 +41484,8 @@
        <rotationref ref="rIdentity"/>
      </physvol>    
       <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-10" unit="cm" x="-328.03" y="168.5" z="-299.3"/>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-10" unit="cm" x="-328.03" y="168.5" z="-299.3"/>
       </physvol>
       <physvol>
        <volumeref ref="volAnodePlate"/>
@@ -41459,8 +41493,8 @@
        <rotationref ref="rIdentity"/>
      </physvol>    
       <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-11" unit="cm" x="-328.03" y="505.5" z="-299.3"/>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-11" unit="cm" x="-328.03" y="505.5" z="-299.3"/>
       </physvol>
       <physvol>
        <volumeref ref="volAnodePlate"/>
@@ -41468,8 +41502,8 @@
        <rotationref ref="rIdentity"/>
      </physvol>    
       <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-12" unit="cm" x="-328.03" y="-505.5" z="1.13686837721616e-13"/>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-12" unit="cm" x="-328.03" y="-505.5" z="1.13686837721616e-13"/>
       </physvol>
       <physvol>
        <volumeref ref="volAnodePlate"/>
@@ -41477,8 +41511,8 @@
        <rotationref ref="rIdentity"/>
      </physvol>    
       <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-13" unit="cm" x="-328.03" y="-168.5" z="1.13686837721616e-13"/>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-13" unit="cm" x="-328.03" y="-168.5" z="1.13686837721616e-13"/>
       </physvol>
       <physvol>
        <volumeref ref="volAnodePlate"/>
@@ -41486,8 +41520,8 @@
        <rotationref ref="rIdentity"/>
      </physvol>    
       <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-14" unit="cm" x="-328.03" y="168.5" z="1.13686837721616e-13"/>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-14" unit="cm" x="-328.03" y="168.5" z="1.13686837721616e-13"/>
       </physvol>
       <physvol>
        <volumeref ref="volAnodePlate"/>
@@ -41495,8 +41529,8 @@
        <rotationref ref="rIdentity"/>
      </physvol>    
       <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-15" unit="cm" x="-328.03" y="505.5" z="1.13686837721616e-13"/>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-15" unit="cm" x="-328.03" y="505.5" z="1.13686837721616e-13"/>
       </physvol>
       <physvol>
        <volumeref ref="volAnodePlate"/>
@@ -41504,8 +41538,8 @@
        <rotationref ref="rIdentity"/>
      </physvol>    
       <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-16" unit="cm" x="-328.03" y="-505.5" z="299.3"/>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-16" unit="cm" x="-328.03" y="-505.5" z="299.3"/>
       </physvol>
       <physvol>
        <volumeref ref="volAnodePlate"/>
@@ -41513,8 +41547,8 @@
        <rotationref ref="rIdentity"/>
      </physvol>    
       <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-17" unit="cm" x="-328.03" y="-168.5" z="299.3"/>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-17" unit="cm" x="-328.03" y="-168.5" z="299.3"/>
       </physvol>
       <physvol>
        <volumeref ref="volAnodePlate"/>
@@ -41522,8 +41556,8 @@
        <rotationref ref="rIdentity"/>
      </physvol>    
       <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-18" unit="cm" x="-328.03" y="168.5" z="299.3"/>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-18" unit="cm" x="-328.03" y="168.5" z="299.3"/>
       </physvol>
       <physvol>
        <volumeref ref="volAnodePlate"/>
@@ -41531,8 +41565,8 @@
        <rotationref ref="rIdentity"/>
      </physvol>    
       <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-19" unit="cm" x="-328.03" y="505.5" z="299.3"/>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-19" unit="cm" x="-328.03" y="505.5" z="299.3"/>
       </physvol>
       <physvol>
        <volumeref ref="volAnodePlate"/>
@@ -41540,8 +41574,8 @@
        <rotationref ref="rIdentity"/>
      </physvol>    
       <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-20" unit="cm" x="-328.03" y="-505.5" z="598.6"/>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-20" unit="cm" x="-328.03" y="-505.5" z="598.6"/>
       </physvol>
       <physvol>
        <volumeref ref="volAnodePlate"/>
@@ -41549,8 +41583,8 @@
        <rotationref ref="rIdentity"/>
      </physvol>    
       <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-21" unit="cm" x="-328.03" y="-168.5" z="598.6"/>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-21" unit="cm" x="-328.03" y="-168.5" z="598.6"/>
       </physvol>
       <physvol>
        <volumeref ref="volAnodePlate"/>
@@ -41558,8 +41592,8 @@
        <rotationref ref="rIdentity"/>
      </physvol>    
       <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-22" unit="cm" x="-328.03" y="168.5" z="598.6"/>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-22" unit="cm" x="-328.03" y="168.5" z="598.6"/>
       </physvol>
       <physvol>
        <volumeref ref="volAnodePlate"/>
@@ -41567,8 +41601,8 @@
        <rotationref ref="rIdentity"/>
      </physvol>    
       <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-23" unit="cm" x="-328.03" y="505.5" z="598.6"/>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-23" unit="cm" x="-328.03" y="505.5" z="598.6"/>
       </physvol>
       <physvol>
        <volumeref ref="volAnodePlate"/>
@@ -41576,8 +41610,8 @@
        <rotationref ref="rIdentity"/>
      </physvol>    
       <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-24" unit="cm" x="-328.03" y="-505.5" z="897.9"/>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-24" unit="cm" x="-328.03" y="-505.5" z="897.9"/>
       </physvol>
       <physvol>
        <volumeref ref="volAnodePlate"/>
@@ -41585,8 +41619,8 @@
        <rotationref ref="rIdentity"/>
      </physvol>    
       <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-25" unit="cm" x="-328.03" y="-168.5" z="897.9"/>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-25" unit="cm" x="-328.03" y="-168.5" z="897.9"/>
       </physvol>
       <physvol>
        <volumeref ref="volAnodePlate"/>
@@ -41594,8 +41628,8 @@
        <rotationref ref="rIdentity"/>
      </physvol>    
       <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-26" unit="cm" x="-328.03" y="168.5" z="897.9"/>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-26" unit="cm" x="-328.03" y="168.5" z="897.9"/>
       </physvol>
       <physvol>
        <volumeref ref="volAnodePlate"/>
@@ -41603,8 +41637,8 @@
        <rotationref ref="rIdentity"/>
      </physvol>    
       <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-27" unit="cm" x="-328.03" y="505.5" z="897.9"/>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-27" unit="cm" x="-328.03" y="505.5" z="897.9"/>
       </physvol>
       <physvol>
        <volumeref ref="volAnodePlate"/>
@@ -41617,7 +41651,7 @@
          x="-328.03"
 	 y="-633.2" 
 	 z="-860.4"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-0"/>
@@ -41632,7 +41666,7 @@
          x="-328.03"
 	 y="-542.5" 
 	 z="-1006.4"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-1"/>
@@ -41647,7 +41681,7 @@
          x="-328.03"
 	 y="-468.5" 
 	 z="-789.4"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-2"/>
@@ -41662,7 +41696,7 @@
          x="-328.03"
 	 y="-377.8" 
 	 z="-935.4"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-3"/>
@@ -41677,7 +41711,7 @@
          x="-328.03"
 	 y="-633.2" 
 	 z="-561.1"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-0"/>
@@ -41692,7 +41726,7 @@
          x="-328.03"
 	 y="-542.5" 
 	 z="-707.1"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-1"/>
@@ -41707,7 +41741,7 @@
          x="-328.03"
 	 y="-468.5" 
 	 z="-490.1"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-2"/>
@@ -41722,7 +41756,7 @@
          x="-328.03"
 	 y="-377.8" 
 	 z="-636.1"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-3"/>
@@ -41737,7 +41771,7 @@
          x="-328.03"
 	 y="-633.2" 
 	 z="-261.8"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-0"/>
@@ -41752,7 +41786,7 @@
          x="-328.03"
 	 y="-542.5" 
 	 z="-407.8"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-1"/>
@@ -41767,7 +41801,7 @@
          x="-328.03"
 	 y="-468.5" 
 	 z="-190.8"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-2"/>
@@ -41782,7 +41816,7 @@
          x="-328.03"
 	 y="-377.8" 
 	 z="-336.8"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-3"/>
@@ -41797,7 +41831,7 @@
          x="-328.03"
 	 y="-633.2" 
 	 z="37.5000000000001"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-3-0"/>
@@ -41812,7 +41846,7 @@
          x="-328.03"
 	 y="-542.5" 
 	 z="-108.5"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-3-1"/>
@@ -41827,7 +41861,7 @@
          x="-328.03"
 	 y="-468.5" 
 	 z="108.5"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-3-2"/>
@@ -41842,7 +41876,7 @@
          x="-328.03"
 	 y="-377.8" 
 	 z="-37.4999999999999"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-3-3"/>
@@ -41857,7 +41891,7 @@
          x="-328.03"
 	 y="-633.2" 
 	 z="336.8"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-4-0"/>
@@ -41872,7 +41906,7 @@
          x="-328.03"
 	 y="-542.5" 
 	 z="190.8"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-4-1"/>
@@ -41887,7 +41921,7 @@
          x="-328.03"
 	 y="-468.5" 
 	 z="407.8"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-4-2"/>
@@ -41902,7 +41936,7 @@
          x="-328.03"
 	 y="-377.8" 
 	 z="261.8"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-4-3"/>
@@ -41917,7 +41951,7 @@
          x="-328.03"
 	 y="-633.2" 
 	 z="636.1"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-5-0"/>
@@ -41932,7 +41966,7 @@
          x="-328.03"
 	 y="-542.5" 
 	 z="490.1"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-5-1"/>
@@ -41947,7 +41981,7 @@
          x="-328.03"
 	 y="-468.5" 
 	 z="707.1"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-5-2"/>
@@ -41962,7 +41996,7 @@
          x="-328.03"
 	 y="-377.8" 
 	 z="561.1"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-5-3"/>
@@ -41977,7 +42011,7 @@
          x="-328.03"
 	 y="-633.2" 
 	 z="935.4"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-6-0"/>
@@ -41992,7 +42026,7 @@
          x="-328.03"
 	 y="-542.5" 
 	 z="789.4"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-6-1"/>
@@ -42007,7 +42041,7 @@
          x="-328.03"
 	 y="-468.5" 
 	 z="1006.4"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-6-2"/>
@@ -42022,7 +42056,7 @@
          x="-328.03"
 	 y="-377.8" 
 	 z="860.4"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-6-3"/>
@@ -42037,7 +42071,7 @@
          x="-328.03"
 	 y="-296.2" 
 	 z="-860.4"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-0"/>
@@ -42052,7 +42086,7 @@
          x="-328.03"
 	 y="-205.5" 
 	 z="-1006.4"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-1"/>
@@ -42067,7 +42101,7 @@
          x="-328.03"
 	 y="-131.5" 
 	 z="-789.4"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-2"/>
@@ -42082,7 +42116,7 @@
          x="-328.03"
 	 y="-40.8" 
 	 z="-935.4"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-3"/>
@@ -42097,7 +42131,7 @@
          x="-328.03"
 	 y="-296.2" 
 	 z="-561.1"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-0"/>
@@ -42112,7 +42146,7 @@
          x="-328.03"
 	 y="-205.5" 
 	 z="-707.1"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-1"/>
@@ -42127,7 +42161,7 @@
          x="-328.03"
 	 y="-131.5" 
 	 z="-490.1"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-2"/>
@@ -42142,7 +42176,7 @@
          x="-328.03"
 	 y="-40.8" 
 	 z="-636.1"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-3"/>
@@ -42157,7 +42191,7 @@
          x="-328.03"
 	 y="-296.2" 
 	 z="-261.8"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-0"/>
@@ -42172,7 +42206,7 @@
          x="-328.03"
 	 y="-205.5" 
 	 z="-407.8"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-1"/>
@@ -42187,7 +42221,7 @@
          x="-328.03"
 	 y="-131.5" 
 	 z="-190.8"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-2"/>
@@ -42202,7 +42236,7 @@
          x="-328.03"
 	 y="-40.8" 
 	 z="-336.8"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-3"/>
@@ -42217,7 +42251,7 @@
          x="-328.03"
 	 y="-296.2" 
 	 z="37.5000000000001"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-3-0"/>
@@ -42232,7 +42266,7 @@
          x="-328.03"
 	 y="-205.5" 
 	 z="-108.5"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-3-1"/>
@@ -42247,7 +42281,7 @@
          x="-328.03"
 	 y="-131.5" 
 	 z="108.5"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-3-2"/>
@@ -42262,7 +42296,7 @@
          x="-328.03"
 	 y="-40.8" 
 	 z="-37.4999999999999"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-3-3"/>
@@ -42277,7 +42311,7 @@
          x="-328.03"
 	 y="-296.2" 
 	 z="336.8"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-4-0"/>
@@ -42292,7 +42326,7 @@
          x="-328.03"
 	 y="-205.5" 
 	 z="190.8"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-4-1"/>
@@ -42307,7 +42341,7 @@
          x="-328.03"
 	 y="-131.5" 
 	 z="407.8"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-4-2"/>
@@ -42322,7 +42356,7 @@
          x="-328.03"
 	 y="-40.8" 
 	 z="261.8"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-4-3"/>
@@ -42337,7 +42371,7 @@
          x="-328.03"
 	 y="-296.2" 
 	 z="636.1"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-5-0"/>
@@ -42352,7 +42386,7 @@
          x="-328.03"
 	 y="-205.5" 
 	 z="490.1"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-5-1"/>
@@ -42367,7 +42401,7 @@
          x="-328.03"
 	 y="-131.5" 
 	 z="707.1"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-5-2"/>
@@ -42382,7 +42416,7 @@
          x="-328.03"
 	 y="-40.8" 
 	 z="561.1"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-5-3"/>
@@ -42397,7 +42431,7 @@
          x="-328.03"
 	 y="-296.2" 
 	 z="935.4"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-6-0"/>
@@ -42412,7 +42446,7 @@
          x="-328.03"
 	 y="-205.5" 
 	 z="789.4"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-6-1"/>
@@ -42427,7 +42461,7 @@
          x="-328.03"
 	 y="-131.5" 
 	 z="1006.4"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-6-2"/>
@@ -42442,7 +42476,7 @@
          x="-328.03"
 	 y="-40.8" 
 	 z="860.4"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-6-3"/>
@@ -42457,7 +42491,7 @@
          x="-328.03"
 	 y="40.8" 
 	 z="-860.4"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-0"/>
@@ -42472,7 +42506,7 @@
          x="-328.03"
 	 y="131.5" 
 	 z="-1006.4"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-1"/>
@@ -42487,7 +42521,7 @@
          x="-328.03"
 	 y="205.5" 
 	 z="-789.4"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-2"/>
@@ -42502,7 +42536,7 @@
          x="-328.03"
 	 y="296.2" 
 	 z="-935.4"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-3"/>
@@ -42517,7 +42551,7 @@
          x="-328.03"
 	 y="40.8" 
 	 z="-561.1"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-0"/>
@@ -42532,7 +42566,7 @@
          x="-328.03"
 	 y="131.5" 
 	 z="-707.1"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-1"/>
@@ -42547,7 +42581,7 @@
          x="-328.03"
 	 y="205.5" 
 	 z="-490.1"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-2"/>
@@ -42562,7 +42596,7 @@
          x="-328.03"
 	 y="296.2" 
 	 z="-636.1"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-3"/>
@@ -42577,7 +42611,7 @@
          x="-328.03"
 	 y="40.8" 
 	 z="-261.8"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-0"/>
@@ -42592,7 +42626,7 @@
          x="-328.03"
 	 y="131.5" 
 	 z="-407.8"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-1"/>
@@ -42607,7 +42641,7 @@
          x="-328.03"
 	 y="205.5" 
 	 z="-190.8"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-2"/>
@@ -42622,7 +42656,7 @@
          x="-328.03"
 	 y="296.2" 
 	 z="-336.8"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-3"/>
@@ -42637,7 +42671,7 @@
          x="-328.03"
 	 y="40.8" 
 	 z="37.5000000000001"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-3-0"/>
@@ -42652,7 +42686,7 @@
          x="-328.03"
 	 y="131.5" 
 	 z="-108.5"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-3-1"/>
@@ -42667,7 +42701,7 @@
          x="-328.03"
 	 y="205.5" 
 	 z="108.5"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-3-2"/>
@@ -42682,7 +42716,7 @@
          x="-328.03"
 	 y="296.2" 
 	 z="-37.4999999999999"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-3-3"/>
@@ -42697,7 +42731,7 @@
          x="-328.03"
 	 y="40.8" 
 	 z="336.8"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-4-0"/>
@@ -42712,7 +42746,7 @@
          x="-328.03"
 	 y="131.5" 
 	 z="190.8"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-4-1"/>
@@ -42727,7 +42761,7 @@
          x="-328.03"
 	 y="205.5" 
 	 z="407.8"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-4-2"/>
@@ -42742,7 +42776,7 @@
          x="-328.03"
 	 y="296.2" 
 	 z="261.8"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-4-3"/>
@@ -42757,7 +42791,7 @@
          x="-328.03"
 	 y="40.8" 
 	 z="636.1"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-5-0"/>
@@ -42772,7 +42806,7 @@
          x="-328.03"
 	 y="131.5" 
 	 z="490.1"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-5-1"/>
@@ -42787,7 +42821,7 @@
          x="-328.03"
 	 y="205.5" 
 	 z="707.1"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-5-2"/>
@@ -42802,7 +42836,7 @@
          x="-328.03"
 	 y="296.2" 
 	 z="561.1"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-5-3"/>
@@ -42817,7 +42851,7 @@
          x="-328.03"
 	 y="40.8" 
 	 z="935.4"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-6-0"/>
@@ -42832,7 +42866,7 @@
          x="-328.03"
 	 y="131.5" 
 	 z="789.4"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-6-1"/>
@@ -42847,7 +42881,7 @@
          x="-328.03"
 	 y="205.5" 
 	 z="1006.4"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-6-2"/>
@@ -42862,7 +42896,7 @@
          x="-328.03"
 	 y="296.2" 
 	 z="860.4"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-6-3"/>
@@ -42877,7 +42911,7 @@
          x="-328.03"
 	 y="377.8" 
 	 z="-860.4"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-0"/>
@@ -42892,7 +42926,7 @@
          x="-328.03"
 	 y="468.5" 
 	 z="-1006.4"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-1"/>
@@ -42907,7 +42941,7 @@
          x="-328.03"
 	 y="542.5" 
 	 z="-789.4"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-2"/>
@@ -42922,7 +42956,7 @@
          x="-328.03"
 	 y="633.2" 
 	 z="-935.4"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-3"/>
@@ -42937,7 +42971,7 @@
          x="-328.03"
 	 y="377.8" 
 	 z="-561.1"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-0"/>
@@ -42952,7 +42986,7 @@
          x="-328.03"
 	 y="468.5" 
 	 z="-707.1"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-1"/>
@@ -42967,7 +43001,7 @@
          x="-328.03"
 	 y="542.5" 
 	 z="-490.1"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-2"/>
@@ -42982,7 +43016,7 @@
          x="-328.03"
 	 y="633.2" 
 	 z="-636.1"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-3"/>
@@ -42997,7 +43031,7 @@
          x="-328.03"
 	 y="377.8" 
 	 z="-261.8"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-0"/>
@@ -43012,7 +43046,7 @@
          x="-328.03"
 	 y="468.5" 
 	 z="-407.8"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-1"/>
@@ -43027,7 +43061,7 @@
          x="-328.03"
 	 y="542.5" 
 	 z="-190.8"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-2"/>
@@ -43042,7 +43076,7 @@
          x="-328.03"
 	 y="633.2" 
 	 z="-336.8"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-3"/>
@@ -43057,7 +43091,7 @@
          x="-328.03"
 	 y="377.8" 
 	 z="37.5000000000001"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-3-0"/>
@@ -43072,7 +43106,7 @@
          x="-328.03"
 	 y="468.5" 
 	 z="-108.5"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-3-1"/>
@@ -43087,7 +43121,7 @@
          x="-328.03"
 	 y="542.5" 
 	 z="108.5"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-3-2"/>
@@ -43102,7 +43136,7 @@
          x="-328.03"
 	 y="633.2" 
 	 z="-37.4999999999999"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-3-3"/>
@@ -43117,7 +43151,7 @@
          x="-328.03"
 	 y="377.8" 
 	 z="336.8"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-4-0"/>
@@ -43132,7 +43166,7 @@
          x="-328.03"
 	 y="468.5" 
 	 z="190.8"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-4-1"/>
@@ -43147,7 +43181,7 @@
          x="-328.03"
 	 y="542.5" 
 	 z="407.8"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-4-2"/>
@@ -43162,7 +43196,7 @@
          x="-328.03"
 	 y="633.2" 
 	 z="261.8"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-4-3"/>
@@ -43177,7 +43211,7 @@
          x="-328.03"
 	 y="377.8" 
 	 z="636.1"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-5-0"/>
@@ -43192,7 +43226,7 @@
          x="-328.03"
 	 y="468.5" 
 	 z="490.1"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-5-1"/>
@@ -43207,7 +43241,7 @@
          x="-328.03"
 	 y="542.5" 
 	 z="707.1"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-5-2"/>
@@ -43222,7 +43256,7 @@
          x="-328.03"
 	 y="633.2" 
 	 z="561.1"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-5-3"/>
@@ -43237,7 +43271,7 @@
          x="-328.03"
 	 y="377.8" 
 	 z="935.4"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-6-0"/>
@@ -43252,7 +43286,7 @@
          x="-328.03"
 	 y="468.5" 
 	 z="789.4"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-6-1"/>
@@ -43267,7 +43301,7 @@
          x="-328.03"
 	 y="542.5" 
 	 z="1006.4"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-6-2"/>
@@ -43282,7 +43316,7 @@
          x="-328.03"
 	 y="633.2" 
 	 z="860.4"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-6-3"/>
@@ -43294,842 +43328,970 @@
      <physvol>
        <volumeref ref="volArapucaLat_0-0"/>
        <position name="posArapuca0-Lat-0" unit="cm" 
-         x="-40"
-	 y="-734" 
+         x="285.02"
+	 y="-745" 
 	 z="-897.9"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-0"/>
        <position name="posOpArapuca0-Lat-0" unit="cm" 
-         x="-40"
-	 y="-733.26" 
+         x="285.02"
+	 y="-744.26" 
 	 z="-897.9"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-1"/>
        <position name="posArapuca1-Lat-0" unit="cm" 
-         x="-115"
-	 y="-734" 
+         x="210.02"
+	 y="-745" 
 	 z="-897.9"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-1"/>
        <position name="posOpArapuca1-Lat-0" unit="cm" 
-         x="-115"
-	 y="-733.26" 
+         x="210.02"
+	 y="-744.26" 
 	 z="-897.9"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-2"/>
        <position name="posArapuca2-Lat-0" unit="cm" 
-         x="-190"
-	 y="-734" 
+         x="135.02"
+	 y="-745" 
 	 z="-897.9"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-2"/>
        <position name="posOpArapuca2-Lat-0" unit="cm" 
-         x="-190"
-	 y="-733.26" 
+         x="135.02"
+	 y="-744.26" 
 	 z="-897.9"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-3"/>
        <position name="posArapuca3-Lat-0" unit="cm" 
-         x="-265"
-	 y="-734" 
+         x="60.02"
+	 y="-745" 
 	 z="-897.9"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-3"/>
        <position name="posOpArapuca3-Lat-0" unit="cm" 
-         x="-265"
-	 y="-733.26" 
+         x="60.02"
+	 y="-744.26" 
 	 z="-897.9"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-4"/>
        <position name="posArapuca4-Lat-0" unit="cm" 
-         x="-40"
-	 y="734" 
+         x="285.02"
+	 y="745" 
 	 z="-897.9"/>
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-4"/>
        <position name="posOpArapuca4-Lat-0" unit="cm" 
-         x="-40"
-	 y="733.26" 
+         x="285.02"
+	 y="744.26" 
 	 z="-897.9"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-5"/>
        <position name="posArapuca5-Lat-0" unit="cm" 
-         x="-115"
-	 y="734" 
+         x="210.02"
+	 y="745" 
 	 z="-897.9"/>
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-5"/>
        <position name="posOpArapuca5-Lat-0" unit="cm" 
-         x="-115"
-	 y="733.26" 
+         x="210.02"
+	 y="744.26" 
 	 z="-897.9"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-6"/>
        <position name="posArapuca6-Lat-0" unit="cm" 
-         x="-190"
-	 y="734" 
+         x="135.02"
+	 y="745" 
 	 z="-897.9"/>
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-6"/>
        <position name="posOpArapuca6-Lat-0" unit="cm" 
-         x="-190"
-	 y="733.26" 
+         x="135.02"
+	 y="744.26" 
 	 z="-897.9"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-7"/>
        <position name="posArapuca7-Lat-0" unit="cm" 
-         x="-265"
-	 y="734" 
+         x="60.02"
+	 y="745" 
 	 z="-897.9"/>
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-7"/>
        <position name="posOpArapuca7-Lat-0" unit="cm" 
-         x="-265"
-	 y="733.26" 
+         x="60.02"
+	 y="744.26" 
 	 z="-897.9"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-0"/>
        <position name="posArapuca0-Lat-1" unit="cm" 
-         x="-40"
-	 y="-734" 
+         x="285.02"
+	 y="-745" 
 	 z="-598.6"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-0"/>
        <position name="posOpArapuca0-Lat-1" unit="cm" 
-         x="-40"
-	 y="-733.26" 
+         x="285.02"
+	 y="-744.26" 
 	 z="-598.6"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-1"/>
        <position name="posArapuca1-Lat-1" unit="cm" 
-         x="-115"
-	 y="-734" 
+         x="210.02"
+	 y="-745" 
 	 z="-598.6"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-1"/>
        <position name="posOpArapuca1-Lat-1" unit="cm" 
-         x="-115"
-	 y="-733.26" 
+         x="210.02"
+	 y="-744.26" 
 	 z="-598.6"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-2"/>
        <position name="posArapuca2-Lat-1" unit="cm" 
-         x="-190"
-	 y="-734" 
+         x="135.02"
+	 y="-745" 
 	 z="-598.6"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-2"/>
        <position name="posOpArapuca2-Lat-1" unit="cm" 
-         x="-190"
-	 y="-733.26" 
+         x="135.02"
+	 y="-744.26" 
 	 z="-598.6"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-3"/>
        <position name="posArapuca3-Lat-1" unit="cm" 
-         x="-265"
-	 y="-734" 
+         x="60.02"
+	 y="-745" 
 	 z="-598.6"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-3"/>
        <position name="posOpArapuca3-Lat-1" unit="cm" 
-         x="-265"
-	 y="-733.26" 
+         x="60.02"
+	 y="-744.26" 
 	 z="-598.6"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-4"/>
        <position name="posArapuca4-Lat-1" unit="cm" 
-         x="-40"
-	 y="734" 
+         x="285.02"
+	 y="745" 
 	 z="-598.6"/>
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-4"/>
        <position name="posOpArapuca4-Lat-1" unit="cm" 
-         x="-40"
-	 y="733.26" 
+         x="285.02"
+	 y="744.26" 
 	 z="-598.6"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-5"/>
        <position name="posArapuca5-Lat-1" unit="cm" 
-         x="-115"
-	 y="734" 
+         x="210.02"
+	 y="745" 
 	 z="-598.6"/>
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-5"/>
        <position name="posOpArapuca5-Lat-1" unit="cm" 
-         x="-115"
-	 y="733.26" 
+         x="210.02"
+	 y="744.26" 
 	 z="-598.6"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-6"/>
        <position name="posArapuca6-Lat-1" unit="cm" 
-         x="-190"
-	 y="734" 
+         x="135.02"
+	 y="745" 
 	 z="-598.6"/>
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-6"/>
        <position name="posOpArapuca6-Lat-1" unit="cm" 
-         x="-190"
-	 y="733.26" 
+         x="135.02"
+	 y="744.26" 
 	 z="-598.6"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-7"/>
        <position name="posArapuca7-Lat-1" unit="cm" 
-         x="-265"
-	 y="734" 
+         x="60.02"
+	 y="745" 
 	 z="-598.6"/>
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-7"/>
        <position name="posOpArapuca7-Lat-1" unit="cm" 
-         x="-265"
-	 y="733.26" 
+         x="60.02"
+	 y="744.26" 
 	 z="-598.6"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-0"/>
        <position name="posArapuca0-Lat-2" unit="cm" 
-         x="-40"
-	 y="-734" 
+         x="285.02"
+	 y="-745" 
 	 z="-299.3"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-0"/>
        <position name="posOpArapuca0-Lat-2" unit="cm" 
-         x="-40"
-	 y="-733.26" 
+         x="285.02"
+	 y="-744.26" 
 	 z="-299.3"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-1"/>
        <position name="posArapuca1-Lat-2" unit="cm" 
-         x="-115"
-	 y="-734" 
+         x="210.02"
+	 y="-745" 
 	 z="-299.3"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-1"/>
        <position name="posOpArapuca1-Lat-2" unit="cm" 
-         x="-115"
-	 y="-733.26" 
+         x="210.02"
+	 y="-744.26" 
 	 z="-299.3"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-2"/>
        <position name="posArapuca2-Lat-2" unit="cm" 
-         x="-190"
-	 y="-734" 
+         x="135.02"
+	 y="-745" 
 	 z="-299.3"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-2"/>
        <position name="posOpArapuca2-Lat-2" unit="cm" 
-         x="-190"
-	 y="-733.26" 
+         x="135.02"
+	 y="-744.26" 
 	 z="-299.3"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-3"/>
        <position name="posArapuca3-Lat-2" unit="cm" 
-         x="-265"
-	 y="-734" 
+         x="60.02"
+	 y="-745" 
 	 z="-299.3"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-3"/>
        <position name="posOpArapuca3-Lat-2" unit="cm" 
-         x="-265"
-	 y="-733.26" 
+         x="60.02"
+	 y="-744.26" 
 	 z="-299.3"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-4"/>
        <position name="posArapuca4-Lat-2" unit="cm" 
-         x="-40"
-	 y="734" 
+         x="285.02"
+	 y="745" 
 	 z="-299.3"/>
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-4"/>
        <position name="posOpArapuca4-Lat-2" unit="cm" 
-         x="-40"
-	 y="733.26" 
+         x="285.02"
+	 y="744.26" 
 	 z="-299.3"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-5"/>
        <position name="posArapuca5-Lat-2" unit="cm" 
-         x="-115"
-	 y="734" 
+         x="210.02"
+	 y="745" 
 	 z="-299.3"/>
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-5"/>
        <position name="posOpArapuca5-Lat-2" unit="cm" 
-         x="-115"
-	 y="733.26" 
+         x="210.02"
+	 y="744.26" 
 	 z="-299.3"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-6"/>
        <position name="posArapuca6-Lat-2" unit="cm" 
-         x="-190"
-	 y="734" 
+         x="135.02"
+	 y="745" 
 	 z="-299.3"/>
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-6"/>
        <position name="posOpArapuca6-Lat-2" unit="cm" 
-         x="-190"
-	 y="733.26" 
+         x="135.02"
+	 y="744.26" 
 	 z="-299.3"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-7"/>
        <position name="posArapuca7-Lat-2" unit="cm" 
-         x="-265"
-	 y="734" 
+         x="60.02"
+	 y="745" 
 	 z="-299.3"/>
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-7"/>
        <position name="posOpArapuca7-Lat-2" unit="cm" 
-         x="-265"
-	 y="733.26" 
+         x="60.02"
+	 y="744.26" 
 	 z="-299.3"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_3-0"/>
        <position name="posArapuca0-Lat-3" unit="cm" 
-         x="-40"
-	 y="-734" 
+         x="285.02"
+	 y="-745" 
 	 z="1.13686837721616e-13"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_3-0"/>
        <position name="posOpArapuca0-Lat-3" unit="cm" 
-         x="-40"
-	 y="-733.26" 
+         x="285.02"
+	 y="-744.26" 
 	 z="1.13686837721616e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_3-1"/>
        <position name="posArapuca1-Lat-3" unit="cm" 
-         x="-115"
-	 y="-734" 
+         x="210.02"
+	 y="-745" 
 	 z="1.13686837721616e-13"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_3-1"/>
        <position name="posOpArapuca1-Lat-3" unit="cm" 
-         x="-115"
-	 y="-733.26" 
+         x="210.02"
+	 y="-744.26" 
 	 z="1.13686837721616e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_3-2"/>
        <position name="posArapuca2-Lat-3" unit="cm" 
-         x="-190"
-	 y="-734" 
+         x="135.02"
+	 y="-745" 
 	 z="1.13686837721616e-13"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_3-2"/>
        <position name="posOpArapuca2-Lat-3" unit="cm" 
-         x="-190"
-	 y="-733.26" 
+         x="135.02"
+	 y="-744.26" 
 	 z="1.13686837721616e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_3-3"/>
        <position name="posArapuca3-Lat-3" unit="cm" 
-         x="-265"
-	 y="-734" 
+         x="60.02"
+	 y="-745" 
 	 z="1.13686837721616e-13"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_3-3"/>
        <position name="posOpArapuca3-Lat-3" unit="cm" 
-         x="-265"
-	 y="-733.26" 
+         x="60.02"
+	 y="-744.26" 
 	 z="1.13686837721616e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_3-4"/>
        <position name="posArapuca4-Lat-3" unit="cm" 
-         x="-40"
-	 y="734" 
+         x="285.02"
+	 y="745" 
 	 z="1.13686837721616e-13"/>
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_3-4"/>
        <position name="posOpArapuca4-Lat-3" unit="cm" 
-         x="-40"
-	 y="733.26" 
+         x="285.02"
+	 y="744.26" 
 	 z="1.13686837721616e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_3-5"/>
        <position name="posArapuca5-Lat-3" unit="cm" 
-         x="-115"
-	 y="734" 
+         x="210.02"
+	 y="745" 
 	 z="1.13686837721616e-13"/>
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_3-5"/>
        <position name="posOpArapuca5-Lat-3" unit="cm" 
-         x="-115"
-	 y="733.26" 
+         x="210.02"
+	 y="744.26" 
 	 z="1.13686837721616e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_3-6"/>
        <position name="posArapuca6-Lat-3" unit="cm" 
-         x="-190"
-	 y="734" 
+         x="135.02"
+	 y="745" 
 	 z="1.13686837721616e-13"/>
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_3-6"/>
        <position name="posOpArapuca6-Lat-3" unit="cm" 
-         x="-190"
-	 y="733.26" 
+         x="135.02"
+	 y="744.26" 
 	 z="1.13686837721616e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_3-7"/>
        <position name="posArapuca7-Lat-3" unit="cm" 
-         x="-265"
-	 y="734" 
+         x="60.02"
+	 y="745" 
 	 z="1.13686837721616e-13"/>
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_3-7"/>
        <position name="posOpArapuca7-Lat-3" unit="cm" 
-         x="-265"
-	 y="733.26" 
+         x="60.02"
+	 y="744.26" 
 	 z="1.13686837721616e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_4-0"/>
        <position name="posArapuca0-Lat-4" unit="cm" 
-         x="-40"
-	 y="-734" 
+         x="285.02"
+	 y="-745" 
 	 z="299.3"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_4-0"/>
        <position name="posOpArapuca0-Lat-4" unit="cm" 
-         x="-40"
-	 y="-733.26" 
+         x="285.02"
+	 y="-744.26" 
 	 z="299.3"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_4-1"/>
        <position name="posArapuca1-Lat-4" unit="cm" 
-         x="-115"
-	 y="-734" 
+         x="210.02"
+	 y="-745" 
 	 z="299.3"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_4-1"/>
        <position name="posOpArapuca1-Lat-4" unit="cm" 
-         x="-115"
-	 y="-733.26" 
+         x="210.02"
+	 y="-744.26" 
 	 z="299.3"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_4-2"/>
        <position name="posArapuca2-Lat-4" unit="cm" 
-         x="-190"
-	 y="-734" 
+         x="135.02"
+	 y="-745" 
 	 z="299.3"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_4-2"/>
        <position name="posOpArapuca2-Lat-4" unit="cm" 
-         x="-190"
-	 y="-733.26" 
+         x="135.02"
+	 y="-744.26" 
 	 z="299.3"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_4-3"/>
        <position name="posArapuca3-Lat-4" unit="cm" 
-         x="-265"
-	 y="-734" 
+         x="60.02"
+	 y="-745" 
 	 z="299.3"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_4-3"/>
        <position name="posOpArapuca3-Lat-4" unit="cm" 
-         x="-265"
-	 y="-733.26" 
+         x="60.02"
+	 y="-744.26" 
 	 z="299.3"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_4-4"/>
        <position name="posArapuca4-Lat-4" unit="cm" 
-         x="-40"
-	 y="734" 
+         x="285.02"
+	 y="745" 
 	 z="299.3"/>
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_4-4"/>
        <position name="posOpArapuca4-Lat-4" unit="cm" 
-         x="-40"
-	 y="733.26" 
+         x="285.02"
+	 y="744.26" 
 	 z="299.3"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_4-5"/>
        <position name="posArapuca5-Lat-4" unit="cm" 
-         x="-115"
-	 y="734" 
+         x="210.02"
+	 y="745" 
 	 z="299.3"/>
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_4-5"/>
        <position name="posOpArapuca5-Lat-4" unit="cm" 
-         x="-115"
-	 y="733.26" 
+         x="210.02"
+	 y="744.26" 
 	 z="299.3"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_4-6"/>
        <position name="posArapuca6-Lat-4" unit="cm" 
-         x="-190"
-	 y="734" 
+         x="135.02"
+	 y="745" 
 	 z="299.3"/>
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_4-6"/>
        <position name="posOpArapuca6-Lat-4" unit="cm" 
-         x="-190"
-	 y="733.26" 
+         x="135.02"
+	 y="744.26" 
 	 z="299.3"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_4-7"/>
        <position name="posArapuca7-Lat-4" unit="cm" 
-         x="-265"
-	 y="734" 
+         x="60.02"
+	 y="745" 
 	 z="299.3"/>
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_4-7"/>
        <position name="posOpArapuca7-Lat-4" unit="cm" 
-         x="-265"
-	 y="733.26" 
+         x="60.02"
+	 y="744.26" 
 	 z="299.3"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_5-0"/>
        <position name="posArapuca0-Lat-5" unit="cm" 
-         x="-40"
-	 y="-734" 
+         x="285.02"
+	 y="-745" 
 	 z="598.6"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_5-0"/>
        <position name="posOpArapuca0-Lat-5" unit="cm" 
-         x="-40"
-	 y="-733.26" 
+         x="285.02"
+	 y="-744.26" 
 	 z="598.6"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_5-1"/>
        <position name="posArapuca1-Lat-5" unit="cm" 
-         x="-115"
-	 y="-734" 
+         x="210.02"
+	 y="-745" 
 	 z="598.6"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_5-1"/>
        <position name="posOpArapuca1-Lat-5" unit="cm" 
-         x="-115"
-	 y="-733.26" 
+         x="210.02"
+	 y="-744.26" 
 	 z="598.6"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_5-2"/>
        <position name="posArapuca2-Lat-5" unit="cm" 
-         x="-190"
-	 y="-734" 
+         x="135.02"
+	 y="-745" 
 	 z="598.6"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_5-2"/>
        <position name="posOpArapuca2-Lat-5" unit="cm" 
-         x="-190"
-	 y="-733.26" 
+         x="135.02"
+	 y="-744.26" 
 	 z="598.6"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_5-3"/>
        <position name="posArapuca3-Lat-5" unit="cm" 
-         x="-265"
-	 y="-734" 
+         x="60.02"
+	 y="-745" 
 	 z="598.6"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_5-3"/>
        <position name="posOpArapuca3-Lat-5" unit="cm" 
-         x="-265"
-	 y="-733.26" 
+         x="60.02"
+	 y="-744.26" 
 	 z="598.6"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_5-4"/>
        <position name="posArapuca4-Lat-5" unit="cm" 
-         x="-40"
-	 y="734" 
+         x="285.02"
+	 y="745" 
 	 z="598.6"/>
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_5-4"/>
        <position name="posOpArapuca4-Lat-5" unit="cm" 
-         x="-40"
-	 y="733.26" 
+         x="285.02"
+	 y="744.26" 
 	 z="598.6"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_5-5"/>
        <position name="posArapuca5-Lat-5" unit="cm" 
-         x="-115"
-	 y="734" 
+         x="210.02"
+	 y="745" 
 	 z="598.6"/>
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_5-5"/>
        <position name="posOpArapuca5-Lat-5" unit="cm" 
-         x="-115"
-	 y="733.26" 
+         x="210.02"
+	 y="744.26" 
 	 z="598.6"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_5-6"/>
        <position name="posArapuca6-Lat-5" unit="cm" 
-         x="-190"
-	 y="734" 
+         x="135.02"
+	 y="745" 
 	 z="598.6"/>
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_5-6"/>
        <position name="posOpArapuca6-Lat-5" unit="cm" 
-         x="-190"
-	 y="733.26" 
+         x="135.02"
+	 y="744.26" 
 	 z="598.6"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_5-7"/>
        <position name="posArapuca7-Lat-5" unit="cm" 
-         x="-265"
-	 y="734" 
+         x="60.02"
+	 y="745" 
 	 z="598.6"/>
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_5-7"/>
        <position name="posOpArapuca7-Lat-5" unit="cm" 
-         x="-265"
-	 y="733.26" 
+         x="60.02"
+	 y="744.26" 
 	 z="598.6"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_6-0"/>
        <position name="posArapuca0-Lat-6" unit="cm" 
-         x="-40"
-	 y="-734" 
+         x="285.02"
+	 y="-745" 
 	 z="897.9"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_6-0"/>
        <position name="posOpArapuca0-Lat-6" unit="cm" 
-         x="-40"
-	 y="-733.26" 
+         x="285.02"
+	 y="-744.26" 
 	 z="897.9"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_6-1"/>
        <position name="posArapuca1-Lat-6" unit="cm" 
-         x="-115"
-	 y="-734" 
+         x="210.02"
+	 y="-745" 
 	 z="897.9"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_6-1"/>
        <position name="posOpArapuca1-Lat-6" unit="cm" 
-         x="-115"
-	 y="-733.26" 
+         x="210.02"
+	 y="-744.26" 
 	 z="897.9"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_6-2"/>
        <position name="posArapuca2-Lat-6" unit="cm" 
-         x="-190"
-	 y="-734" 
+         x="135.02"
+	 y="-745" 
 	 z="897.9"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_6-2"/>
        <position name="posOpArapuca2-Lat-6" unit="cm" 
-         x="-190"
-	 y="-733.26" 
+         x="135.02"
+	 y="-744.26" 
 	 z="897.9"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_6-3"/>
        <position name="posArapuca3-Lat-6" unit="cm" 
-         x="-265"
-	 y="-734" 
+         x="60.02"
+	 y="-745" 
 	 z="897.9"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_6-3"/>
        <position name="posOpArapuca3-Lat-6" unit="cm" 
-         x="-265"
-	 y="-733.26" 
+         x="60.02"
+	 y="-744.26" 
 	 z="897.9"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_6-4"/>
        <position name="posArapuca4-Lat-6" unit="cm" 
-         x="-40"
-	 y="734" 
+         x="285.02"
+	 y="745" 
 	 z="897.9"/>
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_6-4"/>
        <position name="posOpArapuca4-Lat-6" unit="cm" 
-         x="-40"
-	 y="733.26" 
+         x="285.02"
+	 y="744.26" 
 	 z="897.9"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_6-5"/>
        <position name="posArapuca5-Lat-6" unit="cm" 
-         x="-115"
-	 y="734" 
+         x="210.02"
+	 y="745" 
 	 z="897.9"/>
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_6-5"/>
        <position name="posOpArapuca5-Lat-6" unit="cm" 
-         x="-115"
-	 y="733.26" 
+         x="210.02"
+	 y="744.26" 
 	 z="897.9"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_6-6"/>
        <position name="posArapuca6-Lat-6" unit="cm" 
-         x="-190"
-	 y="734" 
+         x="135.02"
+	 y="745" 
 	 z="897.9"/>
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_6-6"/>
        <position name="posOpArapuca6-Lat-6" unit="cm" 
-         x="-190"
-	 y="733.26" 
+         x="135.02"
+	 y="744.26" 
 	 z="897.9"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_6-7"/>
        <position name="posArapuca7-Lat-6" unit="cm" 
-         x="-265"
-	 y="734" 
+         x="60.02"
+	 y="745" 
 	 z="897.9"/>
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_6-7"/>
        <position name="posOpArapuca7-Lat-6" unit="cm" 
-         x="-265"
-	 y="733.26" 
+         x="60.02"
+	 y="744.26" 
 	 z="897.9"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca0-ShortLat-6" unit="cm" 
+         x="285.02"
+	 y="-220" 
+	 z="-1144.55"/>
+       <rotationref ref="rMinus90AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca1-ShortLat-6" unit="cm" 
+         x="210.02"
+	 y="-220" 
+	 z="-1144.55"/>
+       <rotationref ref="rMinus90AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca2-ShortLat-6" unit="cm" 
+         x="135.02"
+	 y="-220" 
+	 z="-1144.55"/>
+       <rotationref ref="rMinus90AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca3-ShortLat-6" unit="cm" 
+         x="60.02"
+	 y="-220" 
+	 z="-1144.55"/>
+       <rotationref ref="rMinus90AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca4-ShortLat-6" unit="cm" 
+         x="285.02"
+	 y="-220" 
+	 z="1144.55"/>
+       <rotationref ref="rPlus90AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca5-ShortLat-6" unit="cm" 
+         x="210.02"
+	 y="-220" 
+	 z="1144.55"/>
+       <rotationref ref="rPlus90AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca6-ShortLat-6" unit="cm" 
+         x="135.02"
+	 y="-220" 
+	 z="1144.55"/>
+       <rotationref ref="rPlus90AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca7-ShortLat-6" unit="cm" 
+         x="60.02"
+	 y="-220" 
+	 z="1144.55"/>
+       <rotationref ref="rPlus90AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca0-ShortLat-6" unit="cm" 
+         x="285.02"
+	 y="220" 
+	 z="-1144.55"/>
+       <rotationref ref="rMinus90AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca1-ShortLat-6" unit="cm" 
+         x="210.02"
+	 y="220" 
+	 z="-1144.55"/>
+       <rotationref ref="rMinus90AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca2-ShortLat-6" unit="cm" 
+         x="135.02"
+	 y="220" 
+	 z="-1144.55"/>
+       <rotationref ref="rMinus90AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca3-ShortLat-6" unit="cm" 
+         x="60.02"
+	 y="220" 
+	 z="-1144.55"/>
+       <rotationref ref="rMinus90AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca4-ShortLat-6" unit="cm" 
+         x="285.02"
+	 y="220" 
+	 z="1144.55"/>
+       <rotationref ref="rPlus90AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca5-ShortLat-6" unit="cm" 
+         x="210.02"
+	 y="220" 
+	 z="1144.55"/>
+       <rotationref ref="rPlus90AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca6-ShortLat-6" unit="cm" 
+         x="135.02"
+	 y="220" 
+	 z="1144.55"/>
+       <rotationref ref="rPlus90AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca7-ShortLat-6" unit="cm" 
+         x="60.02"
+	 y="220" 
+	 z="1144.55"/>
+       <rotationref ref="rPlus90AboutX"/>
      </physvol>
     </volume>
 
@@ -44172,7 +44334,9 @@
 
     </volume>
 </structure>
+
   <setup name="Default" version="1.0">
     <world ref="volWorld"/>
   </setup>
+
 </gdml_simple_extension>

--- a/dunecore/Geometry/gdml/dunevd10kt_3view_30deg_v5_refactored_1x8x14ref_nowires.gdml
+++ b/dunecore/Geometry/gdml/dunevd10kt_3view_30deg_v5_refactored_1x8x14ref_nowires.gdml
@@ -397,6 +397,24 @@
      <tube name="FieldShaperLongtube" rmin="0.5" rmax="2.285" z="2095.1" deltaphi="360" startphi="0" aunit="deg" lunit="cm"/>
      <tube name="FieldShaperLongtubeSlim" rmin="0.5" rmax="0.75" z="2095.1" deltaphi="360" startphi="0" aunit="deg" lunit="cm"/>
      <tube name="FieldShaperShorttube" rmin="0.5" rmax="2.285" z="1348" deltaphi="360" startphi="0" aunit="deg" lunit="cm"/>
+     <tube name="FieldShaperShorttubeWindowSlim" rmin="0.5" rmax="0.75" z="670" deltaphi="360" startphi="0" aunit="deg" lunit="cm"/>
+     <tube name="FieldShaperShorttubeWindowNotSlim" rmin="0.5" rmax="2.285" z="339" deltaphi="360" startphi="0" aunit="deg" lunit="cm"/>
+
+
+    <union name="FSunionWindow1">
+      <first ref="FieldShaperShorttubeWindowSlim"/>
+      <second ref="FieldShaperShorttubeWindowNotSlim"/>
+      <position name="posFieldShaperShortTube_shift1" unit="cm" x="0" y="0" z="504.5"/>
+    </union>
+
+    <union name="FieldShaperShorttubeSlim">
+      <first ref="FSunionWindow1"/>
+      <second ref="FieldShaperShorttubeWindowNotSlim"/>
+      <position name="posFieldShaperShortTube_shift2" unit="cm" x="0" y="0" z="-504.5"/>
+    </union>
+
+
+
 
     <union name="FSunion1">
       <first ref="FieldShaperLongtube"/>
@@ -455,7 +473,7 @@
 
     <union name="FSunionSlim2">
       <first ref="FSunionSlim1"/>
-      <second ref="FieldShaperShorttube"/>
+      <second ref="FieldShaperShorttubeSlim"/>
    		<position name="esquinapos9" unit="cm" x="-676.3" y="0" z="1049.85"/>
    		<rotationref ref="rPlus90AboutY"/>
     </union>
@@ -482,7 +500,7 @@
 
     <union name="FSunionSlim6">
       <first ref="FSunionSlim5"/>
-      <second ref="FieldShaperShorttube"/>
+      <second ref="FieldShaperShorttubeSlim"/>
    		<position name="esquinapos12" unit="cm" x="-676.3" y="0" z="-1049.85"/>
 		<rotationref ref="rPlus90AboutY"/>
     </union>
@@ -942,10 +960,6 @@
       <colorref ref="green"/>
     </volume>
 
-    <volume name="volArapucaShortLat">
-      <materialref ref="G10"/>
-      <solidref ref="ArapucaWalls"/>
-    </volume>
     <volume name="volOpDetSensitive">
       <materialref ref="LAr"/>
       <solidref ref="ArapucaAcceptanceWindow"/>
@@ -969,1350 +983,6 @@
       </physvol>
     </volume>
 
-    <volume name="volArapucaDouble_0-0-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-0-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-0-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-0-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-0-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-0-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-0-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-0-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-1-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-1-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-1-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-1-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-1-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-1-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-1-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-1-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-2-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-2-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-2-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-2-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-2-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-2-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-2-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-2-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-3-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-3-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-3-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-3-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-3-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-3-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-3-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-3-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-4-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-4-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-4-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-4-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-4-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-4-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-4-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-4-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-5-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-5-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-5-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-5-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-5-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-5-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-5-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-5-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-6-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-6-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-6-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-6-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-6-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-6-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-6-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-6-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-0-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-0-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-0-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-0-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-0-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-0-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-0-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-0-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-1-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-1-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-1-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-1-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-1-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-1-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-1-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-1-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-2-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-2-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-2-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-2-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-2-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-2-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-2-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-2-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-3-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-3-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-3-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-3-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-3-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-3-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-3-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-3-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-4-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-4-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-4-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-4-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-4-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-4-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-4-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-4-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-5-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-5-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-5-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-5-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-5-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-5-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-5-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-5-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-6-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-6-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-6-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-6-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-6-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-6-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-6-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-6-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-0-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-0-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-0-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-0-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-0-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-0-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-0-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-0-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-1-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-1-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-1-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-1-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-1-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-1-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-1-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-1-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-2-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-2-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-2-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-2-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-2-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-2-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-2-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-2-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-3-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-3-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-3-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-3-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-3-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-3-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-3-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-3-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-4-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-4-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-4-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-4-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-4-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-4-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-4-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-4-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-5-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-5-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-5-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-5-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-5-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-5-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-5-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-5-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-6-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-6-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-6-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-6-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-6-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-6-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-6-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-6-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-0-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-0-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-0-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-0-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-0-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-0-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-0-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-0-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-1-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-1-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-1-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-1-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-1-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-1-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-1-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-1-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-2-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-2-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-2-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-2-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-2-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-2-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-2-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-2-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-3-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-3-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-3-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-3-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-3-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-3-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-3-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-3-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-4-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-4-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-4-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-4-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-4-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-4-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-4-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-4-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-5-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-5-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-5-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-5-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-5-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-5-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-5-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-5-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-6-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-6-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-6-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-6-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-6-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-6-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-6-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-6-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_0-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_0-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_0-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_0-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_0-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_0-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_0-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_0-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_0-4">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_0-4">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_0-5">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_0-5">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_0-6">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_0-6">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_0-7">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_0-7">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_1-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_1-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_1-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_1-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_1-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_1-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_1-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_1-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_1-4">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_1-4">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_1-5">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_1-5">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_1-6">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_1-6">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_1-7">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_1-7">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_2-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_2-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_2-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_2-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_2-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_2-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_2-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_2-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_2-4">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_2-4">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_2-5">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_2-5">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_2-6">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_2-6">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_2-7">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_2-7">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_3-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_3-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_3-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_3-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_3-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_3-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_3-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_3-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_3-4">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_3-4">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_3-5">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_3-5">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_3-6">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_3-6">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_3-7">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_3-7">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_4-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_4-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_4-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_4-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_4-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_4-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_4-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_4-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_4-4">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_4-4">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_4-5">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_4-5">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_4-6">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_4-6">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_4-7">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_4-7">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_5-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_5-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_5-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_5-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_5-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_5-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_5-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_5-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_5-4">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_5-4">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_5-5">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_5-5">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_5-6">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_5-6">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_5-7">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_5-7">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_6-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_6-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_6-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_6-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_6-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_6-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_6-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_6-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_6-4">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_6-4">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_6-5">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_6-5">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_6-6">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_6-6">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_6-7">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_6-7">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
 
     <volume name="volCryostat">
       <materialref ref="LAr" />
@@ -3682,7 +2352,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>    
      <physvol>
-       <volumeref ref="volArapucaDouble_0-0-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-0-0" unit="cm" 
          x="-328.03"
 	 y="-633.2" 
@@ -3690,14 +2360,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-0"/>
-       <position name="posOpArapucaDouble0-Frame-0-0" unit="cm" 
-         x="-327.29"
-	 y="-633.2" 
-	 z="-860.4"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-0-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-0-0" unit="cm" 
          x="-328.03"
 	 y="-542.5" 
@@ -3705,14 +2368,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-1"/>
-       <position name="posOpArapucaDouble1-Frame-0-0" unit="cm" 
-         x="-327.29"
-	 y="-542.5" 
-	 z="-1006.4"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-0-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-0-0" unit="cm" 
          x="-328.03"
 	 y="-468.5" 
@@ -3720,14 +2376,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-2"/>
-       <position name="posOpArapucaDouble2-Frame-0-0" unit="cm" 
-         x="-327.29"
-	 y="-468.5" 
-	 z="-789.4"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-0-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-0-0" unit="cm" 
          x="-328.03"
 	 y="-377.8" 
@@ -3735,14 +2384,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-3"/>
-       <position name="posOpArapucaDouble3-Frame-0-0" unit="cm" 
-         x="-327.29"
-	 y="-377.8" 
-	 z="-935.4"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-1-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-0-1" unit="cm" 
          x="-328.03"
 	 y="-633.2" 
@@ -3750,14 +2392,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-0"/>
-       <position name="posOpArapucaDouble0-Frame-0-1" unit="cm" 
-         x="-327.29"
-	 y="-633.2" 
-	 z="-561.1"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-1-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-0-1" unit="cm" 
          x="-328.03"
 	 y="-542.5" 
@@ -3765,14 +2400,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-1"/>
-       <position name="posOpArapucaDouble1-Frame-0-1" unit="cm" 
-         x="-327.29"
-	 y="-542.5" 
-	 z="-707.1"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-1-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-0-1" unit="cm" 
          x="-328.03"
 	 y="-468.5" 
@@ -3780,14 +2408,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-2"/>
-       <position name="posOpArapucaDouble2-Frame-0-1" unit="cm" 
-         x="-327.29"
-	 y="-468.5" 
-	 z="-490.1"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-1-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-0-1" unit="cm" 
          x="-328.03"
 	 y="-377.8" 
@@ -3795,14 +2416,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-3"/>
-       <position name="posOpArapucaDouble3-Frame-0-1" unit="cm" 
-         x="-327.29"
-	 y="-377.8" 
-	 z="-636.1"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-2-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-0-2" unit="cm" 
          x="-328.03"
 	 y="-633.2" 
@@ -3810,14 +2424,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-0"/>
-       <position name="posOpArapucaDouble0-Frame-0-2" unit="cm" 
-         x="-327.29"
-	 y="-633.2" 
-	 z="-261.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-2-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-0-2" unit="cm" 
          x="-328.03"
 	 y="-542.5" 
@@ -3825,14 +2432,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-1"/>
-       <position name="posOpArapucaDouble1-Frame-0-2" unit="cm" 
-         x="-327.29"
-	 y="-542.5" 
-	 z="-407.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-2-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-0-2" unit="cm" 
          x="-328.03"
 	 y="-468.5" 
@@ -3840,14 +2440,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-2"/>
-       <position name="posOpArapucaDouble2-Frame-0-2" unit="cm" 
-         x="-327.29"
-	 y="-468.5" 
-	 z="-190.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-2-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-0-2" unit="cm" 
          x="-328.03"
 	 y="-377.8" 
@@ -3855,14 +2448,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-3"/>
-       <position name="posOpArapucaDouble3-Frame-0-2" unit="cm" 
-         x="-327.29"
-	 y="-377.8" 
-	 z="-336.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-3-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-0-3" unit="cm" 
          x="-328.03"
 	 y="-633.2" 
@@ -3870,14 +2456,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-3-0"/>
-       <position name="posOpArapucaDouble0-Frame-0-3" unit="cm" 
-         x="-327.29"
-	 y="-633.2" 
-	 z="37.5000000000001"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-3-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-0-3" unit="cm" 
          x="-328.03"
 	 y="-542.5" 
@@ -3885,14 +2464,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-3-1"/>
-       <position name="posOpArapucaDouble1-Frame-0-3" unit="cm" 
-         x="-327.29"
-	 y="-542.5" 
-	 z="-108.5"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-3-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-0-3" unit="cm" 
          x="-328.03"
 	 y="-468.5" 
@@ -3900,14 +2472,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-3-2"/>
-       <position name="posOpArapucaDouble2-Frame-0-3" unit="cm" 
-         x="-327.29"
-	 y="-468.5" 
-	 z="108.5"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-3-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-0-3" unit="cm" 
          x="-328.03"
 	 y="-377.8" 
@@ -3915,14 +2480,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-3-3"/>
-       <position name="posOpArapucaDouble3-Frame-0-3" unit="cm" 
-         x="-327.29"
-	 y="-377.8" 
-	 z="-37.4999999999999"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-4-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-0-4" unit="cm" 
          x="-328.03"
 	 y="-633.2" 
@@ -3930,14 +2488,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-4-0"/>
-       <position name="posOpArapucaDouble0-Frame-0-4" unit="cm" 
-         x="-327.29"
-	 y="-633.2" 
-	 z="336.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-4-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-0-4" unit="cm" 
          x="-328.03"
 	 y="-542.5" 
@@ -3945,14 +2496,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-4-1"/>
-       <position name="posOpArapucaDouble1-Frame-0-4" unit="cm" 
-         x="-327.29"
-	 y="-542.5" 
-	 z="190.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-4-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-0-4" unit="cm" 
          x="-328.03"
 	 y="-468.5" 
@@ -3960,14 +2504,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-4-2"/>
-       <position name="posOpArapucaDouble2-Frame-0-4" unit="cm" 
-         x="-327.29"
-	 y="-468.5" 
-	 z="407.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-4-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-0-4" unit="cm" 
          x="-328.03"
 	 y="-377.8" 
@@ -3975,14 +2512,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-4-3"/>
-       <position name="posOpArapucaDouble3-Frame-0-4" unit="cm" 
-         x="-327.29"
-	 y="-377.8" 
-	 z="261.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-5-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-0-5" unit="cm" 
          x="-328.03"
 	 y="-633.2" 
@@ -3990,14 +2520,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-5-0"/>
-       <position name="posOpArapucaDouble0-Frame-0-5" unit="cm" 
-         x="-327.29"
-	 y="-633.2" 
-	 z="636.1"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-5-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-0-5" unit="cm" 
          x="-328.03"
 	 y="-542.5" 
@@ -4005,14 +2528,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-5-1"/>
-       <position name="posOpArapucaDouble1-Frame-0-5" unit="cm" 
-         x="-327.29"
-	 y="-542.5" 
-	 z="490.1"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-5-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-0-5" unit="cm" 
          x="-328.03"
 	 y="-468.5" 
@@ -4020,14 +2536,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-5-2"/>
-       <position name="posOpArapucaDouble2-Frame-0-5" unit="cm" 
-         x="-327.29"
-	 y="-468.5" 
-	 z="707.1"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-5-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-0-5" unit="cm" 
          x="-328.03"
 	 y="-377.8" 
@@ -4035,14 +2544,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-5-3"/>
-       <position name="posOpArapucaDouble3-Frame-0-5" unit="cm" 
-         x="-327.29"
-	 y="-377.8" 
-	 z="561.1"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-6-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-0-6" unit="cm" 
          x="-328.03"
 	 y="-633.2" 
@@ -4050,14 +2552,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-6-0"/>
-       <position name="posOpArapucaDouble0-Frame-0-6" unit="cm" 
-         x="-327.29"
-	 y="-633.2" 
-	 z="935.4"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-6-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-0-6" unit="cm" 
          x="-328.03"
 	 y="-542.5" 
@@ -4065,14 +2560,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-6-1"/>
-       <position name="posOpArapucaDouble1-Frame-0-6" unit="cm" 
-         x="-327.29"
-	 y="-542.5" 
-	 z="789.4"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-6-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-0-6" unit="cm" 
          x="-328.03"
 	 y="-468.5" 
@@ -4080,14 +2568,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-6-2"/>
-       <position name="posOpArapucaDouble2-Frame-0-6" unit="cm" 
-         x="-327.29"
-	 y="-468.5" 
-	 z="1006.4"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-6-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-0-6" unit="cm" 
          x="-328.03"
 	 y="-377.8" 
@@ -4095,14 +2576,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-6-3"/>
-       <position name="posOpArapucaDouble3-Frame-0-6" unit="cm" 
-         x="-327.29"
-	 y="-377.8" 
-	 z="860.4"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-0-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-1-0" unit="cm" 
          x="-328.03"
 	 y="-296.2" 
@@ -4110,14 +2584,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-0"/>
-       <position name="posOpArapucaDouble0-Frame-1-0" unit="cm" 
-         x="-327.29"
-	 y="-296.2" 
-	 z="-860.4"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-0-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-1-0" unit="cm" 
          x="-328.03"
 	 y="-205.5" 
@@ -4125,14 +2592,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-1"/>
-       <position name="posOpArapucaDouble1-Frame-1-0" unit="cm" 
-         x="-327.29"
-	 y="-205.5" 
-	 z="-1006.4"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-0-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-1-0" unit="cm" 
          x="-328.03"
 	 y="-131.5" 
@@ -4140,14 +2600,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-2"/>
-       <position name="posOpArapucaDouble2-Frame-1-0" unit="cm" 
-         x="-327.29"
-	 y="-131.5" 
-	 z="-789.4"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-0-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-1-0" unit="cm" 
          x="-328.03"
 	 y="-40.8" 
@@ -4155,14 +2608,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-3"/>
-       <position name="posOpArapucaDouble3-Frame-1-0" unit="cm" 
-         x="-327.29"
-	 y="-40.8" 
-	 z="-935.4"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-1-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-1-1" unit="cm" 
          x="-328.03"
 	 y="-296.2" 
@@ -4170,14 +2616,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-0"/>
-       <position name="posOpArapucaDouble0-Frame-1-1" unit="cm" 
-         x="-327.29"
-	 y="-296.2" 
-	 z="-561.1"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-1-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-1-1" unit="cm" 
          x="-328.03"
 	 y="-205.5" 
@@ -4185,14 +2624,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-1"/>
-       <position name="posOpArapucaDouble1-Frame-1-1" unit="cm" 
-         x="-327.29"
-	 y="-205.5" 
-	 z="-707.1"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-1-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-1-1" unit="cm" 
          x="-328.03"
 	 y="-131.5" 
@@ -4200,14 +2632,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-2"/>
-       <position name="posOpArapucaDouble2-Frame-1-1" unit="cm" 
-         x="-327.29"
-	 y="-131.5" 
-	 z="-490.1"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-1-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-1-1" unit="cm" 
          x="-328.03"
 	 y="-40.8" 
@@ -4215,14 +2640,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-3"/>
-       <position name="posOpArapucaDouble3-Frame-1-1" unit="cm" 
-         x="-327.29"
-	 y="-40.8" 
-	 z="-636.1"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-2-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-1-2" unit="cm" 
          x="-328.03"
 	 y="-296.2" 
@@ -4230,14 +2648,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-0"/>
-       <position name="posOpArapucaDouble0-Frame-1-2" unit="cm" 
-         x="-327.29"
-	 y="-296.2" 
-	 z="-261.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-2-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-1-2" unit="cm" 
          x="-328.03"
 	 y="-205.5" 
@@ -4245,14 +2656,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-1"/>
-       <position name="posOpArapucaDouble1-Frame-1-2" unit="cm" 
-         x="-327.29"
-	 y="-205.5" 
-	 z="-407.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-2-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-1-2" unit="cm" 
          x="-328.03"
 	 y="-131.5" 
@@ -4260,14 +2664,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-2"/>
-       <position name="posOpArapucaDouble2-Frame-1-2" unit="cm" 
-         x="-327.29"
-	 y="-131.5" 
-	 z="-190.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-2-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-1-2" unit="cm" 
          x="-328.03"
 	 y="-40.8" 
@@ -4275,14 +2672,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-3"/>
-       <position name="posOpArapucaDouble3-Frame-1-2" unit="cm" 
-         x="-327.29"
-	 y="-40.8" 
-	 z="-336.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-3-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-1-3" unit="cm" 
          x="-328.03"
 	 y="-296.2" 
@@ -4290,14 +2680,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-3-0"/>
-       <position name="posOpArapucaDouble0-Frame-1-3" unit="cm" 
-         x="-327.29"
-	 y="-296.2" 
-	 z="37.5000000000001"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-3-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-1-3" unit="cm" 
          x="-328.03"
 	 y="-205.5" 
@@ -4305,14 +2688,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-3-1"/>
-       <position name="posOpArapucaDouble1-Frame-1-3" unit="cm" 
-         x="-327.29"
-	 y="-205.5" 
-	 z="-108.5"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-3-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-1-3" unit="cm" 
          x="-328.03"
 	 y="-131.5" 
@@ -4320,14 +2696,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-3-2"/>
-       <position name="posOpArapucaDouble2-Frame-1-3" unit="cm" 
-         x="-327.29"
-	 y="-131.5" 
-	 z="108.5"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-3-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-1-3" unit="cm" 
          x="-328.03"
 	 y="-40.8" 
@@ -4335,14 +2704,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-3-3"/>
-       <position name="posOpArapucaDouble3-Frame-1-3" unit="cm" 
-         x="-327.29"
-	 y="-40.8" 
-	 z="-37.4999999999999"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-4-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-1-4" unit="cm" 
          x="-328.03"
 	 y="-296.2" 
@@ -4350,14 +2712,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-4-0"/>
-       <position name="posOpArapucaDouble0-Frame-1-4" unit="cm" 
-         x="-327.29"
-	 y="-296.2" 
-	 z="336.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-4-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-1-4" unit="cm" 
          x="-328.03"
 	 y="-205.5" 
@@ -4365,14 +2720,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-4-1"/>
-       <position name="posOpArapucaDouble1-Frame-1-4" unit="cm" 
-         x="-327.29"
-	 y="-205.5" 
-	 z="190.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-4-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-1-4" unit="cm" 
          x="-328.03"
 	 y="-131.5" 
@@ -4380,14 +2728,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-4-2"/>
-       <position name="posOpArapucaDouble2-Frame-1-4" unit="cm" 
-         x="-327.29"
-	 y="-131.5" 
-	 z="407.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-4-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-1-4" unit="cm" 
          x="-328.03"
 	 y="-40.8" 
@@ -4395,14 +2736,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-4-3"/>
-       <position name="posOpArapucaDouble3-Frame-1-4" unit="cm" 
-         x="-327.29"
-	 y="-40.8" 
-	 z="261.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-5-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-1-5" unit="cm" 
          x="-328.03"
 	 y="-296.2" 
@@ -4410,14 +2744,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-5-0"/>
-       <position name="posOpArapucaDouble0-Frame-1-5" unit="cm" 
-         x="-327.29"
-	 y="-296.2" 
-	 z="636.1"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-5-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-1-5" unit="cm" 
          x="-328.03"
 	 y="-205.5" 
@@ -4425,14 +2752,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-5-1"/>
-       <position name="posOpArapucaDouble1-Frame-1-5" unit="cm" 
-         x="-327.29"
-	 y="-205.5" 
-	 z="490.1"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-5-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-1-5" unit="cm" 
          x="-328.03"
 	 y="-131.5" 
@@ -4440,14 +2760,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-5-2"/>
-       <position name="posOpArapucaDouble2-Frame-1-5" unit="cm" 
-         x="-327.29"
-	 y="-131.5" 
-	 z="707.1"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-5-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-1-5" unit="cm" 
          x="-328.03"
 	 y="-40.8" 
@@ -4455,14 +2768,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-5-3"/>
-       <position name="posOpArapucaDouble3-Frame-1-5" unit="cm" 
-         x="-327.29"
-	 y="-40.8" 
-	 z="561.1"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-6-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-1-6" unit="cm" 
          x="-328.03"
 	 y="-296.2" 
@@ -4470,14 +2776,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-6-0"/>
-       <position name="posOpArapucaDouble0-Frame-1-6" unit="cm" 
-         x="-327.29"
-	 y="-296.2" 
-	 z="935.4"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-6-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-1-6" unit="cm" 
          x="-328.03"
 	 y="-205.5" 
@@ -4485,14 +2784,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-6-1"/>
-       <position name="posOpArapucaDouble1-Frame-1-6" unit="cm" 
-         x="-327.29"
-	 y="-205.5" 
-	 z="789.4"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-6-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-1-6" unit="cm" 
          x="-328.03"
 	 y="-131.5" 
@@ -4500,14 +2792,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-6-2"/>
-       <position name="posOpArapucaDouble2-Frame-1-6" unit="cm" 
-         x="-327.29"
-	 y="-131.5" 
-	 z="1006.4"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-6-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-1-6" unit="cm" 
          x="-328.03"
 	 y="-40.8" 
@@ -4515,14 +2800,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-6-3"/>
-       <position name="posOpArapucaDouble3-Frame-1-6" unit="cm" 
-         x="-327.29"
-	 y="-40.8" 
-	 z="860.4"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-0-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-2-0" unit="cm" 
          x="-328.03"
 	 y="40.8" 
@@ -4530,14 +2808,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-0"/>
-       <position name="posOpArapucaDouble0-Frame-2-0" unit="cm" 
-         x="-327.29"
-	 y="40.8" 
-	 z="-860.4"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-0-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-2-0" unit="cm" 
          x="-328.03"
 	 y="131.5" 
@@ -4545,14 +2816,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-1"/>
-       <position name="posOpArapucaDouble1-Frame-2-0" unit="cm" 
-         x="-327.29"
-	 y="131.5" 
-	 z="-1006.4"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-0-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-2-0" unit="cm" 
          x="-328.03"
 	 y="205.5" 
@@ -4560,14 +2824,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-2"/>
-       <position name="posOpArapucaDouble2-Frame-2-0" unit="cm" 
-         x="-327.29"
-	 y="205.5" 
-	 z="-789.4"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-0-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-2-0" unit="cm" 
          x="-328.03"
 	 y="296.2" 
@@ -4575,14 +2832,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-3"/>
-       <position name="posOpArapucaDouble3-Frame-2-0" unit="cm" 
-         x="-327.29"
-	 y="296.2" 
-	 z="-935.4"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-1-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-2-1" unit="cm" 
          x="-328.03"
 	 y="40.8" 
@@ -4590,14 +2840,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-0"/>
-       <position name="posOpArapucaDouble0-Frame-2-1" unit="cm" 
-         x="-327.29"
-	 y="40.8" 
-	 z="-561.1"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-1-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-2-1" unit="cm" 
          x="-328.03"
 	 y="131.5" 
@@ -4605,14 +2848,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-1"/>
-       <position name="posOpArapucaDouble1-Frame-2-1" unit="cm" 
-         x="-327.29"
-	 y="131.5" 
-	 z="-707.1"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-1-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-2-1" unit="cm" 
          x="-328.03"
 	 y="205.5" 
@@ -4620,14 +2856,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-2"/>
-       <position name="posOpArapucaDouble2-Frame-2-1" unit="cm" 
-         x="-327.29"
-	 y="205.5" 
-	 z="-490.1"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-1-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-2-1" unit="cm" 
          x="-328.03"
 	 y="296.2" 
@@ -4635,14 +2864,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-3"/>
-       <position name="posOpArapucaDouble3-Frame-2-1" unit="cm" 
-         x="-327.29"
-	 y="296.2" 
-	 z="-636.1"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-2-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-2-2" unit="cm" 
          x="-328.03"
 	 y="40.8" 
@@ -4650,14 +2872,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-0"/>
-       <position name="posOpArapucaDouble0-Frame-2-2" unit="cm" 
-         x="-327.29"
-	 y="40.8" 
-	 z="-261.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-2-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-2-2" unit="cm" 
          x="-328.03"
 	 y="131.5" 
@@ -4665,14 +2880,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-1"/>
-       <position name="posOpArapucaDouble1-Frame-2-2" unit="cm" 
-         x="-327.29"
-	 y="131.5" 
-	 z="-407.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-2-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-2-2" unit="cm" 
          x="-328.03"
 	 y="205.5" 
@@ -4680,14 +2888,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-2"/>
-       <position name="posOpArapucaDouble2-Frame-2-2" unit="cm" 
-         x="-327.29"
-	 y="205.5" 
-	 z="-190.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-2-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-2-2" unit="cm" 
          x="-328.03"
 	 y="296.2" 
@@ -4695,14 +2896,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-3"/>
-       <position name="posOpArapucaDouble3-Frame-2-2" unit="cm" 
-         x="-327.29"
-	 y="296.2" 
-	 z="-336.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-3-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-2-3" unit="cm" 
          x="-328.03"
 	 y="40.8" 
@@ -4710,14 +2904,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-3-0"/>
-       <position name="posOpArapucaDouble0-Frame-2-3" unit="cm" 
-         x="-327.29"
-	 y="40.8" 
-	 z="37.5000000000001"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-3-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-2-3" unit="cm" 
          x="-328.03"
 	 y="131.5" 
@@ -4725,14 +2912,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-3-1"/>
-       <position name="posOpArapucaDouble1-Frame-2-3" unit="cm" 
-         x="-327.29"
-	 y="131.5" 
-	 z="-108.5"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-3-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-2-3" unit="cm" 
          x="-328.03"
 	 y="205.5" 
@@ -4740,14 +2920,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-3-2"/>
-       <position name="posOpArapucaDouble2-Frame-2-3" unit="cm" 
-         x="-327.29"
-	 y="205.5" 
-	 z="108.5"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-3-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-2-3" unit="cm" 
          x="-328.03"
 	 y="296.2" 
@@ -4755,14 +2928,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-3-3"/>
-       <position name="posOpArapucaDouble3-Frame-2-3" unit="cm" 
-         x="-327.29"
-	 y="296.2" 
-	 z="-37.4999999999999"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-4-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-2-4" unit="cm" 
          x="-328.03"
 	 y="40.8" 
@@ -4770,14 +2936,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-4-0"/>
-       <position name="posOpArapucaDouble0-Frame-2-4" unit="cm" 
-         x="-327.29"
-	 y="40.8" 
-	 z="336.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-4-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-2-4" unit="cm" 
          x="-328.03"
 	 y="131.5" 
@@ -4785,14 +2944,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-4-1"/>
-       <position name="posOpArapucaDouble1-Frame-2-4" unit="cm" 
-         x="-327.29"
-	 y="131.5" 
-	 z="190.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-4-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-2-4" unit="cm" 
          x="-328.03"
 	 y="205.5" 
@@ -4800,14 +2952,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-4-2"/>
-       <position name="posOpArapucaDouble2-Frame-2-4" unit="cm" 
-         x="-327.29"
-	 y="205.5" 
-	 z="407.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-4-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-2-4" unit="cm" 
          x="-328.03"
 	 y="296.2" 
@@ -4815,14 +2960,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-4-3"/>
-       <position name="posOpArapucaDouble3-Frame-2-4" unit="cm" 
-         x="-327.29"
-	 y="296.2" 
-	 z="261.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-5-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-2-5" unit="cm" 
          x="-328.03"
 	 y="40.8" 
@@ -4830,14 +2968,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-5-0"/>
-       <position name="posOpArapucaDouble0-Frame-2-5" unit="cm" 
-         x="-327.29"
-	 y="40.8" 
-	 z="636.1"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-5-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-2-5" unit="cm" 
          x="-328.03"
 	 y="131.5" 
@@ -4845,14 +2976,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-5-1"/>
-       <position name="posOpArapucaDouble1-Frame-2-5" unit="cm" 
-         x="-327.29"
-	 y="131.5" 
-	 z="490.1"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-5-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-2-5" unit="cm" 
          x="-328.03"
 	 y="205.5" 
@@ -4860,14 +2984,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-5-2"/>
-       <position name="posOpArapucaDouble2-Frame-2-5" unit="cm" 
-         x="-327.29"
-	 y="205.5" 
-	 z="707.1"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-5-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-2-5" unit="cm" 
          x="-328.03"
 	 y="296.2" 
@@ -4875,14 +2992,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-5-3"/>
-       <position name="posOpArapucaDouble3-Frame-2-5" unit="cm" 
-         x="-327.29"
-	 y="296.2" 
-	 z="561.1"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-6-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-2-6" unit="cm" 
          x="-328.03"
 	 y="40.8" 
@@ -4890,14 +3000,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-6-0"/>
-       <position name="posOpArapucaDouble0-Frame-2-6" unit="cm" 
-         x="-327.29"
-	 y="40.8" 
-	 z="935.4"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-6-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-2-6" unit="cm" 
          x="-328.03"
 	 y="131.5" 
@@ -4905,14 +3008,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-6-1"/>
-       <position name="posOpArapucaDouble1-Frame-2-6" unit="cm" 
-         x="-327.29"
-	 y="131.5" 
-	 z="789.4"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-6-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-2-6" unit="cm" 
          x="-328.03"
 	 y="205.5" 
@@ -4920,14 +3016,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-6-2"/>
-       <position name="posOpArapucaDouble2-Frame-2-6" unit="cm" 
-         x="-327.29"
-	 y="205.5" 
-	 z="1006.4"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-6-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-2-6" unit="cm" 
          x="-328.03"
 	 y="296.2" 
@@ -4935,14 +3024,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-6-3"/>
-       <position name="posOpArapucaDouble3-Frame-2-6" unit="cm" 
-         x="-327.29"
-	 y="296.2" 
-	 z="860.4"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-0-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-3-0" unit="cm" 
          x="-328.03"
 	 y="377.8" 
@@ -4950,14 +3032,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-0"/>
-       <position name="posOpArapucaDouble0-Frame-3-0" unit="cm" 
-         x="-327.29"
-	 y="377.8" 
-	 z="-860.4"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-0-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-3-0" unit="cm" 
          x="-328.03"
 	 y="468.5" 
@@ -4965,14 +3040,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-1"/>
-       <position name="posOpArapucaDouble1-Frame-3-0" unit="cm" 
-         x="-327.29"
-	 y="468.5" 
-	 z="-1006.4"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-0-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-3-0" unit="cm" 
          x="-328.03"
 	 y="542.5" 
@@ -4980,14 +3048,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-2"/>
-       <position name="posOpArapucaDouble2-Frame-3-0" unit="cm" 
-         x="-327.29"
-	 y="542.5" 
-	 z="-789.4"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-0-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-3-0" unit="cm" 
          x="-328.03"
 	 y="633.2" 
@@ -4995,14 +3056,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-3"/>
-       <position name="posOpArapucaDouble3-Frame-3-0" unit="cm" 
-         x="-327.29"
-	 y="633.2" 
-	 z="-935.4"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-1-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-3-1" unit="cm" 
          x="-328.03"
 	 y="377.8" 
@@ -5010,14 +3064,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-0"/>
-       <position name="posOpArapucaDouble0-Frame-3-1" unit="cm" 
-         x="-327.29"
-	 y="377.8" 
-	 z="-561.1"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-1-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-3-1" unit="cm" 
          x="-328.03"
 	 y="468.5" 
@@ -5025,14 +3072,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-1"/>
-       <position name="posOpArapucaDouble1-Frame-3-1" unit="cm" 
-         x="-327.29"
-	 y="468.5" 
-	 z="-707.1"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-1-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-3-1" unit="cm" 
          x="-328.03"
 	 y="542.5" 
@@ -5040,14 +3080,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-2"/>
-       <position name="posOpArapucaDouble2-Frame-3-1" unit="cm" 
-         x="-327.29"
-	 y="542.5" 
-	 z="-490.1"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-1-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-3-1" unit="cm" 
          x="-328.03"
 	 y="633.2" 
@@ -5055,14 +3088,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-3"/>
-       <position name="posOpArapucaDouble3-Frame-3-1" unit="cm" 
-         x="-327.29"
-	 y="633.2" 
-	 z="-636.1"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-2-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-3-2" unit="cm" 
          x="-328.03"
 	 y="377.8" 
@@ -5070,14 +3096,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-0"/>
-       <position name="posOpArapucaDouble0-Frame-3-2" unit="cm" 
-         x="-327.29"
-	 y="377.8" 
-	 z="-261.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-2-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-3-2" unit="cm" 
          x="-328.03"
 	 y="468.5" 
@@ -5085,14 +3104,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-1"/>
-       <position name="posOpArapucaDouble1-Frame-3-2" unit="cm" 
-         x="-327.29"
-	 y="468.5" 
-	 z="-407.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-2-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-3-2" unit="cm" 
          x="-328.03"
 	 y="542.5" 
@@ -5100,14 +3112,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-2"/>
-       <position name="posOpArapucaDouble2-Frame-3-2" unit="cm" 
-         x="-327.29"
-	 y="542.5" 
-	 z="-190.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-2-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-3-2" unit="cm" 
          x="-328.03"
 	 y="633.2" 
@@ -5115,14 +3120,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-3"/>
-       <position name="posOpArapucaDouble3-Frame-3-2" unit="cm" 
-         x="-327.29"
-	 y="633.2" 
-	 z="-336.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-3-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-3-3" unit="cm" 
          x="-328.03"
 	 y="377.8" 
@@ -5130,14 +3128,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-3-0"/>
-       <position name="posOpArapucaDouble0-Frame-3-3" unit="cm" 
-         x="-327.29"
-	 y="377.8" 
-	 z="37.5000000000001"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-3-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-3-3" unit="cm" 
          x="-328.03"
 	 y="468.5" 
@@ -5145,14 +3136,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-3-1"/>
-       <position name="posOpArapucaDouble1-Frame-3-3" unit="cm" 
-         x="-327.29"
-	 y="468.5" 
-	 z="-108.5"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-3-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-3-3" unit="cm" 
          x="-328.03"
 	 y="542.5" 
@@ -5160,14 +3144,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-3-2"/>
-       <position name="posOpArapucaDouble2-Frame-3-3" unit="cm" 
-         x="-327.29"
-	 y="542.5" 
-	 z="108.5"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-3-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-3-3" unit="cm" 
          x="-328.03"
 	 y="633.2" 
@@ -5175,14 +3152,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-3-3"/>
-       <position name="posOpArapucaDouble3-Frame-3-3" unit="cm" 
-         x="-327.29"
-	 y="633.2" 
-	 z="-37.4999999999999"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-4-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-3-4" unit="cm" 
          x="-328.03"
 	 y="377.8" 
@@ -5190,14 +3160,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-4-0"/>
-       <position name="posOpArapucaDouble0-Frame-3-4" unit="cm" 
-         x="-327.29"
-	 y="377.8" 
-	 z="336.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-4-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-3-4" unit="cm" 
          x="-328.03"
 	 y="468.5" 
@@ -5205,14 +3168,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-4-1"/>
-       <position name="posOpArapucaDouble1-Frame-3-4" unit="cm" 
-         x="-327.29"
-	 y="468.5" 
-	 z="190.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-4-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-3-4" unit="cm" 
          x="-328.03"
 	 y="542.5" 
@@ -5220,14 +3176,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-4-2"/>
-       <position name="posOpArapucaDouble2-Frame-3-4" unit="cm" 
-         x="-327.29"
-	 y="542.5" 
-	 z="407.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-4-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-3-4" unit="cm" 
          x="-328.03"
 	 y="633.2" 
@@ -5235,14 +3184,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-4-3"/>
-       <position name="posOpArapucaDouble3-Frame-3-4" unit="cm" 
-         x="-327.29"
-	 y="633.2" 
-	 z="261.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-5-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-3-5" unit="cm" 
          x="-328.03"
 	 y="377.8" 
@@ -5250,14 +3192,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-5-0"/>
-       <position name="posOpArapucaDouble0-Frame-3-5" unit="cm" 
-         x="-327.29"
-	 y="377.8" 
-	 z="636.1"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-5-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-3-5" unit="cm" 
          x="-328.03"
 	 y="468.5" 
@@ -5265,14 +3200,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-5-1"/>
-       <position name="posOpArapucaDouble1-Frame-3-5" unit="cm" 
-         x="-327.29"
-	 y="468.5" 
-	 z="490.1"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-5-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-3-5" unit="cm" 
          x="-328.03"
 	 y="542.5" 
@@ -5280,14 +3208,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-5-2"/>
-       <position name="posOpArapucaDouble2-Frame-3-5" unit="cm" 
-         x="-327.29"
-	 y="542.5" 
-	 z="707.1"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-5-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-3-5" unit="cm" 
          x="-328.03"
 	 y="633.2" 
@@ -5295,14 +3216,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-5-3"/>
-       <position name="posOpArapucaDouble3-Frame-3-5" unit="cm" 
-         x="-327.29"
-	 y="633.2" 
-	 z="561.1"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-6-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-3-6" unit="cm" 
          x="-328.03"
 	 y="377.8" 
@@ -5310,14 +3224,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-6-0"/>
-       <position name="posOpArapucaDouble0-Frame-3-6" unit="cm" 
-         x="-327.29"
-	 y="377.8" 
-	 z="935.4"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-6-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-3-6" unit="cm" 
          x="-328.03"
 	 y="468.5" 
@@ -5325,14 +3232,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-6-1"/>
-       <position name="posOpArapucaDouble1-Frame-3-6" unit="cm" 
-         x="-327.29"
-	 y="468.5" 
-	 z="789.4"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-6-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-3-6" unit="cm" 
          x="-328.03"
 	 y="542.5" 
@@ -5340,14 +3240,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-6-2"/>
-       <position name="posOpArapucaDouble2-Frame-3-6" unit="cm" 
-         x="-327.29"
-	 y="542.5" 
-	 z="1006.4"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-6-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-3-6" unit="cm" 
          x="-328.03"
 	 y="633.2" 
@@ -5355,14 +3248,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-6-3"/>
-       <position name="posOpArapucaDouble3-Frame-3-6" unit="cm" 
-         x="-327.29"
-	 y="633.2" 
-	 z="860.4"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_0-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca0-Lat-0" unit="cm" 
          x="285.02"
 	 y="-745" 
@@ -5370,14 +3256,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_0-0"/>
-       <position name="posOpArapuca0-Lat-0" unit="cm" 
-         x="285.02"
-	 y="-744.26" 
-	 z="-897.9"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_0-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca1-Lat-0" unit="cm" 
          x="210.02"
 	 y="-745" 
@@ -5385,14 +3264,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_0-1"/>
-       <position name="posOpArapuca1-Lat-0" unit="cm" 
-         x="210.02"
-	 y="-744.26" 
-	 z="-897.9"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_0-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca2-Lat-0" unit="cm" 
          x="135.02"
 	 y="-745" 
@@ -5400,14 +3272,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_0-2"/>
-       <position name="posOpArapuca2-Lat-0" unit="cm" 
-         x="135.02"
-	 y="-744.26" 
-	 z="-897.9"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_0-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca3-Lat-0" unit="cm" 
          x="60.02"
 	 y="-745" 
@@ -5415,14 +3280,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_0-3"/>
-       <position name="posOpArapuca3-Lat-0" unit="cm" 
-         x="60.02"
-	 y="-744.26" 
-	 z="-897.9"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_0-4"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca4-Lat-0" unit="cm" 
          x="285.02"
 	 y="745" 
@@ -5430,14 +3288,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_0-4"/>
-       <position name="posOpArapuca4-Lat-0" unit="cm" 
-         x="285.02"
-	 y="744.26" 
-	 z="-897.9"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_0-5"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca5-Lat-0" unit="cm" 
          x="210.02"
 	 y="745" 
@@ -5445,14 +3296,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_0-5"/>
-       <position name="posOpArapuca5-Lat-0" unit="cm" 
-         x="210.02"
-	 y="744.26" 
-	 z="-897.9"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_0-6"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca6-Lat-0" unit="cm" 
          x="135.02"
 	 y="745" 
@@ -5460,14 +3304,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_0-6"/>
-       <position name="posOpArapuca6-Lat-0" unit="cm" 
-         x="135.02"
-	 y="744.26" 
-	 z="-897.9"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_0-7"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca7-Lat-0" unit="cm" 
          x="60.02"
 	 y="745" 
@@ -5475,14 +3312,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_0-7"/>
-       <position name="posOpArapuca7-Lat-0" unit="cm" 
-         x="60.02"
-	 y="744.26" 
-	 z="-897.9"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_1-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca0-Lat-1" unit="cm" 
          x="285.02"
 	 y="-745" 
@@ -5490,14 +3320,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_1-0"/>
-       <position name="posOpArapuca0-Lat-1" unit="cm" 
-         x="285.02"
-	 y="-744.26" 
-	 z="-598.6"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_1-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca1-Lat-1" unit="cm" 
          x="210.02"
 	 y="-745" 
@@ -5505,14 +3328,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_1-1"/>
-       <position name="posOpArapuca1-Lat-1" unit="cm" 
-         x="210.02"
-	 y="-744.26" 
-	 z="-598.6"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_1-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca2-Lat-1" unit="cm" 
          x="135.02"
 	 y="-745" 
@@ -5520,14 +3336,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_1-2"/>
-       <position name="posOpArapuca2-Lat-1" unit="cm" 
-         x="135.02"
-	 y="-744.26" 
-	 z="-598.6"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_1-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca3-Lat-1" unit="cm" 
          x="60.02"
 	 y="-745" 
@@ -5535,14 +3344,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_1-3"/>
-       <position name="posOpArapuca3-Lat-1" unit="cm" 
-         x="60.02"
-	 y="-744.26" 
-	 z="-598.6"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_1-4"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca4-Lat-1" unit="cm" 
          x="285.02"
 	 y="745" 
@@ -5550,14 +3352,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_1-4"/>
-       <position name="posOpArapuca4-Lat-1" unit="cm" 
-         x="285.02"
-	 y="744.26" 
-	 z="-598.6"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_1-5"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca5-Lat-1" unit="cm" 
          x="210.02"
 	 y="745" 
@@ -5565,14 +3360,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_1-5"/>
-       <position name="posOpArapuca5-Lat-1" unit="cm" 
-         x="210.02"
-	 y="744.26" 
-	 z="-598.6"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_1-6"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca6-Lat-1" unit="cm" 
          x="135.02"
 	 y="745" 
@@ -5580,14 +3368,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_1-6"/>
-       <position name="posOpArapuca6-Lat-1" unit="cm" 
-         x="135.02"
-	 y="744.26" 
-	 z="-598.6"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_1-7"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca7-Lat-1" unit="cm" 
          x="60.02"
 	 y="745" 
@@ -5595,14 +3376,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_1-7"/>
-       <position name="posOpArapuca7-Lat-1" unit="cm" 
-         x="60.02"
-	 y="744.26" 
-	 z="-598.6"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_2-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca0-Lat-2" unit="cm" 
          x="285.02"
 	 y="-745" 
@@ -5610,14 +3384,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_2-0"/>
-       <position name="posOpArapuca0-Lat-2" unit="cm" 
-         x="285.02"
-	 y="-744.26" 
-	 z="-299.3"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_2-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca1-Lat-2" unit="cm" 
          x="210.02"
 	 y="-745" 
@@ -5625,14 +3392,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_2-1"/>
-       <position name="posOpArapuca1-Lat-2" unit="cm" 
-         x="210.02"
-	 y="-744.26" 
-	 z="-299.3"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_2-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca2-Lat-2" unit="cm" 
          x="135.02"
 	 y="-745" 
@@ -5640,14 +3400,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_2-2"/>
-       <position name="posOpArapuca2-Lat-2" unit="cm" 
-         x="135.02"
-	 y="-744.26" 
-	 z="-299.3"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_2-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca3-Lat-2" unit="cm" 
          x="60.02"
 	 y="-745" 
@@ -5655,14 +3408,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_2-3"/>
-       <position name="posOpArapuca3-Lat-2" unit="cm" 
-         x="60.02"
-	 y="-744.26" 
-	 z="-299.3"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_2-4"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca4-Lat-2" unit="cm" 
          x="285.02"
 	 y="745" 
@@ -5670,14 +3416,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_2-4"/>
-       <position name="posOpArapuca4-Lat-2" unit="cm" 
-         x="285.02"
-	 y="744.26" 
-	 z="-299.3"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_2-5"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca5-Lat-2" unit="cm" 
          x="210.02"
 	 y="745" 
@@ -5685,14 +3424,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_2-5"/>
-       <position name="posOpArapuca5-Lat-2" unit="cm" 
-         x="210.02"
-	 y="744.26" 
-	 z="-299.3"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_2-6"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca6-Lat-2" unit="cm" 
          x="135.02"
 	 y="745" 
@@ -5700,14 +3432,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_2-6"/>
-       <position name="posOpArapuca6-Lat-2" unit="cm" 
-         x="135.02"
-	 y="744.26" 
-	 z="-299.3"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_2-7"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca7-Lat-2" unit="cm" 
          x="60.02"
 	 y="745" 
@@ -5715,14 +3440,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_2-7"/>
-       <position name="posOpArapuca7-Lat-2" unit="cm" 
-         x="60.02"
-	 y="744.26" 
-	 z="-299.3"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_3-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca0-Lat-3" unit="cm" 
          x="285.02"
 	 y="-745" 
@@ -5730,14 +3448,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_3-0"/>
-       <position name="posOpArapuca0-Lat-3" unit="cm" 
-         x="285.02"
-	 y="-744.26" 
-	 z="1.13686837721616e-13"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_3-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca1-Lat-3" unit="cm" 
          x="210.02"
 	 y="-745" 
@@ -5745,14 +3456,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_3-1"/>
-       <position name="posOpArapuca1-Lat-3" unit="cm" 
-         x="210.02"
-	 y="-744.26" 
-	 z="1.13686837721616e-13"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_3-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca2-Lat-3" unit="cm" 
          x="135.02"
 	 y="-745" 
@@ -5760,14 +3464,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_3-2"/>
-       <position name="posOpArapuca2-Lat-3" unit="cm" 
-         x="135.02"
-	 y="-744.26" 
-	 z="1.13686837721616e-13"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_3-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca3-Lat-3" unit="cm" 
          x="60.02"
 	 y="-745" 
@@ -5775,14 +3472,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_3-3"/>
-       <position name="posOpArapuca3-Lat-3" unit="cm" 
-         x="60.02"
-	 y="-744.26" 
-	 z="1.13686837721616e-13"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_3-4"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca4-Lat-3" unit="cm" 
          x="285.02"
 	 y="745" 
@@ -5790,14 +3480,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_3-4"/>
-       <position name="posOpArapuca4-Lat-3" unit="cm" 
-         x="285.02"
-	 y="744.26" 
-	 z="1.13686837721616e-13"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_3-5"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca5-Lat-3" unit="cm" 
          x="210.02"
 	 y="745" 
@@ -5805,14 +3488,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_3-5"/>
-       <position name="posOpArapuca5-Lat-3" unit="cm" 
-         x="210.02"
-	 y="744.26" 
-	 z="1.13686837721616e-13"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_3-6"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca6-Lat-3" unit="cm" 
          x="135.02"
 	 y="745" 
@@ -5820,14 +3496,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_3-6"/>
-       <position name="posOpArapuca6-Lat-3" unit="cm" 
-         x="135.02"
-	 y="744.26" 
-	 z="1.13686837721616e-13"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_3-7"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca7-Lat-3" unit="cm" 
          x="60.02"
 	 y="745" 
@@ -5835,14 +3504,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_3-7"/>
-       <position name="posOpArapuca7-Lat-3" unit="cm" 
-         x="60.02"
-	 y="744.26" 
-	 z="1.13686837721616e-13"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_4-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca0-Lat-4" unit="cm" 
          x="285.02"
 	 y="-745" 
@@ -5850,14 +3512,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_4-0"/>
-       <position name="posOpArapuca0-Lat-4" unit="cm" 
-         x="285.02"
-	 y="-744.26" 
-	 z="299.3"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_4-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca1-Lat-4" unit="cm" 
          x="210.02"
 	 y="-745" 
@@ -5865,14 +3520,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_4-1"/>
-       <position name="posOpArapuca1-Lat-4" unit="cm" 
-         x="210.02"
-	 y="-744.26" 
-	 z="299.3"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_4-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca2-Lat-4" unit="cm" 
          x="135.02"
 	 y="-745" 
@@ -5880,14 +3528,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_4-2"/>
-       <position name="posOpArapuca2-Lat-4" unit="cm" 
-         x="135.02"
-	 y="-744.26" 
-	 z="299.3"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_4-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca3-Lat-4" unit="cm" 
          x="60.02"
 	 y="-745" 
@@ -5895,14 +3536,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_4-3"/>
-       <position name="posOpArapuca3-Lat-4" unit="cm" 
-         x="60.02"
-	 y="-744.26" 
-	 z="299.3"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_4-4"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca4-Lat-4" unit="cm" 
          x="285.02"
 	 y="745" 
@@ -5910,14 +3544,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_4-4"/>
-       <position name="posOpArapuca4-Lat-4" unit="cm" 
-         x="285.02"
-	 y="744.26" 
-	 z="299.3"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_4-5"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca5-Lat-4" unit="cm" 
          x="210.02"
 	 y="745" 
@@ -5925,14 +3552,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_4-5"/>
-       <position name="posOpArapuca5-Lat-4" unit="cm" 
-         x="210.02"
-	 y="744.26" 
-	 z="299.3"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_4-6"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca6-Lat-4" unit="cm" 
          x="135.02"
 	 y="745" 
@@ -5940,14 +3560,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_4-6"/>
-       <position name="posOpArapuca6-Lat-4" unit="cm" 
-         x="135.02"
-	 y="744.26" 
-	 z="299.3"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_4-7"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca7-Lat-4" unit="cm" 
          x="60.02"
 	 y="745" 
@@ -5955,14 +3568,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_4-7"/>
-       <position name="posOpArapuca7-Lat-4" unit="cm" 
-         x="60.02"
-	 y="744.26" 
-	 z="299.3"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_5-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca0-Lat-5" unit="cm" 
          x="285.02"
 	 y="-745" 
@@ -5970,14 +3576,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_5-0"/>
-       <position name="posOpArapuca0-Lat-5" unit="cm" 
-         x="285.02"
-	 y="-744.26" 
-	 z="598.6"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_5-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca1-Lat-5" unit="cm" 
          x="210.02"
 	 y="-745" 
@@ -5985,14 +3584,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_5-1"/>
-       <position name="posOpArapuca1-Lat-5" unit="cm" 
-         x="210.02"
-	 y="-744.26" 
-	 z="598.6"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_5-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca2-Lat-5" unit="cm" 
          x="135.02"
 	 y="-745" 
@@ -6000,14 +3592,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_5-2"/>
-       <position name="posOpArapuca2-Lat-5" unit="cm" 
-         x="135.02"
-	 y="-744.26" 
-	 z="598.6"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_5-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca3-Lat-5" unit="cm" 
          x="60.02"
 	 y="-745" 
@@ -6015,14 +3600,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_5-3"/>
-       <position name="posOpArapuca3-Lat-5" unit="cm" 
-         x="60.02"
-	 y="-744.26" 
-	 z="598.6"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_5-4"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca4-Lat-5" unit="cm" 
          x="285.02"
 	 y="745" 
@@ -6030,14 +3608,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_5-4"/>
-       <position name="posOpArapuca4-Lat-5" unit="cm" 
-         x="285.02"
-	 y="744.26" 
-	 z="598.6"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_5-5"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca5-Lat-5" unit="cm" 
          x="210.02"
 	 y="745" 
@@ -6045,14 +3616,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_5-5"/>
-       <position name="posOpArapuca5-Lat-5" unit="cm" 
-         x="210.02"
-	 y="744.26" 
-	 z="598.6"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_5-6"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca6-Lat-5" unit="cm" 
          x="135.02"
 	 y="745" 
@@ -6060,14 +3624,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_5-6"/>
-       <position name="posOpArapuca6-Lat-5" unit="cm" 
-         x="135.02"
-	 y="744.26" 
-	 z="598.6"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_5-7"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca7-Lat-5" unit="cm" 
          x="60.02"
 	 y="745" 
@@ -6075,14 +3632,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_5-7"/>
-       <position name="posOpArapuca7-Lat-5" unit="cm" 
-         x="60.02"
-	 y="744.26" 
-	 z="598.6"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_6-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca0-Lat-6" unit="cm" 
          x="285.02"
 	 y="-745" 
@@ -6090,14 +3640,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_6-0"/>
-       <position name="posOpArapuca0-Lat-6" unit="cm" 
-         x="285.02"
-	 y="-744.26" 
-	 z="897.9"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_6-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca1-Lat-6" unit="cm" 
          x="210.02"
 	 y="-745" 
@@ -6105,14 +3648,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_6-1"/>
-       <position name="posOpArapuca1-Lat-6" unit="cm" 
-         x="210.02"
-	 y="-744.26" 
-	 z="897.9"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_6-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca2-Lat-6" unit="cm" 
          x="135.02"
 	 y="-745" 
@@ -6120,14 +3656,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_6-2"/>
-       <position name="posOpArapuca2-Lat-6" unit="cm" 
-         x="135.02"
-	 y="-744.26" 
-	 z="897.9"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_6-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca3-Lat-6" unit="cm" 
          x="60.02"
 	 y="-745" 
@@ -6135,14 +3664,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_6-3"/>
-       <position name="posOpArapuca3-Lat-6" unit="cm" 
-         x="60.02"
-	 y="-744.26" 
-	 z="897.9"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_6-4"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca4-Lat-6" unit="cm" 
          x="285.02"
 	 y="745" 
@@ -6150,14 +3672,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_6-4"/>
-       <position name="posOpArapuca4-Lat-6" unit="cm" 
-         x="285.02"
-	 y="744.26" 
-	 z="897.9"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_6-5"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca5-Lat-6" unit="cm" 
          x="210.02"
 	 y="745" 
@@ -6165,14 +3680,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_6-5"/>
-       <position name="posOpArapuca5-Lat-6" unit="cm" 
-         x="210.02"
-	 y="744.26" 
-	 z="897.9"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_6-6"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca6-Lat-6" unit="cm" 
          x="135.02"
 	 y="745" 
@@ -6180,14 +3688,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_6-6"/>
-       <position name="posOpArapuca6-Lat-6" unit="cm" 
-         x="135.02"
-	 y="744.26" 
-	 z="897.9"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_6-7"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca7-Lat-6" unit="cm" 
          x="60.02"
 	 y="745" 
@@ -6195,15 +3696,8 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_6-7"/>
-       <position name="posOpArapuca7-Lat-6" unit="cm" 
-         x="60.02"
-	 y="744.26" 
-	 z="897.9"/>
-     </physvol>
-     <physvol>
        <volumeref ref="volArapuca"/>
-       <position name="posArapuca0-ShortLat-6" unit="cm" 
+       <position name="posArapuca0-ShortLat-220" unit="cm" 
          x="285.02"
 	 y="-220" 
 	 z="-1144.55"/>
@@ -6211,7 +3705,7 @@
      </physvol>
      <physvol>
        <volumeref ref="volArapuca"/>
-       <position name="posArapuca1-ShortLat-6" unit="cm" 
+       <position name="posArapuca1-ShortLat-220" unit="cm" 
          x="210.02"
 	 y="-220" 
 	 z="-1144.55"/>
@@ -6219,7 +3713,7 @@
      </physvol>
      <physvol>
        <volumeref ref="volArapuca"/>
-       <position name="posArapuca2-ShortLat-6" unit="cm" 
+       <position name="posArapuca2-ShortLat-220" unit="cm" 
          x="135.02"
 	 y="-220" 
 	 z="-1144.55"/>
@@ -6227,7 +3721,7 @@
      </physvol>
      <physvol>
        <volumeref ref="volArapuca"/>
-       <position name="posArapuca3-ShortLat-6" unit="cm" 
+       <position name="posArapuca3-ShortLat-220" unit="cm" 
          x="60.02"
 	 y="-220" 
 	 z="-1144.55"/>
@@ -6235,7 +3729,7 @@
      </physvol>
      <physvol>
        <volumeref ref="volArapuca"/>
-       <position name="posArapuca4-ShortLat-6" unit="cm" 
+       <position name="posArapuca4-ShortLat-220" unit="cm" 
          x="285.02"
 	 y="-220" 
 	 z="1144.55"/>
@@ -6243,7 +3737,7 @@
      </physvol>
      <physvol>
        <volumeref ref="volArapuca"/>
-       <position name="posArapuca5-ShortLat-6" unit="cm" 
+       <position name="posArapuca5-ShortLat-220" unit="cm" 
          x="210.02"
 	 y="-220" 
 	 z="1144.55"/>
@@ -6251,7 +3745,7 @@
      </physvol>
      <physvol>
        <volumeref ref="volArapuca"/>
-       <position name="posArapuca6-ShortLat-6" unit="cm" 
+       <position name="posArapuca6-ShortLat-220" unit="cm" 
          x="135.02"
 	 y="-220" 
 	 z="1144.55"/>
@@ -6259,7 +3753,7 @@
      </physvol>
      <physvol>
        <volumeref ref="volArapuca"/>
-       <position name="posArapuca7-ShortLat-6" unit="cm" 
+       <position name="posArapuca7-ShortLat-220" unit="cm" 
          x="60.02"
 	 y="-220" 
 	 z="1144.55"/>
@@ -6267,7 +3761,7 @@
      </physvol>
      <physvol>
        <volumeref ref="volArapuca"/>
-       <position name="posArapuca0-ShortLat-6" unit="cm" 
+       <position name="posArapuca0-ShortLat220" unit="cm" 
          x="285.02"
 	 y="220" 
 	 z="-1144.55"/>
@@ -6275,7 +3769,7 @@
      </physvol>
      <physvol>
        <volumeref ref="volArapuca"/>
-       <position name="posArapuca1-ShortLat-6" unit="cm" 
+       <position name="posArapuca1-ShortLat220" unit="cm" 
          x="210.02"
 	 y="220" 
 	 z="-1144.55"/>
@@ -6283,7 +3777,7 @@
      </physvol>
      <physvol>
        <volumeref ref="volArapuca"/>
-       <position name="posArapuca2-ShortLat-6" unit="cm" 
+       <position name="posArapuca2-ShortLat220" unit="cm" 
          x="135.02"
 	 y="220" 
 	 z="-1144.55"/>
@@ -6291,7 +3785,7 @@
      </physvol>
      <physvol>
        <volumeref ref="volArapuca"/>
-       <position name="posArapuca3-ShortLat-6" unit="cm" 
+       <position name="posArapuca3-ShortLat220" unit="cm" 
          x="60.02"
 	 y="220" 
 	 z="-1144.55"/>
@@ -6299,7 +3793,7 @@
      </physvol>
      <physvol>
        <volumeref ref="volArapuca"/>
-       <position name="posArapuca4-ShortLat-6" unit="cm" 
+       <position name="posArapuca4-ShortLat220" unit="cm" 
          x="285.02"
 	 y="220" 
 	 z="1144.55"/>
@@ -6307,7 +3801,7 @@
      </physvol>
      <physvol>
        <volumeref ref="volArapuca"/>
-       <position name="posArapuca5-ShortLat-6" unit="cm" 
+       <position name="posArapuca5-ShortLat220" unit="cm" 
          x="210.02"
 	 y="220" 
 	 z="1144.55"/>
@@ -6315,7 +3809,7 @@
      </physvol>
      <physvol>
        <volumeref ref="volArapuca"/>
-       <position name="posArapuca6-ShortLat-6" unit="cm" 
+       <position name="posArapuca6-ShortLat220" unit="cm" 
          x="135.02"
 	 y="220" 
 	 z="1144.55"/>
@@ -6323,7 +3817,7 @@
      </physvol>
      <physvol>
        <volumeref ref="volArapuca"/>
-       <position name="posArapuca7-ShortLat-6" unit="cm" 
+       <position name="posArapuca7-ShortLat220" unit="cm" 
          x="60.02"
 	 y="220" 
 	 z="1144.55"/>

--- a/dunecore/Geometry/gdml/dunevd10kt_3view_30deg_v5_refactored_1x8x14ref_nowires.gdml
+++ b/dunecore/Geometry/gdml/dunevd10kt_3view_30deg_v5_refactored_1x8x14ref_nowires.gdml
@@ -2,6 +2,8 @@
 <gdml_simple_extension xmlns:gdml_simple_extension="http://www.example.org"
                        xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"          
                        xs:noNamespaceSchemaLocation="RefactoredGDMLSchema/SimpleExtension.xsd"> 
+
+
 <extension>
    <color name="magenta"     R="0.0"  G="1.0"  B="0.0"  A="1.0" />
    <color name="green"       R="0.0"  G="1.0"  B="0.0"  A="1.0" />
@@ -31,6 +33,10 @@
    <rotation name="rPlus180AboutY"	unit="deg" x="0" y="180"   z="0"/>
    <rotation name="rPlus180AboutXPlus180AboutY"	unit="deg" x="180" y="180"   z="0"/>
    <rotation name="rIdentity"		unit="deg" x="0" y="0"   z="0"/>
+   <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+   <rotation name="rPlus90AboutXPlus180AboutY" unit="deg" x="90" y="180" z="0" />
+   <rotation name="rPlus90AboutXMinux90AboutY" unit="deg" x="90" y="270" z="0" />
+   <rotation name="rPlus90AboutZ" unit="deg" x="0" y="0" z="90" />
 </define>
 <materials>
   <element name="videRef" formula="VACUUM" Z="1">  <atom value="1"/> </element>
@@ -396,21 +402,21 @@
       <first ref="FieldShaperLongtube"/>
       <second ref="FieldShaperCorner"/>
    		<position name="esquinapos1" unit="cm" x="-2.3" y="0" z="1047.55"/>
-		<rotation name="rot1" unit="deg" x="90" y="0" z="0" />
+		<rotationref ref="rPlus90AboutX"/>
     </union>
 
     <union name="FSunion2">
       <first ref="FSunion1"/>
       <second ref="FieldShaperShorttube"/>
    		<position name="esquinapos2" unit="cm" x="-676.3" y="0" z="1049.85"/>
-   		<rotation name="rot2" unit="deg" x="0" y="90" z="0" />
+   		<rotationref ref="rPlus90AboutY"/>
     </union>
 
     <union name="FSunion3">
       <first ref="FSunion2"/>
       <second ref="FieldShaperCorner"/>
    		<position name="esquinapos3" unit="cm" x="-1350.3" y="0" z="1047.55"/>
-		<rotation name="rot3" unit="deg" x="90" y="270" z="0" />
+		<rotationref ref="rPlus90AboutXMinux90AboutY"/>
     </union>
 
     <union name="FSunion4">
@@ -423,42 +429,42 @@
       <first ref="FSunion4"/>
       <second ref="FieldShaperCorner"/>
    		<position name="esquinapos5" unit="cm" x="-1350.3" y="0" z="-1047.55"/>
-		<rotation name="rot5" unit="deg" x="90" y="180" z="0" />
+		<rotationref ref="rPlus90AboutXPlus180AboutY"/>
     </union>
 
     <union name="FSunion6">
       <first ref="FSunion5"/>
       <second ref="FieldShaperShorttube"/>
    		<position name="esquinapos6" unit="cm" x="-676.3" y="0" z="-1049.85"/>
-		<rotation name="rot6" unit="deg" x="0" y="90" z="0" />
+		<rotationref ref="rPlus90AboutY"/>
     </union>
 
     <union name="FieldShaperSolid">
       <first ref="FSunion6"/>
       <second ref="FieldShaperCorner"/>
    		<position name="esquinapos7" unit="cm" x="-2.3" y="0" z="-1047.55"/>
-		<rotation name="rot7" unit="deg" x="90" y="90" z="0" />
+		<rotationref ref="rPlus90AboutXPlus90AboutY"/>
     </union>
     
     <union name="FSunionSlim1">
       <first ref="FieldShaperLongtubeSlim"/>
       <second ref="FieldShaperCorner"/>
-   		<position name="esquinapos1" unit="cm" x="-2.3" y="0" z="1047.55"/>
-		<rotation name="rot1" unit="deg" x="90" y="0" z="0" />
+   		<position name="esquinapos8" unit="cm" x="-2.3" y="0" z="1047.55"/>
+		<rotationref ref="rPlus90AboutX"/>
     </union>
 
     <union name="FSunionSlim2">
       <first ref="FSunionSlim1"/>
       <second ref="FieldShaperShorttube"/>
-   		<position name="esquinapos2" unit="cm" x="-676.3" y="0" z="1049.85"/>
-   		<rotation name="rot2" unit="deg" x="0" y="90" z="0" />
+   		<position name="esquinapos9" unit="cm" x="-676.3" y="0" z="1049.85"/>
+   		<rotationref ref="rPlus90AboutY"/>
     </union>
 
     <union name="FSunionSlim3">
       <first ref="FSunionSlim2"/>
       <second ref="FieldShaperCorner"/>
-   		<position name="esquinapos3" unit="cm" x="-1350.3" y="0" z="1047.55"/>
-		<rotation name="rot3" unit="deg" x="90" y="270" z="0" />
+   		<position name="esquinapos10" unit="cm" x="-1350.3" y="0" z="1047.55"/>
+		<rotationref ref="rPlus90AboutXMinux90AboutY"/>
     </union>
 
     <union name="FSunionSlim4">
@@ -470,22 +476,22 @@
     <union name="FSunionSlim5">
       <first ref="FSunionSlim4"/>
       <second ref="FieldShaperCorner"/>
-   		<position name="esquinapos5" unit="cm" x="-1350.3" y="0" z="-1047.55"/>
-		<rotation name="rot5" unit="deg" x="90" y="180" z="0" />
+   		<position name="esquinapos11" unit="cm" x="-1350.3" y="0" z="-1047.55"/>
+		<rotationref ref="rPlus90AboutXPlus180AboutY"/>
     </union>
 
     <union name="FSunionSlim6">
       <first ref="FSunionSlim5"/>
       <second ref="FieldShaperShorttube"/>
-   		<position name="esquinapos6" unit="cm" x="-676.3" y="0" z="-1049.85"/>
-		<rotation name="rot6" unit="deg" x="0" y="90" z="0" />
+   		<position name="esquinapos12" unit="cm" x="-676.3" y="0" z="-1049.85"/>
+		<rotationref ref="rPlus90AboutY"/>
     </union>
 
     <union name="FieldShaperSolidSlim">
       <first ref="FSunionSlim6"/>
       <second ref="FieldShaperCorner"/>
-   		<position name="esquinapos7" unit="cm" x="-2.3" y="0" z="-1047.55"/>
-		<rotation name="rot7" unit="deg" x="90" y="90" z="0" />
+   		<position name="esquinapos13" unit="cm" x="-2.3" y="0" z="-1047.55"/>
+		<rotationref ref="rPlus90AboutXPlus90AboutY"/>
     </union>
     
 
@@ -563,28 +569,28 @@
 
     <box name="Cryostat" lunit="cm" 
       x="850.3" 
-      y="1548.24" 
-      z="2295.34"/>
+      y="1510.24" 
+      z="2309.34"/>
 
     <box name="ArgonInterior" lunit="cm" 
       x="850.06"
-      y="1548"
-      z="2295.1"/>
+      y="1510"
+      z="2309.1"/>
 
     <box name="GaseousArgon" lunit="cm" 
       x="100 - 0.01"
-      y="1548"
-      z="2295.1"/>
+      y="1510"
+      z="2309.1"/>
 
     <box name="ExternalAuxOut" lunit="cm" 
       x="850.06 - 99.9999999999999"
-      y="1548 - 2*2.5 - 2*40"
-      z="2295.1"/>
+      y="1510 - 2*2.5 - 2*10"
+      z="2309.1"/>
 
     <box name="ExternalAuxIn" lunit="cm" 
       x="850.06"
       y="1359.17"
-      z="2295.1 + 1"/>
+      z="2309.1 + 1"/>
 
    <subtraction name="ExternalActive">
       <first ref="ExternalAuxOut"/>
@@ -697,8 +703,8 @@
 
     <box name="FoamPadBlock" lunit="cm"
       x="1010.3"
-      y="1708.24"
-      z="2455.34" />
+      y="1670.24"
+      z="2469.34" />
 
     <subtraction name="FoamPadding">
       <first ref="FoamPadBlock"/>
@@ -708,8 +714,8 @@
 
     <box name="SteelSupportBlock" lunit="cm"
       x="1210.3"
-      y="1908.24"
-      z="2655.34" />
+      y="1870.24"
+      z="2669.34" />
 
     <subtraction name="SteelSupport">
       <first ref="SteelSupportBlock"/>
@@ -719,22 +725,22 @@
 
     <box name="DetEnclosure" lunit="cm" 
       x="1310.3"
-      y="2108.24"
-      z="2855.34"/>
+      y="2070.24"
+      z="2869.34"/>
 
 
     <box name="World" lunit="cm" 
       x="9310.3" 
-      y="10108.24" 
-      z="10855.34"/>
+      y="10070.24" 
+      z="10869.34"/>
 </solids>
 <structure>
 <volume name="volFieldShaper">
-  <materialref ref="Al2O3"/>
+  <materialref ref="ALUMINUM_Al"/>
   <solidref ref="FieldShaperSolid"/>
 </volume>
 <volume name="volFieldShaperSlim">
-  <materialref ref="Al2O3"/>
+  <materialref ref="ALUMINUM_Al"/>
   <solidref ref="FieldShaperSolidSlim"/>
 </volume>
 
@@ -915,8 +921,8 @@
       <materialref ref="STEEL_STAINLESS_Fe7Cr2Ni" />
       <solidref ref="SteelShell" />
     </volume>
-    <volume name="volGroundGrid">
-      <materialref ref="STEEL_STAINLESS_Fe7Cr2Ni" />
+    <volume name="volCathodeGrid">
+      <materialref ref="G10" />
       <solidref ref="CathodeGrid" />
     </volume>
     <volume name="volAnodePlate">
@@ -935,6 +941,34 @@
       <auxiliary auxtype="Efield" auxunit="V/cm" auxvalue="0*V/cm"/>
       <colorref ref="green"/>
     </volume>
+
+    <volume name="volArapucaShortLat">
+      <materialref ref="G10"/>
+      <solidref ref="ArapucaWalls"/>
+    </volume>
+    <volume name="volOpDetSensitive">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+
+    <volume name="Arapuca">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+
+    <volume name="volArapuca">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaOut"/>
+      <physvol>
+        <volumeref ref="Arapuca"/>
+        <positionref ref="posCenter"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volOpDetSensitive"/>
+        <position name="opdetshift" unit="cm" x="0" y="0.5" z="0"/>
+      </physvol>
+    </volume>
+
     <volume name="volArapucaDouble_0-0-0">
       <materialref ref="G10" />
       <solidref ref="ArapucaWalls" />
@@ -2858,546 +2892,546 @@
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper0" unit="cm"  x="-322.03" y="-676.3" z="0" />
-     <rotation name="rotFS0" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper1" unit="cm"  x="-316.03" y="-676.3" z="0" />
-     <rotation name="rotFS1" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper2" unit="cm"  x="-310.03" y="-676.3" z="0" />
-     <rotation name="rotFS2" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper3" unit="cm"  x="-304.03" y="-676.3" z="0" />
-     <rotation name="rotFS3" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper4" unit="cm"  x="-298.03" y="-676.3" z="0" />
-     <rotation name="rotFS4" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper5" unit="cm"  x="-292.03" y="-676.3" z="0" />
-     <rotation name="rotFS5" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper6" unit="cm"  x="-286.03" y="-676.3" z="0" />
-     <rotation name="rotFS6" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper7" unit="cm"  x="-280.03" y="-676.3" z="0" />
-     <rotation name="rotFS7" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper8" unit="cm"  x="-274.03" y="-676.3" z="0" />
-     <rotation name="rotFS8" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper9" unit="cm"  x="-268.03" y="-676.3" z="0" />
-     <rotation name="rotFS9" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper10" unit="cm"  x="-262.03" y="-676.3" z="0" />
-     <rotation name="rotFS10" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper11" unit="cm"  x="-256.03" y="-676.3" z="0" />
-     <rotation name="rotFS11" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper12" unit="cm"  x="-250.03" y="-676.3" z="0" />
-     <rotation name="rotFS12" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper13" unit="cm"  x="-244.03" y="-676.3" z="0" />
-     <rotation name="rotFS13" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper14" unit="cm"  x="-238.03" y="-676.3" z="0" />
-     <rotation name="rotFS14" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper15" unit="cm"  x="-232.03" y="-676.3" z="0" />
-     <rotation name="rotFS15" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper16" unit="cm"  x="-226.03" y="-676.3" z="0" />
-     <rotation name="rotFS16" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper17" unit="cm"  x="-220.03" y="-676.3" z="0" />
-     <rotation name="rotFS17" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper18" unit="cm"  x="-214.03" y="-676.3" z="0" />
-     <rotation name="rotFS18" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper19" unit="cm"  x="-208.03" y="-676.3" z="0" />
-     <rotation name="rotFS19" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper20" unit="cm"  x="-202.03" y="-676.3" z="0" />
-     <rotation name="rotFS20" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper21" unit="cm"  x="-196.03" y="-676.3" z="0" />
-     <rotation name="rotFS21" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper22" unit="cm"  x="-190.03" y="-676.3" z="0" />
-     <rotation name="rotFS22" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper23" unit="cm"  x="-184.03" y="-676.3" z="0" />
-     <rotation name="rotFS23" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper24" unit="cm"  x="-178.03" y="-676.3" z="0" />
-     <rotation name="rotFS24" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper25" unit="cm"  x="-172.03" y="-676.3" z="0" />
-     <rotation name="rotFS25" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper26" unit="cm"  x="-166.03" y="-676.3" z="0" />
-     <rotation name="rotFS26" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper27" unit="cm"  x="-160.03" y="-676.3" z="0" />
-     <rotation name="rotFS27" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper28" unit="cm"  x="-154.03" y="-676.3" z="0" />
-     <rotation name="rotFS28" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper29" unit="cm"  x="-148.03" y="-676.3" z="0" />
-     <rotation name="rotFS29" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper30" unit="cm"  x="-142.03" y="-676.3" z="0" />
-     <rotation name="rotFS30" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper31" unit="cm"  x="-136.03" y="-676.3" z="0" />
-     <rotation name="rotFS31" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper32" unit="cm"  x="-130.03" y="-676.3" z="0" />
-     <rotation name="rotFS32" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper33" unit="cm"  x="-124.03" y="-676.3" z="0" />
-     <rotation name="rotFS33" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper34" unit="cm"  x="-118.03" y="-676.3" z="0" />
-     <rotation name="rotFS34" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper35" unit="cm"  x="-112.03" y="-676.3" z="0" />
-     <rotation name="rotFS35" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper36" unit="cm"  x="-106.03" y="-676.3" z="0" />
-     <rotation name="rotFS36" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper37" unit="cm"  x="-100.03" y="-676.3" z="0" />
-     <rotation name="rotFS37" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper38" unit="cm"  x="-94.03" y="-676.3" z="0" />
-     <rotation name="rotFS38" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper39" unit="cm"  x="-88.03" y="-676.3" z="0" />
-     <rotation name="rotFS39" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper40" unit="cm"  x="-82.03" y="-676.3" z="0" />
-     <rotation name="rotFS40" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper41" unit="cm"  x="-76.03" y="-676.3" z="0" />
-     <rotation name="rotFS41" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper42" unit="cm"  x="-70.03" y="-676.3" z="0" />
-     <rotation name="rotFS42" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper43" unit="cm"  x="-64.03" y="-676.3" z="0" />
-     <rotation name="rotFS43" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper44" unit="cm"  x="-58.03" y="-676.3" z="0" />
-     <rotation name="rotFS44" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper45" unit="cm"  x="-52.03" y="-676.3" z="0" />
-     <rotation name="rotFS45" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper46" unit="cm"  x="-46.03" y="-676.3" z="0" />
-     <rotation name="rotFS46" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper47" unit="cm"  x="-40.03" y="-676.3" z="0" />
-     <rotation name="rotFS47" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper48" unit="cm"  x="-34.03" y="-676.3" z="0" />
-     <rotation name="rotFS48" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper49" unit="cm"  x="-28.03" y="-676.3" z="0" />
-     <rotation name="rotFS49" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper50" unit="cm"  x="-22.03" y="-676.3" z="0" />
-     <rotation name="rotFS50" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper51" unit="cm"  x="-16.03" y="-676.3" z="0" />
-     <rotation name="rotFS51" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper52" unit="cm"  x="-10.03" y="-676.3" z="0" />
-     <rotation name="rotFS52" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper53" unit="cm"  x="-4.03000000000002" y="-676.3" z="0" />
-     <rotation name="rotFS53" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper54" unit="cm"  x="1.96999999999998" y="-676.3" z="0" />
-     <rotation name="rotFS54" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper55" unit="cm"  x="7.96999999999998" y="-676.3" z="0" />
-     <rotation name="rotFS55" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper56" unit="cm"  x="13.97" y="-676.3" z="0" />
-     <rotation name="rotFS56" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper57" unit="cm"  x="19.97" y="-676.3" z="0" />
-     <rotation name="rotFS57" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper58" unit="cm"  x="25.97" y="-676.3" z="0" />
-     <rotation name="rotFS58" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper59" unit="cm"  x="31.97" y="-676.3" z="0" />
-     <rotation name="rotFS59" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper60" unit="cm"  x="37.97" y="-676.3" z="0" />
-     <rotation name="rotFS60" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper61" unit="cm"  x="43.97" y="-676.3" z="0" />
-     <rotation name="rotFS61" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper62" unit="cm"  x="49.97" y="-676.3" z="0" />
-     <rotation name="rotFS62" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper63" unit="cm"  x="55.97" y="-676.3" z="0" />
-     <rotation name="rotFS63" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper64" unit="cm"  x="61.97" y="-676.3" z="0" />
-     <rotation name="rotFS64" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper65" unit="cm"  x="67.97" y="-676.3" z="0" />
-     <rotation name="rotFS65" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper66" unit="cm"  x="73.97" y="-676.3" z="0" />
-     <rotation name="rotFS66" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper67" unit="cm"  x="79.97" y="-676.3" z="0" />
-     <rotation name="rotFS67" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper68" unit="cm"  x="85.97" y="-676.3" z="0" />
-     <rotation name="rotFS68" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper69" unit="cm"  x="91.97" y="-676.3" z="0" />
-     <rotation name="rotFS69" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper70" unit="cm"  x="97.97" y="-676.3" z="0" />
-     <rotation name="rotFS70" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper71" unit="cm"  x="103.97" y="-676.3" z="0" />
-     <rotation name="rotFS71" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper72" unit="cm"  x="109.97" y="-676.3" z="0" />
-     <rotation name="rotFS72" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper73" unit="cm"  x="115.97" y="-676.3" z="0" />
-     <rotation name="rotFS73" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper74" unit="cm"  x="121.97" y="-676.3" z="0" />
-     <rotation name="rotFS74" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper75" unit="cm"  x="127.97" y="-676.3" z="0" />
-     <rotation name="rotFS75" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper76" unit="cm"  x="133.97" y="-676.3" z="0" />
-     <rotation name="rotFS76" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper77" unit="cm"  x="139.97" y="-676.3" z="0" />
-     <rotation name="rotFS77" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper78" unit="cm"  x="145.97" y="-676.3" z="0" />
-     <rotation name="rotFS78" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper79" unit="cm"  x="151.97" y="-676.3" z="0" />
-     <rotation name="rotFS79" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper80" unit="cm"  x="157.97" y="-676.3" z="0" />
-     <rotation name="rotFS80" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper81" unit="cm"  x="163.97" y="-676.3" z="0" />
-     <rotation name="rotFS81" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper82" unit="cm"  x="169.97" y="-676.3" z="0" />
-     <rotation name="rotFS82" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper83" unit="cm"  x="175.97" y="-676.3" z="0" />
-     <rotation name="rotFS83" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper84" unit="cm"  x="181.97" y="-676.3" z="0" />
-     <rotation name="rotFS84" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper85" unit="cm"  x="187.97" y="-676.3" z="0" />
-     <rotation name="rotFS85" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper86" unit="cm"  x="193.97" y="-676.3" z="0" />
-     <rotation name="rotFS86" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper87" unit="cm"  x="199.97" y="-676.3" z="0" />
-     <rotation name="rotFS87" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper88" unit="cm"  x="205.97" y="-676.3" z="0" />
-     <rotation name="rotFS88" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper89" unit="cm"  x="211.97" y="-676.3" z="0" />
-     <rotation name="rotFS89" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper90" unit="cm"  x="217.97" y="-676.3" z="0" />
-     <rotation name="rotFS90" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper91" unit="cm"  x="223.97" y="-676.3" z="0" />
-     <rotation name="rotFS91" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper92" unit="cm"  x="229.97" y="-676.3" z="0" />
-     <rotation name="rotFS92" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper93" unit="cm"  x="235.97" y="-676.3" z="0" />
-     <rotation name="rotFS93" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper94" unit="cm"  x="241.97" y="-676.3" z="0" />
-     <rotation name="rotFS94" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper95" unit="cm"  x="247.97" y="-676.3" z="0" />
-     <rotation name="rotFS95" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper96" unit="cm"  x="253.97" y="-676.3" z="0" />
-     <rotation name="rotFS96" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper97" unit="cm"  x="259.97" y="-676.3" z="0" />
-     <rotation name="rotFS97" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper98" unit="cm"  x="265.97" y="-676.3" z="0" />
-     <rotation name="rotFS98" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper99" unit="cm"  x="271.97" y="-676.3" z="0" />
-     <rotation name="rotFS99" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper100" unit="cm"  x="277.97" y="-676.3" z="0" />
-     <rotation name="rotFS100" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper101" unit="cm"  x="283.97" y="-676.3" z="0" />
-     <rotation name="rotFS101" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper102" unit="cm"  x="289.97" y="-676.3" z="0" />
-     <rotation name="rotFS102" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper103" unit="cm"  x="295.97" y="-676.3" z="0" />
-     <rotation name="rotFS103" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper104" unit="cm"  x="301.97" y="-676.3" z="0" />
-     <rotation name="rotFS104" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper105" unit="cm"  x="307.97" y="-676.3" z="0" />
-     <rotation name="rotFS105" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper106" unit="cm"  x="313.97" y="-676.3" z="0" />
-     <rotation name="rotFS106" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper107" unit="cm"  x="319.97" y="-676.3" z="0" />
-     <rotation name="rotFS107" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
       <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-0" unit="cm" x="-328.03" y="-505.5" z="-897.9"/>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-0" unit="cm" x="-328.03" y="-505.5" z="-897.9"/>
       </physvol>
       <physvol>
        <volumeref ref="volAnodePlate"/>
@@ -3405,8 +3439,8 @@
        <rotationref ref="rIdentity"/>
      </physvol>    
       <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-1" unit="cm" x="-328.03" y="-168.5" z="-897.9"/>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-1" unit="cm" x="-328.03" y="-168.5" z="-897.9"/>
       </physvol>
       <physvol>
        <volumeref ref="volAnodePlate"/>
@@ -3414,8 +3448,8 @@
        <rotationref ref="rIdentity"/>
      </physvol>    
       <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-2" unit="cm" x="-328.03" y="168.5" z="-897.9"/>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-2" unit="cm" x="-328.03" y="168.5" z="-897.9"/>
       </physvol>
       <physvol>
        <volumeref ref="volAnodePlate"/>
@@ -3423,8 +3457,8 @@
        <rotationref ref="rIdentity"/>
      </physvol>    
       <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-3" unit="cm" x="-328.03" y="505.5" z="-897.9"/>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-3" unit="cm" x="-328.03" y="505.5" z="-897.9"/>
       </physvol>
       <physvol>
        <volumeref ref="volAnodePlate"/>
@@ -3432,8 +3466,8 @@
        <rotationref ref="rIdentity"/>
      </physvol>    
       <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-4" unit="cm" x="-328.03" y="-505.5" z="-598.6"/>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-4" unit="cm" x="-328.03" y="-505.5" z="-598.6"/>
       </physvol>
       <physvol>
        <volumeref ref="volAnodePlate"/>
@@ -3441,8 +3475,8 @@
        <rotationref ref="rIdentity"/>
      </physvol>    
       <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-5" unit="cm" x="-328.03" y="-168.5" z="-598.6"/>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-5" unit="cm" x="-328.03" y="-168.5" z="-598.6"/>
       </physvol>
       <physvol>
        <volumeref ref="volAnodePlate"/>
@@ -3450,8 +3484,8 @@
        <rotationref ref="rIdentity"/>
      </physvol>    
       <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-6" unit="cm" x="-328.03" y="168.5" z="-598.6"/>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-6" unit="cm" x="-328.03" y="168.5" z="-598.6"/>
       </physvol>
       <physvol>
        <volumeref ref="volAnodePlate"/>
@@ -3459,8 +3493,8 @@
        <rotationref ref="rIdentity"/>
      </physvol>    
       <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-7" unit="cm" x="-328.03" y="505.5" z="-598.6"/>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-7" unit="cm" x="-328.03" y="505.5" z="-598.6"/>
       </physvol>
       <physvol>
        <volumeref ref="volAnodePlate"/>
@@ -3468,8 +3502,8 @@
        <rotationref ref="rIdentity"/>
      </physvol>    
       <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-8" unit="cm" x="-328.03" y="-505.5" z="-299.3"/>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-8" unit="cm" x="-328.03" y="-505.5" z="-299.3"/>
       </physvol>
       <physvol>
        <volumeref ref="volAnodePlate"/>
@@ -3477,8 +3511,8 @@
        <rotationref ref="rIdentity"/>
      </physvol>    
       <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-9" unit="cm" x="-328.03" y="-168.5" z="-299.3"/>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-9" unit="cm" x="-328.03" y="-168.5" z="-299.3"/>
       </physvol>
       <physvol>
        <volumeref ref="volAnodePlate"/>
@@ -3486,8 +3520,8 @@
        <rotationref ref="rIdentity"/>
      </physvol>    
       <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-10" unit="cm" x="-328.03" y="168.5" z="-299.3"/>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-10" unit="cm" x="-328.03" y="168.5" z="-299.3"/>
       </physvol>
       <physvol>
        <volumeref ref="volAnodePlate"/>
@@ -3495,8 +3529,8 @@
        <rotationref ref="rIdentity"/>
      </physvol>    
       <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-11" unit="cm" x="-328.03" y="505.5" z="-299.3"/>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-11" unit="cm" x="-328.03" y="505.5" z="-299.3"/>
       </physvol>
       <physvol>
        <volumeref ref="volAnodePlate"/>
@@ -3504,8 +3538,8 @@
        <rotationref ref="rIdentity"/>
      </physvol>    
       <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-12" unit="cm" x="-328.03" y="-505.5" z="1.13686837721616e-13"/>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-12" unit="cm" x="-328.03" y="-505.5" z="1.13686837721616e-13"/>
       </physvol>
       <physvol>
        <volumeref ref="volAnodePlate"/>
@@ -3513,8 +3547,8 @@
        <rotationref ref="rIdentity"/>
      </physvol>    
       <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-13" unit="cm" x="-328.03" y="-168.5" z="1.13686837721616e-13"/>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-13" unit="cm" x="-328.03" y="-168.5" z="1.13686837721616e-13"/>
       </physvol>
       <physvol>
        <volumeref ref="volAnodePlate"/>
@@ -3522,8 +3556,8 @@
        <rotationref ref="rIdentity"/>
      </physvol>    
       <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-14" unit="cm" x="-328.03" y="168.5" z="1.13686837721616e-13"/>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-14" unit="cm" x="-328.03" y="168.5" z="1.13686837721616e-13"/>
       </physvol>
       <physvol>
        <volumeref ref="volAnodePlate"/>
@@ -3531,8 +3565,8 @@
        <rotationref ref="rIdentity"/>
      </physvol>    
       <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-15" unit="cm" x="-328.03" y="505.5" z="1.13686837721616e-13"/>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-15" unit="cm" x="-328.03" y="505.5" z="1.13686837721616e-13"/>
       </physvol>
       <physvol>
        <volumeref ref="volAnodePlate"/>
@@ -3540,8 +3574,8 @@
        <rotationref ref="rIdentity"/>
      </physvol>    
       <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-16" unit="cm" x="-328.03" y="-505.5" z="299.3"/>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-16" unit="cm" x="-328.03" y="-505.5" z="299.3"/>
       </physvol>
       <physvol>
        <volumeref ref="volAnodePlate"/>
@@ -3549,8 +3583,8 @@
        <rotationref ref="rIdentity"/>
      </physvol>    
       <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-17" unit="cm" x="-328.03" y="-168.5" z="299.3"/>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-17" unit="cm" x="-328.03" y="-168.5" z="299.3"/>
       </physvol>
       <physvol>
        <volumeref ref="volAnodePlate"/>
@@ -3558,8 +3592,8 @@
        <rotationref ref="rIdentity"/>
      </physvol>    
       <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-18" unit="cm" x="-328.03" y="168.5" z="299.3"/>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-18" unit="cm" x="-328.03" y="168.5" z="299.3"/>
       </physvol>
       <physvol>
        <volumeref ref="volAnodePlate"/>
@@ -3567,8 +3601,8 @@
        <rotationref ref="rIdentity"/>
      </physvol>    
       <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-19" unit="cm" x="-328.03" y="505.5" z="299.3"/>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-19" unit="cm" x="-328.03" y="505.5" z="299.3"/>
       </physvol>
       <physvol>
        <volumeref ref="volAnodePlate"/>
@@ -3576,8 +3610,8 @@
        <rotationref ref="rIdentity"/>
      </physvol>    
       <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-20" unit="cm" x="-328.03" y="-505.5" z="598.6"/>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-20" unit="cm" x="-328.03" y="-505.5" z="598.6"/>
       </physvol>
       <physvol>
        <volumeref ref="volAnodePlate"/>
@@ -3585,8 +3619,8 @@
        <rotationref ref="rIdentity"/>
      </physvol>    
       <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-21" unit="cm" x="-328.03" y="-168.5" z="598.6"/>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-21" unit="cm" x="-328.03" y="-168.5" z="598.6"/>
       </physvol>
       <physvol>
        <volumeref ref="volAnodePlate"/>
@@ -3594,8 +3628,8 @@
        <rotationref ref="rIdentity"/>
      </physvol>    
       <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-22" unit="cm" x="-328.03" y="168.5" z="598.6"/>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-22" unit="cm" x="-328.03" y="168.5" z="598.6"/>
       </physvol>
       <physvol>
        <volumeref ref="volAnodePlate"/>
@@ -3603,8 +3637,8 @@
        <rotationref ref="rIdentity"/>
      </physvol>    
       <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-23" unit="cm" x="-328.03" y="505.5" z="598.6"/>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-23" unit="cm" x="-328.03" y="505.5" z="598.6"/>
       </physvol>
       <physvol>
        <volumeref ref="volAnodePlate"/>
@@ -3612,8 +3646,8 @@
        <rotationref ref="rIdentity"/>
      </physvol>    
       <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-24" unit="cm" x="-328.03" y="-505.5" z="897.9"/>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-24" unit="cm" x="-328.03" y="-505.5" z="897.9"/>
       </physvol>
       <physvol>
        <volumeref ref="volAnodePlate"/>
@@ -3621,8 +3655,8 @@
        <rotationref ref="rIdentity"/>
      </physvol>    
       <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-25" unit="cm" x="-328.03" y="-168.5" z="897.9"/>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-25" unit="cm" x="-328.03" y="-168.5" z="897.9"/>
       </physvol>
       <physvol>
        <volumeref ref="volAnodePlate"/>
@@ -3630,8 +3664,8 @@
        <rotationref ref="rIdentity"/>
      </physvol>    
       <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-26" unit="cm" x="-328.03" y="168.5" z="897.9"/>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-26" unit="cm" x="-328.03" y="168.5" z="897.9"/>
       </physvol>
       <physvol>
        <volumeref ref="volAnodePlate"/>
@@ -3639,8 +3673,8 @@
        <rotationref ref="rIdentity"/>
      </physvol>    
       <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-27" unit="cm" x="-328.03" y="505.5" z="897.9"/>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-27" unit="cm" x="-328.03" y="505.5" z="897.9"/>
       </physvol>
       <physvol>
        <volumeref ref="volAnodePlate"/>
@@ -3653,7 +3687,7 @@
          x="-328.03"
 	 y="-633.2" 
 	 z="-860.4"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-0"/>
@@ -3668,7 +3702,7 @@
          x="-328.03"
 	 y="-542.5" 
 	 z="-1006.4"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-1"/>
@@ -3683,7 +3717,7 @@
          x="-328.03"
 	 y="-468.5" 
 	 z="-789.4"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-2"/>
@@ -3698,7 +3732,7 @@
          x="-328.03"
 	 y="-377.8" 
 	 z="-935.4"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-3"/>
@@ -3713,7 +3747,7 @@
          x="-328.03"
 	 y="-633.2" 
 	 z="-561.1"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-0"/>
@@ -3728,7 +3762,7 @@
          x="-328.03"
 	 y="-542.5" 
 	 z="-707.1"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-1"/>
@@ -3743,7 +3777,7 @@
          x="-328.03"
 	 y="-468.5" 
 	 z="-490.1"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-2"/>
@@ -3758,7 +3792,7 @@
          x="-328.03"
 	 y="-377.8" 
 	 z="-636.1"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-3"/>
@@ -3773,7 +3807,7 @@
          x="-328.03"
 	 y="-633.2" 
 	 z="-261.8"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-0"/>
@@ -3788,7 +3822,7 @@
          x="-328.03"
 	 y="-542.5" 
 	 z="-407.8"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-1"/>
@@ -3803,7 +3837,7 @@
          x="-328.03"
 	 y="-468.5" 
 	 z="-190.8"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-2"/>
@@ -3818,7 +3852,7 @@
          x="-328.03"
 	 y="-377.8" 
 	 z="-336.8"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-3"/>
@@ -3833,7 +3867,7 @@
          x="-328.03"
 	 y="-633.2" 
 	 z="37.5000000000001"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-3-0"/>
@@ -3848,7 +3882,7 @@
          x="-328.03"
 	 y="-542.5" 
 	 z="-108.5"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-3-1"/>
@@ -3863,7 +3897,7 @@
          x="-328.03"
 	 y="-468.5" 
 	 z="108.5"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-3-2"/>
@@ -3878,7 +3912,7 @@
          x="-328.03"
 	 y="-377.8" 
 	 z="-37.4999999999999"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-3-3"/>
@@ -3893,7 +3927,7 @@
          x="-328.03"
 	 y="-633.2" 
 	 z="336.8"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-4-0"/>
@@ -3908,7 +3942,7 @@
          x="-328.03"
 	 y="-542.5" 
 	 z="190.8"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-4-1"/>
@@ -3923,7 +3957,7 @@
          x="-328.03"
 	 y="-468.5" 
 	 z="407.8"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-4-2"/>
@@ -3938,7 +3972,7 @@
          x="-328.03"
 	 y="-377.8" 
 	 z="261.8"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-4-3"/>
@@ -3953,7 +3987,7 @@
          x="-328.03"
 	 y="-633.2" 
 	 z="636.1"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-5-0"/>
@@ -3968,7 +4002,7 @@
          x="-328.03"
 	 y="-542.5" 
 	 z="490.1"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-5-1"/>
@@ -3983,7 +4017,7 @@
          x="-328.03"
 	 y="-468.5" 
 	 z="707.1"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-5-2"/>
@@ -3998,7 +4032,7 @@
          x="-328.03"
 	 y="-377.8" 
 	 z="561.1"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-5-3"/>
@@ -4013,7 +4047,7 @@
          x="-328.03"
 	 y="-633.2" 
 	 z="935.4"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-6-0"/>
@@ -4028,7 +4062,7 @@
          x="-328.03"
 	 y="-542.5" 
 	 z="789.4"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-6-1"/>
@@ -4043,7 +4077,7 @@
          x="-328.03"
 	 y="-468.5" 
 	 z="1006.4"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-6-2"/>
@@ -4058,7 +4092,7 @@
          x="-328.03"
 	 y="-377.8" 
 	 z="860.4"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-6-3"/>
@@ -4073,7 +4107,7 @@
          x="-328.03"
 	 y="-296.2" 
 	 z="-860.4"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-0"/>
@@ -4088,7 +4122,7 @@
          x="-328.03"
 	 y="-205.5" 
 	 z="-1006.4"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-1"/>
@@ -4103,7 +4137,7 @@
          x="-328.03"
 	 y="-131.5" 
 	 z="-789.4"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-2"/>
@@ -4118,7 +4152,7 @@
          x="-328.03"
 	 y="-40.8" 
 	 z="-935.4"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-3"/>
@@ -4133,7 +4167,7 @@
          x="-328.03"
 	 y="-296.2" 
 	 z="-561.1"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-0"/>
@@ -4148,7 +4182,7 @@
          x="-328.03"
 	 y="-205.5" 
 	 z="-707.1"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-1"/>
@@ -4163,7 +4197,7 @@
          x="-328.03"
 	 y="-131.5" 
 	 z="-490.1"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-2"/>
@@ -4178,7 +4212,7 @@
          x="-328.03"
 	 y="-40.8" 
 	 z="-636.1"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-3"/>
@@ -4193,7 +4227,7 @@
          x="-328.03"
 	 y="-296.2" 
 	 z="-261.8"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-0"/>
@@ -4208,7 +4242,7 @@
          x="-328.03"
 	 y="-205.5" 
 	 z="-407.8"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-1"/>
@@ -4223,7 +4257,7 @@
          x="-328.03"
 	 y="-131.5" 
 	 z="-190.8"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-2"/>
@@ -4238,7 +4272,7 @@
          x="-328.03"
 	 y="-40.8" 
 	 z="-336.8"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-3"/>
@@ -4253,7 +4287,7 @@
          x="-328.03"
 	 y="-296.2" 
 	 z="37.5000000000001"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-3-0"/>
@@ -4268,7 +4302,7 @@
          x="-328.03"
 	 y="-205.5" 
 	 z="-108.5"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-3-1"/>
@@ -4283,7 +4317,7 @@
          x="-328.03"
 	 y="-131.5" 
 	 z="108.5"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-3-2"/>
@@ -4298,7 +4332,7 @@
          x="-328.03"
 	 y="-40.8" 
 	 z="-37.4999999999999"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-3-3"/>
@@ -4313,7 +4347,7 @@
          x="-328.03"
 	 y="-296.2" 
 	 z="336.8"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-4-0"/>
@@ -4328,7 +4362,7 @@
          x="-328.03"
 	 y="-205.5" 
 	 z="190.8"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-4-1"/>
@@ -4343,7 +4377,7 @@
          x="-328.03"
 	 y="-131.5" 
 	 z="407.8"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-4-2"/>
@@ -4358,7 +4392,7 @@
          x="-328.03"
 	 y="-40.8" 
 	 z="261.8"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-4-3"/>
@@ -4373,7 +4407,7 @@
          x="-328.03"
 	 y="-296.2" 
 	 z="636.1"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-5-0"/>
@@ -4388,7 +4422,7 @@
          x="-328.03"
 	 y="-205.5" 
 	 z="490.1"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-5-1"/>
@@ -4403,7 +4437,7 @@
          x="-328.03"
 	 y="-131.5" 
 	 z="707.1"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-5-2"/>
@@ -4418,7 +4452,7 @@
          x="-328.03"
 	 y="-40.8" 
 	 z="561.1"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-5-3"/>
@@ -4433,7 +4467,7 @@
          x="-328.03"
 	 y="-296.2" 
 	 z="935.4"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-6-0"/>
@@ -4448,7 +4482,7 @@
          x="-328.03"
 	 y="-205.5" 
 	 z="789.4"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-6-1"/>
@@ -4463,7 +4497,7 @@
          x="-328.03"
 	 y="-131.5" 
 	 z="1006.4"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-6-2"/>
@@ -4478,7 +4512,7 @@
          x="-328.03"
 	 y="-40.8" 
 	 z="860.4"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-6-3"/>
@@ -4493,7 +4527,7 @@
          x="-328.03"
 	 y="40.8" 
 	 z="-860.4"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-0"/>
@@ -4508,7 +4542,7 @@
          x="-328.03"
 	 y="131.5" 
 	 z="-1006.4"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-1"/>
@@ -4523,7 +4557,7 @@
          x="-328.03"
 	 y="205.5" 
 	 z="-789.4"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-2"/>
@@ -4538,7 +4572,7 @@
          x="-328.03"
 	 y="296.2" 
 	 z="-935.4"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-3"/>
@@ -4553,7 +4587,7 @@
          x="-328.03"
 	 y="40.8" 
 	 z="-561.1"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-0"/>
@@ -4568,7 +4602,7 @@
          x="-328.03"
 	 y="131.5" 
 	 z="-707.1"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-1"/>
@@ -4583,7 +4617,7 @@
          x="-328.03"
 	 y="205.5" 
 	 z="-490.1"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-2"/>
@@ -4598,7 +4632,7 @@
          x="-328.03"
 	 y="296.2" 
 	 z="-636.1"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-3"/>
@@ -4613,7 +4647,7 @@
          x="-328.03"
 	 y="40.8" 
 	 z="-261.8"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-0"/>
@@ -4628,7 +4662,7 @@
          x="-328.03"
 	 y="131.5" 
 	 z="-407.8"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-1"/>
@@ -4643,7 +4677,7 @@
          x="-328.03"
 	 y="205.5" 
 	 z="-190.8"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-2"/>
@@ -4658,7 +4692,7 @@
          x="-328.03"
 	 y="296.2" 
 	 z="-336.8"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-3"/>
@@ -4673,7 +4707,7 @@
          x="-328.03"
 	 y="40.8" 
 	 z="37.5000000000001"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-3-0"/>
@@ -4688,7 +4722,7 @@
          x="-328.03"
 	 y="131.5" 
 	 z="-108.5"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-3-1"/>
@@ -4703,7 +4737,7 @@
          x="-328.03"
 	 y="205.5" 
 	 z="108.5"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-3-2"/>
@@ -4718,7 +4752,7 @@
          x="-328.03"
 	 y="296.2" 
 	 z="-37.4999999999999"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-3-3"/>
@@ -4733,7 +4767,7 @@
          x="-328.03"
 	 y="40.8" 
 	 z="336.8"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-4-0"/>
@@ -4748,7 +4782,7 @@
          x="-328.03"
 	 y="131.5" 
 	 z="190.8"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-4-1"/>
@@ -4763,7 +4797,7 @@
          x="-328.03"
 	 y="205.5" 
 	 z="407.8"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-4-2"/>
@@ -4778,7 +4812,7 @@
          x="-328.03"
 	 y="296.2" 
 	 z="261.8"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-4-3"/>
@@ -4793,7 +4827,7 @@
          x="-328.03"
 	 y="40.8" 
 	 z="636.1"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-5-0"/>
@@ -4808,7 +4842,7 @@
          x="-328.03"
 	 y="131.5" 
 	 z="490.1"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-5-1"/>
@@ -4823,7 +4857,7 @@
          x="-328.03"
 	 y="205.5" 
 	 z="707.1"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-5-2"/>
@@ -4838,7 +4872,7 @@
          x="-328.03"
 	 y="296.2" 
 	 z="561.1"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-5-3"/>
@@ -4853,7 +4887,7 @@
          x="-328.03"
 	 y="40.8" 
 	 z="935.4"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-6-0"/>
@@ -4868,7 +4902,7 @@
          x="-328.03"
 	 y="131.5" 
 	 z="789.4"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-6-1"/>
@@ -4883,7 +4917,7 @@
          x="-328.03"
 	 y="205.5" 
 	 z="1006.4"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-6-2"/>
@@ -4898,7 +4932,7 @@
          x="-328.03"
 	 y="296.2" 
 	 z="860.4"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-6-3"/>
@@ -4913,7 +4947,7 @@
          x="-328.03"
 	 y="377.8" 
 	 z="-860.4"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-0"/>
@@ -4928,7 +4962,7 @@
          x="-328.03"
 	 y="468.5" 
 	 z="-1006.4"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-1"/>
@@ -4943,7 +4977,7 @@
          x="-328.03"
 	 y="542.5" 
 	 z="-789.4"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-2"/>
@@ -4958,7 +4992,7 @@
          x="-328.03"
 	 y="633.2" 
 	 z="-935.4"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-3"/>
@@ -4973,7 +5007,7 @@
          x="-328.03"
 	 y="377.8" 
 	 z="-561.1"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-0"/>
@@ -4988,7 +5022,7 @@
          x="-328.03"
 	 y="468.5" 
 	 z="-707.1"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-1"/>
@@ -5003,7 +5037,7 @@
          x="-328.03"
 	 y="542.5" 
 	 z="-490.1"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-2"/>
@@ -5018,7 +5052,7 @@
          x="-328.03"
 	 y="633.2" 
 	 z="-636.1"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-3"/>
@@ -5033,7 +5067,7 @@
          x="-328.03"
 	 y="377.8" 
 	 z="-261.8"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-0"/>
@@ -5048,7 +5082,7 @@
          x="-328.03"
 	 y="468.5" 
 	 z="-407.8"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-1"/>
@@ -5063,7 +5097,7 @@
          x="-328.03"
 	 y="542.5" 
 	 z="-190.8"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-2"/>
@@ -5078,7 +5112,7 @@
          x="-328.03"
 	 y="633.2" 
 	 z="-336.8"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-3"/>
@@ -5093,7 +5127,7 @@
          x="-328.03"
 	 y="377.8" 
 	 z="37.5000000000001"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-3-0"/>
@@ -5108,7 +5142,7 @@
          x="-328.03"
 	 y="468.5" 
 	 z="-108.5"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-3-1"/>
@@ -5123,7 +5157,7 @@
          x="-328.03"
 	 y="542.5" 
 	 z="108.5"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-3-2"/>
@@ -5138,7 +5172,7 @@
          x="-328.03"
 	 y="633.2" 
 	 z="-37.4999999999999"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-3-3"/>
@@ -5153,7 +5187,7 @@
          x="-328.03"
 	 y="377.8" 
 	 z="336.8"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-4-0"/>
@@ -5168,7 +5202,7 @@
          x="-328.03"
 	 y="468.5" 
 	 z="190.8"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-4-1"/>
@@ -5183,7 +5217,7 @@
          x="-328.03"
 	 y="542.5" 
 	 z="407.8"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-4-2"/>
@@ -5198,7 +5232,7 @@
          x="-328.03"
 	 y="633.2" 
 	 z="261.8"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-4-3"/>
@@ -5213,7 +5247,7 @@
          x="-328.03"
 	 y="377.8" 
 	 z="636.1"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-5-0"/>
@@ -5228,7 +5262,7 @@
          x="-328.03"
 	 y="468.5" 
 	 z="490.1"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-5-1"/>
@@ -5243,7 +5277,7 @@
          x="-328.03"
 	 y="542.5" 
 	 z="707.1"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-5-2"/>
@@ -5258,7 +5292,7 @@
          x="-328.03"
 	 y="633.2" 
 	 z="561.1"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-5-3"/>
@@ -5273,7 +5307,7 @@
          x="-328.03"
 	 y="377.8" 
 	 z="935.4"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-6-0"/>
@@ -5288,7 +5322,7 @@
          x="-328.03"
 	 y="468.5" 
 	 z="789.4"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-6-1"/>
@@ -5303,7 +5337,7 @@
          x="-328.03"
 	 y="542.5" 
 	 z="1006.4"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-6-2"/>
@@ -5318,7 +5352,7 @@
          x="-328.03"
 	 y="633.2" 
 	 z="860.4"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-6-3"/>
@@ -5330,842 +5364,970 @@
      <physvol>
        <volumeref ref="volArapucaLat_0-0"/>
        <position name="posArapuca0-Lat-0" unit="cm" 
-         x="-40"
-	 y="-734" 
+         x="285.02"
+	 y="-745" 
 	 z="-897.9"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-0"/>
        <position name="posOpArapuca0-Lat-0" unit="cm" 
-         x="-40"
-	 y="-733.26" 
+         x="285.02"
+	 y="-744.26" 
 	 z="-897.9"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-1"/>
        <position name="posArapuca1-Lat-0" unit="cm" 
-         x="-115"
-	 y="-734" 
+         x="210.02"
+	 y="-745" 
 	 z="-897.9"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-1"/>
        <position name="posOpArapuca1-Lat-0" unit="cm" 
-         x="-115"
-	 y="-733.26" 
+         x="210.02"
+	 y="-744.26" 
 	 z="-897.9"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-2"/>
        <position name="posArapuca2-Lat-0" unit="cm" 
-         x="-190"
-	 y="-734" 
+         x="135.02"
+	 y="-745" 
 	 z="-897.9"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-2"/>
        <position name="posOpArapuca2-Lat-0" unit="cm" 
-         x="-190"
-	 y="-733.26" 
+         x="135.02"
+	 y="-744.26" 
 	 z="-897.9"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-3"/>
        <position name="posArapuca3-Lat-0" unit="cm" 
-         x="-265"
-	 y="-734" 
+         x="60.02"
+	 y="-745" 
 	 z="-897.9"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-3"/>
        <position name="posOpArapuca3-Lat-0" unit="cm" 
-         x="-265"
-	 y="-733.26" 
+         x="60.02"
+	 y="-744.26" 
 	 z="-897.9"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-4"/>
        <position name="posArapuca4-Lat-0" unit="cm" 
-         x="-40"
-	 y="734" 
+         x="285.02"
+	 y="745" 
 	 z="-897.9"/>
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-4"/>
        <position name="posOpArapuca4-Lat-0" unit="cm" 
-         x="-40"
-	 y="733.26" 
+         x="285.02"
+	 y="744.26" 
 	 z="-897.9"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-5"/>
        <position name="posArapuca5-Lat-0" unit="cm" 
-         x="-115"
-	 y="734" 
+         x="210.02"
+	 y="745" 
 	 z="-897.9"/>
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-5"/>
        <position name="posOpArapuca5-Lat-0" unit="cm" 
-         x="-115"
-	 y="733.26" 
+         x="210.02"
+	 y="744.26" 
 	 z="-897.9"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-6"/>
        <position name="posArapuca6-Lat-0" unit="cm" 
-         x="-190"
-	 y="734" 
+         x="135.02"
+	 y="745" 
 	 z="-897.9"/>
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-6"/>
        <position name="posOpArapuca6-Lat-0" unit="cm" 
-         x="-190"
-	 y="733.26" 
+         x="135.02"
+	 y="744.26" 
 	 z="-897.9"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-7"/>
        <position name="posArapuca7-Lat-0" unit="cm" 
-         x="-265"
-	 y="734" 
+         x="60.02"
+	 y="745" 
 	 z="-897.9"/>
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-7"/>
        <position name="posOpArapuca7-Lat-0" unit="cm" 
-         x="-265"
-	 y="733.26" 
+         x="60.02"
+	 y="744.26" 
 	 z="-897.9"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-0"/>
        <position name="posArapuca0-Lat-1" unit="cm" 
-         x="-40"
-	 y="-734" 
+         x="285.02"
+	 y="-745" 
 	 z="-598.6"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-0"/>
        <position name="posOpArapuca0-Lat-1" unit="cm" 
-         x="-40"
-	 y="-733.26" 
+         x="285.02"
+	 y="-744.26" 
 	 z="-598.6"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-1"/>
        <position name="posArapuca1-Lat-1" unit="cm" 
-         x="-115"
-	 y="-734" 
+         x="210.02"
+	 y="-745" 
 	 z="-598.6"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-1"/>
        <position name="posOpArapuca1-Lat-1" unit="cm" 
-         x="-115"
-	 y="-733.26" 
+         x="210.02"
+	 y="-744.26" 
 	 z="-598.6"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-2"/>
        <position name="posArapuca2-Lat-1" unit="cm" 
-         x="-190"
-	 y="-734" 
+         x="135.02"
+	 y="-745" 
 	 z="-598.6"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-2"/>
        <position name="posOpArapuca2-Lat-1" unit="cm" 
-         x="-190"
-	 y="-733.26" 
+         x="135.02"
+	 y="-744.26" 
 	 z="-598.6"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-3"/>
        <position name="posArapuca3-Lat-1" unit="cm" 
-         x="-265"
-	 y="-734" 
+         x="60.02"
+	 y="-745" 
 	 z="-598.6"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-3"/>
        <position name="posOpArapuca3-Lat-1" unit="cm" 
-         x="-265"
-	 y="-733.26" 
+         x="60.02"
+	 y="-744.26" 
 	 z="-598.6"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-4"/>
        <position name="posArapuca4-Lat-1" unit="cm" 
-         x="-40"
-	 y="734" 
+         x="285.02"
+	 y="745" 
 	 z="-598.6"/>
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-4"/>
        <position name="posOpArapuca4-Lat-1" unit="cm" 
-         x="-40"
-	 y="733.26" 
+         x="285.02"
+	 y="744.26" 
 	 z="-598.6"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-5"/>
        <position name="posArapuca5-Lat-1" unit="cm" 
-         x="-115"
-	 y="734" 
+         x="210.02"
+	 y="745" 
 	 z="-598.6"/>
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-5"/>
        <position name="posOpArapuca5-Lat-1" unit="cm" 
-         x="-115"
-	 y="733.26" 
+         x="210.02"
+	 y="744.26" 
 	 z="-598.6"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-6"/>
        <position name="posArapuca6-Lat-1" unit="cm" 
-         x="-190"
-	 y="734" 
+         x="135.02"
+	 y="745" 
 	 z="-598.6"/>
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-6"/>
        <position name="posOpArapuca6-Lat-1" unit="cm" 
-         x="-190"
-	 y="733.26" 
+         x="135.02"
+	 y="744.26" 
 	 z="-598.6"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-7"/>
        <position name="posArapuca7-Lat-1" unit="cm" 
-         x="-265"
-	 y="734" 
+         x="60.02"
+	 y="745" 
 	 z="-598.6"/>
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-7"/>
        <position name="posOpArapuca7-Lat-1" unit="cm" 
-         x="-265"
-	 y="733.26" 
+         x="60.02"
+	 y="744.26" 
 	 z="-598.6"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-0"/>
        <position name="posArapuca0-Lat-2" unit="cm" 
-         x="-40"
-	 y="-734" 
+         x="285.02"
+	 y="-745" 
 	 z="-299.3"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-0"/>
        <position name="posOpArapuca0-Lat-2" unit="cm" 
-         x="-40"
-	 y="-733.26" 
+         x="285.02"
+	 y="-744.26" 
 	 z="-299.3"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-1"/>
        <position name="posArapuca1-Lat-2" unit="cm" 
-         x="-115"
-	 y="-734" 
+         x="210.02"
+	 y="-745" 
 	 z="-299.3"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-1"/>
        <position name="posOpArapuca1-Lat-2" unit="cm" 
-         x="-115"
-	 y="-733.26" 
+         x="210.02"
+	 y="-744.26" 
 	 z="-299.3"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-2"/>
        <position name="posArapuca2-Lat-2" unit="cm" 
-         x="-190"
-	 y="-734" 
+         x="135.02"
+	 y="-745" 
 	 z="-299.3"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-2"/>
        <position name="posOpArapuca2-Lat-2" unit="cm" 
-         x="-190"
-	 y="-733.26" 
+         x="135.02"
+	 y="-744.26" 
 	 z="-299.3"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-3"/>
        <position name="posArapuca3-Lat-2" unit="cm" 
-         x="-265"
-	 y="-734" 
+         x="60.02"
+	 y="-745" 
 	 z="-299.3"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-3"/>
        <position name="posOpArapuca3-Lat-2" unit="cm" 
-         x="-265"
-	 y="-733.26" 
+         x="60.02"
+	 y="-744.26" 
 	 z="-299.3"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-4"/>
        <position name="posArapuca4-Lat-2" unit="cm" 
-         x="-40"
-	 y="734" 
+         x="285.02"
+	 y="745" 
 	 z="-299.3"/>
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-4"/>
        <position name="posOpArapuca4-Lat-2" unit="cm" 
-         x="-40"
-	 y="733.26" 
+         x="285.02"
+	 y="744.26" 
 	 z="-299.3"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-5"/>
        <position name="posArapuca5-Lat-2" unit="cm" 
-         x="-115"
-	 y="734" 
+         x="210.02"
+	 y="745" 
 	 z="-299.3"/>
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-5"/>
        <position name="posOpArapuca5-Lat-2" unit="cm" 
-         x="-115"
-	 y="733.26" 
+         x="210.02"
+	 y="744.26" 
 	 z="-299.3"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-6"/>
        <position name="posArapuca6-Lat-2" unit="cm" 
-         x="-190"
-	 y="734" 
+         x="135.02"
+	 y="745" 
 	 z="-299.3"/>
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-6"/>
        <position name="posOpArapuca6-Lat-2" unit="cm" 
-         x="-190"
-	 y="733.26" 
+         x="135.02"
+	 y="744.26" 
 	 z="-299.3"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-7"/>
        <position name="posArapuca7-Lat-2" unit="cm" 
-         x="-265"
-	 y="734" 
+         x="60.02"
+	 y="745" 
 	 z="-299.3"/>
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-7"/>
        <position name="posOpArapuca7-Lat-2" unit="cm" 
-         x="-265"
-	 y="733.26" 
+         x="60.02"
+	 y="744.26" 
 	 z="-299.3"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_3-0"/>
        <position name="posArapuca0-Lat-3" unit="cm" 
-         x="-40"
-	 y="-734" 
+         x="285.02"
+	 y="-745" 
 	 z="1.13686837721616e-13"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_3-0"/>
        <position name="posOpArapuca0-Lat-3" unit="cm" 
-         x="-40"
-	 y="-733.26" 
+         x="285.02"
+	 y="-744.26" 
 	 z="1.13686837721616e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_3-1"/>
        <position name="posArapuca1-Lat-3" unit="cm" 
-         x="-115"
-	 y="-734" 
+         x="210.02"
+	 y="-745" 
 	 z="1.13686837721616e-13"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_3-1"/>
        <position name="posOpArapuca1-Lat-3" unit="cm" 
-         x="-115"
-	 y="-733.26" 
+         x="210.02"
+	 y="-744.26" 
 	 z="1.13686837721616e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_3-2"/>
        <position name="posArapuca2-Lat-3" unit="cm" 
-         x="-190"
-	 y="-734" 
+         x="135.02"
+	 y="-745" 
 	 z="1.13686837721616e-13"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_3-2"/>
        <position name="posOpArapuca2-Lat-3" unit="cm" 
-         x="-190"
-	 y="-733.26" 
+         x="135.02"
+	 y="-744.26" 
 	 z="1.13686837721616e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_3-3"/>
        <position name="posArapuca3-Lat-3" unit="cm" 
-         x="-265"
-	 y="-734" 
+         x="60.02"
+	 y="-745" 
 	 z="1.13686837721616e-13"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_3-3"/>
        <position name="posOpArapuca3-Lat-3" unit="cm" 
-         x="-265"
-	 y="-733.26" 
+         x="60.02"
+	 y="-744.26" 
 	 z="1.13686837721616e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_3-4"/>
        <position name="posArapuca4-Lat-3" unit="cm" 
-         x="-40"
-	 y="734" 
+         x="285.02"
+	 y="745" 
 	 z="1.13686837721616e-13"/>
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_3-4"/>
        <position name="posOpArapuca4-Lat-3" unit="cm" 
-         x="-40"
-	 y="733.26" 
+         x="285.02"
+	 y="744.26" 
 	 z="1.13686837721616e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_3-5"/>
        <position name="posArapuca5-Lat-3" unit="cm" 
-         x="-115"
-	 y="734" 
+         x="210.02"
+	 y="745" 
 	 z="1.13686837721616e-13"/>
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_3-5"/>
        <position name="posOpArapuca5-Lat-3" unit="cm" 
-         x="-115"
-	 y="733.26" 
+         x="210.02"
+	 y="744.26" 
 	 z="1.13686837721616e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_3-6"/>
        <position name="posArapuca6-Lat-3" unit="cm" 
-         x="-190"
-	 y="734" 
+         x="135.02"
+	 y="745" 
 	 z="1.13686837721616e-13"/>
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_3-6"/>
        <position name="posOpArapuca6-Lat-3" unit="cm" 
-         x="-190"
-	 y="733.26" 
+         x="135.02"
+	 y="744.26" 
 	 z="1.13686837721616e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_3-7"/>
        <position name="posArapuca7-Lat-3" unit="cm" 
-         x="-265"
-	 y="734" 
+         x="60.02"
+	 y="745" 
 	 z="1.13686837721616e-13"/>
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_3-7"/>
        <position name="posOpArapuca7-Lat-3" unit="cm" 
-         x="-265"
-	 y="733.26" 
+         x="60.02"
+	 y="744.26" 
 	 z="1.13686837721616e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_4-0"/>
        <position name="posArapuca0-Lat-4" unit="cm" 
-         x="-40"
-	 y="-734" 
+         x="285.02"
+	 y="-745" 
 	 z="299.3"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_4-0"/>
        <position name="posOpArapuca0-Lat-4" unit="cm" 
-         x="-40"
-	 y="-733.26" 
+         x="285.02"
+	 y="-744.26" 
 	 z="299.3"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_4-1"/>
        <position name="posArapuca1-Lat-4" unit="cm" 
-         x="-115"
-	 y="-734" 
+         x="210.02"
+	 y="-745" 
 	 z="299.3"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_4-1"/>
        <position name="posOpArapuca1-Lat-4" unit="cm" 
-         x="-115"
-	 y="-733.26" 
+         x="210.02"
+	 y="-744.26" 
 	 z="299.3"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_4-2"/>
        <position name="posArapuca2-Lat-4" unit="cm" 
-         x="-190"
-	 y="-734" 
+         x="135.02"
+	 y="-745" 
 	 z="299.3"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_4-2"/>
        <position name="posOpArapuca2-Lat-4" unit="cm" 
-         x="-190"
-	 y="-733.26" 
+         x="135.02"
+	 y="-744.26" 
 	 z="299.3"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_4-3"/>
        <position name="posArapuca3-Lat-4" unit="cm" 
-         x="-265"
-	 y="-734" 
+         x="60.02"
+	 y="-745" 
 	 z="299.3"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_4-3"/>
        <position name="posOpArapuca3-Lat-4" unit="cm" 
-         x="-265"
-	 y="-733.26" 
+         x="60.02"
+	 y="-744.26" 
 	 z="299.3"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_4-4"/>
        <position name="posArapuca4-Lat-4" unit="cm" 
-         x="-40"
-	 y="734" 
+         x="285.02"
+	 y="745" 
 	 z="299.3"/>
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_4-4"/>
        <position name="posOpArapuca4-Lat-4" unit="cm" 
-         x="-40"
-	 y="733.26" 
+         x="285.02"
+	 y="744.26" 
 	 z="299.3"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_4-5"/>
        <position name="posArapuca5-Lat-4" unit="cm" 
-         x="-115"
-	 y="734" 
+         x="210.02"
+	 y="745" 
 	 z="299.3"/>
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_4-5"/>
        <position name="posOpArapuca5-Lat-4" unit="cm" 
-         x="-115"
-	 y="733.26" 
+         x="210.02"
+	 y="744.26" 
 	 z="299.3"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_4-6"/>
        <position name="posArapuca6-Lat-4" unit="cm" 
-         x="-190"
-	 y="734" 
+         x="135.02"
+	 y="745" 
 	 z="299.3"/>
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_4-6"/>
        <position name="posOpArapuca6-Lat-4" unit="cm" 
-         x="-190"
-	 y="733.26" 
+         x="135.02"
+	 y="744.26" 
 	 z="299.3"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_4-7"/>
        <position name="posArapuca7-Lat-4" unit="cm" 
-         x="-265"
-	 y="734" 
+         x="60.02"
+	 y="745" 
 	 z="299.3"/>
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_4-7"/>
        <position name="posOpArapuca7-Lat-4" unit="cm" 
-         x="-265"
-	 y="733.26" 
+         x="60.02"
+	 y="744.26" 
 	 z="299.3"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_5-0"/>
        <position name="posArapuca0-Lat-5" unit="cm" 
-         x="-40"
-	 y="-734" 
+         x="285.02"
+	 y="-745" 
 	 z="598.6"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_5-0"/>
        <position name="posOpArapuca0-Lat-5" unit="cm" 
-         x="-40"
-	 y="-733.26" 
+         x="285.02"
+	 y="-744.26" 
 	 z="598.6"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_5-1"/>
        <position name="posArapuca1-Lat-5" unit="cm" 
-         x="-115"
-	 y="-734" 
+         x="210.02"
+	 y="-745" 
 	 z="598.6"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_5-1"/>
        <position name="posOpArapuca1-Lat-5" unit="cm" 
-         x="-115"
-	 y="-733.26" 
+         x="210.02"
+	 y="-744.26" 
 	 z="598.6"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_5-2"/>
        <position name="posArapuca2-Lat-5" unit="cm" 
-         x="-190"
-	 y="-734" 
+         x="135.02"
+	 y="-745" 
 	 z="598.6"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_5-2"/>
        <position name="posOpArapuca2-Lat-5" unit="cm" 
-         x="-190"
-	 y="-733.26" 
+         x="135.02"
+	 y="-744.26" 
 	 z="598.6"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_5-3"/>
        <position name="posArapuca3-Lat-5" unit="cm" 
-         x="-265"
-	 y="-734" 
+         x="60.02"
+	 y="-745" 
 	 z="598.6"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_5-3"/>
        <position name="posOpArapuca3-Lat-5" unit="cm" 
-         x="-265"
-	 y="-733.26" 
+         x="60.02"
+	 y="-744.26" 
 	 z="598.6"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_5-4"/>
        <position name="posArapuca4-Lat-5" unit="cm" 
-         x="-40"
-	 y="734" 
+         x="285.02"
+	 y="745" 
 	 z="598.6"/>
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_5-4"/>
        <position name="posOpArapuca4-Lat-5" unit="cm" 
-         x="-40"
-	 y="733.26" 
+         x="285.02"
+	 y="744.26" 
 	 z="598.6"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_5-5"/>
        <position name="posArapuca5-Lat-5" unit="cm" 
-         x="-115"
-	 y="734" 
+         x="210.02"
+	 y="745" 
 	 z="598.6"/>
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_5-5"/>
        <position name="posOpArapuca5-Lat-5" unit="cm" 
-         x="-115"
-	 y="733.26" 
+         x="210.02"
+	 y="744.26" 
 	 z="598.6"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_5-6"/>
        <position name="posArapuca6-Lat-5" unit="cm" 
-         x="-190"
-	 y="734" 
+         x="135.02"
+	 y="745" 
 	 z="598.6"/>
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_5-6"/>
        <position name="posOpArapuca6-Lat-5" unit="cm" 
-         x="-190"
-	 y="733.26" 
+         x="135.02"
+	 y="744.26" 
 	 z="598.6"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_5-7"/>
        <position name="posArapuca7-Lat-5" unit="cm" 
-         x="-265"
-	 y="734" 
+         x="60.02"
+	 y="745" 
 	 z="598.6"/>
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_5-7"/>
        <position name="posOpArapuca7-Lat-5" unit="cm" 
-         x="-265"
-	 y="733.26" 
+         x="60.02"
+	 y="744.26" 
 	 z="598.6"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_6-0"/>
        <position name="posArapuca0-Lat-6" unit="cm" 
-         x="-40"
-	 y="-734" 
+         x="285.02"
+	 y="-745" 
 	 z="897.9"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_6-0"/>
        <position name="posOpArapuca0-Lat-6" unit="cm" 
-         x="-40"
-	 y="-733.26" 
+         x="285.02"
+	 y="-744.26" 
 	 z="897.9"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_6-1"/>
        <position name="posArapuca1-Lat-6" unit="cm" 
-         x="-115"
-	 y="-734" 
+         x="210.02"
+	 y="-745" 
 	 z="897.9"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_6-1"/>
        <position name="posOpArapuca1-Lat-6" unit="cm" 
-         x="-115"
-	 y="-733.26" 
+         x="210.02"
+	 y="-744.26" 
 	 z="897.9"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_6-2"/>
        <position name="posArapuca2-Lat-6" unit="cm" 
-         x="-190"
-	 y="-734" 
+         x="135.02"
+	 y="-745" 
 	 z="897.9"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_6-2"/>
        <position name="posOpArapuca2-Lat-6" unit="cm" 
-         x="-190"
-	 y="-733.26" 
+         x="135.02"
+	 y="-744.26" 
 	 z="897.9"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_6-3"/>
        <position name="posArapuca3-Lat-6" unit="cm" 
-         x="-265"
-	 y="-734" 
+         x="60.02"
+	 y="-745" 
 	 z="897.9"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_6-3"/>
        <position name="posOpArapuca3-Lat-6" unit="cm" 
-         x="-265"
-	 y="-733.26" 
+         x="60.02"
+	 y="-744.26" 
 	 z="897.9"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_6-4"/>
        <position name="posArapuca4-Lat-6" unit="cm" 
-         x="-40"
-	 y="734" 
+         x="285.02"
+	 y="745" 
 	 z="897.9"/>
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_6-4"/>
        <position name="posOpArapuca4-Lat-6" unit="cm" 
-         x="-40"
-	 y="733.26" 
+         x="285.02"
+	 y="744.26" 
 	 z="897.9"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_6-5"/>
        <position name="posArapuca5-Lat-6" unit="cm" 
-         x="-115"
-	 y="734" 
+         x="210.02"
+	 y="745" 
 	 z="897.9"/>
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_6-5"/>
        <position name="posOpArapuca5-Lat-6" unit="cm" 
-         x="-115"
-	 y="733.26" 
+         x="210.02"
+	 y="744.26" 
 	 z="897.9"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_6-6"/>
        <position name="posArapuca6-Lat-6" unit="cm" 
-         x="-190"
-	 y="734" 
+         x="135.02"
+	 y="745" 
 	 z="897.9"/>
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_6-6"/>
        <position name="posOpArapuca6-Lat-6" unit="cm" 
-         x="-190"
-	 y="733.26" 
+         x="135.02"
+	 y="744.26" 
 	 z="897.9"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_6-7"/>
        <position name="posArapuca7-Lat-6" unit="cm" 
-         x="-265"
-	 y="734" 
+         x="60.02"
+	 y="745" 
 	 z="897.9"/>
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_6-7"/>
        <position name="posOpArapuca7-Lat-6" unit="cm" 
-         x="-265"
-	 y="733.26" 
+         x="60.02"
+	 y="744.26" 
 	 z="897.9"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca0-ShortLat-6" unit="cm" 
+         x="285.02"
+	 y="-220" 
+	 z="-1144.55"/>
+       <rotationref ref="rMinus90AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca1-ShortLat-6" unit="cm" 
+         x="210.02"
+	 y="-220" 
+	 z="-1144.55"/>
+       <rotationref ref="rMinus90AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca2-ShortLat-6" unit="cm" 
+         x="135.02"
+	 y="-220" 
+	 z="-1144.55"/>
+       <rotationref ref="rMinus90AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca3-ShortLat-6" unit="cm" 
+         x="60.02"
+	 y="-220" 
+	 z="-1144.55"/>
+       <rotationref ref="rMinus90AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca4-ShortLat-6" unit="cm" 
+         x="285.02"
+	 y="-220" 
+	 z="1144.55"/>
+       <rotationref ref="rPlus90AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca5-ShortLat-6" unit="cm" 
+         x="210.02"
+	 y="-220" 
+	 z="1144.55"/>
+       <rotationref ref="rPlus90AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca6-ShortLat-6" unit="cm" 
+         x="135.02"
+	 y="-220" 
+	 z="1144.55"/>
+       <rotationref ref="rPlus90AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca7-ShortLat-6" unit="cm" 
+         x="60.02"
+	 y="-220" 
+	 z="1144.55"/>
+       <rotationref ref="rPlus90AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca0-ShortLat-6" unit="cm" 
+         x="285.02"
+	 y="220" 
+	 z="-1144.55"/>
+       <rotationref ref="rMinus90AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca1-ShortLat-6" unit="cm" 
+         x="210.02"
+	 y="220" 
+	 z="-1144.55"/>
+       <rotationref ref="rMinus90AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca2-ShortLat-6" unit="cm" 
+         x="135.02"
+	 y="220" 
+	 z="-1144.55"/>
+       <rotationref ref="rMinus90AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca3-ShortLat-6" unit="cm" 
+         x="60.02"
+	 y="220" 
+	 z="-1144.55"/>
+       <rotationref ref="rMinus90AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca4-ShortLat-6" unit="cm" 
+         x="285.02"
+	 y="220" 
+	 z="1144.55"/>
+       <rotationref ref="rPlus90AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca5-ShortLat-6" unit="cm" 
+         x="210.02"
+	 y="220" 
+	 z="1144.55"/>
+       <rotationref ref="rPlus90AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca6-ShortLat-6" unit="cm" 
+         x="135.02"
+	 y="220" 
+	 z="1144.55"/>
+       <rotationref ref="rPlus90AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca7-ShortLat-6" unit="cm" 
+         x="60.02"
+	 y="220" 
+	 z="1144.55"/>
+       <rotationref ref="rPlus90AboutX"/>
      </physvol>
     </volume>
 
@@ -6208,7 +6370,9 @@
 
     </volume>
 </structure>
+
   <setup name="Default" version="1.0">
     <world ref="volWorld"/>
   </setup>
+
 </gdml_simple_extension>

--- a/dunecore/Geometry/gdml/dunevd10kt_3view_30deg_v5_refactored_1x8x20ref.gdml
+++ b/dunecore/Geometry/gdml/dunevd10kt_3view_30deg_v5_refactored_1x8x20ref.gdml
@@ -394,28 +394,28 @@
 </materials>
 <solids>
      <torus name="FieldShaperCorner" rmin="0.5" rmax="2.285" rtor="2.3" deltaphi="90" startphi="0" aunit="deg" lunit="cm"/>
-     <tube name="FieldShaperLongtube" rmin="0.5" rmax="2.285" z="897.9" deltaphi="360" startphi="0" aunit="deg" lunit="cm"/>
-     <tube name="FieldShaperLongtubeSlim" rmin="0.5" rmax="0.75" z="897.9" deltaphi="360" startphi="0" aunit="deg" lunit="cm"/>
+     <tube name="FieldShaperLongtube" rmin="0.5" rmax="2.285" z="5986" deltaphi="360" startphi="0" aunit="deg" lunit="cm"/>
+     <tube name="FieldShaperLongtubeSlim" rmin="0.5" rmax="0.75" z="5986" deltaphi="360" startphi="0" aunit="deg" lunit="cm"/>
      <tube name="FieldShaperShorttube" rmin="0.5" rmax="2.285" z="1348" deltaphi="360" startphi="0" aunit="deg" lunit="cm"/>
 
     <union name="FSunion1">
       <first ref="FieldShaperLongtube"/>
       <second ref="FieldShaperCorner"/>
-   		<position name="esquinapos1" unit="cm" x="-2.3" y="0" z="448.95"/>
+   		<position name="esquinapos1" unit="cm" x="-2.3" y="0" z="2993"/>
 		<rotationref ref="rPlus90AboutX"/>
     </union>
 
     <union name="FSunion2">
       <first ref="FSunion1"/>
       <second ref="FieldShaperShorttube"/>
-   		<position name="esquinapos2" unit="cm" x="-676.3" y="0" z="451.25"/>
+   		<position name="esquinapos2" unit="cm" x="-676.3" y="0" z="2995.3"/>
    		<rotationref ref="rPlus90AboutY"/>
     </union>
 
     <union name="FSunion3">
       <first ref="FSunion2"/>
       <second ref="FieldShaperCorner"/>
-   		<position name="esquinapos3" unit="cm" x="-1350.3" y="0" z="448.95"/>
+   		<position name="esquinapos3" unit="cm" x="-1350.3" y="0" z="2993"/>
 		<rotationref ref="rPlus90AboutXMinux90AboutY"/>
     </union>
 
@@ -428,42 +428,42 @@
     <union name="FSunion5">
       <first ref="FSunion4"/>
       <second ref="FieldShaperCorner"/>
-   		<position name="esquinapos5" unit="cm" x="-1350.3" y="0" z="-448.95"/>
+   		<position name="esquinapos5" unit="cm" x="-1350.3" y="0" z="-2993"/>
 		<rotationref ref="rPlus90AboutXPlus180AboutY"/>
     </union>
 
     <union name="FSunion6">
       <first ref="FSunion5"/>
       <second ref="FieldShaperShorttube"/>
-   		<position name="esquinapos6" unit="cm" x="-676.3" y="0" z="-451.25"/>
+   		<position name="esquinapos6" unit="cm" x="-676.3" y="0" z="-2995.3"/>
 		<rotationref ref="rPlus90AboutY"/>
     </union>
 
     <union name="FieldShaperSolid">
       <first ref="FSunion6"/>
       <second ref="FieldShaperCorner"/>
-   		<position name="esquinapos7" unit="cm" x="-2.3" y="0" z="-448.95"/>
+   		<position name="esquinapos7" unit="cm" x="-2.3" y="0" z="-2993"/>
 		<rotationref ref="rPlus90AboutXPlus90AboutY"/>
     </union>
     
     <union name="FSunionSlim1">
       <first ref="FieldShaperLongtubeSlim"/>
       <second ref="FieldShaperCorner"/>
-   		<position name="esquinapos8" unit="cm" x="-2.3" y="0" z="448.95"/>
+   		<position name="esquinapos8" unit="cm" x="-2.3" y="0" z="2993"/>
 		<rotationref ref="rPlus90AboutX"/>
     </union>
 
     <union name="FSunionSlim2">
       <first ref="FSunionSlim1"/>
       <second ref="FieldShaperShorttube"/>
-   		<position name="esquinapos9" unit="cm" x="-676.3" y="0" z="451.25"/>
+   		<position name="esquinapos9" unit="cm" x="-676.3" y="0" z="2995.3"/>
    		<rotationref ref="rPlus90AboutY"/>
     </union>
 
     <union name="FSunionSlim3">
       <first ref="FSunionSlim2"/>
       <second ref="FieldShaperCorner"/>
-   		<position name="esquinapos10" unit="cm" x="-1350.3" y="0" z="448.95"/>
+   		<position name="esquinapos10" unit="cm" x="-1350.3" y="0" z="2993"/>
 		<rotationref ref="rPlus90AboutXMinux90AboutY"/>
     </union>
 
@@ -476,21 +476,21 @@
     <union name="FSunionSlim5">
       <first ref="FSunionSlim4"/>
       <second ref="FieldShaperCorner"/>
-   		<position name="esquinapos11" unit="cm" x="-1350.3" y="0" z="-448.95"/>
+   		<position name="esquinapos11" unit="cm" x="-1350.3" y="0" z="-2993"/>
 		<rotationref ref="rPlus90AboutXPlus180AboutY"/>
     </union>
 
     <union name="FSunionSlim6">
       <first ref="FSunionSlim5"/>
       <second ref="FieldShaperShorttube"/>
-   		<position name="esquinapos12" unit="cm" x="-676.3" y="0" z="-451.25"/>
+   		<position name="esquinapos12" unit="cm" x="-676.3" y="0" z="-2995.3"/>
 		<rotationref ref="rPlus90AboutY"/>
     </union>
 
     <union name="FieldShaperSolidSlim">
       <first ref="FSunionSlim6"/>
       <second ref="FieldShaperCorner"/>
-   		<position name="esquinapos13" unit="cm" x="-2.3" y="0" z="-448.95"/>
+   		<position name="esquinapos13" unit="cm" x="-2.3" y="0" z="-2993"/>
 		<rotationref ref="rPlus90AboutXPlus90AboutY"/>
     </union>
     
@@ -12050,27 +12050,27 @@
     <box name="Cryostat" lunit="cm" 
       x="850.3" 
       y="1510.24" 
-      z="1112.14"/>
+      z="6200.24"/>
 
     <box name="ArgonInterior" lunit="cm" 
       x="850.06"
       y="1510"
-      z="1111.9"/>
+      z="6200"/>
 
     <box name="GaseousArgon" lunit="cm" 
       x="100 - 0.01"
       y="1510"
-      z="1111.9"/>
+      z="6200"/>
 
     <box name="ExternalAuxOut" lunit="cm" 
       x="850.06 - 99.9999999999999"
       y="1510 - 2*2.5 - 2*10"
-      z="1111.9"/>
+      z="6200"/>
 
     <box name="ExternalAuxIn" lunit="cm" 
       x="850.06"
       y="1359.17"
-      z="1111.9 + 1"/>
+      z="6200 + 1"/>
 
    <subtraction name="ExternalActive">
       <first ref="ExternalAuxOut"/>
@@ -12184,7 +12184,7 @@
     <box name="FoamPadBlock" lunit="cm"
       x="1010.3"
       y="1670.24"
-      z="1272.14" />
+      z="6360.24" />
 
     <subtraction name="FoamPadding">
       <first ref="FoamPadBlock"/>
@@ -12195,7 +12195,7 @@
     <box name="SteelSupportBlock" lunit="cm"
       x="1210.3"
       y="1870.24"
-      z="1472.14" />
+      z="6560.24" />
 
     <subtraction name="SteelSupport">
       <first ref="SteelSupportBlock"/>
@@ -12206,13 +12206,13 @@
     <box name="DetEnclosure" lunit="cm" 
       x="1310.3"
       y="2070.24"
-      z="1672.14"/>
+      z="6760.24"/>
 
 
     <box name="World" lunit="cm" 
       x="9310.3" 
       y="10070.24" 
-      z="9672.14"/>
+      z="14760.24"/>
 </solids>
 <structure>
 <volume name="volFieldShaper">
@@ -39029,6 +39029,550 @@
       <materialref ref="LAr"/>
       <solidref ref="ArapucaCathodeAcceptanceWindow"/>
     </volume>
+    <volume name="volArapucaDouble_0-3-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-3-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-3-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-3-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-3-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-3-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-3-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-3-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-4-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-4-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-4-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-4-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-4-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-4-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-4-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-4-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-5-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-5-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-5-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-5-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-5-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-5-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-5-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-5-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-6-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-6-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-6-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-6-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-6-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-6-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-6-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-6-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-7-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-7-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-7-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-7-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-7-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-7-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-7-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-7-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-8-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-8-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-8-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-8-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-8-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-8-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-8-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-8-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-9-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-9-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-9-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-9-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-9-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-9-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-9-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-9-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-10-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-10-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-10-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-10-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-10-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-10-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-10-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-10-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-11-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-11-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-11-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-11-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-11-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-11-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-11-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-11-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-12-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-12-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-12-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-12-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-12-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-12-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-12-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-12-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-13-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-13-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-13-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-13-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-13-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-13-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-13-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-13-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-14-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-14-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-14-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-14-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-14-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-14-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-14-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-14-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-15-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-15-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-15-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-15-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-15-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-15-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-15-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-15-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-16-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-16-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-16-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-16-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-16-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-16-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-16-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-16-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-17-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-17-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-17-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-17-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-17-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-17-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-17-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-17-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-18-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-18-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-18-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-18-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-18-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-18-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-18-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-18-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-19-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-19-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-19-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-19-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-19-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-19-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-19-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-19-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
     <volume name="volArapucaDouble_1-0-0">
       <materialref ref="G10" />
       <solidref ref="ArapucaWalls" />
@@ -39122,6 +39666,550 @@
       <solidref ref="ArapucaWalls" />
     </volume>
     <volume name="volOpDetSensitive_ArapucaDouble_1-2-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-3-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-3-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-3-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-3-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-3-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-3-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-3-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-3-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-4-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-4-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-4-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-4-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-4-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-4-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-4-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-4-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-5-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-5-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-5-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-5-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-5-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-5-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-5-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-5-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-6-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-6-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-6-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-6-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-6-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-6-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-6-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-6-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-7-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-7-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-7-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-7-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-7-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-7-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-7-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-7-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-8-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-8-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-8-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-8-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-8-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-8-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-8-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-8-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-9-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-9-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-9-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-9-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-9-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-9-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-9-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-9-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-10-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-10-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-10-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-10-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-10-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-10-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-10-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-10-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-11-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-11-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-11-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-11-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-11-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-11-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-11-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-11-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-12-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-12-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-12-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-12-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-12-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-12-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-12-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-12-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-13-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-13-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-13-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-13-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-13-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-13-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-13-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-13-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-14-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-14-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-14-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-14-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-14-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-14-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-14-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-14-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-15-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-15-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-15-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-15-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-15-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-15-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-15-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-15-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-16-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-16-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-16-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-16-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-16-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-16-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-16-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-16-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-17-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-17-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-17-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-17-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-17-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-17-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-17-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-17-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-18-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-18-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-18-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-18-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-18-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-18-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-18-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-18-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-19-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-19-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-19-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-19-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-19-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-19-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-19-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-19-3">
       <materialref ref="LAr"/>
       <solidref ref="ArapucaCathodeAcceptanceWindow"/>
     </volume>
@@ -39221,6 +40309,550 @@
       <materialref ref="LAr"/>
       <solidref ref="ArapucaCathodeAcceptanceWindow"/>
     </volume>
+    <volume name="volArapucaDouble_2-3-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-3-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-3-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-3-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-3-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-3-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-3-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-3-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-4-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-4-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-4-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-4-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-4-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-4-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-4-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-4-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-5-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-5-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-5-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-5-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-5-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-5-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-5-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-5-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-6-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-6-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-6-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-6-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-6-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-6-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-6-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-6-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-7-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-7-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-7-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-7-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-7-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-7-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-7-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-7-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-8-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-8-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-8-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-8-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-8-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-8-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-8-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-8-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-9-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-9-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-9-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-9-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-9-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-9-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-9-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-9-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-10-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-10-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-10-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-10-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-10-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-10-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-10-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-10-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-11-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-11-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-11-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-11-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-11-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-11-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-11-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-11-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-12-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-12-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-12-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-12-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-12-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-12-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-12-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-12-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-13-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-13-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-13-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-13-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-13-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-13-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-13-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-13-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-14-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-14-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-14-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-14-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-14-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-14-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-14-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-14-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-15-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-15-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-15-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-15-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-15-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-15-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-15-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-15-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-16-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-16-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-16-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-16-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-16-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-16-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-16-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-16-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-17-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-17-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-17-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-17-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-17-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-17-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-17-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-17-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-18-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-18-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-18-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-18-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-18-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-18-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-18-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-18-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-19-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-19-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-19-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-19-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-19-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-19-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-19-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-19-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
     <volume name="volArapucaDouble_3-0-0">
       <materialref ref="G10" />
       <solidref ref="ArapucaWalls" />
@@ -39314,6 +40946,550 @@
       <solidref ref="ArapucaWalls" />
     </volume>
     <volume name="volOpDetSensitive_ArapucaDouble_3-2-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-3-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-3-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-3-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-3-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-3-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-3-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-3-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-3-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-4-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-4-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-4-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-4-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-4-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-4-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-4-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-4-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-5-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-5-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-5-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-5-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-5-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-5-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-5-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-5-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-6-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-6-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-6-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-6-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-6-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-6-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-6-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-6-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-7-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-7-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-7-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-7-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-7-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-7-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-7-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-7-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-8-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-8-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-8-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-8-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-8-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-8-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-8-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-8-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-9-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-9-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-9-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-9-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-9-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-9-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-9-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-9-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-10-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-10-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-10-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-10-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-10-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-10-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-10-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-10-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-11-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-11-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-11-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-11-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-11-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-11-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-11-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-11-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-12-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-12-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-12-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-12-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-12-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-12-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-12-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-12-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-13-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-13-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-13-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-13-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-13-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-13-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-13-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-13-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-14-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-14-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-14-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-14-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-14-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-14-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-14-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-14-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-15-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-15-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-15-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-15-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-15-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-15-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-15-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-15-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-16-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-16-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-16-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-16-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-16-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-16-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-16-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-16-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-17-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-17-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-17-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-17-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-17-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-17-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-17-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-17-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-18-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-18-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-18-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-18-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-18-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-18-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-18-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-18-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-19-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-19-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-19-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-19-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-19-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-19-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-19-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-19-3">
       <materialref ref="LAr"/>
       <solidref ref="ArapucaCathodeAcceptanceWindow"/>
     </volume>
@@ -39509,6 +41685,1094 @@
       <materialref ref="LAr"/>
       <solidref ref="ArapucaAcceptanceWindow"/>
     </volume>
+    <volume name="volArapucaLat_3-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_3-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_3-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_3-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_3-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_3-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_3-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_3-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_3-4">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_3-4">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_3-5">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_3-5">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_3-6">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_3-6">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_3-7">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_3-7">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_4-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_4-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_4-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_4-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_4-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_4-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_4-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_4-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_4-4">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_4-4">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_4-5">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_4-5">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_4-6">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_4-6">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_4-7">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_4-7">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_5-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_5-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_5-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_5-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_5-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_5-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_5-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_5-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_5-4">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_5-4">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_5-5">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_5-5">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_5-6">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_5-6">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_5-7">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_5-7">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_6-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_6-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_6-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_6-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_6-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_6-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_6-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_6-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_6-4">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_6-4">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_6-5">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_6-5">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_6-6">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_6-6">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_6-7">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_6-7">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_7-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_7-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_7-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_7-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_7-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_7-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_7-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_7-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_7-4">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_7-4">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_7-5">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_7-5">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_7-6">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_7-6">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_7-7">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_7-7">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_8-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_8-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_8-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_8-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_8-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_8-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_8-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_8-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_8-4">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_8-4">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_8-5">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_8-5">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_8-6">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_8-6">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_8-7">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_8-7">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_9-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_9-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_9-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_9-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_9-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_9-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_9-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_9-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_9-4">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_9-4">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_9-5">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_9-5">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_9-6">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_9-6">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_9-7">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_9-7">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_10-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_10-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_10-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_10-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_10-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_10-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_10-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_10-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_10-4">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_10-4">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_10-5">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_10-5">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_10-6">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_10-6">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_10-7">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_10-7">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_11-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_11-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_11-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_11-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_11-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_11-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_11-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_11-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_11-4">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_11-4">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_11-5">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_11-5">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_11-6">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_11-6">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_11-7">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_11-7">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_12-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_12-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_12-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_12-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_12-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_12-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_12-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_12-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_12-4">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_12-4">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_12-5">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_12-5">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_12-6">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_12-6">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_12-7">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_12-7">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_13-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_13-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_13-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_13-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_13-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_13-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_13-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_13-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_13-4">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_13-4">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_13-5">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_13-5">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_13-6">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_13-6">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_13-7">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_13-7">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_14-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_14-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_14-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_14-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_14-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_14-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_14-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_14-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_14-4">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_14-4">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_14-5">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_14-5">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_14-6">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_14-6">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_14-7">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_14-7">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_15-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_15-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_15-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_15-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_15-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_15-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_15-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_15-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_15-4">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_15-4">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_15-5">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_15-5">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_15-6">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_15-6">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_15-7">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_15-7">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_16-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_16-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_16-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_16-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_16-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_16-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_16-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_16-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_16-4">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_16-4">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_16-5">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_16-5">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_16-6">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_16-6">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_16-7">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_16-7">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_17-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_17-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_17-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_17-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_17-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_17-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_17-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_17-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_17-4">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_17-4">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_17-5">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_17-5">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_17-6">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_17-6">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_17-7">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_17-7">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_18-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_18-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_18-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_18-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_18-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_18-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_18-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_18-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_18-4">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_18-4">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_18-5">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_18-5">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_18-6">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_18-6">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_18-7">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_18-7">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_19-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_19-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_19-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_19-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_19-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_19-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_19-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_19-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_19-4">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_19-4">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_19-5">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_19-5">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_19-6">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_19-6">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_19-7">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_19-7">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
 
     <volume name="volCryostat">
       <materialref ref="LAr" />
@@ -39528,242 +42792,1602 @@
       <physvol>
         <volumeref ref="volTPC0"/>
 	<position name="posTopTPC-0" unit="cm"
-           x="0" y="-589.75" z="-374.125"/>
+           x="0" y="-589.75" z="-2918.175"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC1"/>
 	<position name="posTopTPC-1" unit="cm"
-           x="0" y="-421.25" z="-374.125"/>
+           x="0" y="-421.25" z="-2918.175"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC0"/>
 	<position name="posTopTPC-2" unit="cm"
-           x="0" y="-252.75" z="-374.125"/>
+           x="0" y="-252.75" z="-2918.175"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC1"/>
 	<position name="posTopTPC-3" unit="cm"
-           x="0" y="-84.25" z="-374.125"/>
+           x="0" y="-84.25" z="-2918.175"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC0"/>
 	<position name="posTopTPC-4" unit="cm"
-           x="0" y="84.25" z="-374.125"/>
+           x="0" y="84.25" z="-2918.175"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC1"/>
 	<position name="posTopTPC-5" unit="cm"
-           x="0" y="252.75" z="-374.125"/>
+           x="0" y="252.75" z="-2918.175"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC0"/>
 	<position name="posTopTPC-6" unit="cm"
-           x="0" y="421.25" z="-374.125"/>
+           x="0" y="421.25" z="-2918.175"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC1"/>
 	<position name="posTopTPC-7" unit="cm"
-           x="0" y="589.75" z="-374.125"/>
+           x="0" y="589.75" z="-2918.175"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC2"/>
 	<position name="posTopTPC-8" unit="cm"
-           x="0" y="-589.75" z="-224.475"/>
+           x="0" y="-589.75" z="-2768.525"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC3"/>
 	<position name="posTopTPC-9" unit="cm"
-           x="0" y="-421.25" z="-224.475"/>
+           x="0" y="-421.25" z="-2768.525"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC2"/>
 	<position name="posTopTPC-10" unit="cm"
-           x="0" y="-252.75" z="-224.475"/>
+           x="0" y="-252.75" z="-2768.525"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC3"/>
 	<position name="posTopTPC-11" unit="cm"
-           x="0" y="-84.25" z="-224.475"/>
+           x="0" y="-84.25" z="-2768.525"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC2"/>
 	<position name="posTopTPC-12" unit="cm"
-           x="0" y="84.25" z="-224.475"/>
+           x="0" y="84.25" z="-2768.525"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC3"/>
 	<position name="posTopTPC-13" unit="cm"
-           x="0" y="252.75" z="-224.475"/>
+           x="0" y="252.75" z="-2768.525"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC2"/>
 	<position name="posTopTPC-14" unit="cm"
-           x="0" y="421.25" z="-224.475"/>
+           x="0" y="421.25" z="-2768.525"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC3"/>
 	<position name="posTopTPC-15" unit="cm"
-           x="0" y="589.75" z="-224.475"/>
+           x="0" y="589.75" z="-2768.525"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC0"/>
 	<position name="posTopTPC-16" unit="cm"
-           x="0" y="-589.75" z="-74.8250000000001"/>
+           x="0" y="-589.75" z="-2618.875"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC1"/>
 	<position name="posTopTPC-17" unit="cm"
-           x="0" y="-421.25" z="-74.8250000000001"/>
+           x="0" y="-421.25" z="-2618.875"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC0"/>
 	<position name="posTopTPC-18" unit="cm"
-           x="0" y="-252.75" z="-74.8250000000001"/>
+           x="0" y="-252.75" z="-2618.875"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC1"/>
 	<position name="posTopTPC-19" unit="cm"
-           x="0" y="-84.25" z="-74.8250000000001"/>
+           x="0" y="-84.25" z="-2618.875"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC0"/>
 	<position name="posTopTPC-20" unit="cm"
-           x="0" y="84.25" z="-74.8250000000001"/>
+           x="0" y="84.25" z="-2618.875"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC1"/>
 	<position name="posTopTPC-21" unit="cm"
-           x="0" y="252.75" z="-74.8250000000001"/>
+           x="0" y="252.75" z="-2618.875"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC0"/>
 	<position name="posTopTPC-22" unit="cm"
-           x="0" y="421.25" z="-74.8250000000001"/>
+           x="0" y="421.25" z="-2618.875"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC1"/>
 	<position name="posTopTPC-23" unit="cm"
-           x="0" y="589.75" z="-74.8250000000001"/>
+           x="0" y="589.75" z="-2618.875"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC2"/>
 	<position name="posTopTPC-24" unit="cm"
-           x="0" y="-589.75" z="74.8249999999999"/>
+           x="0" y="-589.75" z="-2469.225"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC3"/>
 	<position name="posTopTPC-25" unit="cm"
-           x="0" y="-421.25" z="74.8249999999999"/>
+           x="0" y="-421.25" z="-2469.225"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC2"/>
 	<position name="posTopTPC-26" unit="cm"
-           x="0" y="-252.75" z="74.8249999999999"/>
+           x="0" y="-252.75" z="-2469.225"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC3"/>
 	<position name="posTopTPC-27" unit="cm"
-           x="0" y="-84.25" z="74.8249999999999"/>
+           x="0" y="-84.25" z="-2469.225"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC2"/>
 	<position name="posTopTPC-28" unit="cm"
-           x="0" y="84.25" z="74.8249999999999"/>
+           x="0" y="84.25" z="-2469.225"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC3"/>
 	<position name="posTopTPC-29" unit="cm"
-           x="0" y="252.75" z="74.8249999999999"/>
+           x="0" y="252.75" z="-2469.225"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC2"/>
 	<position name="posTopTPC-30" unit="cm"
-           x="0" y="421.25" z="74.8249999999999"/>
+           x="0" y="421.25" z="-2469.225"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC3"/>
 	<position name="posTopTPC-31" unit="cm"
-           x="0" y="589.75" z="74.8249999999999"/>
+           x="0" y="589.75" z="-2469.225"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC0"/>
 	<position name="posTopTPC-32" unit="cm"
-           x="0" y="-589.75" z="224.475"/>
+           x="0" y="-589.75" z="-2319.575"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC1"/>
 	<position name="posTopTPC-33" unit="cm"
-           x="0" y="-421.25" z="224.475"/>
+           x="0" y="-421.25" z="-2319.575"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC0"/>
 	<position name="posTopTPC-34" unit="cm"
-           x="0" y="-252.75" z="224.475"/>
+           x="0" y="-252.75" z="-2319.575"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC1"/>
 	<position name="posTopTPC-35" unit="cm"
-           x="0" y="-84.25" z="224.475"/>
+           x="0" y="-84.25" z="-2319.575"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC0"/>
 	<position name="posTopTPC-36" unit="cm"
-           x="0" y="84.25" z="224.475"/>
+           x="0" y="84.25" z="-2319.575"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC1"/>
 	<position name="posTopTPC-37" unit="cm"
-           x="0" y="252.75" z="224.475"/>
+           x="0" y="252.75" z="-2319.575"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC0"/>
 	<position name="posTopTPC-38" unit="cm"
-           x="0" y="421.25" z="224.475"/>
+           x="0" y="421.25" z="-2319.575"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC1"/>
 	<position name="posTopTPC-39" unit="cm"
-           x="0" y="589.75" z="224.475"/>
+           x="0" y="589.75" z="-2319.575"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC2"/>
 	<position name="posTopTPC-40" unit="cm"
-           x="0" y="-589.75" z="374.125"/>
+           x="0" y="-589.75" z="-2169.925"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC3"/>
 	<position name="posTopTPC-41" unit="cm"
-           x="0" y="-421.25" z="374.125"/>
+           x="0" y="-421.25" z="-2169.925"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC2"/>
 	<position name="posTopTPC-42" unit="cm"
-           x="0" y="-252.75" z="374.125"/>
+           x="0" y="-252.75" z="-2169.925"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC3"/>
 	<position name="posTopTPC-43" unit="cm"
-           x="0" y="-84.25" z="374.125"/>
+           x="0" y="-84.25" z="-2169.925"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC2"/>
 	<position name="posTopTPC-44" unit="cm"
-           x="0" y="84.25" z="374.125"/>
+           x="0" y="84.25" z="-2169.925"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC3"/>
 	<position name="posTopTPC-45" unit="cm"
-           x="0" y="252.75" z="374.125"/>
+           x="0" y="252.75" z="-2169.925"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC2"/>
 	<position name="posTopTPC-46" unit="cm"
-           x="0" y="421.25" z="374.125"/>
+           x="0" y="421.25" z="-2169.925"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC3"/>
 	<position name="posTopTPC-47" unit="cm"
+           x="0" y="589.75" z="-2169.925"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-48" unit="cm"
+           x="0" y="-589.75" z="-2020.275"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-49" unit="cm"
+           x="0" y="-421.25" z="-2020.275"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-50" unit="cm"
+           x="0" y="-252.75" z="-2020.275"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-51" unit="cm"
+           x="0" y="-84.25" z="-2020.275"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-52" unit="cm"
+           x="0" y="84.25" z="-2020.275"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-53" unit="cm"
+           x="0" y="252.75" z="-2020.275"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-54" unit="cm"
+           x="0" y="421.25" z="-2020.275"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-55" unit="cm"
+           x="0" y="589.75" z="-2020.275"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-56" unit="cm"
+           x="0" y="-589.75" z="-1870.625"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-57" unit="cm"
+           x="0" y="-421.25" z="-1870.625"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-58" unit="cm"
+           x="0" y="-252.75" z="-1870.625"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-59" unit="cm"
+           x="0" y="-84.25" z="-1870.625"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-60" unit="cm"
+           x="0" y="84.25" z="-1870.625"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-61" unit="cm"
+           x="0" y="252.75" z="-1870.625"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-62" unit="cm"
+           x="0" y="421.25" z="-1870.625"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-63" unit="cm"
+           x="0" y="589.75" z="-1870.625"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-64" unit="cm"
+           x="0" y="-589.75" z="-1720.975"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-65" unit="cm"
+           x="0" y="-421.25" z="-1720.975"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-66" unit="cm"
+           x="0" y="-252.75" z="-1720.975"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-67" unit="cm"
+           x="0" y="-84.25" z="-1720.975"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-68" unit="cm"
+           x="0" y="84.25" z="-1720.975"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-69" unit="cm"
+           x="0" y="252.75" z="-1720.975"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-70" unit="cm"
+           x="0" y="421.25" z="-1720.975"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-71" unit="cm"
+           x="0" y="589.75" z="-1720.975"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-72" unit="cm"
+           x="0" y="-589.75" z="-1571.325"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-73" unit="cm"
+           x="0" y="-421.25" z="-1571.325"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-74" unit="cm"
+           x="0" y="-252.75" z="-1571.325"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-75" unit="cm"
+           x="0" y="-84.25" z="-1571.325"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-76" unit="cm"
+           x="0" y="84.25" z="-1571.325"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-77" unit="cm"
+           x="0" y="252.75" z="-1571.325"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-78" unit="cm"
+           x="0" y="421.25" z="-1571.325"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-79" unit="cm"
+           x="0" y="589.75" z="-1571.325"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-80" unit="cm"
+           x="0" y="-589.75" z="-1421.675"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-81" unit="cm"
+           x="0" y="-421.25" z="-1421.675"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-82" unit="cm"
+           x="0" y="-252.75" z="-1421.675"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-83" unit="cm"
+           x="0" y="-84.25" z="-1421.675"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-84" unit="cm"
+           x="0" y="84.25" z="-1421.675"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-85" unit="cm"
+           x="0" y="252.75" z="-1421.675"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-86" unit="cm"
+           x="0" y="421.25" z="-1421.675"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-87" unit="cm"
+           x="0" y="589.75" z="-1421.675"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-88" unit="cm"
+           x="0" y="-589.75" z="-1272.025"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-89" unit="cm"
+           x="0" y="-421.25" z="-1272.025"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-90" unit="cm"
+           x="0" y="-252.75" z="-1272.025"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-91" unit="cm"
+           x="0" y="-84.25" z="-1272.025"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-92" unit="cm"
+           x="0" y="84.25" z="-1272.025"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-93" unit="cm"
+           x="0" y="252.75" z="-1272.025"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-94" unit="cm"
+           x="0" y="421.25" z="-1272.025"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-95" unit="cm"
+           x="0" y="589.75" z="-1272.025"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-96" unit="cm"
+           x="0" y="-589.75" z="-1122.375"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-97" unit="cm"
+           x="0" y="-421.25" z="-1122.375"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-98" unit="cm"
+           x="0" y="-252.75" z="-1122.375"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-99" unit="cm"
+           x="0" y="-84.25" z="-1122.375"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-100" unit="cm"
+           x="0" y="84.25" z="-1122.375"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-101" unit="cm"
+           x="0" y="252.75" z="-1122.375"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-102" unit="cm"
+           x="0" y="421.25" z="-1122.375"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-103" unit="cm"
+           x="0" y="589.75" z="-1122.375"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-104" unit="cm"
+           x="0" y="-589.75" z="-972.725"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-105" unit="cm"
+           x="0" y="-421.25" z="-972.725"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-106" unit="cm"
+           x="0" y="-252.75" z="-972.725"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-107" unit="cm"
+           x="0" y="-84.25" z="-972.725"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-108" unit="cm"
+           x="0" y="84.25" z="-972.725"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-109" unit="cm"
+           x="0" y="252.75" z="-972.725"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-110" unit="cm"
+           x="0" y="421.25" z="-972.725"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-111" unit="cm"
+           x="0" y="589.75" z="-972.725"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-112" unit="cm"
+           x="0" y="-589.75" z="-823.075"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-113" unit="cm"
+           x="0" y="-421.25" z="-823.075"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-114" unit="cm"
+           x="0" y="-252.75" z="-823.075"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-115" unit="cm"
+           x="0" y="-84.25" z="-823.075"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-116" unit="cm"
+           x="0" y="84.25" z="-823.075"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-117" unit="cm"
+           x="0" y="252.75" z="-823.075"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-118" unit="cm"
+           x="0" y="421.25" z="-823.075"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-119" unit="cm"
+           x="0" y="589.75" z="-823.075"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-120" unit="cm"
+           x="0" y="-589.75" z="-673.425"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-121" unit="cm"
+           x="0" y="-421.25" z="-673.425"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-122" unit="cm"
+           x="0" y="-252.75" z="-673.425"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-123" unit="cm"
+           x="0" y="-84.25" z="-673.425"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-124" unit="cm"
+           x="0" y="84.25" z="-673.425"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-125" unit="cm"
+           x="0" y="252.75" z="-673.425"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-126" unit="cm"
+           x="0" y="421.25" z="-673.425"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-127" unit="cm"
+           x="0" y="589.75" z="-673.425"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-128" unit="cm"
+           x="0" y="-589.75" z="-523.775"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-129" unit="cm"
+           x="0" y="-421.25" z="-523.775"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-130" unit="cm"
+           x="0" y="-252.75" z="-523.775"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-131" unit="cm"
+           x="0" y="-84.25" z="-523.775"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-132" unit="cm"
+           x="0" y="84.25" z="-523.775"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-133" unit="cm"
+           x="0" y="252.75" z="-523.775"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-134" unit="cm"
+           x="0" y="421.25" z="-523.775"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-135" unit="cm"
+           x="0" y="589.75" z="-523.775"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-136" unit="cm"
+           x="0" y="-589.75" z="-374.125"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-137" unit="cm"
+           x="0" y="-421.25" z="-374.125"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-138" unit="cm"
+           x="0" y="-252.75" z="-374.125"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-139" unit="cm"
+           x="0" y="-84.25" z="-374.125"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-140" unit="cm"
+           x="0" y="84.25" z="-374.125"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-141" unit="cm"
+           x="0" y="252.75" z="-374.125"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-142" unit="cm"
+           x="0" y="421.25" z="-374.125"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-143" unit="cm"
+           x="0" y="589.75" z="-374.125"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-144" unit="cm"
+           x="0" y="-589.75" z="-224.475"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-145" unit="cm"
+           x="0" y="-421.25" z="-224.475"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-146" unit="cm"
+           x="0" y="-252.75" z="-224.475"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-147" unit="cm"
+           x="0" y="-84.25" z="-224.475"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-148" unit="cm"
+           x="0" y="84.25" z="-224.475"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-149" unit="cm"
+           x="0" y="252.75" z="-224.475"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-150" unit="cm"
+           x="0" y="421.25" z="-224.475"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-151" unit="cm"
+           x="0" y="589.75" z="-224.475"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-152" unit="cm"
+           x="0" y="-589.75" z="-74.8249999999997"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-153" unit="cm"
+           x="0" y="-421.25" z="-74.8249999999997"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-154" unit="cm"
+           x="0" y="-252.75" z="-74.8249999999997"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-155" unit="cm"
+           x="0" y="-84.25" z="-74.8249999999997"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-156" unit="cm"
+           x="0" y="84.25" z="-74.8249999999997"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-157" unit="cm"
+           x="0" y="252.75" z="-74.8249999999997"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-158" unit="cm"
+           x="0" y="421.25" z="-74.8249999999997"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-159" unit="cm"
+           x="0" y="589.75" z="-74.8249999999997"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-160" unit="cm"
+           x="0" y="-589.75" z="74.8250000000003"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-161" unit="cm"
+           x="0" y="-421.25" z="74.8250000000003"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-162" unit="cm"
+           x="0" y="-252.75" z="74.8250000000003"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-163" unit="cm"
+           x="0" y="-84.25" z="74.8250000000003"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-164" unit="cm"
+           x="0" y="84.25" z="74.8250000000003"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-165" unit="cm"
+           x="0" y="252.75" z="74.8250000000003"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-166" unit="cm"
+           x="0" y="421.25" z="74.8250000000003"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-167" unit="cm"
+           x="0" y="589.75" z="74.8250000000003"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-168" unit="cm"
+           x="0" y="-589.75" z="224.475"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-169" unit="cm"
+           x="0" y="-421.25" z="224.475"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-170" unit="cm"
+           x="0" y="-252.75" z="224.475"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-171" unit="cm"
+           x="0" y="-84.25" z="224.475"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-172" unit="cm"
+           x="0" y="84.25" z="224.475"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-173" unit="cm"
+           x="0" y="252.75" z="224.475"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-174" unit="cm"
+           x="0" y="421.25" z="224.475"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-175" unit="cm"
+           x="0" y="589.75" z="224.475"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-176" unit="cm"
+           x="0" y="-589.75" z="374.125"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-177" unit="cm"
+           x="0" y="-421.25" z="374.125"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-178" unit="cm"
+           x="0" y="-252.75" z="374.125"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-179" unit="cm"
+           x="0" y="-84.25" z="374.125"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-180" unit="cm"
+           x="0" y="84.25" z="374.125"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-181" unit="cm"
+           x="0" y="252.75" z="374.125"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-182" unit="cm"
+           x="0" y="421.25" z="374.125"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-183" unit="cm"
            x="0" y="589.75" z="374.125"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-184" unit="cm"
+           x="0" y="-589.75" z="523.775"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-185" unit="cm"
+           x="0" y="-421.25" z="523.775"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-186" unit="cm"
+           x="0" y="-252.75" z="523.775"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-187" unit="cm"
+           x="0" y="-84.25" z="523.775"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-188" unit="cm"
+           x="0" y="84.25" z="523.775"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-189" unit="cm"
+           x="0" y="252.75" z="523.775"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-190" unit="cm"
+           x="0" y="421.25" z="523.775"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-191" unit="cm"
+           x="0" y="589.75" z="523.775"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-192" unit="cm"
+           x="0" y="-589.75" z="673.425"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-193" unit="cm"
+           x="0" y="-421.25" z="673.425"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-194" unit="cm"
+           x="0" y="-252.75" z="673.425"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-195" unit="cm"
+           x="0" y="-84.25" z="673.425"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-196" unit="cm"
+           x="0" y="84.25" z="673.425"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-197" unit="cm"
+           x="0" y="252.75" z="673.425"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-198" unit="cm"
+           x="0" y="421.25" z="673.425"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-199" unit="cm"
+           x="0" y="589.75" z="673.425"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-200" unit="cm"
+           x="0" y="-589.75" z="823.075"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-201" unit="cm"
+           x="0" y="-421.25" z="823.075"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-202" unit="cm"
+           x="0" y="-252.75" z="823.075"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-203" unit="cm"
+           x="0" y="-84.25" z="823.075"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-204" unit="cm"
+           x="0" y="84.25" z="823.075"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-205" unit="cm"
+           x="0" y="252.75" z="823.075"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-206" unit="cm"
+           x="0" y="421.25" z="823.075"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-207" unit="cm"
+           x="0" y="589.75" z="823.075"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-208" unit="cm"
+           x="0" y="-589.75" z="972.725"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-209" unit="cm"
+           x="0" y="-421.25" z="972.725"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-210" unit="cm"
+           x="0" y="-252.75" z="972.725"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-211" unit="cm"
+           x="0" y="-84.25" z="972.725"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-212" unit="cm"
+           x="0" y="84.25" z="972.725"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-213" unit="cm"
+           x="0" y="252.75" z="972.725"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-214" unit="cm"
+           x="0" y="421.25" z="972.725"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-215" unit="cm"
+           x="0" y="589.75" z="972.725"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-216" unit="cm"
+           x="0" y="-589.75" z="1122.375"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-217" unit="cm"
+           x="0" y="-421.25" z="1122.375"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-218" unit="cm"
+           x="0" y="-252.75" z="1122.375"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-219" unit="cm"
+           x="0" y="-84.25" z="1122.375"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-220" unit="cm"
+           x="0" y="84.25" z="1122.375"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-221" unit="cm"
+           x="0" y="252.75" z="1122.375"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-222" unit="cm"
+           x="0" y="421.25" z="1122.375"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-223" unit="cm"
+           x="0" y="589.75" z="1122.375"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-224" unit="cm"
+           x="0" y="-589.75" z="1272.025"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-225" unit="cm"
+           x="0" y="-421.25" z="1272.025"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-226" unit="cm"
+           x="0" y="-252.75" z="1272.025"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-227" unit="cm"
+           x="0" y="-84.25" z="1272.025"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-228" unit="cm"
+           x="0" y="84.25" z="1272.025"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-229" unit="cm"
+           x="0" y="252.75" z="1272.025"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-230" unit="cm"
+           x="0" y="421.25" z="1272.025"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-231" unit="cm"
+           x="0" y="589.75" z="1272.025"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-232" unit="cm"
+           x="0" y="-589.75" z="1421.675"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-233" unit="cm"
+           x="0" y="-421.25" z="1421.675"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-234" unit="cm"
+           x="0" y="-252.75" z="1421.675"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-235" unit="cm"
+           x="0" y="-84.25" z="1421.675"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-236" unit="cm"
+           x="0" y="84.25" z="1421.675"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-237" unit="cm"
+           x="0" y="252.75" z="1421.675"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-238" unit="cm"
+           x="0" y="421.25" z="1421.675"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-239" unit="cm"
+           x="0" y="589.75" z="1421.675"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-240" unit="cm"
+           x="0" y="-589.75" z="1571.325"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-241" unit="cm"
+           x="0" y="-421.25" z="1571.325"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-242" unit="cm"
+           x="0" y="-252.75" z="1571.325"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-243" unit="cm"
+           x="0" y="-84.25" z="1571.325"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-244" unit="cm"
+           x="0" y="84.25" z="1571.325"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-245" unit="cm"
+           x="0" y="252.75" z="1571.325"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-246" unit="cm"
+           x="0" y="421.25" z="1571.325"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-247" unit="cm"
+           x="0" y="589.75" z="1571.325"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-248" unit="cm"
+           x="0" y="-589.75" z="1720.975"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-249" unit="cm"
+           x="0" y="-421.25" z="1720.975"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-250" unit="cm"
+           x="0" y="-252.75" z="1720.975"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-251" unit="cm"
+           x="0" y="-84.25" z="1720.975"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-252" unit="cm"
+           x="0" y="84.25" z="1720.975"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-253" unit="cm"
+           x="0" y="252.75" z="1720.975"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-254" unit="cm"
+           x="0" y="421.25" z="1720.975"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-255" unit="cm"
+           x="0" y="589.75" z="1720.975"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-256" unit="cm"
+           x="0" y="-589.75" z="1870.625"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-257" unit="cm"
+           x="0" y="-421.25" z="1870.625"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-258" unit="cm"
+           x="0" y="-252.75" z="1870.625"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-259" unit="cm"
+           x="0" y="-84.25" z="1870.625"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-260" unit="cm"
+           x="0" y="84.25" z="1870.625"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-261" unit="cm"
+           x="0" y="252.75" z="1870.625"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-262" unit="cm"
+           x="0" y="421.25" z="1870.625"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-263" unit="cm"
+           x="0" y="589.75" z="1870.625"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-264" unit="cm"
+           x="0" y="-589.75" z="2020.275"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-265" unit="cm"
+           x="0" y="-421.25" z="2020.275"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-266" unit="cm"
+           x="0" y="-252.75" z="2020.275"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-267" unit="cm"
+           x="0" y="-84.25" z="2020.275"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-268" unit="cm"
+           x="0" y="84.25" z="2020.275"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-269" unit="cm"
+           x="0" y="252.75" z="2020.275"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-270" unit="cm"
+           x="0" y="421.25" z="2020.275"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-271" unit="cm"
+           x="0" y="589.75" z="2020.275"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-272" unit="cm"
+           x="0" y="-589.75" z="2169.925"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-273" unit="cm"
+           x="0" y="-421.25" z="2169.925"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-274" unit="cm"
+           x="0" y="-252.75" z="2169.925"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-275" unit="cm"
+           x="0" y="-84.25" z="2169.925"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-276" unit="cm"
+           x="0" y="84.25" z="2169.925"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-277" unit="cm"
+           x="0" y="252.75" z="2169.925"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-278" unit="cm"
+           x="0" y="421.25" z="2169.925"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-279" unit="cm"
+           x="0" y="589.75" z="2169.925"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-280" unit="cm"
+           x="0" y="-589.75" z="2319.575"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-281" unit="cm"
+           x="0" y="-421.25" z="2319.575"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-282" unit="cm"
+           x="0" y="-252.75" z="2319.575"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-283" unit="cm"
+           x="0" y="-84.25" z="2319.575"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-284" unit="cm"
+           x="0" y="84.25" z="2319.575"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-285" unit="cm"
+           x="0" y="252.75" z="2319.575"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-286" unit="cm"
+           x="0" y="421.25" z="2319.575"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-287" unit="cm"
+           x="0" y="589.75" z="2319.575"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-288" unit="cm"
+           x="0" y="-589.75" z="2469.225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-289" unit="cm"
+           x="0" y="-421.25" z="2469.225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-290" unit="cm"
+           x="0" y="-252.75" z="2469.225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-291" unit="cm"
+           x="0" y="-84.25" z="2469.225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-292" unit="cm"
+           x="0" y="84.25" z="2469.225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-293" unit="cm"
+           x="0" y="252.75" z="2469.225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-294" unit="cm"
+           x="0" y="421.25" z="2469.225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-295" unit="cm"
+           x="0" y="589.75" z="2469.225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-296" unit="cm"
+           x="0" y="-589.75" z="2618.875"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-297" unit="cm"
+           x="0" y="-421.25" z="2618.875"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-298" unit="cm"
+           x="0" y="-252.75" z="2618.875"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-299" unit="cm"
+           x="0" y="-84.25" z="2618.875"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-300" unit="cm"
+           x="0" y="84.25" z="2618.875"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-301" unit="cm"
+           x="0" y="252.75" z="2618.875"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-302" unit="cm"
+           x="0" y="421.25" z="2618.875"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-303" unit="cm"
+           x="0" y="589.75" z="2618.875"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-304" unit="cm"
+           x="0" y="-589.75" z="2768.525"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-305" unit="cm"
+           x="0" y="-421.25" z="2768.525"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-306" unit="cm"
+           x="0" y="-252.75" z="2768.525"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-307" unit="cm"
+           x="0" y="-84.25" z="2768.525"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-308" unit="cm"
+           x="0" y="84.25" z="2768.525"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-309" unit="cm"
+           x="0" y="252.75" z="2768.525"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-310" unit="cm"
+           x="0" y="421.25" z="2768.525"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-311" unit="cm"
+           x="0" y="589.75" z="2768.525"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-312" unit="cm"
+           x="0" y="-589.75" z="2918.175"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-313" unit="cm"
+           x="0" y="-421.25" z="2918.175"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-314" unit="cm"
+           x="0" y="-252.75" z="2918.175"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-315" unit="cm"
+           x="0" y="-84.25" z="2918.175"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-316" unit="cm"
+           x="0" y="84.25" z="2918.175"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-317" unit="cm"
+           x="0" y="252.75" z="2918.175"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-318" unit="cm"
+           x="0" y="421.25" z="2918.175"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-319" unit="cm"
+           x="0" y="589.75" z="2918.175"/>
       </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
@@ -40307,110 +44931,722 @@
   </physvol>
       <physvol>
    <volumeref ref="volCathodeGrid"/>
-   <position name="posCathodeGrid-0" unit="cm" x="-328.03" y="-505.5" z="-299.3"/>
+   <position name="posCathodeGrid-0" unit="cm" x="-328.03" y="-505.5" z="-2843.35"/>
       </physvol>
       <physvol>
        <volumeref ref="volAnodePlate"/>
-       <position name="posAnodePlate-0" unit="cm" x="325.035" y="-505.5" z="-299.3"/>
+       <position name="posAnodePlate-0" unit="cm" x="325.035" y="-505.5" z="-2843.35"/>
        <rotationref ref="rIdentity"/>
      </physvol>    
       <physvol>
    <volumeref ref="volCathodeGrid"/>
-   <position name="posCathodeGrid-1" unit="cm" x="-328.03" y="-168.5" z="-299.3"/>
+   <position name="posCathodeGrid-1" unit="cm" x="-328.03" y="-168.5" z="-2843.35"/>
       </physvol>
       <physvol>
        <volumeref ref="volAnodePlate"/>
-       <position name="posAnodePlate-1" unit="cm" x="325.035" y="-168.5" z="-299.3"/>
+       <position name="posAnodePlate-1" unit="cm" x="325.035" y="-168.5" z="-2843.35"/>
        <rotationref ref="rIdentity"/>
      </physvol>    
       <physvol>
    <volumeref ref="volCathodeGrid"/>
-   <position name="posCathodeGrid-2" unit="cm" x="-328.03" y="168.5" z="-299.3"/>
+   <position name="posCathodeGrid-2" unit="cm" x="-328.03" y="168.5" z="-2843.35"/>
       </physvol>
       <physvol>
        <volumeref ref="volAnodePlate"/>
-       <position name="posAnodePlate-2" unit="cm" x="325.035" y="168.5" z="-299.3"/>
+       <position name="posAnodePlate-2" unit="cm" x="325.035" y="168.5" z="-2843.35"/>
        <rotationref ref="rIdentity"/>
      </physvol>    
       <physvol>
    <volumeref ref="volCathodeGrid"/>
-   <position name="posCathodeGrid-3" unit="cm" x="-328.03" y="505.5" z="-299.3"/>
+   <position name="posCathodeGrid-3" unit="cm" x="-328.03" y="505.5" z="-2843.35"/>
       </physvol>
       <physvol>
        <volumeref ref="volAnodePlate"/>
-       <position name="posAnodePlate-3" unit="cm" x="325.035" y="505.5" z="-299.3"/>
+       <position name="posAnodePlate-3" unit="cm" x="325.035" y="505.5" z="-2843.35"/>
        <rotationref ref="rIdentity"/>
      </physvol>    
       <physvol>
    <volumeref ref="volCathodeGrid"/>
-   <position name="posCathodeGrid-4" unit="cm" x="-328.03" y="-505.5" z="-5.6843418860808e-14"/>
+   <position name="posCathodeGrid-4" unit="cm" x="-328.03" y="-505.5" z="-2544.05"/>
       </physvol>
       <physvol>
        <volumeref ref="volAnodePlate"/>
-       <position name="posAnodePlate-4" unit="cm" x="325.035" y="-505.5" z="-5.6843418860808e-14"/>
+       <position name="posAnodePlate-4" unit="cm" x="325.035" y="-505.5" z="-2544.05"/>
        <rotationref ref="rIdentity"/>
      </physvol>    
       <physvol>
    <volumeref ref="volCathodeGrid"/>
-   <position name="posCathodeGrid-5" unit="cm" x="-328.03" y="-168.5" z="-5.6843418860808e-14"/>
+   <position name="posCathodeGrid-5" unit="cm" x="-328.03" y="-168.5" z="-2544.05"/>
       </physvol>
       <physvol>
        <volumeref ref="volAnodePlate"/>
-       <position name="posAnodePlate-5" unit="cm" x="325.035" y="-168.5" z="-5.6843418860808e-14"/>
+       <position name="posAnodePlate-5" unit="cm" x="325.035" y="-168.5" z="-2544.05"/>
        <rotationref ref="rIdentity"/>
      </physvol>    
       <physvol>
    <volumeref ref="volCathodeGrid"/>
-   <position name="posCathodeGrid-6" unit="cm" x="-328.03" y="168.5" z="-5.6843418860808e-14"/>
+   <position name="posCathodeGrid-6" unit="cm" x="-328.03" y="168.5" z="-2544.05"/>
       </physvol>
       <physvol>
        <volumeref ref="volAnodePlate"/>
-       <position name="posAnodePlate-6" unit="cm" x="325.035" y="168.5" z="-5.6843418860808e-14"/>
+       <position name="posAnodePlate-6" unit="cm" x="325.035" y="168.5" z="-2544.05"/>
        <rotationref ref="rIdentity"/>
      </physvol>    
       <physvol>
    <volumeref ref="volCathodeGrid"/>
-   <position name="posCathodeGrid-7" unit="cm" x="-328.03" y="505.5" z="-5.6843418860808e-14"/>
+   <position name="posCathodeGrid-7" unit="cm" x="-328.03" y="505.5" z="-2544.05"/>
       </physvol>
       <physvol>
        <volumeref ref="volAnodePlate"/>
-       <position name="posAnodePlate-7" unit="cm" x="325.035" y="505.5" z="-5.6843418860808e-14"/>
+       <position name="posAnodePlate-7" unit="cm" x="325.035" y="505.5" z="-2544.05"/>
        <rotationref ref="rIdentity"/>
      </physvol>    
       <physvol>
    <volumeref ref="volCathodeGrid"/>
-   <position name="posCathodeGrid-8" unit="cm" x="-328.03" y="-505.5" z="299.3"/>
+   <position name="posCathodeGrid-8" unit="cm" x="-328.03" y="-505.5" z="-2244.75"/>
       </physvol>
       <physvol>
        <volumeref ref="volAnodePlate"/>
-       <position name="posAnodePlate-8" unit="cm" x="325.035" y="-505.5" z="299.3"/>
+       <position name="posAnodePlate-8" unit="cm" x="325.035" y="-505.5" z="-2244.75"/>
        <rotationref ref="rIdentity"/>
      </physvol>    
       <physvol>
    <volumeref ref="volCathodeGrid"/>
-   <position name="posCathodeGrid-9" unit="cm" x="-328.03" y="-168.5" z="299.3"/>
+   <position name="posCathodeGrid-9" unit="cm" x="-328.03" y="-168.5" z="-2244.75"/>
       </physvol>
       <physvol>
        <volumeref ref="volAnodePlate"/>
-       <position name="posAnodePlate-9" unit="cm" x="325.035" y="-168.5" z="299.3"/>
+       <position name="posAnodePlate-9" unit="cm" x="325.035" y="-168.5" z="-2244.75"/>
        <rotationref ref="rIdentity"/>
      </physvol>    
       <physvol>
    <volumeref ref="volCathodeGrid"/>
-   <position name="posCathodeGrid-10" unit="cm" x="-328.03" y="168.5" z="299.3"/>
+   <position name="posCathodeGrid-10" unit="cm" x="-328.03" y="168.5" z="-2244.75"/>
       </physvol>
       <physvol>
        <volumeref ref="volAnodePlate"/>
-       <position name="posAnodePlate-10" unit="cm" x="325.035" y="168.5" z="299.3"/>
+       <position name="posAnodePlate-10" unit="cm" x="325.035" y="168.5" z="-2244.75"/>
        <rotationref ref="rIdentity"/>
      </physvol>    
       <physvol>
    <volumeref ref="volCathodeGrid"/>
-   <position name="posCathodeGrid-11" unit="cm" x="-328.03" y="505.5" z="299.3"/>
+   <position name="posCathodeGrid-11" unit="cm" x="-328.03" y="505.5" z="-2244.75"/>
       </physvol>
       <physvol>
        <volumeref ref="volAnodePlate"/>
-       <position name="posAnodePlate-11" unit="cm" x="325.035" y="505.5" z="299.3"/>
+       <position name="posAnodePlate-11" unit="cm" x="325.035" y="505.5" z="-2244.75"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-12" unit="cm" x="-328.03" y="-505.5" z="-1945.45"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-12" unit="cm" x="325.035" y="-505.5" z="-1945.45"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-13" unit="cm" x="-328.03" y="-168.5" z="-1945.45"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-13" unit="cm" x="325.035" y="-168.5" z="-1945.45"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-14" unit="cm" x="-328.03" y="168.5" z="-1945.45"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-14" unit="cm" x="325.035" y="168.5" z="-1945.45"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-15" unit="cm" x="-328.03" y="505.5" z="-1945.45"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-15" unit="cm" x="325.035" y="505.5" z="-1945.45"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-16" unit="cm" x="-328.03" y="-505.5" z="-1646.15"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-16" unit="cm" x="325.035" y="-505.5" z="-1646.15"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-17" unit="cm" x="-328.03" y="-168.5" z="-1646.15"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-17" unit="cm" x="325.035" y="-168.5" z="-1646.15"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-18" unit="cm" x="-328.03" y="168.5" z="-1646.15"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-18" unit="cm" x="325.035" y="168.5" z="-1646.15"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-19" unit="cm" x="-328.03" y="505.5" z="-1646.15"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-19" unit="cm" x="325.035" y="505.5" z="-1646.15"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-20" unit="cm" x="-328.03" y="-505.5" z="-1346.85"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-20" unit="cm" x="325.035" y="-505.5" z="-1346.85"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-21" unit="cm" x="-328.03" y="-168.5" z="-1346.85"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-21" unit="cm" x="325.035" y="-168.5" z="-1346.85"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-22" unit="cm" x="-328.03" y="168.5" z="-1346.85"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-22" unit="cm" x="325.035" y="168.5" z="-1346.85"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-23" unit="cm" x="-328.03" y="505.5" z="-1346.85"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-23" unit="cm" x="325.035" y="505.5" z="-1346.85"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-24" unit="cm" x="-328.03" y="-505.5" z="-1047.55"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-24" unit="cm" x="325.035" y="-505.5" z="-1047.55"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-25" unit="cm" x="-328.03" y="-168.5" z="-1047.55"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-25" unit="cm" x="325.035" y="-168.5" z="-1047.55"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-26" unit="cm" x="-328.03" y="168.5" z="-1047.55"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-26" unit="cm" x="325.035" y="168.5" z="-1047.55"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-27" unit="cm" x="-328.03" y="505.5" z="-1047.55"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-27" unit="cm" x="325.035" y="505.5" z="-1047.55"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-28" unit="cm" x="-328.03" y="-505.5" z="-748.25"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-28" unit="cm" x="325.035" y="-505.5" z="-748.25"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-29" unit="cm" x="-328.03" y="-168.5" z="-748.25"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-29" unit="cm" x="325.035" y="-168.5" z="-748.25"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-30" unit="cm" x="-328.03" y="168.5" z="-748.25"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-30" unit="cm" x="325.035" y="168.5" z="-748.25"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-31" unit="cm" x="-328.03" y="505.5" z="-748.25"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-31" unit="cm" x="325.035" y="505.5" z="-748.25"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-32" unit="cm" x="-328.03" y="-505.5" z="-448.95"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-32" unit="cm" x="325.035" y="-505.5" z="-448.95"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-33" unit="cm" x="-328.03" y="-168.5" z="-448.95"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-33" unit="cm" x="325.035" y="-168.5" z="-448.95"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-34" unit="cm" x="-328.03" y="168.5" z="-448.95"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-34" unit="cm" x="325.035" y="168.5" z="-448.95"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-35" unit="cm" x="-328.03" y="505.5" z="-448.95"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-35" unit="cm" x="325.035" y="505.5" z="-448.95"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-36" unit="cm" x="-328.03" y="-505.5" z="-149.65"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-36" unit="cm" x="325.035" y="-505.5" z="-149.65"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-37" unit="cm" x="-328.03" y="-168.5" z="-149.65"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-37" unit="cm" x="325.035" y="-168.5" z="-149.65"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-38" unit="cm" x="-328.03" y="168.5" z="-149.65"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-38" unit="cm" x="325.035" y="168.5" z="-149.65"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-39" unit="cm" x="-328.03" y="505.5" z="-149.65"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-39" unit="cm" x="325.035" y="505.5" z="-149.65"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-40" unit="cm" x="-328.03" y="-505.5" z="149.65"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-40" unit="cm" x="325.035" y="-505.5" z="149.65"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-41" unit="cm" x="-328.03" y="-168.5" z="149.65"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-41" unit="cm" x="325.035" y="-168.5" z="149.65"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-42" unit="cm" x="-328.03" y="168.5" z="149.65"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-42" unit="cm" x="325.035" y="168.5" z="149.65"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-43" unit="cm" x="-328.03" y="505.5" z="149.65"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-43" unit="cm" x="325.035" y="505.5" z="149.65"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-44" unit="cm" x="-328.03" y="-505.5" z="448.95"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-44" unit="cm" x="325.035" y="-505.5" z="448.95"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-45" unit="cm" x="-328.03" y="-168.5" z="448.95"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-45" unit="cm" x="325.035" y="-168.5" z="448.95"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-46" unit="cm" x="-328.03" y="168.5" z="448.95"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-46" unit="cm" x="325.035" y="168.5" z="448.95"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-47" unit="cm" x="-328.03" y="505.5" z="448.95"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-47" unit="cm" x="325.035" y="505.5" z="448.95"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-48" unit="cm" x="-328.03" y="-505.5" z="748.25"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-48" unit="cm" x="325.035" y="-505.5" z="748.25"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-49" unit="cm" x="-328.03" y="-168.5" z="748.25"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-49" unit="cm" x="325.035" y="-168.5" z="748.25"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-50" unit="cm" x="-328.03" y="168.5" z="748.25"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-50" unit="cm" x="325.035" y="168.5" z="748.25"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-51" unit="cm" x="-328.03" y="505.5" z="748.25"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-51" unit="cm" x="325.035" y="505.5" z="748.25"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-52" unit="cm" x="-328.03" y="-505.5" z="1047.55"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-52" unit="cm" x="325.035" y="-505.5" z="1047.55"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-53" unit="cm" x="-328.03" y="-168.5" z="1047.55"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-53" unit="cm" x="325.035" y="-168.5" z="1047.55"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-54" unit="cm" x="-328.03" y="168.5" z="1047.55"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-54" unit="cm" x="325.035" y="168.5" z="1047.55"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-55" unit="cm" x="-328.03" y="505.5" z="1047.55"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-55" unit="cm" x="325.035" y="505.5" z="1047.55"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-56" unit="cm" x="-328.03" y="-505.5" z="1346.85"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-56" unit="cm" x="325.035" y="-505.5" z="1346.85"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-57" unit="cm" x="-328.03" y="-168.5" z="1346.85"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-57" unit="cm" x="325.035" y="-168.5" z="1346.85"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-58" unit="cm" x="-328.03" y="168.5" z="1346.85"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-58" unit="cm" x="325.035" y="168.5" z="1346.85"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-59" unit="cm" x="-328.03" y="505.5" z="1346.85"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-59" unit="cm" x="325.035" y="505.5" z="1346.85"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-60" unit="cm" x="-328.03" y="-505.5" z="1646.15"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-60" unit="cm" x="325.035" y="-505.5" z="1646.15"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-61" unit="cm" x="-328.03" y="-168.5" z="1646.15"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-61" unit="cm" x="325.035" y="-168.5" z="1646.15"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-62" unit="cm" x="-328.03" y="168.5" z="1646.15"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-62" unit="cm" x="325.035" y="168.5" z="1646.15"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-63" unit="cm" x="-328.03" y="505.5" z="1646.15"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-63" unit="cm" x="325.035" y="505.5" z="1646.15"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-64" unit="cm" x="-328.03" y="-505.5" z="1945.45"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-64" unit="cm" x="325.035" y="-505.5" z="1945.45"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-65" unit="cm" x="-328.03" y="-168.5" z="1945.45"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-65" unit="cm" x="325.035" y="-168.5" z="1945.45"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-66" unit="cm" x="-328.03" y="168.5" z="1945.45"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-66" unit="cm" x="325.035" y="168.5" z="1945.45"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-67" unit="cm" x="-328.03" y="505.5" z="1945.45"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-67" unit="cm" x="325.035" y="505.5" z="1945.45"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-68" unit="cm" x="-328.03" y="-505.5" z="2244.75"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-68" unit="cm" x="325.035" y="-505.5" z="2244.75"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-69" unit="cm" x="-328.03" y="-168.5" z="2244.75"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-69" unit="cm" x="325.035" y="-168.5" z="2244.75"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-70" unit="cm" x="-328.03" y="168.5" z="2244.75"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-70" unit="cm" x="325.035" y="168.5" z="2244.75"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-71" unit="cm" x="-328.03" y="505.5" z="2244.75"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-71" unit="cm" x="325.035" y="505.5" z="2244.75"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-72" unit="cm" x="-328.03" y="-505.5" z="2544.05"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-72" unit="cm" x="325.035" y="-505.5" z="2544.05"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-73" unit="cm" x="-328.03" y="-168.5" z="2544.05"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-73" unit="cm" x="325.035" y="-168.5" z="2544.05"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-74" unit="cm" x="-328.03" y="168.5" z="2544.05"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-74" unit="cm" x="325.035" y="168.5" z="2544.05"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-75" unit="cm" x="-328.03" y="505.5" z="2544.05"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-75" unit="cm" x="325.035" y="505.5" z="2544.05"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-76" unit="cm" x="-328.03" y="-505.5" z="2843.35"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-76" unit="cm" x="325.035" y="-505.5" z="2843.35"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-77" unit="cm" x="-328.03" y="-168.5" z="2843.35"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-77" unit="cm" x="325.035" y="-168.5" z="2843.35"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-78" unit="cm" x="-328.03" y="168.5" z="2843.35"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-78" unit="cm" x="325.035" y="168.5" z="2843.35"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-79" unit="cm" x="-328.03" y="505.5" z="2843.35"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-79" unit="cm" x="325.035" y="505.5" z="2843.35"/>
        <rotationref ref="rIdentity"/>
      </physvol>    
      <physvol>
@@ -40418,7 +45654,7 @@
        <position name="posArapucaDouble0-Frame-0-0" unit="cm" 
          x="-328.03"
 	 y="-633.2" 
-	 z="-261.8"/>
+	 z="-2805.85"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
@@ -40426,14 +45662,14 @@
        <position name="posOpArapucaDouble0-Frame-0-0" unit="cm" 
          x="-327.29"
 	 y="-633.2" 
-	 z="-261.8"/>
+	 z="-2805.85"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-0-1"/>
        <position name="posArapucaDouble1-Frame-0-0" unit="cm" 
          x="-328.03"
 	 y="-542.5" 
-	 z="-407.8"/>
+	 z="-2951.85"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
@@ -40441,14 +45677,14 @@
        <position name="posOpArapucaDouble1-Frame-0-0" unit="cm" 
          x="-327.29"
 	 y="-542.5" 
-	 z="-407.8"/>
+	 z="-2951.85"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-0-2"/>
        <position name="posArapucaDouble2-Frame-0-0" unit="cm" 
          x="-328.03"
 	 y="-468.5" 
-	 z="-190.8"/>
+	 z="-2734.85"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
@@ -40456,14 +45692,14 @@
        <position name="posOpArapucaDouble2-Frame-0-0" unit="cm" 
          x="-327.29"
 	 y="-468.5" 
-	 z="-190.8"/>
+	 z="-2734.85"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-0-3"/>
        <position name="posArapucaDouble3-Frame-0-0" unit="cm" 
          x="-328.03"
 	 y="-377.8" 
-	 z="-336.8"/>
+	 z="-2880.85"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
@@ -40471,14 +45707,14 @@
        <position name="posOpArapucaDouble3-Frame-0-0" unit="cm" 
          x="-327.29"
 	 y="-377.8" 
-	 z="-336.8"/>
+	 z="-2880.85"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-1-0"/>
        <position name="posArapucaDouble0-Frame-0-1" unit="cm" 
          x="-328.03"
 	 y="-633.2" 
-	 z="37.4999999999999"/>
+	 z="-2506.55"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
@@ -40486,14 +45722,14 @@
        <position name="posOpArapucaDouble0-Frame-0-1" unit="cm" 
          x="-327.29"
 	 y="-633.2" 
-	 z="37.4999999999999"/>
+	 z="-2506.55"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-1-1"/>
        <position name="posArapucaDouble1-Frame-0-1" unit="cm" 
          x="-328.03"
 	 y="-542.5" 
-	 z="-108.5"/>
+	 z="-2652.55"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
@@ -40501,14 +45737,14 @@
        <position name="posOpArapucaDouble1-Frame-0-1" unit="cm" 
          x="-327.29"
 	 y="-542.5" 
-	 z="-108.5"/>
+	 z="-2652.55"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-1-2"/>
        <position name="posArapucaDouble2-Frame-0-1" unit="cm" 
          x="-328.03"
 	 y="-468.5" 
-	 z="108.5"/>
+	 z="-2435.55"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
@@ -40516,14 +45752,14 @@
        <position name="posOpArapucaDouble2-Frame-0-1" unit="cm" 
          x="-327.29"
 	 y="-468.5" 
-	 z="108.5"/>
+	 z="-2435.55"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-1-3"/>
        <position name="posArapucaDouble3-Frame-0-1" unit="cm" 
          x="-328.03"
 	 y="-377.8" 
-	 z="-37.5000000000001"/>
+	 z="-2581.55"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
@@ -40531,14 +45767,14 @@
        <position name="posOpArapucaDouble3-Frame-0-1" unit="cm" 
          x="-327.29"
 	 y="-377.8" 
-	 z="-37.5000000000001"/>
+	 z="-2581.55"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-2-0"/>
        <position name="posArapucaDouble0-Frame-0-2" unit="cm" 
          x="-328.03"
 	 y="-633.2" 
-	 z="336.8"/>
+	 z="-2207.25"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
@@ -40546,14 +45782,14 @@
        <position name="posOpArapucaDouble0-Frame-0-2" unit="cm" 
          x="-327.29"
 	 y="-633.2" 
-	 z="336.8"/>
+	 z="-2207.25"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-2-1"/>
        <position name="posArapucaDouble1-Frame-0-2" unit="cm" 
          x="-328.03"
 	 y="-542.5" 
-	 z="190.8"/>
+	 z="-2353.25"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
@@ -40561,14 +45797,14 @@
        <position name="posOpArapucaDouble1-Frame-0-2" unit="cm" 
          x="-327.29"
 	 y="-542.5" 
-	 z="190.8"/>
+	 z="-2353.25"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-2-2"/>
        <position name="posArapucaDouble2-Frame-0-2" unit="cm" 
          x="-328.03"
 	 y="-468.5" 
-	 z="407.8"/>
+	 z="-2136.25"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
@@ -40576,14 +45812,14 @@
        <position name="posOpArapucaDouble2-Frame-0-2" unit="cm" 
          x="-327.29"
 	 y="-468.5" 
-	 z="407.8"/>
+	 z="-2136.25"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_0-2-3"/>
        <position name="posArapucaDouble3-Frame-0-2" unit="cm" 
          x="-328.03"
 	 y="-377.8" 
-	 z="261.8"/>
+	 z="-2282.25"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
@@ -40591,14 +45827,1034 @@
        <position name="posOpArapucaDouble3-Frame-0-2" unit="cm" 
          x="-327.29"
 	 y="-377.8" 
-	 z="261.8"/>
+	 z="-2282.25"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-3-0"/>
+       <position name="posArapucaDouble0-Frame-0-3" unit="cm" 
+         x="-328.03"
+	 y="-633.2" 
+	 z="-1907.95"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-3-0"/>
+       <position name="posOpArapucaDouble0-Frame-0-3" unit="cm" 
+         x="-327.29"
+	 y="-633.2" 
+	 z="-1907.95"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-3-1"/>
+       <position name="posArapucaDouble1-Frame-0-3" unit="cm" 
+         x="-328.03"
+	 y="-542.5" 
+	 z="-2053.95"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-3-1"/>
+       <position name="posOpArapucaDouble1-Frame-0-3" unit="cm" 
+         x="-327.29"
+	 y="-542.5" 
+	 z="-2053.95"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-3-2"/>
+       <position name="posArapucaDouble2-Frame-0-3" unit="cm" 
+         x="-328.03"
+	 y="-468.5" 
+	 z="-1836.95"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-3-2"/>
+       <position name="posOpArapucaDouble2-Frame-0-3" unit="cm" 
+         x="-327.29"
+	 y="-468.5" 
+	 z="-1836.95"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-3-3"/>
+       <position name="posArapucaDouble3-Frame-0-3" unit="cm" 
+         x="-328.03"
+	 y="-377.8" 
+	 z="-1982.95"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-3-3"/>
+       <position name="posOpArapucaDouble3-Frame-0-3" unit="cm" 
+         x="-327.29"
+	 y="-377.8" 
+	 z="-1982.95"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-4-0"/>
+       <position name="posArapucaDouble0-Frame-0-4" unit="cm" 
+         x="-328.03"
+	 y="-633.2" 
+	 z="-1608.65"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-4-0"/>
+       <position name="posOpArapucaDouble0-Frame-0-4" unit="cm" 
+         x="-327.29"
+	 y="-633.2" 
+	 z="-1608.65"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-4-1"/>
+       <position name="posArapucaDouble1-Frame-0-4" unit="cm" 
+         x="-328.03"
+	 y="-542.5" 
+	 z="-1754.65"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-4-1"/>
+       <position name="posOpArapucaDouble1-Frame-0-4" unit="cm" 
+         x="-327.29"
+	 y="-542.5" 
+	 z="-1754.65"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-4-2"/>
+       <position name="posArapucaDouble2-Frame-0-4" unit="cm" 
+         x="-328.03"
+	 y="-468.5" 
+	 z="-1537.65"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-4-2"/>
+       <position name="posOpArapucaDouble2-Frame-0-4" unit="cm" 
+         x="-327.29"
+	 y="-468.5" 
+	 z="-1537.65"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-4-3"/>
+       <position name="posArapucaDouble3-Frame-0-4" unit="cm" 
+         x="-328.03"
+	 y="-377.8" 
+	 z="-1683.65"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-4-3"/>
+       <position name="posOpArapucaDouble3-Frame-0-4" unit="cm" 
+         x="-327.29"
+	 y="-377.8" 
+	 z="-1683.65"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-5-0"/>
+       <position name="posArapucaDouble0-Frame-0-5" unit="cm" 
+         x="-328.03"
+	 y="-633.2" 
+	 z="-1309.35"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-5-0"/>
+       <position name="posOpArapucaDouble0-Frame-0-5" unit="cm" 
+         x="-327.29"
+	 y="-633.2" 
+	 z="-1309.35"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-5-1"/>
+       <position name="posArapucaDouble1-Frame-0-5" unit="cm" 
+         x="-328.03"
+	 y="-542.5" 
+	 z="-1455.35"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-5-1"/>
+       <position name="posOpArapucaDouble1-Frame-0-5" unit="cm" 
+         x="-327.29"
+	 y="-542.5" 
+	 z="-1455.35"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-5-2"/>
+       <position name="posArapucaDouble2-Frame-0-5" unit="cm" 
+         x="-328.03"
+	 y="-468.5" 
+	 z="-1238.35"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-5-2"/>
+       <position name="posOpArapucaDouble2-Frame-0-5" unit="cm" 
+         x="-327.29"
+	 y="-468.5" 
+	 z="-1238.35"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-5-3"/>
+       <position name="posArapucaDouble3-Frame-0-5" unit="cm" 
+         x="-328.03"
+	 y="-377.8" 
+	 z="-1384.35"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-5-3"/>
+       <position name="posOpArapucaDouble3-Frame-0-5" unit="cm" 
+         x="-327.29"
+	 y="-377.8" 
+	 z="-1384.35"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-6-0"/>
+       <position name="posArapucaDouble0-Frame-0-6" unit="cm" 
+         x="-328.03"
+	 y="-633.2" 
+	 z="-1010.05"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-6-0"/>
+       <position name="posOpArapucaDouble0-Frame-0-6" unit="cm" 
+         x="-327.29"
+	 y="-633.2" 
+	 z="-1010.05"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-6-1"/>
+       <position name="posArapucaDouble1-Frame-0-6" unit="cm" 
+         x="-328.03"
+	 y="-542.5" 
+	 z="-1156.05"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-6-1"/>
+       <position name="posOpArapucaDouble1-Frame-0-6" unit="cm" 
+         x="-327.29"
+	 y="-542.5" 
+	 z="-1156.05"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-6-2"/>
+       <position name="posArapucaDouble2-Frame-0-6" unit="cm" 
+         x="-328.03"
+	 y="-468.5" 
+	 z="-939.05"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-6-2"/>
+       <position name="posOpArapucaDouble2-Frame-0-6" unit="cm" 
+         x="-327.29"
+	 y="-468.5" 
+	 z="-939.05"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-6-3"/>
+       <position name="posArapucaDouble3-Frame-0-6" unit="cm" 
+         x="-328.03"
+	 y="-377.8" 
+	 z="-1085.05"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-6-3"/>
+       <position name="posOpArapucaDouble3-Frame-0-6" unit="cm" 
+         x="-327.29"
+	 y="-377.8" 
+	 z="-1085.05"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-7-0"/>
+       <position name="posArapucaDouble0-Frame-0-7" unit="cm" 
+         x="-328.03"
+	 y="-633.2" 
+	 z="-710.75"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-7-0"/>
+       <position name="posOpArapucaDouble0-Frame-0-7" unit="cm" 
+         x="-327.29"
+	 y="-633.2" 
+	 z="-710.75"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-7-1"/>
+       <position name="posArapucaDouble1-Frame-0-7" unit="cm" 
+         x="-328.03"
+	 y="-542.5" 
+	 z="-856.75"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-7-1"/>
+       <position name="posOpArapucaDouble1-Frame-0-7" unit="cm" 
+         x="-327.29"
+	 y="-542.5" 
+	 z="-856.75"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-7-2"/>
+       <position name="posArapucaDouble2-Frame-0-7" unit="cm" 
+         x="-328.03"
+	 y="-468.5" 
+	 z="-639.75"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-7-2"/>
+       <position name="posOpArapucaDouble2-Frame-0-7" unit="cm" 
+         x="-327.29"
+	 y="-468.5" 
+	 z="-639.75"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-7-3"/>
+       <position name="posArapucaDouble3-Frame-0-7" unit="cm" 
+         x="-328.03"
+	 y="-377.8" 
+	 z="-785.75"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-7-3"/>
+       <position name="posOpArapucaDouble3-Frame-0-7" unit="cm" 
+         x="-327.29"
+	 y="-377.8" 
+	 z="-785.75"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-8-0"/>
+       <position name="posArapucaDouble0-Frame-0-8" unit="cm" 
+         x="-328.03"
+	 y="-633.2" 
+	 z="-411.45"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-8-0"/>
+       <position name="posOpArapucaDouble0-Frame-0-8" unit="cm" 
+         x="-327.29"
+	 y="-633.2" 
+	 z="-411.45"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-8-1"/>
+       <position name="posArapucaDouble1-Frame-0-8" unit="cm" 
+         x="-328.03"
+	 y="-542.5" 
+	 z="-557.45"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-8-1"/>
+       <position name="posOpArapucaDouble1-Frame-0-8" unit="cm" 
+         x="-327.29"
+	 y="-542.5" 
+	 z="-557.45"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-8-2"/>
+       <position name="posArapucaDouble2-Frame-0-8" unit="cm" 
+         x="-328.03"
+	 y="-468.5" 
+	 z="-340.45"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-8-2"/>
+       <position name="posOpArapucaDouble2-Frame-0-8" unit="cm" 
+         x="-327.29"
+	 y="-468.5" 
+	 z="-340.45"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-8-3"/>
+       <position name="posArapucaDouble3-Frame-0-8" unit="cm" 
+         x="-328.03"
+	 y="-377.8" 
+	 z="-486.45"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-8-3"/>
+       <position name="posOpArapucaDouble3-Frame-0-8" unit="cm" 
+         x="-327.29"
+	 y="-377.8" 
+	 z="-486.45"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-9-0"/>
+       <position name="posArapucaDouble0-Frame-0-9" unit="cm" 
+         x="-328.03"
+	 y="-633.2" 
+	 z="-112.15"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-9-0"/>
+       <position name="posOpArapucaDouble0-Frame-0-9" unit="cm" 
+         x="-327.29"
+	 y="-633.2" 
+	 z="-112.15"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-9-1"/>
+       <position name="posArapucaDouble1-Frame-0-9" unit="cm" 
+         x="-328.03"
+	 y="-542.5" 
+	 z="-258.15"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-9-1"/>
+       <position name="posOpArapucaDouble1-Frame-0-9" unit="cm" 
+         x="-327.29"
+	 y="-542.5" 
+	 z="-258.15"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-9-2"/>
+       <position name="posArapucaDouble2-Frame-0-9" unit="cm" 
+         x="-328.03"
+	 y="-468.5" 
+	 z="-41.1499999999997"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-9-2"/>
+       <position name="posOpArapucaDouble2-Frame-0-9" unit="cm" 
+         x="-327.29"
+	 y="-468.5" 
+	 z="-41.1499999999997"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-9-3"/>
+       <position name="posArapucaDouble3-Frame-0-9" unit="cm" 
+         x="-328.03"
+	 y="-377.8" 
+	 z="-187.15"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-9-3"/>
+       <position name="posOpArapucaDouble3-Frame-0-9" unit="cm" 
+         x="-327.29"
+	 y="-377.8" 
+	 z="-187.15"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-10-0"/>
+       <position name="posArapucaDouble0-Frame-0-10" unit="cm" 
+         x="-328.03"
+	 y="-633.2" 
+	 z="187.15"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-10-0"/>
+       <position name="posOpArapucaDouble0-Frame-0-10" unit="cm" 
+         x="-327.29"
+	 y="-633.2" 
+	 z="187.15"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-10-1"/>
+       <position name="posArapucaDouble1-Frame-0-10" unit="cm" 
+         x="-328.03"
+	 y="-542.5" 
+	 z="41.1500000000003"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-10-1"/>
+       <position name="posOpArapucaDouble1-Frame-0-10" unit="cm" 
+         x="-327.29"
+	 y="-542.5" 
+	 z="41.1500000000003"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-10-2"/>
+       <position name="posArapucaDouble2-Frame-0-10" unit="cm" 
+         x="-328.03"
+	 y="-468.5" 
+	 z="258.15"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-10-2"/>
+       <position name="posOpArapucaDouble2-Frame-0-10" unit="cm" 
+         x="-327.29"
+	 y="-468.5" 
+	 z="258.15"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-10-3"/>
+       <position name="posArapucaDouble3-Frame-0-10" unit="cm" 
+         x="-328.03"
+	 y="-377.8" 
+	 z="112.15"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-10-3"/>
+       <position name="posOpArapucaDouble3-Frame-0-10" unit="cm" 
+         x="-327.29"
+	 y="-377.8" 
+	 z="112.15"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-11-0"/>
+       <position name="posArapucaDouble0-Frame-0-11" unit="cm" 
+         x="-328.03"
+	 y="-633.2" 
+	 z="486.45"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-11-0"/>
+       <position name="posOpArapucaDouble0-Frame-0-11" unit="cm" 
+         x="-327.29"
+	 y="-633.2" 
+	 z="486.45"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-11-1"/>
+       <position name="posArapucaDouble1-Frame-0-11" unit="cm" 
+         x="-328.03"
+	 y="-542.5" 
+	 z="340.45"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-11-1"/>
+       <position name="posOpArapucaDouble1-Frame-0-11" unit="cm" 
+         x="-327.29"
+	 y="-542.5" 
+	 z="340.45"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-11-2"/>
+       <position name="posArapucaDouble2-Frame-0-11" unit="cm" 
+         x="-328.03"
+	 y="-468.5" 
+	 z="557.45"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-11-2"/>
+       <position name="posOpArapucaDouble2-Frame-0-11" unit="cm" 
+         x="-327.29"
+	 y="-468.5" 
+	 z="557.45"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-11-3"/>
+       <position name="posArapucaDouble3-Frame-0-11" unit="cm" 
+         x="-328.03"
+	 y="-377.8" 
+	 z="411.45"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-11-3"/>
+       <position name="posOpArapucaDouble3-Frame-0-11" unit="cm" 
+         x="-327.29"
+	 y="-377.8" 
+	 z="411.45"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-12-0"/>
+       <position name="posArapucaDouble0-Frame-0-12" unit="cm" 
+         x="-328.03"
+	 y="-633.2" 
+	 z="785.75"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-12-0"/>
+       <position name="posOpArapucaDouble0-Frame-0-12" unit="cm" 
+         x="-327.29"
+	 y="-633.2" 
+	 z="785.75"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-12-1"/>
+       <position name="posArapucaDouble1-Frame-0-12" unit="cm" 
+         x="-328.03"
+	 y="-542.5" 
+	 z="639.75"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-12-1"/>
+       <position name="posOpArapucaDouble1-Frame-0-12" unit="cm" 
+         x="-327.29"
+	 y="-542.5" 
+	 z="639.75"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-12-2"/>
+       <position name="posArapucaDouble2-Frame-0-12" unit="cm" 
+         x="-328.03"
+	 y="-468.5" 
+	 z="856.75"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-12-2"/>
+       <position name="posOpArapucaDouble2-Frame-0-12" unit="cm" 
+         x="-327.29"
+	 y="-468.5" 
+	 z="856.75"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-12-3"/>
+       <position name="posArapucaDouble3-Frame-0-12" unit="cm" 
+         x="-328.03"
+	 y="-377.8" 
+	 z="710.75"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-12-3"/>
+       <position name="posOpArapucaDouble3-Frame-0-12" unit="cm" 
+         x="-327.29"
+	 y="-377.8" 
+	 z="710.75"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-13-0"/>
+       <position name="posArapucaDouble0-Frame-0-13" unit="cm" 
+         x="-328.03"
+	 y="-633.2" 
+	 z="1085.05"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-13-0"/>
+       <position name="posOpArapucaDouble0-Frame-0-13" unit="cm" 
+         x="-327.29"
+	 y="-633.2" 
+	 z="1085.05"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-13-1"/>
+       <position name="posArapucaDouble1-Frame-0-13" unit="cm" 
+         x="-328.03"
+	 y="-542.5" 
+	 z="939.05"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-13-1"/>
+       <position name="posOpArapucaDouble1-Frame-0-13" unit="cm" 
+         x="-327.29"
+	 y="-542.5" 
+	 z="939.05"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-13-2"/>
+       <position name="posArapucaDouble2-Frame-0-13" unit="cm" 
+         x="-328.03"
+	 y="-468.5" 
+	 z="1156.05"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-13-2"/>
+       <position name="posOpArapucaDouble2-Frame-0-13" unit="cm" 
+         x="-327.29"
+	 y="-468.5" 
+	 z="1156.05"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-13-3"/>
+       <position name="posArapucaDouble3-Frame-0-13" unit="cm" 
+         x="-328.03"
+	 y="-377.8" 
+	 z="1010.05"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-13-3"/>
+       <position name="posOpArapucaDouble3-Frame-0-13" unit="cm" 
+         x="-327.29"
+	 y="-377.8" 
+	 z="1010.05"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-14-0"/>
+       <position name="posArapucaDouble0-Frame-0-14" unit="cm" 
+         x="-328.03"
+	 y="-633.2" 
+	 z="1384.35"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-14-0"/>
+       <position name="posOpArapucaDouble0-Frame-0-14" unit="cm" 
+         x="-327.29"
+	 y="-633.2" 
+	 z="1384.35"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-14-1"/>
+       <position name="posArapucaDouble1-Frame-0-14" unit="cm" 
+         x="-328.03"
+	 y="-542.5" 
+	 z="1238.35"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-14-1"/>
+       <position name="posOpArapucaDouble1-Frame-0-14" unit="cm" 
+         x="-327.29"
+	 y="-542.5" 
+	 z="1238.35"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-14-2"/>
+       <position name="posArapucaDouble2-Frame-0-14" unit="cm" 
+         x="-328.03"
+	 y="-468.5" 
+	 z="1455.35"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-14-2"/>
+       <position name="posOpArapucaDouble2-Frame-0-14" unit="cm" 
+         x="-327.29"
+	 y="-468.5" 
+	 z="1455.35"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-14-3"/>
+       <position name="posArapucaDouble3-Frame-0-14" unit="cm" 
+         x="-328.03"
+	 y="-377.8" 
+	 z="1309.35"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-14-3"/>
+       <position name="posOpArapucaDouble3-Frame-0-14" unit="cm" 
+         x="-327.29"
+	 y="-377.8" 
+	 z="1309.35"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-15-0"/>
+       <position name="posArapucaDouble0-Frame-0-15" unit="cm" 
+         x="-328.03"
+	 y="-633.2" 
+	 z="1683.65"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-15-0"/>
+       <position name="posOpArapucaDouble0-Frame-0-15" unit="cm" 
+         x="-327.29"
+	 y="-633.2" 
+	 z="1683.65"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-15-1"/>
+       <position name="posArapucaDouble1-Frame-0-15" unit="cm" 
+         x="-328.03"
+	 y="-542.5" 
+	 z="1537.65"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-15-1"/>
+       <position name="posOpArapucaDouble1-Frame-0-15" unit="cm" 
+         x="-327.29"
+	 y="-542.5" 
+	 z="1537.65"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-15-2"/>
+       <position name="posArapucaDouble2-Frame-0-15" unit="cm" 
+         x="-328.03"
+	 y="-468.5" 
+	 z="1754.65"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-15-2"/>
+       <position name="posOpArapucaDouble2-Frame-0-15" unit="cm" 
+         x="-327.29"
+	 y="-468.5" 
+	 z="1754.65"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-15-3"/>
+       <position name="posArapucaDouble3-Frame-0-15" unit="cm" 
+         x="-328.03"
+	 y="-377.8" 
+	 z="1608.65"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-15-3"/>
+       <position name="posOpArapucaDouble3-Frame-0-15" unit="cm" 
+         x="-327.29"
+	 y="-377.8" 
+	 z="1608.65"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-16-0"/>
+       <position name="posArapucaDouble0-Frame-0-16" unit="cm" 
+         x="-328.03"
+	 y="-633.2" 
+	 z="1982.95"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-16-0"/>
+       <position name="posOpArapucaDouble0-Frame-0-16" unit="cm" 
+         x="-327.29"
+	 y="-633.2" 
+	 z="1982.95"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-16-1"/>
+       <position name="posArapucaDouble1-Frame-0-16" unit="cm" 
+         x="-328.03"
+	 y="-542.5" 
+	 z="1836.95"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-16-1"/>
+       <position name="posOpArapucaDouble1-Frame-0-16" unit="cm" 
+         x="-327.29"
+	 y="-542.5" 
+	 z="1836.95"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-16-2"/>
+       <position name="posArapucaDouble2-Frame-0-16" unit="cm" 
+         x="-328.03"
+	 y="-468.5" 
+	 z="2053.95"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-16-2"/>
+       <position name="posOpArapucaDouble2-Frame-0-16" unit="cm" 
+         x="-327.29"
+	 y="-468.5" 
+	 z="2053.95"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-16-3"/>
+       <position name="posArapucaDouble3-Frame-0-16" unit="cm" 
+         x="-328.03"
+	 y="-377.8" 
+	 z="1907.95"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-16-3"/>
+       <position name="posOpArapucaDouble3-Frame-0-16" unit="cm" 
+         x="-327.29"
+	 y="-377.8" 
+	 z="1907.95"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-17-0"/>
+       <position name="posArapucaDouble0-Frame-0-17" unit="cm" 
+         x="-328.03"
+	 y="-633.2" 
+	 z="2282.25"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-17-0"/>
+       <position name="posOpArapucaDouble0-Frame-0-17" unit="cm" 
+         x="-327.29"
+	 y="-633.2" 
+	 z="2282.25"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-17-1"/>
+       <position name="posArapucaDouble1-Frame-0-17" unit="cm" 
+         x="-328.03"
+	 y="-542.5" 
+	 z="2136.25"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-17-1"/>
+       <position name="posOpArapucaDouble1-Frame-0-17" unit="cm" 
+         x="-327.29"
+	 y="-542.5" 
+	 z="2136.25"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-17-2"/>
+       <position name="posArapucaDouble2-Frame-0-17" unit="cm" 
+         x="-328.03"
+	 y="-468.5" 
+	 z="2353.25"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-17-2"/>
+       <position name="posOpArapucaDouble2-Frame-0-17" unit="cm" 
+         x="-327.29"
+	 y="-468.5" 
+	 z="2353.25"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-17-3"/>
+       <position name="posArapucaDouble3-Frame-0-17" unit="cm" 
+         x="-328.03"
+	 y="-377.8" 
+	 z="2207.25"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-17-3"/>
+       <position name="posOpArapucaDouble3-Frame-0-17" unit="cm" 
+         x="-327.29"
+	 y="-377.8" 
+	 z="2207.25"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-18-0"/>
+       <position name="posArapucaDouble0-Frame-0-18" unit="cm" 
+         x="-328.03"
+	 y="-633.2" 
+	 z="2581.55"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-18-0"/>
+       <position name="posOpArapucaDouble0-Frame-0-18" unit="cm" 
+         x="-327.29"
+	 y="-633.2" 
+	 z="2581.55"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-18-1"/>
+       <position name="posArapucaDouble1-Frame-0-18" unit="cm" 
+         x="-328.03"
+	 y="-542.5" 
+	 z="2435.55"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-18-1"/>
+       <position name="posOpArapucaDouble1-Frame-0-18" unit="cm" 
+         x="-327.29"
+	 y="-542.5" 
+	 z="2435.55"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-18-2"/>
+       <position name="posArapucaDouble2-Frame-0-18" unit="cm" 
+         x="-328.03"
+	 y="-468.5" 
+	 z="2652.55"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-18-2"/>
+       <position name="posOpArapucaDouble2-Frame-0-18" unit="cm" 
+         x="-327.29"
+	 y="-468.5" 
+	 z="2652.55"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-18-3"/>
+       <position name="posArapucaDouble3-Frame-0-18" unit="cm" 
+         x="-328.03"
+	 y="-377.8" 
+	 z="2506.55"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-18-3"/>
+       <position name="posOpArapucaDouble3-Frame-0-18" unit="cm" 
+         x="-327.29"
+	 y="-377.8" 
+	 z="2506.55"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-19-0"/>
+       <position name="posArapucaDouble0-Frame-0-19" unit="cm" 
+         x="-328.03"
+	 y="-633.2" 
+	 z="2880.85"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-19-0"/>
+       <position name="posOpArapucaDouble0-Frame-0-19" unit="cm" 
+         x="-327.29"
+	 y="-633.2" 
+	 z="2880.85"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-19-1"/>
+       <position name="posArapucaDouble1-Frame-0-19" unit="cm" 
+         x="-328.03"
+	 y="-542.5" 
+	 z="2734.85"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-19-1"/>
+       <position name="posOpArapucaDouble1-Frame-0-19" unit="cm" 
+         x="-327.29"
+	 y="-542.5" 
+	 z="2734.85"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-19-2"/>
+       <position name="posArapucaDouble2-Frame-0-19" unit="cm" 
+         x="-328.03"
+	 y="-468.5" 
+	 z="2951.85"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-19-2"/>
+       <position name="posOpArapucaDouble2-Frame-0-19" unit="cm" 
+         x="-327.29"
+	 y="-468.5" 
+	 z="2951.85"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-19-3"/>
+       <position name="posArapucaDouble3-Frame-0-19" unit="cm" 
+         x="-328.03"
+	 y="-377.8" 
+	 z="2805.85"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-19-3"/>
+       <position name="posOpArapucaDouble3-Frame-0-19" unit="cm" 
+         x="-327.29"
+	 y="-377.8" 
+	 z="2805.85"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-0-0"/>
        <position name="posArapucaDouble0-Frame-1-0" unit="cm" 
          x="-328.03"
 	 y="-296.2" 
-	 z="-261.8"/>
+	 z="-2805.85"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
@@ -40606,14 +46862,14 @@
        <position name="posOpArapucaDouble0-Frame-1-0" unit="cm" 
          x="-327.29"
 	 y="-296.2" 
-	 z="-261.8"/>
+	 z="-2805.85"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-0-1"/>
        <position name="posArapucaDouble1-Frame-1-0" unit="cm" 
          x="-328.03"
 	 y="-205.5" 
-	 z="-407.8"/>
+	 z="-2951.85"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
@@ -40621,14 +46877,14 @@
        <position name="posOpArapucaDouble1-Frame-1-0" unit="cm" 
          x="-327.29"
 	 y="-205.5" 
-	 z="-407.8"/>
+	 z="-2951.85"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-0-2"/>
        <position name="posArapucaDouble2-Frame-1-0" unit="cm" 
          x="-328.03"
 	 y="-131.5" 
-	 z="-190.8"/>
+	 z="-2734.85"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
@@ -40636,14 +46892,14 @@
        <position name="posOpArapucaDouble2-Frame-1-0" unit="cm" 
          x="-327.29"
 	 y="-131.5" 
-	 z="-190.8"/>
+	 z="-2734.85"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-0-3"/>
        <position name="posArapucaDouble3-Frame-1-0" unit="cm" 
          x="-328.03"
 	 y="-40.8" 
-	 z="-336.8"/>
+	 z="-2880.85"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
@@ -40651,14 +46907,14 @@
        <position name="posOpArapucaDouble3-Frame-1-0" unit="cm" 
          x="-327.29"
 	 y="-40.8" 
-	 z="-336.8"/>
+	 z="-2880.85"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-1-0"/>
        <position name="posArapucaDouble0-Frame-1-1" unit="cm" 
          x="-328.03"
 	 y="-296.2" 
-	 z="37.4999999999999"/>
+	 z="-2506.55"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
@@ -40666,14 +46922,14 @@
        <position name="posOpArapucaDouble0-Frame-1-1" unit="cm" 
          x="-327.29"
 	 y="-296.2" 
-	 z="37.4999999999999"/>
+	 z="-2506.55"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-1-1"/>
        <position name="posArapucaDouble1-Frame-1-1" unit="cm" 
          x="-328.03"
 	 y="-205.5" 
-	 z="-108.5"/>
+	 z="-2652.55"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
@@ -40681,14 +46937,14 @@
        <position name="posOpArapucaDouble1-Frame-1-1" unit="cm" 
          x="-327.29"
 	 y="-205.5" 
-	 z="-108.5"/>
+	 z="-2652.55"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-1-2"/>
        <position name="posArapucaDouble2-Frame-1-1" unit="cm" 
          x="-328.03"
 	 y="-131.5" 
-	 z="108.5"/>
+	 z="-2435.55"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
@@ -40696,14 +46952,14 @@
        <position name="posOpArapucaDouble2-Frame-1-1" unit="cm" 
          x="-327.29"
 	 y="-131.5" 
-	 z="108.5"/>
+	 z="-2435.55"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-1-3"/>
        <position name="posArapucaDouble3-Frame-1-1" unit="cm" 
          x="-328.03"
 	 y="-40.8" 
-	 z="-37.5000000000001"/>
+	 z="-2581.55"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
@@ -40711,14 +46967,14 @@
        <position name="posOpArapucaDouble3-Frame-1-1" unit="cm" 
          x="-327.29"
 	 y="-40.8" 
-	 z="-37.5000000000001"/>
+	 z="-2581.55"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-2-0"/>
        <position name="posArapucaDouble0-Frame-1-2" unit="cm" 
          x="-328.03"
 	 y="-296.2" 
-	 z="336.8"/>
+	 z="-2207.25"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
@@ -40726,14 +46982,14 @@
        <position name="posOpArapucaDouble0-Frame-1-2" unit="cm" 
          x="-327.29"
 	 y="-296.2" 
-	 z="336.8"/>
+	 z="-2207.25"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-2-1"/>
        <position name="posArapucaDouble1-Frame-1-2" unit="cm" 
          x="-328.03"
 	 y="-205.5" 
-	 z="190.8"/>
+	 z="-2353.25"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
@@ -40741,14 +46997,14 @@
        <position name="posOpArapucaDouble1-Frame-1-2" unit="cm" 
          x="-327.29"
 	 y="-205.5" 
-	 z="190.8"/>
+	 z="-2353.25"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-2-2"/>
        <position name="posArapucaDouble2-Frame-1-2" unit="cm" 
          x="-328.03"
 	 y="-131.5" 
-	 z="407.8"/>
+	 z="-2136.25"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
@@ -40756,14 +47012,14 @@
        <position name="posOpArapucaDouble2-Frame-1-2" unit="cm" 
          x="-327.29"
 	 y="-131.5" 
-	 z="407.8"/>
+	 z="-2136.25"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_1-2-3"/>
        <position name="posArapucaDouble3-Frame-1-2" unit="cm" 
          x="-328.03"
 	 y="-40.8" 
-	 z="261.8"/>
+	 z="-2282.25"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
@@ -40771,14 +47027,1034 @@
        <position name="posOpArapucaDouble3-Frame-1-2" unit="cm" 
          x="-327.29"
 	 y="-40.8" 
-	 z="261.8"/>
+	 z="-2282.25"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-3-0"/>
+       <position name="posArapucaDouble0-Frame-1-3" unit="cm" 
+         x="-328.03"
+	 y="-296.2" 
+	 z="-1907.95"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-3-0"/>
+       <position name="posOpArapucaDouble0-Frame-1-3" unit="cm" 
+         x="-327.29"
+	 y="-296.2" 
+	 z="-1907.95"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-3-1"/>
+       <position name="posArapucaDouble1-Frame-1-3" unit="cm" 
+         x="-328.03"
+	 y="-205.5" 
+	 z="-2053.95"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-3-1"/>
+       <position name="posOpArapucaDouble1-Frame-1-3" unit="cm" 
+         x="-327.29"
+	 y="-205.5" 
+	 z="-2053.95"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-3-2"/>
+       <position name="posArapucaDouble2-Frame-1-3" unit="cm" 
+         x="-328.03"
+	 y="-131.5" 
+	 z="-1836.95"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-3-2"/>
+       <position name="posOpArapucaDouble2-Frame-1-3" unit="cm" 
+         x="-327.29"
+	 y="-131.5" 
+	 z="-1836.95"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-3-3"/>
+       <position name="posArapucaDouble3-Frame-1-3" unit="cm" 
+         x="-328.03"
+	 y="-40.8" 
+	 z="-1982.95"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-3-3"/>
+       <position name="posOpArapucaDouble3-Frame-1-3" unit="cm" 
+         x="-327.29"
+	 y="-40.8" 
+	 z="-1982.95"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-4-0"/>
+       <position name="posArapucaDouble0-Frame-1-4" unit="cm" 
+         x="-328.03"
+	 y="-296.2" 
+	 z="-1608.65"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-4-0"/>
+       <position name="posOpArapucaDouble0-Frame-1-4" unit="cm" 
+         x="-327.29"
+	 y="-296.2" 
+	 z="-1608.65"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-4-1"/>
+       <position name="posArapucaDouble1-Frame-1-4" unit="cm" 
+         x="-328.03"
+	 y="-205.5" 
+	 z="-1754.65"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-4-1"/>
+       <position name="posOpArapucaDouble1-Frame-1-4" unit="cm" 
+         x="-327.29"
+	 y="-205.5" 
+	 z="-1754.65"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-4-2"/>
+       <position name="posArapucaDouble2-Frame-1-4" unit="cm" 
+         x="-328.03"
+	 y="-131.5" 
+	 z="-1537.65"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-4-2"/>
+       <position name="posOpArapucaDouble2-Frame-1-4" unit="cm" 
+         x="-327.29"
+	 y="-131.5" 
+	 z="-1537.65"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-4-3"/>
+       <position name="posArapucaDouble3-Frame-1-4" unit="cm" 
+         x="-328.03"
+	 y="-40.8" 
+	 z="-1683.65"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-4-3"/>
+       <position name="posOpArapucaDouble3-Frame-1-4" unit="cm" 
+         x="-327.29"
+	 y="-40.8" 
+	 z="-1683.65"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-5-0"/>
+       <position name="posArapucaDouble0-Frame-1-5" unit="cm" 
+         x="-328.03"
+	 y="-296.2" 
+	 z="-1309.35"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-5-0"/>
+       <position name="posOpArapucaDouble0-Frame-1-5" unit="cm" 
+         x="-327.29"
+	 y="-296.2" 
+	 z="-1309.35"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-5-1"/>
+       <position name="posArapucaDouble1-Frame-1-5" unit="cm" 
+         x="-328.03"
+	 y="-205.5" 
+	 z="-1455.35"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-5-1"/>
+       <position name="posOpArapucaDouble1-Frame-1-5" unit="cm" 
+         x="-327.29"
+	 y="-205.5" 
+	 z="-1455.35"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-5-2"/>
+       <position name="posArapucaDouble2-Frame-1-5" unit="cm" 
+         x="-328.03"
+	 y="-131.5" 
+	 z="-1238.35"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-5-2"/>
+       <position name="posOpArapucaDouble2-Frame-1-5" unit="cm" 
+         x="-327.29"
+	 y="-131.5" 
+	 z="-1238.35"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-5-3"/>
+       <position name="posArapucaDouble3-Frame-1-5" unit="cm" 
+         x="-328.03"
+	 y="-40.8" 
+	 z="-1384.35"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-5-3"/>
+       <position name="posOpArapucaDouble3-Frame-1-5" unit="cm" 
+         x="-327.29"
+	 y="-40.8" 
+	 z="-1384.35"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-6-0"/>
+       <position name="posArapucaDouble0-Frame-1-6" unit="cm" 
+         x="-328.03"
+	 y="-296.2" 
+	 z="-1010.05"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-6-0"/>
+       <position name="posOpArapucaDouble0-Frame-1-6" unit="cm" 
+         x="-327.29"
+	 y="-296.2" 
+	 z="-1010.05"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-6-1"/>
+       <position name="posArapucaDouble1-Frame-1-6" unit="cm" 
+         x="-328.03"
+	 y="-205.5" 
+	 z="-1156.05"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-6-1"/>
+       <position name="posOpArapucaDouble1-Frame-1-6" unit="cm" 
+         x="-327.29"
+	 y="-205.5" 
+	 z="-1156.05"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-6-2"/>
+       <position name="posArapucaDouble2-Frame-1-6" unit="cm" 
+         x="-328.03"
+	 y="-131.5" 
+	 z="-939.05"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-6-2"/>
+       <position name="posOpArapucaDouble2-Frame-1-6" unit="cm" 
+         x="-327.29"
+	 y="-131.5" 
+	 z="-939.05"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-6-3"/>
+       <position name="posArapucaDouble3-Frame-1-6" unit="cm" 
+         x="-328.03"
+	 y="-40.8" 
+	 z="-1085.05"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-6-3"/>
+       <position name="posOpArapucaDouble3-Frame-1-6" unit="cm" 
+         x="-327.29"
+	 y="-40.8" 
+	 z="-1085.05"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-7-0"/>
+       <position name="posArapucaDouble0-Frame-1-7" unit="cm" 
+         x="-328.03"
+	 y="-296.2" 
+	 z="-710.75"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-7-0"/>
+       <position name="posOpArapucaDouble0-Frame-1-7" unit="cm" 
+         x="-327.29"
+	 y="-296.2" 
+	 z="-710.75"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-7-1"/>
+       <position name="posArapucaDouble1-Frame-1-7" unit="cm" 
+         x="-328.03"
+	 y="-205.5" 
+	 z="-856.75"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-7-1"/>
+       <position name="posOpArapucaDouble1-Frame-1-7" unit="cm" 
+         x="-327.29"
+	 y="-205.5" 
+	 z="-856.75"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-7-2"/>
+       <position name="posArapucaDouble2-Frame-1-7" unit="cm" 
+         x="-328.03"
+	 y="-131.5" 
+	 z="-639.75"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-7-2"/>
+       <position name="posOpArapucaDouble2-Frame-1-7" unit="cm" 
+         x="-327.29"
+	 y="-131.5" 
+	 z="-639.75"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-7-3"/>
+       <position name="posArapucaDouble3-Frame-1-7" unit="cm" 
+         x="-328.03"
+	 y="-40.8" 
+	 z="-785.75"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-7-3"/>
+       <position name="posOpArapucaDouble3-Frame-1-7" unit="cm" 
+         x="-327.29"
+	 y="-40.8" 
+	 z="-785.75"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-8-0"/>
+       <position name="posArapucaDouble0-Frame-1-8" unit="cm" 
+         x="-328.03"
+	 y="-296.2" 
+	 z="-411.45"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-8-0"/>
+       <position name="posOpArapucaDouble0-Frame-1-8" unit="cm" 
+         x="-327.29"
+	 y="-296.2" 
+	 z="-411.45"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-8-1"/>
+       <position name="posArapucaDouble1-Frame-1-8" unit="cm" 
+         x="-328.03"
+	 y="-205.5" 
+	 z="-557.45"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-8-1"/>
+       <position name="posOpArapucaDouble1-Frame-1-8" unit="cm" 
+         x="-327.29"
+	 y="-205.5" 
+	 z="-557.45"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-8-2"/>
+       <position name="posArapucaDouble2-Frame-1-8" unit="cm" 
+         x="-328.03"
+	 y="-131.5" 
+	 z="-340.45"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-8-2"/>
+       <position name="posOpArapucaDouble2-Frame-1-8" unit="cm" 
+         x="-327.29"
+	 y="-131.5" 
+	 z="-340.45"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-8-3"/>
+       <position name="posArapucaDouble3-Frame-1-8" unit="cm" 
+         x="-328.03"
+	 y="-40.8" 
+	 z="-486.45"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-8-3"/>
+       <position name="posOpArapucaDouble3-Frame-1-8" unit="cm" 
+         x="-327.29"
+	 y="-40.8" 
+	 z="-486.45"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-9-0"/>
+       <position name="posArapucaDouble0-Frame-1-9" unit="cm" 
+         x="-328.03"
+	 y="-296.2" 
+	 z="-112.15"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-9-0"/>
+       <position name="posOpArapucaDouble0-Frame-1-9" unit="cm" 
+         x="-327.29"
+	 y="-296.2" 
+	 z="-112.15"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-9-1"/>
+       <position name="posArapucaDouble1-Frame-1-9" unit="cm" 
+         x="-328.03"
+	 y="-205.5" 
+	 z="-258.15"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-9-1"/>
+       <position name="posOpArapucaDouble1-Frame-1-9" unit="cm" 
+         x="-327.29"
+	 y="-205.5" 
+	 z="-258.15"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-9-2"/>
+       <position name="posArapucaDouble2-Frame-1-9" unit="cm" 
+         x="-328.03"
+	 y="-131.5" 
+	 z="-41.1499999999997"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-9-2"/>
+       <position name="posOpArapucaDouble2-Frame-1-9" unit="cm" 
+         x="-327.29"
+	 y="-131.5" 
+	 z="-41.1499999999997"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-9-3"/>
+       <position name="posArapucaDouble3-Frame-1-9" unit="cm" 
+         x="-328.03"
+	 y="-40.8" 
+	 z="-187.15"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-9-3"/>
+       <position name="posOpArapucaDouble3-Frame-1-9" unit="cm" 
+         x="-327.29"
+	 y="-40.8" 
+	 z="-187.15"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-10-0"/>
+       <position name="posArapucaDouble0-Frame-1-10" unit="cm" 
+         x="-328.03"
+	 y="-296.2" 
+	 z="187.15"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-10-0"/>
+       <position name="posOpArapucaDouble0-Frame-1-10" unit="cm" 
+         x="-327.29"
+	 y="-296.2" 
+	 z="187.15"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-10-1"/>
+       <position name="posArapucaDouble1-Frame-1-10" unit="cm" 
+         x="-328.03"
+	 y="-205.5" 
+	 z="41.1500000000003"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-10-1"/>
+       <position name="posOpArapucaDouble1-Frame-1-10" unit="cm" 
+         x="-327.29"
+	 y="-205.5" 
+	 z="41.1500000000003"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-10-2"/>
+       <position name="posArapucaDouble2-Frame-1-10" unit="cm" 
+         x="-328.03"
+	 y="-131.5" 
+	 z="258.15"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-10-2"/>
+       <position name="posOpArapucaDouble2-Frame-1-10" unit="cm" 
+         x="-327.29"
+	 y="-131.5" 
+	 z="258.15"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-10-3"/>
+       <position name="posArapucaDouble3-Frame-1-10" unit="cm" 
+         x="-328.03"
+	 y="-40.8" 
+	 z="112.15"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-10-3"/>
+       <position name="posOpArapucaDouble3-Frame-1-10" unit="cm" 
+         x="-327.29"
+	 y="-40.8" 
+	 z="112.15"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-11-0"/>
+       <position name="posArapucaDouble0-Frame-1-11" unit="cm" 
+         x="-328.03"
+	 y="-296.2" 
+	 z="486.45"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-11-0"/>
+       <position name="posOpArapucaDouble0-Frame-1-11" unit="cm" 
+         x="-327.29"
+	 y="-296.2" 
+	 z="486.45"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-11-1"/>
+       <position name="posArapucaDouble1-Frame-1-11" unit="cm" 
+         x="-328.03"
+	 y="-205.5" 
+	 z="340.45"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-11-1"/>
+       <position name="posOpArapucaDouble1-Frame-1-11" unit="cm" 
+         x="-327.29"
+	 y="-205.5" 
+	 z="340.45"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-11-2"/>
+       <position name="posArapucaDouble2-Frame-1-11" unit="cm" 
+         x="-328.03"
+	 y="-131.5" 
+	 z="557.45"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-11-2"/>
+       <position name="posOpArapucaDouble2-Frame-1-11" unit="cm" 
+         x="-327.29"
+	 y="-131.5" 
+	 z="557.45"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-11-3"/>
+       <position name="posArapucaDouble3-Frame-1-11" unit="cm" 
+         x="-328.03"
+	 y="-40.8" 
+	 z="411.45"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-11-3"/>
+       <position name="posOpArapucaDouble3-Frame-1-11" unit="cm" 
+         x="-327.29"
+	 y="-40.8" 
+	 z="411.45"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-12-0"/>
+       <position name="posArapucaDouble0-Frame-1-12" unit="cm" 
+         x="-328.03"
+	 y="-296.2" 
+	 z="785.75"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-12-0"/>
+       <position name="posOpArapucaDouble0-Frame-1-12" unit="cm" 
+         x="-327.29"
+	 y="-296.2" 
+	 z="785.75"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-12-1"/>
+       <position name="posArapucaDouble1-Frame-1-12" unit="cm" 
+         x="-328.03"
+	 y="-205.5" 
+	 z="639.75"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-12-1"/>
+       <position name="posOpArapucaDouble1-Frame-1-12" unit="cm" 
+         x="-327.29"
+	 y="-205.5" 
+	 z="639.75"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-12-2"/>
+       <position name="posArapucaDouble2-Frame-1-12" unit="cm" 
+         x="-328.03"
+	 y="-131.5" 
+	 z="856.75"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-12-2"/>
+       <position name="posOpArapucaDouble2-Frame-1-12" unit="cm" 
+         x="-327.29"
+	 y="-131.5" 
+	 z="856.75"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-12-3"/>
+       <position name="posArapucaDouble3-Frame-1-12" unit="cm" 
+         x="-328.03"
+	 y="-40.8" 
+	 z="710.75"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-12-3"/>
+       <position name="posOpArapucaDouble3-Frame-1-12" unit="cm" 
+         x="-327.29"
+	 y="-40.8" 
+	 z="710.75"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-13-0"/>
+       <position name="posArapucaDouble0-Frame-1-13" unit="cm" 
+         x="-328.03"
+	 y="-296.2" 
+	 z="1085.05"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-13-0"/>
+       <position name="posOpArapucaDouble0-Frame-1-13" unit="cm" 
+         x="-327.29"
+	 y="-296.2" 
+	 z="1085.05"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-13-1"/>
+       <position name="posArapucaDouble1-Frame-1-13" unit="cm" 
+         x="-328.03"
+	 y="-205.5" 
+	 z="939.05"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-13-1"/>
+       <position name="posOpArapucaDouble1-Frame-1-13" unit="cm" 
+         x="-327.29"
+	 y="-205.5" 
+	 z="939.05"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-13-2"/>
+       <position name="posArapucaDouble2-Frame-1-13" unit="cm" 
+         x="-328.03"
+	 y="-131.5" 
+	 z="1156.05"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-13-2"/>
+       <position name="posOpArapucaDouble2-Frame-1-13" unit="cm" 
+         x="-327.29"
+	 y="-131.5" 
+	 z="1156.05"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-13-3"/>
+       <position name="posArapucaDouble3-Frame-1-13" unit="cm" 
+         x="-328.03"
+	 y="-40.8" 
+	 z="1010.05"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-13-3"/>
+       <position name="posOpArapucaDouble3-Frame-1-13" unit="cm" 
+         x="-327.29"
+	 y="-40.8" 
+	 z="1010.05"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-14-0"/>
+       <position name="posArapucaDouble0-Frame-1-14" unit="cm" 
+         x="-328.03"
+	 y="-296.2" 
+	 z="1384.35"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-14-0"/>
+       <position name="posOpArapucaDouble0-Frame-1-14" unit="cm" 
+         x="-327.29"
+	 y="-296.2" 
+	 z="1384.35"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-14-1"/>
+       <position name="posArapucaDouble1-Frame-1-14" unit="cm" 
+         x="-328.03"
+	 y="-205.5" 
+	 z="1238.35"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-14-1"/>
+       <position name="posOpArapucaDouble1-Frame-1-14" unit="cm" 
+         x="-327.29"
+	 y="-205.5" 
+	 z="1238.35"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-14-2"/>
+       <position name="posArapucaDouble2-Frame-1-14" unit="cm" 
+         x="-328.03"
+	 y="-131.5" 
+	 z="1455.35"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-14-2"/>
+       <position name="posOpArapucaDouble2-Frame-1-14" unit="cm" 
+         x="-327.29"
+	 y="-131.5" 
+	 z="1455.35"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-14-3"/>
+       <position name="posArapucaDouble3-Frame-1-14" unit="cm" 
+         x="-328.03"
+	 y="-40.8" 
+	 z="1309.35"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-14-3"/>
+       <position name="posOpArapucaDouble3-Frame-1-14" unit="cm" 
+         x="-327.29"
+	 y="-40.8" 
+	 z="1309.35"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-15-0"/>
+       <position name="posArapucaDouble0-Frame-1-15" unit="cm" 
+         x="-328.03"
+	 y="-296.2" 
+	 z="1683.65"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-15-0"/>
+       <position name="posOpArapucaDouble0-Frame-1-15" unit="cm" 
+         x="-327.29"
+	 y="-296.2" 
+	 z="1683.65"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-15-1"/>
+       <position name="posArapucaDouble1-Frame-1-15" unit="cm" 
+         x="-328.03"
+	 y="-205.5" 
+	 z="1537.65"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-15-1"/>
+       <position name="posOpArapucaDouble1-Frame-1-15" unit="cm" 
+         x="-327.29"
+	 y="-205.5" 
+	 z="1537.65"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-15-2"/>
+       <position name="posArapucaDouble2-Frame-1-15" unit="cm" 
+         x="-328.03"
+	 y="-131.5" 
+	 z="1754.65"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-15-2"/>
+       <position name="posOpArapucaDouble2-Frame-1-15" unit="cm" 
+         x="-327.29"
+	 y="-131.5" 
+	 z="1754.65"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-15-3"/>
+       <position name="posArapucaDouble3-Frame-1-15" unit="cm" 
+         x="-328.03"
+	 y="-40.8" 
+	 z="1608.65"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-15-3"/>
+       <position name="posOpArapucaDouble3-Frame-1-15" unit="cm" 
+         x="-327.29"
+	 y="-40.8" 
+	 z="1608.65"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-16-0"/>
+       <position name="posArapucaDouble0-Frame-1-16" unit="cm" 
+         x="-328.03"
+	 y="-296.2" 
+	 z="1982.95"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-16-0"/>
+       <position name="posOpArapucaDouble0-Frame-1-16" unit="cm" 
+         x="-327.29"
+	 y="-296.2" 
+	 z="1982.95"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-16-1"/>
+       <position name="posArapucaDouble1-Frame-1-16" unit="cm" 
+         x="-328.03"
+	 y="-205.5" 
+	 z="1836.95"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-16-1"/>
+       <position name="posOpArapucaDouble1-Frame-1-16" unit="cm" 
+         x="-327.29"
+	 y="-205.5" 
+	 z="1836.95"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-16-2"/>
+       <position name="posArapucaDouble2-Frame-1-16" unit="cm" 
+         x="-328.03"
+	 y="-131.5" 
+	 z="2053.95"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-16-2"/>
+       <position name="posOpArapucaDouble2-Frame-1-16" unit="cm" 
+         x="-327.29"
+	 y="-131.5" 
+	 z="2053.95"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-16-3"/>
+       <position name="posArapucaDouble3-Frame-1-16" unit="cm" 
+         x="-328.03"
+	 y="-40.8" 
+	 z="1907.95"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-16-3"/>
+       <position name="posOpArapucaDouble3-Frame-1-16" unit="cm" 
+         x="-327.29"
+	 y="-40.8" 
+	 z="1907.95"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-17-0"/>
+       <position name="posArapucaDouble0-Frame-1-17" unit="cm" 
+         x="-328.03"
+	 y="-296.2" 
+	 z="2282.25"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-17-0"/>
+       <position name="posOpArapucaDouble0-Frame-1-17" unit="cm" 
+         x="-327.29"
+	 y="-296.2" 
+	 z="2282.25"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-17-1"/>
+       <position name="posArapucaDouble1-Frame-1-17" unit="cm" 
+         x="-328.03"
+	 y="-205.5" 
+	 z="2136.25"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-17-1"/>
+       <position name="posOpArapucaDouble1-Frame-1-17" unit="cm" 
+         x="-327.29"
+	 y="-205.5" 
+	 z="2136.25"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-17-2"/>
+       <position name="posArapucaDouble2-Frame-1-17" unit="cm" 
+         x="-328.03"
+	 y="-131.5" 
+	 z="2353.25"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-17-2"/>
+       <position name="posOpArapucaDouble2-Frame-1-17" unit="cm" 
+         x="-327.29"
+	 y="-131.5" 
+	 z="2353.25"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-17-3"/>
+       <position name="posArapucaDouble3-Frame-1-17" unit="cm" 
+         x="-328.03"
+	 y="-40.8" 
+	 z="2207.25"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-17-3"/>
+       <position name="posOpArapucaDouble3-Frame-1-17" unit="cm" 
+         x="-327.29"
+	 y="-40.8" 
+	 z="2207.25"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-18-0"/>
+       <position name="posArapucaDouble0-Frame-1-18" unit="cm" 
+         x="-328.03"
+	 y="-296.2" 
+	 z="2581.55"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-18-0"/>
+       <position name="posOpArapucaDouble0-Frame-1-18" unit="cm" 
+         x="-327.29"
+	 y="-296.2" 
+	 z="2581.55"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-18-1"/>
+       <position name="posArapucaDouble1-Frame-1-18" unit="cm" 
+         x="-328.03"
+	 y="-205.5" 
+	 z="2435.55"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-18-1"/>
+       <position name="posOpArapucaDouble1-Frame-1-18" unit="cm" 
+         x="-327.29"
+	 y="-205.5" 
+	 z="2435.55"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-18-2"/>
+       <position name="posArapucaDouble2-Frame-1-18" unit="cm" 
+         x="-328.03"
+	 y="-131.5" 
+	 z="2652.55"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-18-2"/>
+       <position name="posOpArapucaDouble2-Frame-1-18" unit="cm" 
+         x="-327.29"
+	 y="-131.5" 
+	 z="2652.55"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-18-3"/>
+       <position name="posArapucaDouble3-Frame-1-18" unit="cm" 
+         x="-328.03"
+	 y="-40.8" 
+	 z="2506.55"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-18-3"/>
+       <position name="posOpArapucaDouble3-Frame-1-18" unit="cm" 
+         x="-327.29"
+	 y="-40.8" 
+	 z="2506.55"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-19-0"/>
+       <position name="posArapucaDouble0-Frame-1-19" unit="cm" 
+         x="-328.03"
+	 y="-296.2" 
+	 z="2880.85"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-19-0"/>
+       <position name="posOpArapucaDouble0-Frame-1-19" unit="cm" 
+         x="-327.29"
+	 y="-296.2" 
+	 z="2880.85"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-19-1"/>
+       <position name="posArapucaDouble1-Frame-1-19" unit="cm" 
+         x="-328.03"
+	 y="-205.5" 
+	 z="2734.85"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-19-1"/>
+       <position name="posOpArapucaDouble1-Frame-1-19" unit="cm" 
+         x="-327.29"
+	 y="-205.5" 
+	 z="2734.85"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-19-2"/>
+       <position name="posArapucaDouble2-Frame-1-19" unit="cm" 
+         x="-328.03"
+	 y="-131.5" 
+	 z="2951.85"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-19-2"/>
+       <position name="posOpArapucaDouble2-Frame-1-19" unit="cm" 
+         x="-327.29"
+	 y="-131.5" 
+	 z="2951.85"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-19-3"/>
+       <position name="posArapucaDouble3-Frame-1-19" unit="cm" 
+         x="-328.03"
+	 y="-40.8" 
+	 z="2805.85"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-19-3"/>
+       <position name="posOpArapucaDouble3-Frame-1-19" unit="cm" 
+         x="-327.29"
+	 y="-40.8" 
+	 z="2805.85"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-0-0"/>
        <position name="posArapucaDouble0-Frame-2-0" unit="cm" 
          x="-328.03"
 	 y="40.8" 
-	 z="-261.8"/>
+	 z="-2805.85"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
@@ -40786,14 +48062,14 @@
        <position name="posOpArapucaDouble0-Frame-2-0" unit="cm" 
          x="-327.29"
 	 y="40.8" 
-	 z="-261.8"/>
+	 z="-2805.85"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-0-1"/>
        <position name="posArapucaDouble1-Frame-2-0" unit="cm" 
          x="-328.03"
 	 y="131.5" 
-	 z="-407.8"/>
+	 z="-2951.85"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
@@ -40801,14 +48077,14 @@
        <position name="posOpArapucaDouble1-Frame-2-0" unit="cm" 
          x="-327.29"
 	 y="131.5" 
-	 z="-407.8"/>
+	 z="-2951.85"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-0-2"/>
        <position name="posArapucaDouble2-Frame-2-0" unit="cm" 
          x="-328.03"
 	 y="205.5" 
-	 z="-190.8"/>
+	 z="-2734.85"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
@@ -40816,14 +48092,14 @@
        <position name="posOpArapucaDouble2-Frame-2-0" unit="cm" 
          x="-327.29"
 	 y="205.5" 
-	 z="-190.8"/>
+	 z="-2734.85"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-0-3"/>
        <position name="posArapucaDouble3-Frame-2-0" unit="cm" 
          x="-328.03"
 	 y="296.2" 
-	 z="-336.8"/>
+	 z="-2880.85"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
@@ -40831,14 +48107,14 @@
        <position name="posOpArapucaDouble3-Frame-2-0" unit="cm" 
          x="-327.29"
 	 y="296.2" 
-	 z="-336.8"/>
+	 z="-2880.85"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-1-0"/>
        <position name="posArapucaDouble0-Frame-2-1" unit="cm" 
          x="-328.03"
 	 y="40.8" 
-	 z="37.4999999999999"/>
+	 z="-2506.55"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
@@ -40846,14 +48122,14 @@
        <position name="posOpArapucaDouble0-Frame-2-1" unit="cm" 
          x="-327.29"
 	 y="40.8" 
-	 z="37.4999999999999"/>
+	 z="-2506.55"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-1-1"/>
        <position name="posArapucaDouble1-Frame-2-1" unit="cm" 
          x="-328.03"
 	 y="131.5" 
-	 z="-108.5"/>
+	 z="-2652.55"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
@@ -40861,14 +48137,14 @@
        <position name="posOpArapucaDouble1-Frame-2-1" unit="cm" 
          x="-327.29"
 	 y="131.5" 
-	 z="-108.5"/>
+	 z="-2652.55"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-1-2"/>
        <position name="posArapucaDouble2-Frame-2-1" unit="cm" 
          x="-328.03"
 	 y="205.5" 
-	 z="108.5"/>
+	 z="-2435.55"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
@@ -40876,14 +48152,14 @@
        <position name="posOpArapucaDouble2-Frame-2-1" unit="cm" 
          x="-327.29"
 	 y="205.5" 
-	 z="108.5"/>
+	 z="-2435.55"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-1-3"/>
        <position name="posArapucaDouble3-Frame-2-1" unit="cm" 
          x="-328.03"
 	 y="296.2" 
-	 z="-37.5000000000001"/>
+	 z="-2581.55"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
@@ -40891,14 +48167,14 @@
        <position name="posOpArapucaDouble3-Frame-2-1" unit="cm" 
          x="-327.29"
 	 y="296.2" 
-	 z="-37.5000000000001"/>
+	 z="-2581.55"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-2-0"/>
        <position name="posArapucaDouble0-Frame-2-2" unit="cm" 
          x="-328.03"
 	 y="40.8" 
-	 z="336.8"/>
+	 z="-2207.25"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
@@ -40906,14 +48182,14 @@
        <position name="posOpArapucaDouble0-Frame-2-2" unit="cm" 
          x="-327.29"
 	 y="40.8" 
-	 z="336.8"/>
+	 z="-2207.25"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-2-1"/>
        <position name="posArapucaDouble1-Frame-2-2" unit="cm" 
          x="-328.03"
 	 y="131.5" 
-	 z="190.8"/>
+	 z="-2353.25"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
@@ -40921,14 +48197,14 @@
        <position name="posOpArapucaDouble1-Frame-2-2" unit="cm" 
          x="-327.29"
 	 y="131.5" 
-	 z="190.8"/>
+	 z="-2353.25"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-2-2"/>
        <position name="posArapucaDouble2-Frame-2-2" unit="cm" 
          x="-328.03"
 	 y="205.5" 
-	 z="407.8"/>
+	 z="-2136.25"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
@@ -40936,14 +48212,14 @@
        <position name="posOpArapucaDouble2-Frame-2-2" unit="cm" 
          x="-327.29"
 	 y="205.5" 
-	 z="407.8"/>
+	 z="-2136.25"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_2-2-3"/>
        <position name="posArapucaDouble3-Frame-2-2" unit="cm" 
          x="-328.03"
 	 y="296.2" 
-	 z="261.8"/>
+	 z="-2282.25"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
@@ -40951,14 +48227,1034 @@
        <position name="posOpArapucaDouble3-Frame-2-2" unit="cm" 
          x="-327.29"
 	 y="296.2" 
-	 z="261.8"/>
+	 z="-2282.25"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-3-0"/>
+       <position name="posArapucaDouble0-Frame-2-3" unit="cm" 
+         x="-328.03"
+	 y="40.8" 
+	 z="-1907.95"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-3-0"/>
+       <position name="posOpArapucaDouble0-Frame-2-3" unit="cm" 
+         x="-327.29"
+	 y="40.8" 
+	 z="-1907.95"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-3-1"/>
+       <position name="posArapucaDouble1-Frame-2-3" unit="cm" 
+         x="-328.03"
+	 y="131.5" 
+	 z="-2053.95"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-3-1"/>
+       <position name="posOpArapucaDouble1-Frame-2-3" unit="cm" 
+         x="-327.29"
+	 y="131.5" 
+	 z="-2053.95"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-3-2"/>
+       <position name="posArapucaDouble2-Frame-2-3" unit="cm" 
+         x="-328.03"
+	 y="205.5" 
+	 z="-1836.95"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-3-2"/>
+       <position name="posOpArapucaDouble2-Frame-2-3" unit="cm" 
+         x="-327.29"
+	 y="205.5" 
+	 z="-1836.95"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-3-3"/>
+       <position name="posArapucaDouble3-Frame-2-3" unit="cm" 
+         x="-328.03"
+	 y="296.2" 
+	 z="-1982.95"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-3-3"/>
+       <position name="posOpArapucaDouble3-Frame-2-3" unit="cm" 
+         x="-327.29"
+	 y="296.2" 
+	 z="-1982.95"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-4-0"/>
+       <position name="posArapucaDouble0-Frame-2-4" unit="cm" 
+         x="-328.03"
+	 y="40.8" 
+	 z="-1608.65"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-4-0"/>
+       <position name="posOpArapucaDouble0-Frame-2-4" unit="cm" 
+         x="-327.29"
+	 y="40.8" 
+	 z="-1608.65"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-4-1"/>
+       <position name="posArapucaDouble1-Frame-2-4" unit="cm" 
+         x="-328.03"
+	 y="131.5" 
+	 z="-1754.65"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-4-1"/>
+       <position name="posOpArapucaDouble1-Frame-2-4" unit="cm" 
+         x="-327.29"
+	 y="131.5" 
+	 z="-1754.65"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-4-2"/>
+       <position name="posArapucaDouble2-Frame-2-4" unit="cm" 
+         x="-328.03"
+	 y="205.5" 
+	 z="-1537.65"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-4-2"/>
+       <position name="posOpArapucaDouble2-Frame-2-4" unit="cm" 
+         x="-327.29"
+	 y="205.5" 
+	 z="-1537.65"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-4-3"/>
+       <position name="posArapucaDouble3-Frame-2-4" unit="cm" 
+         x="-328.03"
+	 y="296.2" 
+	 z="-1683.65"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-4-3"/>
+       <position name="posOpArapucaDouble3-Frame-2-4" unit="cm" 
+         x="-327.29"
+	 y="296.2" 
+	 z="-1683.65"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-5-0"/>
+       <position name="posArapucaDouble0-Frame-2-5" unit="cm" 
+         x="-328.03"
+	 y="40.8" 
+	 z="-1309.35"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-5-0"/>
+       <position name="posOpArapucaDouble0-Frame-2-5" unit="cm" 
+         x="-327.29"
+	 y="40.8" 
+	 z="-1309.35"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-5-1"/>
+       <position name="posArapucaDouble1-Frame-2-5" unit="cm" 
+         x="-328.03"
+	 y="131.5" 
+	 z="-1455.35"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-5-1"/>
+       <position name="posOpArapucaDouble1-Frame-2-5" unit="cm" 
+         x="-327.29"
+	 y="131.5" 
+	 z="-1455.35"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-5-2"/>
+       <position name="posArapucaDouble2-Frame-2-5" unit="cm" 
+         x="-328.03"
+	 y="205.5" 
+	 z="-1238.35"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-5-2"/>
+       <position name="posOpArapucaDouble2-Frame-2-5" unit="cm" 
+         x="-327.29"
+	 y="205.5" 
+	 z="-1238.35"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-5-3"/>
+       <position name="posArapucaDouble3-Frame-2-5" unit="cm" 
+         x="-328.03"
+	 y="296.2" 
+	 z="-1384.35"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-5-3"/>
+       <position name="posOpArapucaDouble3-Frame-2-5" unit="cm" 
+         x="-327.29"
+	 y="296.2" 
+	 z="-1384.35"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-6-0"/>
+       <position name="posArapucaDouble0-Frame-2-6" unit="cm" 
+         x="-328.03"
+	 y="40.8" 
+	 z="-1010.05"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-6-0"/>
+       <position name="posOpArapucaDouble0-Frame-2-6" unit="cm" 
+         x="-327.29"
+	 y="40.8" 
+	 z="-1010.05"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-6-1"/>
+       <position name="posArapucaDouble1-Frame-2-6" unit="cm" 
+         x="-328.03"
+	 y="131.5" 
+	 z="-1156.05"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-6-1"/>
+       <position name="posOpArapucaDouble1-Frame-2-6" unit="cm" 
+         x="-327.29"
+	 y="131.5" 
+	 z="-1156.05"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-6-2"/>
+       <position name="posArapucaDouble2-Frame-2-6" unit="cm" 
+         x="-328.03"
+	 y="205.5" 
+	 z="-939.05"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-6-2"/>
+       <position name="posOpArapucaDouble2-Frame-2-6" unit="cm" 
+         x="-327.29"
+	 y="205.5" 
+	 z="-939.05"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-6-3"/>
+       <position name="posArapucaDouble3-Frame-2-6" unit="cm" 
+         x="-328.03"
+	 y="296.2" 
+	 z="-1085.05"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-6-3"/>
+       <position name="posOpArapucaDouble3-Frame-2-6" unit="cm" 
+         x="-327.29"
+	 y="296.2" 
+	 z="-1085.05"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-7-0"/>
+       <position name="posArapucaDouble0-Frame-2-7" unit="cm" 
+         x="-328.03"
+	 y="40.8" 
+	 z="-710.75"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-7-0"/>
+       <position name="posOpArapucaDouble0-Frame-2-7" unit="cm" 
+         x="-327.29"
+	 y="40.8" 
+	 z="-710.75"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-7-1"/>
+       <position name="posArapucaDouble1-Frame-2-7" unit="cm" 
+         x="-328.03"
+	 y="131.5" 
+	 z="-856.75"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-7-1"/>
+       <position name="posOpArapucaDouble1-Frame-2-7" unit="cm" 
+         x="-327.29"
+	 y="131.5" 
+	 z="-856.75"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-7-2"/>
+       <position name="posArapucaDouble2-Frame-2-7" unit="cm" 
+         x="-328.03"
+	 y="205.5" 
+	 z="-639.75"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-7-2"/>
+       <position name="posOpArapucaDouble2-Frame-2-7" unit="cm" 
+         x="-327.29"
+	 y="205.5" 
+	 z="-639.75"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-7-3"/>
+       <position name="posArapucaDouble3-Frame-2-7" unit="cm" 
+         x="-328.03"
+	 y="296.2" 
+	 z="-785.75"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-7-3"/>
+       <position name="posOpArapucaDouble3-Frame-2-7" unit="cm" 
+         x="-327.29"
+	 y="296.2" 
+	 z="-785.75"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-8-0"/>
+       <position name="posArapucaDouble0-Frame-2-8" unit="cm" 
+         x="-328.03"
+	 y="40.8" 
+	 z="-411.45"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-8-0"/>
+       <position name="posOpArapucaDouble0-Frame-2-8" unit="cm" 
+         x="-327.29"
+	 y="40.8" 
+	 z="-411.45"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-8-1"/>
+       <position name="posArapucaDouble1-Frame-2-8" unit="cm" 
+         x="-328.03"
+	 y="131.5" 
+	 z="-557.45"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-8-1"/>
+       <position name="posOpArapucaDouble1-Frame-2-8" unit="cm" 
+         x="-327.29"
+	 y="131.5" 
+	 z="-557.45"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-8-2"/>
+       <position name="posArapucaDouble2-Frame-2-8" unit="cm" 
+         x="-328.03"
+	 y="205.5" 
+	 z="-340.45"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-8-2"/>
+       <position name="posOpArapucaDouble2-Frame-2-8" unit="cm" 
+         x="-327.29"
+	 y="205.5" 
+	 z="-340.45"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-8-3"/>
+       <position name="posArapucaDouble3-Frame-2-8" unit="cm" 
+         x="-328.03"
+	 y="296.2" 
+	 z="-486.45"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-8-3"/>
+       <position name="posOpArapucaDouble3-Frame-2-8" unit="cm" 
+         x="-327.29"
+	 y="296.2" 
+	 z="-486.45"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-9-0"/>
+       <position name="posArapucaDouble0-Frame-2-9" unit="cm" 
+         x="-328.03"
+	 y="40.8" 
+	 z="-112.15"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-9-0"/>
+       <position name="posOpArapucaDouble0-Frame-2-9" unit="cm" 
+         x="-327.29"
+	 y="40.8" 
+	 z="-112.15"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-9-1"/>
+       <position name="posArapucaDouble1-Frame-2-9" unit="cm" 
+         x="-328.03"
+	 y="131.5" 
+	 z="-258.15"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-9-1"/>
+       <position name="posOpArapucaDouble1-Frame-2-9" unit="cm" 
+         x="-327.29"
+	 y="131.5" 
+	 z="-258.15"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-9-2"/>
+       <position name="posArapucaDouble2-Frame-2-9" unit="cm" 
+         x="-328.03"
+	 y="205.5" 
+	 z="-41.1499999999997"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-9-2"/>
+       <position name="posOpArapucaDouble2-Frame-2-9" unit="cm" 
+         x="-327.29"
+	 y="205.5" 
+	 z="-41.1499999999997"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-9-3"/>
+       <position name="posArapucaDouble3-Frame-2-9" unit="cm" 
+         x="-328.03"
+	 y="296.2" 
+	 z="-187.15"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-9-3"/>
+       <position name="posOpArapucaDouble3-Frame-2-9" unit="cm" 
+         x="-327.29"
+	 y="296.2" 
+	 z="-187.15"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-10-0"/>
+       <position name="posArapucaDouble0-Frame-2-10" unit="cm" 
+         x="-328.03"
+	 y="40.8" 
+	 z="187.15"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-10-0"/>
+       <position name="posOpArapucaDouble0-Frame-2-10" unit="cm" 
+         x="-327.29"
+	 y="40.8" 
+	 z="187.15"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-10-1"/>
+       <position name="posArapucaDouble1-Frame-2-10" unit="cm" 
+         x="-328.03"
+	 y="131.5" 
+	 z="41.1500000000003"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-10-1"/>
+       <position name="posOpArapucaDouble1-Frame-2-10" unit="cm" 
+         x="-327.29"
+	 y="131.5" 
+	 z="41.1500000000003"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-10-2"/>
+       <position name="posArapucaDouble2-Frame-2-10" unit="cm" 
+         x="-328.03"
+	 y="205.5" 
+	 z="258.15"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-10-2"/>
+       <position name="posOpArapucaDouble2-Frame-2-10" unit="cm" 
+         x="-327.29"
+	 y="205.5" 
+	 z="258.15"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-10-3"/>
+       <position name="posArapucaDouble3-Frame-2-10" unit="cm" 
+         x="-328.03"
+	 y="296.2" 
+	 z="112.15"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-10-3"/>
+       <position name="posOpArapucaDouble3-Frame-2-10" unit="cm" 
+         x="-327.29"
+	 y="296.2" 
+	 z="112.15"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-11-0"/>
+       <position name="posArapucaDouble0-Frame-2-11" unit="cm" 
+         x="-328.03"
+	 y="40.8" 
+	 z="486.45"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-11-0"/>
+       <position name="posOpArapucaDouble0-Frame-2-11" unit="cm" 
+         x="-327.29"
+	 y="40.8" 
+	 z="486.45"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-11-1"/>
+       <position name="posArapucaDouble1-Frame-2-11" unit="cm" 
+         x="-328.03"
+	 y="131.5" 
+	 z="340.45"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-11-1"/>
+       <position name="posOpArapucaDouble1-Frame-2-11" unit="cm" 
+         x="-327.29"
+	 y="131.5" 
+	 z="340.45"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-11-2"/>
+       <position name="posArapucaDouble2-Frame-2-11" unit="cm" 
+         x="-328.03"
+	 y="205.5" 
+	 z="557.45"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-11-2"/>
+       <position name="posOpArapucaDouble2-Frame-2-11" unit="cm" 
+         x="-327.29"
+	 y="205.5" 
+	 z="557.45"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-11-3"/>
+       <position name="posArapucaDouble3-Frame-2-11" unit="cm" 
+         x="-328.03"
+	 y="296.2" 
+	 z="411.45"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-11-3"/>
+       <position name="posOpArapucaDouble3-Frame-2-11" unit="cm" 
+         x="-327.29"
+	 y="296.2" 
+	 z="411.45"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-12-0"/>
+       <position name="posArapucaDouble0-Frame-2-12" unit="cm" 
+         x="-328.03"
+	 y="40.8" 
+	 z="785.75"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-12-0"/>
+       <position name="posOpArapucaDouble0-Frame-2-12" unit="cm" 
+         x="-327.29"
+	 y="40.8" 
+	 z="785.75"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-12-1"/>
+       <position name="posArapucaDouble1-Frame-2-12" unit="cm" 
+         x="-328.03"
+	 y="131.5" 
+	 z="639.75"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-12-1"/>
+       <position name="posOpArapucaDouble1-Frame-2-12" unit="cm" 
+         x="-327.29"
+	 y="131.5" 
+	 z="639.75"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-12-2"/>
+       <position name="posArapucaDouble2-Frame-2-12" unit="cm" 
+         x="-328.03"
+	 y="205.5" 
+	 z="856.75"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-12-2"/>
+       <position name="posOpArapucaDouble2-Frame-2-12" unit="cm" 
+         x="-327.29"
+	 y="205.5" 
+	 z="856.75"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-12-3"/>
+       <position name="posArapucaDouble3-Frame-2-12" unit="cm" 
+         x="-328.03"
+	 y="296.2" 
+	 z="710.75"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-12-3"/>
+       <position name="posOpArapucaDouble3-Frame-2-12" unit="cm" 
+         x="-327.29"
+	 y="296.2" 
+	 z="710.75"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-13-0"/>
+       <position name="posArapucaDouble0-Frame-2-13" unit="cm" 
+         x="-328.03"
+	 y="40.8" 
+	 z="1085.05"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-13-0"/>
+       <position name="posOpArapucaDouble0-Frame-2-13" unit="cm" 
+         x="-327.29"
+	 y="40.8" 
+	 z="1085.05"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-13-1"/>
+       <position name="posArapucaDouble1-Frame-2-13" unit="cm" 
+         x="-328.03"
+	 y="131.5" 
+	 z="939.05"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-13-1"/>
+       <position name="posOpArapucaDouble1-Frame-2-13" unit="cm" 
+         x="-327.29"
+	 y="131.5" 
+	 z="939.05"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-13-2"/>
+       <position name="posArapucaDouble2-Frame-2-13" unit="cm" 
+         x="-328.03"
+	 y="205.5" 
+	 z="1156.05"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-13-2"/>
+       <position name="posOpArapucaDouble2-Frame-2-13" unit="cm" 
+         x="-327.29"
+	 y="205.5" 
+	 z="1156.05"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-13-3"/>
+       <position name="posArapucaDouble3-Frame-2-13" unit="cm" 
+         x="-328.03"
+	 y="296.2" 
+	 z="1010.05"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-13-3"/>
+       <position name="posOpArapucaDouble3-Frame-2-13" unit="cm" 
+         x="-327.29"
+	 y="296.2" 
+	 z="1010.05"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-14-0"/>
+       <position name="posArapucaDouble0-Frame-2-14" unit="cm" 
+         x="-328.03"
+	 y="40.8" 
+	 z="1384.35"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-14-0"/>
+       <position name="posOpArapucaDouble0-Frame-2-14" unit="cm" 
+         x="-327.29"
+	 y="40.8" 
+	 z="1384.35"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-14-1"/>
+       <position name="posArapucaDouble1-Frame-2-14" unit="cm" 
+         x="-328.03"
+	 y="131.5" 
+	 z="1238.35"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-14-1"/>
+       <position name="posOpArapucaDouble1-Frame-2-14" unit="cm" 
+         x="-327.29"
+	 y="131.5" 
+	 z="1238.35"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-14-2"/>
+       <position name="posArapucaDouble2-Frame-2-14" unit="cm" 
+         x="-328.03"
+	 y="205.5" 
+	 z="1455.35"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-14-2"/>
+       <position name="posOpArapucaDouble2-Frame-2-14" unit="cm" 
+         x="-327.29"
+	 y="205.5" 
+	 z="1455.35"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-14-3"/>
+       <position name="posArapucaDouble3-Frame-2-14" unit="cm" 
+         x="-328.03"
+	 y="296.2" 
+	 z="1309.35"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-14-3"/>
+       <position name="posOpArapucaDouble3-Frame-2-14" unit="cm" 
+         x="-327.29"
+	 y="296.2" 
+	 z="1309.35"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-15-0"/>
+       <position name="posArapucaDouble0-Frame-2-15" unit="cm" 
+         x="-328.03"
+	 y="40.8" 
+	 z="1683.65"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-15-0"/>
+       <position name="posOpArapucaDouble0-Frame-2-15" unit="cm" 
+         x="-327.29"
+	 y="40.8" 
+	 z="1683.65"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-15-1"/>
+       <position name="posArapucaDouble1-Frame-2-15" unit="cm" 
+         x="-328.03"
+	 y="131.5" 
+	 z="1537.65"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-15-1"/>
+       <position name="posOpArapucaDouble1-Frame-2-15" unit="cm" 
+         x="-327.29"
+	 y="131.5" 
+	 z="1537.65"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-15-2"/>
+       <position name="posArapucaDouble2-Frame-2-15" unit="cm" 
+         x="-328.03"
+	 y="205.5" 
+	 z="1754.65"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-15-2"/>
+       <position name="posOpArapucaDouble2-Frame-2-15" unit="cm" 
+         x="-327.29"
+	 y="205.5" 
+	 z="1754.65"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-15-3"/>
+       <position name="posArapucaDouble3-Frame-2-15" unit="cm" 
+         x="-328.03"
+	 y="296.2" 
+	 z="1608.65"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-15-3"/>
+       <position name="posOpArapucaDouble3-Frame-2-15" unit="cm" 
+         x="-327.29"
+	 y="296.2" 
+	 z="1608.65"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-16-0"/>
+       <position name="posArapucaDouble0-Frame-2-16" unit="cm" 
+         x="-328.03"
+	 y="40.8" 
+	 z="1982.95"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-16-0"/>
+       <position name="posOpArapucaDouble0-Frame-2-16" unit="cm" 
+         x="-327.29"
+	 y="40.8" 
+	 z="1982.95"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-16-1"/>
+       <position name="posArapucaDouble1-Frame-2-16" unit="cm" 
+         x="-328.03"
+	 y="131.5" 
+	 z="1836.95"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-16-1"/>
+       <position name="posOpArapucaDouble1-Frame-2-16" unit="cm" 
+         x="-327.29"
+	 y="131.5" 
+	 z="1836.95"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-16-2"/>
+       <position name="posArapucaDouble2-Frame-2-16" unit="cm" 
+         x="-328.03"
+	 y="205.5" 
+	 z="2053.95"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-16-2"/>
+       <position name="posOpArapucaDouble2-Frame-2-16" unit="cm" 
+         x="-327.29"
+	 y="205.5" 
+	 z="2053.95"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-16-3"/>
+       <position name="posArapucaDouble3-Frame-2-16" unit="cm" 
+         x="-328.03"
+	 y="296.2" 
+	 z="1907.95"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-16-3"/>
+       <position name="posOpArapucaDouble3-Frame-2-16" unit="cm" 
+         x="-327.29"
+	 y="296.2" 
+	 z="1907.95"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-17-0"/>
+       <position name="posArapucaDouble0-Frame-2-17" unit="cm" 
+         x="-328.03"
+	 y="40.8" 
+	 z="2282.25"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-17-0"/>
+       <position name="posOpArapucaDouble0-Frame-2-17" unit="cm" 
+         x="-327.29"
+	 y="40.8" 
+	 z="2282.25"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-17-1"/>
+       <position name="posArapucaDouble1-Frame-2-17" unit="cm" 
+         x="-328.03"
+	 y="131.5" 
+	 z="2136.25"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-17-1"/>
+       <position name="posOpArapucaDouble1-Frame-2-17" unit="cm" 
+         x="-327.29"
+	 y="131.5" 
+	 z="2136.25"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-17-2"/>
+       <position name="posArapucaDouble2-Frame-2-17" unit="cm" 
+         x="-328.03"
+	 y="205.5" 
+	 z="2353.25"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-17-2"/>
+       <position name="posOpArapucaDouble2-Frame-2-17" unit="cm" 
+         x="-327.29"
+	 y="205.5" 
+	 z="2353.25"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-17-3"/>
+       <position name="posArapucaDouble3-Frame-2-17" unit="cm" 
+         x="-328.03"
+	 y="296.2" 
+	 z="2207.25"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-17-3"/>
+       <position name="posOpArapucaDouble3-Frame-2-17" unit="cm" 
+         x="-327.29"
+	 y="296.2" 
+	 z="2207.25"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-18-0"/>
+       <position name="posArapucaDouble0-Frame-2-18" unit="cm" 
+         x="-328.03"
+	 y="40.8" 
+	 z="2581.55"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-18-0"/>
+       <position name="posOpArapucaDouble0-Frame-2-18" unit="cm" 
+         x="-327.29"
+	 y="40.8" 
+	 z="2581.55"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-18-1"/>
+       <position name="posArapucaDouble1-Frame-2-18" unit="cm" 
+         x="-328.03"
+	 y="131.5" 
+	 z="2435.55"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-18-1"/>
+       <position name="posOpArapucaDouble1-Frame-2-18" unit="cm" 
+         x="-327.29"
+	 y="131.5" 
+	 z="2435.55"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-18-2"/>
+       <position name="posArapucaDouble2-Frame-2-18" unit="cm" 
+         x="-328.03"
+	 y="205.5" 
+	 z="2652.55"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-18-2"/>
+       <position name="posOpArapucaDouble2-Frame-2-18" unit="cm" 
+         x="-327.29"
+	 y="205.5" 
+	 z="2652.55"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-18-3"/>
+       <position name="posArapucaDouble3-Frame-2-18" unit="cm" 
+         x="-328.03"
+	 y="296.2" 
+	 z="2506.55"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-18-3"/>
+       <position name="posOpArapucaDouble3-Frame-2-18" unit="cm" 
+         x="-327.29"
+	 y="296.2" 
+	 z="2506.55"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-19-0"/>
+       <position name="posArapucaDouble0-Frame-2-19" unit="cm" 
+         x="-328.03"
+	 y="40.8" 
+	 z="2880.85"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-19-0"/>
+       <position name="posOpArapucaDouble0-Frame-2-19" unit="cm" 
+         x="-327.29"
+	 y="40.8" 
+	 z="2880.85"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-19-1"/>
+       <position name="posArapucaDouble1-Frame-2-19" unit="cm" 
+         x="-328.03"
+	 y="131.5" 
+	 z="2734.85"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-19-1"/>
+       <position name="posOpArapucaDouble1-Frame-2-19" unit="cm" 
+         x="-327.29"
+	 y="131.5" 
+	 z="2734.85"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-19-2"/>
+       <position name="posArapucaDouble2-Frame-2-19" unit="cm" 
+         x="-328.03"
+	 y="205.5" 
+	 z="2951.85"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-19-2"/>
+       <position name="posOpArapucaDouble2-Frame-2-19" unit="cm" 
+         x="-327.29"
+	 y="205.5" 
+	 z="2951.85"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-19-3"/>
+       <position name="posArapucaDouble3-Frame-2-19" unit="cm" 
+         x="-328.03"
+	 y="296.2" 
+	 z="2805.85"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-19-3"/>
+       <position name="posOpArapucaDouble3-Frame-2-19" unit="cm" 
+         x="-327.29"
+	 y="296.2" 
+	 z="2805.85"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-0-0"/>
        <position name="posArapucaDouble0-Frame-3-0" unit="cm" 
          x="-328.03"
 	 y="377.8" 
-	 z="-261.8"/>
+	 z="-2805.85"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
@@ -40966,14 +49262,14 @@
        <position name="posOpArapucaDouble0-Frame-3-0" unit="cm" 
          x="-327.29"
 	 y="377.8" 
-	 z="-261.8"/>
+	 z="-2805.85"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-0-1"/>
        <position name="posArapucaDouble1-Frame-3-0" unit="cm" 
          x="-328.03"
 	 y="468.5" 
-	 z="-407.8"/>
+	 z="-2951.85"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
@@ -40981,14 +49277,14 @@
        <position name="posOpArapucaDouble1-Frame-3-0" unit="cm" 
          x="-327.29"
 	 y="468.5" 
-	 z="-407.8"/>
+	 z="-2951.85"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-0-2"/>
        <position name="posArapucaDouble2-Frame-3-0" unit="cm" 
          x="-328.03"
 	 y="542.5" 
-	 z="-190.8"/>
+	 z="-2734.85"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
@@ -40996,14 +49292,14 @@
        <position name="posOpArapucaDouble2-Frame-3-0" unit="cm" 
          x="-327.29"
 	 y="542.5" 
-	 z="-190.8"/>
+	 z="-2734.85"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-0-3"/>
        <position name="posArapucaDouble3-Frame-3-0" unit="cm" 
          x="-328.03"
 	 y="633.2" 
-	 z="-336.8"/>
+	 z="-2880.85"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
@@ -41011,14 +49307,14 @@
        <position name="posOpArapucaDouble3-Frame-3-0" unit="cm" 
          x="-327.29"
 	 y="633.2" 
-	 z="-336.8"/>
+	 z="-2880.85"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-1-0"/>
        <position name="posArapucaDouble0-Frame-3-1" unit="cm" 
          x="-328.03"
 	 y="377.8" 
-	 z="37.4999999999999"/>
+	 z="-2506.55"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
@@ -41026,14 +49322,14 @@
        <position name="posOpArapucaDouble0-Frame-3-1" unit="cm" 
          x="-327.29"
 	 y="377.8" 
-	 z="37.4999999999999"/>
+	 z="-2506.55"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-1-1"/>
        <position name="posArapucaDouble1-Frame-3-1" unit="cm" 
          x="-328.03"
 	 y="468.5" 
-	 z="-108.5"/>
+	 z="-2652.55"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
@@ -41041,14 +49337,14 @@
        <position name="posOpArapucaDouble1-Frame-3-1" unit="cm" 
          x="-327.29"
 	 y="468.5" 
-	 z="-108.5"/>
+	 z="-2652.55"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-1-2"/>
        <position name="posArapucaDouble2-Frame-3-1" unit="cm" 
          x="-328.03"
 	 y="542.5" 
-	 z="108.5"/>
+	 z="-2435.55"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
@@ -41056,14 +49352,14 @@
        <position name="posOpArapucaDouble2-Frame-3-1" unit="cm" 
          x="-327.29"
 	 y="542.5" 
-	 z="108.5"/>
+	 z="-2435.55"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-1-3"/>
        <position name="posArapucaDouble3-Frame-3-1" unit="cm" 
          x="-328.03"
 	 y="633.2" 
-	 z="-37.5000000000001"/>
+	 z="-2581.55"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
@@ -41071,14 +49367,14 @@
        <position name="posOpArapucaDouble3-Frame-3-1" unit="cm" 
          x="-327.29"
 	 y="633.2" 
-	 z="-37.5000000000001"/>
+	 z="-2581.55"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-2-0"/>
        <position name="posArapucaDouble0-Frame-3-2" unit="cm" 
          x="-328.03"
 	 y="377.8" 
-	 z="336.8"/>
+	 z="-2207.25"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
@@ -41086,14 +49382,14 @@
        <position name="posOpArapucaDouble0-Frame-3-2" unit="cm" 
          x="-327.29"
 	 y="377.8" 
-	 z="336.8"/>
+	 z="-2207.25"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-2-1"/>
        <position name="posArapucaDouble1-Frame-3-2" unit="cm" 
          x="-328.03"
 	 y="468.5" 
-	 z="190.8"/>
+	 z="-2353.25"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
@@ -41101,14 +49397,14 @@
        <position name="posOpArapucaDouble1-Frame-3-2" unit="cm" 
          x="-327.29"
 	 y="468.5" 
-	 z="190.8"/>
+	 z="-2353.25"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-2-2"/>
        <position name="posArapucaDouble2-Frame-3-2" unit="cm" 
          x="-328.03"
 	 y="542.5" 
-	 z="407.8"/>
+	 z="-2136.25"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
@@ -41116,14 +49412,14 @@
        <position name="posOpArapucaDouble2-Frame-3-2" unit="cm" 
          x="-327.29"
 	 y="542.5" 
-	 z="407.8"/>
+	 z="-2136.25"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaDouble_3-2-3"/>
        <position name="posArapucaDouble3-Frame-3-2" unit="cm" 
          x="-328.03"
 	 y="633.2" 
-	 z="261.8"/>
+	 z="-2282.25"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
@@ -41131,14 +49427,1034 @@
        <position name="posOpArapucaDouble3-Frame-3-2" unit="cm" 
          x="-327.29"
 	 y="633.2" 
-	 z="261.8"/>
+	 z="-2282.25"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-3-0"/>
+       <position name="posArapucaDouble0-Frame-3-3" unit="cm" 
+         x="-328.03"
+	 y="377.8" 
+	 z="-1907.95"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-3-0"/>
+       <position name="posOpArapucaDouble0-Frame-3-3" unit="cm" 
+         x="-327.29"
+	 y="377.8" 
+	 z="-1907.95"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-3-1"/>
+       <position name="posArapucaDouble1-Frame-3-3" unit="cm" 
+         x="-328.03"
+	 y="468.5" 
+	 z="-2053.95"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-3-1"/>
+       <position name="posOpArapucaDouble1-Frame-3-3" unit="cm" 
+         x="-327.29"
+	 y="468.5" 
+	 z="-2053.95"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-3-2"/>
+       <position name="posArapucaDouble2-Frame-3-3" unit="cm" 
+         x="-328.03"
+	 y="542.5" 
+	 z="-1836.95"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-3-2"/>
+       <position name="posOpArapucaDouble2-Frame-3-3" unit="cm" 
+         x="-327.29"
+	 y="542.5" 
+	 z="-1836.95"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-3-3"/>
+       <position name="posArapucaDouble3-Frame-3-3" unit="cm" 
+         x="-328.03"
+	 y="633.2" 
+	 z="-1982.95"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-3-3"/>
+       <position name="posOpArapucaDouble3-Frame-3-3" unit="cm" 
+         x="-327.29"
+	 y="633.2" 
+	 z="-1982.95"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-4-0"/>
+       <position name="posArapucaDouble0-Frame-3-4" unit="cm" 
+         x="-328.03"
+	 y="377.8" 
+	 z="-1608.65"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-4-0"/>
+       <position name="posOpArapucaDouble0-Frame-3-4" unit="cm" 
+         x="-327.29"
+	 y="377.8" 
+	 z="-1608.65"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-4-1"/>
+       <position name="posArapucaDouble1-Frame-3-4" unit="cm" 
+         x="-328.03"
+	 y="468.5" 
+	 z="-1754.65"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-4-1"/>
+       <position name="posOpArapucaDouble1-Frame-3-4" unit="cm" 
+         x="-327.29"
+	 y="468.5" 
+	 z="-1754.65"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-4-2"/>
+       <position name="posArapucaDouble2-Frame-3-4" unit="cm" 
+         x="-328.03"
+	 y="542.5" 
+	 z="-1537.65"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-4-2"/>
+       <position name="posOpArapucaDouble2-Frame-3-4" unit="cm" 
+         x="-327.29"
+	 y="542.5" 
+	 z="-1537.65"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-4-3"/>
+       <position name="posArapucaDouble3-Frame-3-4" unit="cm" 
+         x="-328.03"
+	 y="633.2" 
+	 z="-1683.65"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-4-3"/>
+       <position name="posOpArapucaDouble3-Frame-3-4" unit="cm" 
+         x="-327.29"
+	 y="633.2" 
+	 z="-1683.65"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-5-0"/>
+       <position name="posArapucaDouble0-Frame-3-5" unit="cm" 
+         x="-328.03"
+	 y="377.8" 
+	 z="-1309.35"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-5-0"/>
+       <position name="posOpArapucaDouble0-Frame-3-5" unit="cm" 
+         x="-327.29"
+	 y="377.8" 
+	 z="-1309.35"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-5-1"/>
+       <position name="posArapucaDouble1-Frame-3-5" unit="cm" 
+         x="-328.03"
+	 y="468.5" 
+	 z="-1455.35"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-5-1"/>
+       <position name="posOpArapucaDouble1-Frame-3-5" unit="cm" 
+         x="-327.29"
+	 y="468.5" 
+	 z="-1455.35"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-5-2"/>
+       <position name="posArapucaDouble2-Frame-3-5" unit="cm" 
+         x="-328.03"
+	 y="542.5" 
+	 z="-1238.35"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-5-2"/>
+       <position name="posOpArapucaDouble2-Frame-3-5" unit="cm" 
+         x="-327.29"
+	 y="542.5" 
+	 z="-1238.35"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-5-3"/>
+       <position name="posArapucaDouble3-Frame-3-5" unit="cm" 
+         x="-328.03"
+	 y="633.2" 
+	 z="-1384.35"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-5-3"/>
+       <position name="posOpArapucaDouble3-Frame-3-5" unit="cm" 
+         x="-327.29"
+	 y="633.2" 
+	 z="-1384.35"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-6-0"/>
+       <position name="posArapucaDouble0-Frame-3-6" unit="cm" 
+         x="-328.03"
+	 y="377.8" 
+	 z="-1010.05"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-6-0"/>
+       <position name="posOpArapucaDouble0-Frame-3-6" unit="cm" 
+         x="-327.29"
+	 y="377.8" 
+	 z="-1010.05"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-6-1"/>
+       <position name="posArapucaDouble1-Frame-3-6" unit="cm" 
+         x="-328.03"
+	 y="468.5" 
+	 z="-1156.05"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-6-1"/>
+       <position name="posOpArapucaDouble1-Frame-3-6" unit="cm" 
+         x="-327.29"
+	 y="468.5" 
+	 z="-1156.05"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-6-2"/>
+       <position name="posArapucaDouble2-Frame-3-6" unit="cm" 
+         x="-328.03"
+	 y="542.5" 
+	 z="-939.05"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-6-2"/>
+       <position name="posOpArapucaDouble2-Frame-3-6" unit="cm" 
+         x="-327.29"
+	 y="542.5" 
+	 z="-939.05"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-6-3"/>
+       <position name="posArapucaDouble3-Frame-3-6" unit="cm" 
+         x="-328.03"
+	 y="633.2" 
+	 z="-1085.05"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-6-3"/>
+       <position name="posOpArapucaDouble3-Frame-3-6" unit="cm" 
+         x="-327.29"
+	 y="633.2" 
+	 z="-1085.05"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-7-0"/>
+       <position name="posArapucaDouble0-Frame-3-7" unit="cm" 
+         x="-328.03"
+	 y="377.8" 
+	 z="-710.75"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-7-0"/>
+       <position name="posOpArapucaDouble0-Frame-3-7" unit="cm" 
+         x="-327.29"
+	 y="377.8" 
+	 z="-710.75"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-7-1"/>
+       <position name="posArapucaDouble1-Frame-3-7" unit="cm" 
+         x="-328.03"
+	 y="468.5" 
+	 z="-856.75"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-7-1"/>
+       <position name="posOpArapucaDouble1-Frame-3-7" unit="cm" 
+         x="-327.29"
+	 y="468.5" 
+	 z="-856.75"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-7-2"/>
+       <position name="posArapucaDouble2-Frame-3-7" unit="cm" 
+         x="-328.03"
+	 y="542.5" 
+	 z="-639.75"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-7-2"/>
+       <position name="posOpArapucaDouble2-Frame-3-7" unit="cm" 
+         x="-327.29"
+	 y="542.5" 
+	 z="-639.75"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-7-3"/>
+       <position name="posArapucaDouble3-Frame-3-7" unit="cm" 
+         x="-328.03"
+	 y="633.2" 
+	 z="-785.75"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-7-3"/>
+       <position name="posOpArapucaDouble3-Frame-3-7" unit="cm" 
+         x="-327.29"
+	 y="633.2" 
+	 z="-785.75"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-8-0"/>
+       <position name="posArapucaDouble0-Frame-3-8" unit="cm" 
+         x="-328.03"
+	 y="377.8" 
+	 z="-411.45"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-8-0"/>
+       <position name="posOpArapucaDouble0-Frame-3-8" unit="cm" 
+         x="-327.29"
+	 y="377.8" 
+	 z="-411.45"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-8-1"/>
+       <position name="posArapucaDouble1-Frame-3-8" unit="cm" 
+         x="-328.03"
+	 y="468.5" 
+	 z="-557.45"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-8-1"/>
+       <position name="posOpArapucaDouble1-Frame-3-8" unit="cm" 
+         x="-327.29"
+	 y="468.5" 
+	 z="-557.45"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-8-2"/>
+       <position name="posArapucaDouble2-Frame-3-8" unit="cm" 
+         x="-328.03"
+	 y="542.5" 
+	 z="-340.45"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-8-2"/>
+       <position name="posOpArapucaDouble2-Frame-3-8" unit="cm" 
+         x="-327.29"
+	 y="542.5" 
+	 z="-340.45"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-8-3"/>
+       <position name="posArapucaDouble3-Frame-3-8" unit="cm" 
+         x="-328.03"
+	 y="633.2" 
+	 z="-486.45"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-8-3"/>
+       <position name="posOpArapucaDouble3-Frame-3-8" unit="cm" 
+         x="-327.29"
+	 y="633.2" 
+	 z="-486.45"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-9-0"/>
+       <position name="posArapucaDouble0-Frame-3-9" unit="cm" 
+         x="-328.03"
+	 y="377.8" 
+	 z="-112.15"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-9-0"/>
+       <position name="posOpArapucaDouble0-Frame-3-9" unit="cm" 
+         x="-327.29"
+	 y="377.8" 
+	 z="-112.15"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-9-1"/>
+       <position name="posArapucaDouble1-Frame-3-9" unit="cm" 
+         x="-328.03"
+	 y="468.5" 
+	 z="-258.15"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-9-1"/>
+       <position name="posOpArapucaDouble1-Frame-3-9" unit="cm" 
+         x="-327.29"
+	 y="468.5" 
+	 z="-258.15"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-9-2"/>
+       <position name="posArapucaDouble2-Frame-3-9" unit="cm" 
+         x="-328.03"
+	 y="542.5" 
+	 z="-41.1499999999997"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-9-2"/>
+       <position name="posOpArapucaDouble2-Frame-3-9" unit="cm" 
+         x="-327.29"
+	 y="542.5" 
+	 z="-41.1499999999997"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-9-3"/>
+       <position name="posArapucaDouble3-Frame-3-9" unit="cm" 
+         x="-328.03"
+	 y="633.2" 
+	 z="-187.15"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-9-3"/>
+       <position name="posOpArapucaDouble3-Frame-3-9" unit="cm" 
+         x="-327.29"
+	 y="633.2" 
+	 z="-187.15"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-10-0"/>
+       <position name="posArapucaDouble0-Frame-3-10" unit="cm" 
+         x="-328.03"
+	 y="377.8" 
+	 z="187.15"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-10-0"/>
+       <position name="posOpArapucaDouble0-Frame-3-10" unit="cm" 
+         x="-327.29"
+	 y="377.8" 
+	 z="187.15"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-10-1"/>
+       <position name="posArapucaDouble1-Frame-3-10" unit="cm" 
+         x="-328.03"
+	 y="468.5" 
+	 z="41.1500000000003"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-10-1"/>
+       <position name="posOpArapucaDouble1-Frame-3-10" unit="cm" 
+         x="-327.29"
+	 y="468.5" 
+	 z="41.1500000000003"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-10-2"/>
+       <position name="posArapucaDouble2-Frame-3-10" unit="cm" 
+         x="-328.03"
+	 y="542.5" 
+	 z="258.15"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-10-2"/>
+       <position name="posOpArapucaDouble2-Frame-3-10" unit="cm" 
+         x="-327.29"
+	 y="542.5" 
+	 z="258.15"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-10-3"/>
+       <position name="posArapucaDouble3-Frame-3-10" unit="cm" 
+         x="-328.03"
+	 y="633.2" 
+	 z="112.15"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-10-3"/>
+       <position name="posOpArapucaDouble3-Frame-3-10" unit="cm" 
+         x="-327.29"
+	 y="633.2" 
+	 z="112.15"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-11-0"/>
+       <position name="posArapucaDouble0-Frame-3-11" unit="cm" 
+         x="-328.03"
+	 y="377.8" 
+	 z="486.45"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-11-0"/>
+       <position name="posOpArapucaDouble0-Frame-3-11" unit="cm" 
+         x="-327.29"
+	 y="377.8" 
+	 z="486.45"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-11-1"/>
+       <position name="posArapucaDouble1-Frame-3-11" unit="cm" 
+         x="-328.03"
+	 y="468.5" 
+	 z="340.45"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-11-1"/>
+       <position name="posOpArapucaDouble1-Frame-3-11" unit="cm" 
+         x="-327.29"
+	 y="468.5" 
+	 z="340.45"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-11-2"/>
+       <position name="posArapucaDouble2-Frame-3-11" unit="cm" 
+         x="-328.03"
+	 y="542.5" 
+	 z="557.45"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-11-2"/>
+       <position name="posOpArapucaDouble2-Frame-3-11" unit="cm" 
+         x="-327.29"
+	 y="542.5" 
+	 z="557.45"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-11-3"/>
+       <position name="posArapucaDouble3-Frame-3-11" unit="cm" 
+         x="-328.03"
+	 y="633.2" 
+	 z="411.45"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-11-3"/>
+       <position name="posOpArapucaDouble3-Frame-3-11" unit="cm" 
+         x="-327.29"
+	 y="633.2" 
+	 z="411.45"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-12-0"/>
+       <position name="posArapucaDouble0-Frame-3-12" unit="cm" 
+         x="-328.03"
+	 y="377.8" 
+	 z="785.75"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-12-0"/>
+       <position name="posOpArapucaDouble0-Frame-3-12" unit="cm" 
+         x="-327.29"
+	 y="377.8" 
+	 z="785.75"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-12-1"/>
+       <position name="posArapucaDouble1-Frame-3-12" unit="cm" 
+         x="-328.03"
+	 y="468.5" 
+	 z="639.75"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-12-1"/>
+       <position name="posOpArapucaDouble1-Frame-3-12" unit="cm" 
+         x="-327.29"
+	 y="468.5" 
+	 z="639.75"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-12-2"/>
+       <position name="posArapucaDouble2-Frame-3-12" unit="cm" 
+         x="-328.03"
+	 y="542.5" 
+	 z="856.75"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-12-2"/>
+       <position name="posOpArapucaDouble2-Frame-3-12" unit="cm" 
+         x="-327.29"
+	 y="542.5" 
+	 z="856.75"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-12-3"/>
+       <position name="posArapucaDouble3-Frame-3-12" unit="cm" 
+         x="-328.03"
+	 y="633.2" 
+	 z="710.75"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-12-3"/>
+       <position name="posOpArapucaDouble3-Frame-3-12" unit="cm" 
+         x="-327.29"
+	 y="633.2" 
+	 z="710.75"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-13-0"/>
+       <position name="posArapucaDouble0-Frame-3-13" unit="cm" 
+         x="-328.03"
+	 y="377.8" 
+	 z="1085.05"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-13-0"/>
+       <position name="posOpArapucaDouble0-Frame-3-13" unit="cm" 
+         x="-327.29"
+	 y="377.8" 
+	 z="1085.05"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-13-1"/>
+       <position name="posArapucaDouble1-Frame-3-13" unit="cm" 
+         x="-328.03"
+	 y="468.5" 
+	 z="939.05"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-13-1"/>
+       <position name="posOpArapucaDouble1-Frame-3-13" unit="cm" 
+         x="-327.29"
+	 y="468.5" 
+	 z="939.05"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-13-2"/>
+       <position name="posArapucaDouble2-Frame-3-13" unit="cm" 
+         x="-328.03"
+	 y="542.5" 
+	 z="1156.05"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-13-2"/>
+       <position name="posOpArapucaDouble2-Frame-3-13" unit="cm" 
+         x="-327.29"
+	 y="542.5" 
+	 z="1156.05"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-13-3"/>
+       <position name="posArapucaDouble3-Frame-3-13" unit="cm" 
+         x="-328.03"
+	 y="633.2" 
+	 z="1010.05"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-13-3"/>
+       <position name="posOpArapucaDouble3-Frame-3-13" unit="cm" 
+         x="-327.29"
+	 y="633.2" 
+	 z="1010.05"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-14-0"/>
+       <position name="posArapucaDouble0-Frame-3-14" unit="cm" 
+         x="-328.03"
+	 y="377.8" 
+	 z="1384.35"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-14-0"/>
+       <position name="posOpArapucaDouble0-Frame-3-14" unit="cm" 
+         x="-327.29"
+	 y="377.8" 
+	 z="1384.35"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-14-1"/>
+       <position name="posArapucaDouble1-Frame-3-14" unit="cm" 
+         x="-328.03"
+	 y="468.5" 
+	 z="1238.35"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-14-1"/>
+       <position name="posOpArapucaDouble1-Frame-3-14" unit="cm" 
+         x="-327.29"
+	 y="468.5" 
+	 z="1238.35"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-14-2"/>
+       <position name="posArapucaDouble2-Frame-3-14" unit="cm" 
+         x="-328.03"
+	 y="542.5" 
+	 z="1455.35"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-14-2"/>
+       <position name="posOpArapucaDouble2-Frame-3-14" unit="cm" 
+         x="-327.29"
+	 y="542.5" 
+	 z="1455.35"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-14-3"/>
+       <position name="posArapucaDouble3-Frame-3-14" unit="cm" 
+         x="-328.03"
+	 y="633.2" 
+	 z="1309.35"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-14-3"/>
+       <position name="posOpArapucaDouble3-Frame-3-14" unit="cm" 
+         x="-327.29"
+	 y="633.2" 
+	 z="1309.35"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-15-0"/>
+       <position name="posArapucaDouble0-Frame-3-15" unit="cm" 
+         x="-328.03"
+	 y="377.8" 
+	 z="1683.65"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-15-0"/>
+       <position name="posOpArapucaDouble0-Frame-3-15" unit="cm" 
+         x="-327.29"
+	 y="377.8" 
+	 z="1683.65"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-15-1"/>
+       <position name="posArapucaDouble1-Frame-3-15" unit="cm" 
+         x="-328.03"
+	 y="468.5" 
+	 z="1537.65"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-15-1"/>
+       <position name="posOpArapucaDouble1-Frame-3-15" unit="cm" 
+         x="-327.29"
+	 y="468.5" 
+	 z="1537.65"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-15-2"/>
+       <position name="posArapucaDouble2-Frame-3-15" unit="cm" 
+         x="-328.03"
+	 y="542.5" 
+	 z="1754.65"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-15-2"/>
+       <position name="posOpArapucaDouble2-Frame-3-15" unit="cm" 
+         x="-327.29"
+	 y="542.5" 
+	 z="1754.65"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-15-3"/>
+       <position name="posArapucaDouble3-Frame-3-15" unit="cm" 
+         x="-328.03"
+	 y="633.2" 
+	 z="1608.65"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-15-3"/>
+       <position name="posOpArapucaDouble3-Frame-3-15" unit="cm" 
+         x="-327.29"
+	 y="633.2" 
+	 z="1608.65"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-16-0"/>
+       <position name="posArapucaDouble0-Frame-3-16" unit="cm" 
+         x="-328.03"
+	 y="377.8" 
+	 z="1982.95"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-16-0"/>
+       <position name="posOpArapucaDouble0-Frame-3-16" unit="cm" 
+         x="-327.29"
+	 y="377.8" 
+	 z="1982.95"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-16-1"/>
+       <position name="posArapucaDouble1-Frame-3-16" unit="cm" 
+         x="-328.03"
+	 y="468.5" 
+	 z="1836.95"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-16-1"/>
+       <position name="posOpArapucaDouble1-Frame-3-16" unit="cm" 
+         x="-327.29"
+	 y="468.5" 
+	 z="1836.95"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-16-2"/>
+       <position name="posArapucaDouble2-Frame-3-16" unit="cm" 
+         x="-328.03"
+	 y="542.5" 
+	 z="2053.95"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-16-2"/>
+       <position name="posOpArapucaDouble2-Frame-3-16" unit="cm" 
+         x="-327.29"
+	 y="542.5" 
+	 z="2053.95"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-16-3"/>
+       <position name="posArapucaDouble3-Frame-3-16" unit="cm" 
+         x="-328.03"
+	 y="633.2" 
+	 z="1907.95"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-16-3"/>
+       <position name="posOpArapucaDouble3-Frame-3-16" unit="cm" 
+         x="-327.29"
+	 y="633.2" 
+	 z="1907.95"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-17-0"/>
+       <position name="posArapucaDouble0-Frame-3-17" unit="cm" 
+         x="-328.03"
+	 y="377.8" 
+	 z="2282.25"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-17-0"/>
+       <position name="posOpArapucaDouble0-Frame-3-17" unit="cm" 
+         x="-327.29"
+	 y="377.8" 
+	 z="2282.25"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-17-1"/>
+       <position name="posArapucaDouble1-Frame-3-17" unit="cm" 
+         x="-328.03"
+	 y="468.5" 
+	 z="2136.25"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-17-1"/>
+       <position name="posOpArapucaDouble1-Frame-3-17" unit="cm" 
+         x="-327.29"
+	 y="468.5" 
+	 z="2136.25"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-17-2"/>
+       <position name="posArapucaDouble2-Frame-3-17" unit="cm" 
+         x="-328.03"
+	 y="542.5" 
+	 z="2353.25"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-17-2"/>
+       <position name="posOpArapucaDouble2-Frame-3-17" unit="cm" 
+         x="-327.29"
+	 y="542.5" 
+	 z="2353.25"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-17-3"/>
+       <position name="posArapucaDouble3-Frame-3-17" unit="cm" 
+         x="-328.03"
+	 y="633.2" 
+	 z="2207.25"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-17-3"/>
+       <position name="posOpArapucaDouble3-Frame-3-17" unit="cm" 
+         x="-327.29"
+	 y="633.2" 
+	 z="2207.25"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-18-0"/>
+       <position name="posArapucaDouble0-Frame-3-18" unit="cm" 
+         x="-328.03"
+	 y="377.8" 
+	 z="2581.55"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-18-0"/>
+       <position name="posOpArapucaDouble0-Frame-3-18" unit="cm" 
+         x="-327.29"
+	 y="377.8" 
+	 z="2581.55"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-18-1"/>
+       <position name="posArapucaDouble1-Frame-3-18" unit="cm" 
+         x="-328.03"
+	 y="468.5" 
+	 z="2435.55"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-18-1"/>
+       <position name="posOpArapucaDouble1-Frame-3-18" unit="cm" 
+         x="-327.29"
+	 y="468.5" 
+	 z="2435.55"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-18-2"/>
+       <position name="posArapucaDouble2-Frame-3-18" unit="cm" 
+         x="-328.03"
+	 y="542.5" 
+	 z="2652.55"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-18-2"/>
+       <position name="posOpArapucaDouble2-Frame-3-18" unit="cm" 
+         x="-327.29"
+	 y="542.5" 
+	 z="2652.55"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-18-3"/>
+       <position name="posArapucaDouble3-Frame-3-18" unit="cm" 
+         x="-328.03"
+	 y="633.2" 
+	 z="2506.55"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-18-3"/>
+       <position name="posOpArapucaDouble3-Frame-3-18" unit="cm" 
+         x="-327.29"
+	 y="633.2" 
+	 z="2506.55"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-19-0"/>
+       <position name="posArapucaDouble0-Frame-3-19" unit="cm" 
+         x="-328.03"
+	 y="377.8" 
+	 z="2880.85"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-19-0"/>
+       <position name="posOpArapucaDouble0-Frame-3-19" unit="cm" 
+         x="-327.29"
+	 y="377.8" 
+	 z="2880.85"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-19-1"/>
+       <position name="posArapucaDouble1-Frame-3-19" unit="cm" 
+         x="-328.03"
+	 y="468.5" 
+	 z="2734.85"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-19-1"/>
+       <position name="posOpArapucaDouble1-Frame-3-19" unit="cm" 
+         x="-327.29"
+	 y="468.5" 
+	 z="2734.85"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-19-2"/>
+       <position name="posArapucaDouble2-Frame-3-19" unit="cm" 
+         x="-328.03"
+	 y="542.5" 
+	 z="2951.85"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-19-2"/>
+       <position name="posOpArapucaDouble2-Frame-3-19" unit="cm" 
+         x="-327.29"
+	 y="542.5" 
+	 z="2951.85"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-19-3"/>
+       <position name="posArapucaDouble3-Frame-3-19" unit="cm" 
+         x="-328.03"
+	 y="633.2" 
+	 z="2805.85"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-19-3"/>
+       <position name="posOpArapucaDouble3-Frame-3-19" unit="cm" 
+         x="-327.29"
+	 y="633.2" 
+	 z="2805.85"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-0"/>
        <position name="posArapuca0-Lat-0" unit="cm" 
          x="285.02"
 	 y="-745" 
-	 z="-299.3"/>
+	 z="-2843.35"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
@@ -41146,14 +50462,14 @@
        <position name="posOpArapuca0-Lat-0" unit="cm" 
          x="285.02"
 	 y="-744.26" 
-	 z="-299.3"/>
+	 z="-2843.35"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-1"/>
        <position name="posArapuca1-Lat-0" unit="cm" 
          x="210.02"
 	 y="-745" 
-	 z="-299.3"/>
+	 z="-2843.35"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
@@ -41161,14 +50477,14 @@
        <position name="posOpArapuca1-Lat-0" unit="cm" 
          x="210.02"
 	 y="-744.26" 
-	 z="-299.3"/>
+	 z="-2843.35"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-2"/>
        <position name="posArapuca2-Lat-0" unit="cm" 
          x="135.02"
 	 y="-745" 
-	 z="-299.3"/>
+	 z="-2843.35"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
@@ -41176,14 +50492,14 @@
        <position name="posOpArapuca2-Lat-0" unit="cm" 
          x="135.02"
 	 y="-744.26" 
-	 z="-299.3"/>
+	 z="-2843.35"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-3"/>
        <position name="posArapuca3-Lat-0" unit="cm" 
          x="60.02"
 	 y="-745" 
-	 z="-299.3"/>
+	 z="-2843.35"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
@@ -41191,14 +50507,14 @@
        <position name="posOpArapuca3-Lat-0" unit="cm" 
          x="60.02"
 	 y="-744.26" 
-	 z="-299.3"/>
+	 z="-2843.35"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-4"/>
        <position name="posArapuca4-Lat-0" unit="cm" 
          x="285.02"
 	 y="745" 
-	 z="-299.3"/>
+	 z="-2843.35"/>
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
@@ -41206,14 +50522,14 @@
        <position name="posOpArapuca4-Lat-0" unit="cm" 
          x="285.02"
 	 y="744.26" 
-	 z="-299.3"/>
+	 z="-2843.35"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-5"/>
        <position name="posArapuca5-Lat-0" unit="cm" 
          x="210.02"
 	 y="745" 
-	 z="-299.3"/>
+	 z="-2843.35"/>
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
@@ -41221,14 +50537,14 @@
        <position name="posOpArapuca5-Lat-0" unit="cm" 
          x="210.02"
 	 y="744.26" 
-	 z="-299.3"/>
+	 z="-2843.35"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-6"/>
        <position name="posArapuca6-Lat-0" unit="cm" 
          x="135.02"
 	 y="745" 
-	 z="-299.3"/>
+	 z="-2843.35"/>
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
@@ -41236,14 +50552,14 @@
        <position name="posOpArapuca6-Lat-0" unit="cm" 
          x="135.02"
 	 y="744.26" 
-	 z="-299.3"/>
+	 z="-2843.35"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-7"/>
        <position name="posArapuca7-Lat-0" unit="cm" 
          x="60.02"
 	 y="745" 
-	 z="-299.3"/>
+	 z="-2843.35"/>
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
@@ -41251,14 +50567,14 @@
        <position name="posOpArapuca7-Lat-0" unit="cm" 
          x="60.02"
 	 y="744.26" 
-	 z="-299.3"/>
+	 z="-2843.35"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-0"/>
        <position name="posArapuca0-Lat-1" unit="cm" 
          x="285.02"
 	 y="-745" 
-	 z="2.8421709430404e-13"/>
+	 z="-2544.05"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
@@ -41266,14 +50582,14 @@
        <position name="posOpArapuca0-Lat-1" unit="cm" 
          x="285.02"
 	 y="-744.26" 
-	 z="2.8421709430404e-13"/>
+	 z="-2544.05"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-1"/>
        <position name="posArapuca1-Lat-1" unit="cm" 
          x="210.02"
 	 y="-745" 
-	 z="2.8421709430404e-13"/>
+	 z="-2544.05"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
@@ -41281,14 +50597,14 @@
        <position name="posOpArapuca1-Lat-1" unit="cm" 
          x="210.02"
 	 y="-744.26" 
-	 z="2.8421709430404e-13"/>
+	 z="-2544.05"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-2"/>
        <position name="posArapuca2-Lat-1" unit="cm" 
          x="135.02"
 	 y="-745" 
-	 z="2.8421709430404e-13"/>
+	 z="-2544.05"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
@@ -41296,14 +50612,14 @@
        <position name="posOpArapuca2-Lat-1" unit="cm" 
          x="135.02"
 	 y="-744.26" 
-	 z="2.8421709430404e-13"/>
+	 z="-2544.05"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-3"/>
        <position name="posArapuca3-Lat-1" unit="cm" 
          x="60.02"
 	 y="-745" 
-	 z="2.8421709430404e-13"/>
+	 z="-2544.05"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
@@ -41311,14 +50627,14 @@
        <position name="posOpArapuca3-Lat-1" unit="cm" 
          x="60.02"
 	 y="-744.26" 
-	 z="2.8421709430404e-13"/>
+	 z="-2544.05"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-4"/>
        <position name="posArapuca4-Lat-1" unit="cm" 
          x="285.02"
 	 y="745" 
-	 z="2.8421709430404e-13"/>
+	 z="-2544.05"/>
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
@@ -41326,14 +50642,14 @@
        <position name="posOpArapuca4-Lat-1" unit="cm" 
          x="285.02"
 	 y="744.26" 
-	 z="2.8421709430404e-13"/>
+	 z="-2544.05"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-5"/>
        <position name="posArapuca5-Lat-1" unit="cm" 
          x="210.02"
 	 y="745" 
-	 z="2.8421709430404e-13"/>
+	 z="-2544.05"/>
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
@@ -41341,14 +50657,14 @@
        <position name="posOpArapuca5-Lat-1" unit="cm" 
          x="210.02"
 	 y="744.26" 
-	 z="2.8421709430404e-13"/>
+	 z="-2544.05"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-6"/>
        <position name="posArapuca6-Lat-1" unit="cm" 
          x="135.02"
 	 y="745" 
-	 z="2.8421709430404e-13"/>
+	 z="-2544.05"/>
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
@@ -41356,14 +50672,14 @@
        <position name="posOpArapuca6-Lat-1" unit="cm" 
          x="135.02"
 	 y="744.26" 
-	 z="2.8421709430404e-13"/>
+	 z="-2544.05"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-7"/>
        <position name="posArapuca7-Lat-1" unit="cm" 
          x="60.02"
 	 y="745" 
-	 z="2.8421709430404e-13"/>
+	 z="-2544.05"/>
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
@@ -41371,14 +50687,14 @@
        <position name="posOpArapuca7-Lat-1" unit="cm" 
          x="60.02"
 	 y="744.26" 
-	 z="2.8421709430404e-13"/>
+	 z="-2544.05"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-0"/>
        <position name="posArapuca0-Lat-2" unit="cm" 
          x="285.02"
 	 y="-745" 
-	 z="299.3"/>
+	 z="-2244.75"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
@@ -41386,14 +50702,14 @@
        <position name="posOpArapuca0-Lat-2" unit="cm" 
          x="285.02"
 	 y="-744.26" 
-	 z="299.3"/>
+	 z="-2244.75"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-1"/>
        <position name="posArapuca1-Lat-2" unit="cm" 
          x="210.02"
 	 y="-745" 
-	 z="299.3"/>
+	 z="-2244.75"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
@@ -41401,14 +50717,14 @@
        <position name="posOpArapuca1-Lat-2" unit="cm" 
          x="210.02"
 	 y="-744.26" 
-	 z="299.3"/>
+	 z="-2244.75"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-2"/>
        <position name="posArapuca2-Lat-2" unit="cm" 
          x="135.02"
 	 y="-745" 
-	 z="299.3"/>
+	 z="-2244.75"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
@@ -41416,14 +50732,14 @@
        <position name="posOpArapuca2-Lat-2" unit="cm" 
          x="135.02"
 	 y="-744.26" 
-	 z="299.3"/>
+	 z="-2244.75"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-3"/>
        <position name="posArapuca3-Lat-2" unit="cm" 
          x="60.02"
 	 y="-745" 
-	 z="299.3"/>
+	 z="-2244.75"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
@@ -41431,14 +50747,14 @@
        <position name="posOpArapuca3-Lat-2" unit="cm" 
          x="60.02"
 	 y="-744.26" 
-	 z="299.3"/>
+	 z="-2244.75"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-4"/>
        <position name="posArapuca4-Lat-2" unit="cm" 
          x="285.02"
 	 y="745" 
-	 z="299.3"/>
+	 z="-2244.75"/>
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
@@ -41446,14 +50762,14 @@
        <position name="posOpArapuca4-Lat-2" unit="cm" 
          x="285.02"
 	 y="744.26" 
-	 z="299.3"/>
+	 z="-2244.75"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-5"/>
        <position name="posArapuca5-Lat-2" unit="cm" 
          x="210.02"
 	 y="745" 
-	 z="299.3"/>
+	 z="-2244.75"/>
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
@@ -41461,14 +50777,14 @@
        <position name="posOpArapuca5-Lat-2" unit="cm" 
          x="210.02"
 	 y="744.26" 
-	 z="299.3"/>
+	 z="-2244.75"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-6"/>
        <position name="posArapuca6-Lat-2" unit="cm" 
          x="135.02"
 	 y="745" 
-	 z="299.3"/>
+	 z="-2244.75"/>
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
@@ -41476,14 +50792,14 @@
        <position name="posOpArapuca6-Lat-2" unit="cm" 
          x="135.02"
 	 y="744.26" 
-	 z="299.3"/>
+	 z="-2244.75"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-7"/>
        <position name="posArapuca7-Lat-2" unit="cm" 
          x="60.02"
 	 y="745" 
-	 z="299.3"/>
+	 z="-2244.75"/>
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
@@ -41491,134 +50807,2174 @@
        <position name="posOpArapuca7-Lat-2" unit="cm" 
          x="60.02"
 	 y="744.26" 
-	 z="299.3"/>
+	 z="-2244.75"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_3-0"/>
+       <position name="posArapuca0-Lat-3" unit="cm" 
+         x="285.02"
+	 y="-745" 
+	 z="-1945.45"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_3-0"/>
+       <position name="posOpArapuca0-Lat-3" unit="cm" 
+         x="285.02"
+	 y="-744.26" 
+	 z="-1945.45"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_3-1"/>
+       <position name="posArapuca1-Lat-3" unit="cm" 
+         x="210.02"
+	 y="-745" 
+	 z="-1945.45"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_3-1"/>
+       <position name="posOpArapuca1-Lat-3" unit="cm" 
+         x="210.02"
+	 y="-744.26" 
+	 z="-1945.45"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_3-2"/>
+       <position name="posArapuca2-Lat-3" unit="cm" 
+         x="135.02"
+	 y="-745" 
+	 z="-1945.45"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_3-2"/>
+       <position name="posOpArapuca2-Lat-3" unit="cm" 
+         x="135.02"
+	 y="-744.26" 
+	 z="-1945.45"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_3-3"/>
+       <position name="posArapuca3-Lat-3" unit="cm" 
+         x="60.02"
+	 y="-745" 
+	 z="-1945.45"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_3-3"/>
+       <position name="posOpArapuca3-Lat-3" unit="cm" 
+         x="60.02"
+	 y="-744.26" 
+	 z="-1945.45"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_3-4"/>
+       <position name="posArapuca4-Lat-3" unit="cm" 
+         x="285.02"
+	 y="745" 
+	 z="-1945.45"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_3-4"/>
+       <position name="posOpArapuca4-Lat-3" unit="cm" 
+         x="285.02"
+	 y="744.26" 
+	 z="-1945.45"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_3-5"/>
+       <position name="posArapuca5-Lat-3" unit="cm" 
+         x="210.02"
+	 y="745" 
+	 z="-1945.45"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_3-5"/>
+       <position name="posOpArapuca5-Lat-3" unit="cm" 
+         x="210.02"
+	 y="744.26" 
+	 z="-1945.45"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_3-6"/>
+       <position name="posArapuca6-Lat-3" unit="cm" 
+         x="135.02"
+	 y="745" 
+	 z="-1945.45"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_3-6"/>
+       <position name="posOpArapuca6-Lat-3" unit="cm" 
+         x="135.02"
+	 y="744.26" 
+	 z="-1945.45"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_3-7"/>
+       <position name="posArapuca7-Lat-3" unit="cm" 
+         x="60.02"
+	 y="745" 
+	 z="-1945.45"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_3-7"/>
+       <position name="posOpArapuca7-Lat-3" unit="cm" 
+         x="60.02"
+	 y="744.26" 
+	 z="-1945.45"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_4-0"/>
+       <position name="posArapuca0-Lat-4" unit="cm" 
+         x="285.02"
+	 y="-745" 
+	 z="-1646.15"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_4-0"/>
+       <position name="posOpArapuca0-Lat-4" unit="cm" 
+         x="285.02"
+	 y="-744.26" 
+	 z="-1646.15"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_4-1"/>
+       <position name="posArapuca1-Lat-4" unit="cm" 
+         x="210.02"
+	 y="-745" 
+	 z="-1646.15"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_4-1"/>
+       <position name="posOpArapuca1-Lat-4" unit="cm" 
+         x="210.02"
+	 y="-744.26" 
+	 z="-1646.15"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_4-2"/>
+       <position name="posArapuca2-Lat-4" unit="cm" 
+         x="135.02"
+	 y="-745" 
+	 z="-1646.15"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_4-2"/>
+       <position name="posOpArapuca2-Lat-4" unit="cm" 
+         x="135.02"
+	 y="-744.26" 
+	 z="-1646.15"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_4-3"/>
+       <position name="posArapuca3-Lat-4" unit="cm" 
+         x="60.02"
+	 y="-745" 
+	 z="-1646.15"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_4-3"/>
+       <position name="posOpArapuca3-Lat-4" unit="cm" 
+         x="60.02"
+	 y="-744.26" 
+	 z="-1646.15"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_4-4"/>
+       <position name="posArapuca4-Lat-4" unit="cm" 
+         x="285.02"
+	 y="745" 
+	 z="-1646.15"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_4-4"/>
+       <position name="posOpArapuca4-Lat-4" unit="cm" 
+         x="285.02"
+	 y="744.26" 
+	 z="-1646.15"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_4-5"/>
+       <position name="posArapuca5-Lat-4" unit="cm" 
+         x="210.02"
+	 y="745" 
+	 z="-1646.15"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_4-5"/>
+       <position name="posOpArapuca5-Lat-4" unit="cm" 
+         x="210.02"
+	 y="744.26" 
+	 z="-1646.15"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_4-6"/>
+       <position name="posArapuca6-Lat-4" unit="cm" 
+         x="135.02"
+	 y="745" 
+	 z="-1646.15"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_4-6"/>
+       <position name="posOpArapuca6-Lat-4" unit="cm" 
+         x="135.02"
+	 y="744.26" 
+	 z="-1646.15"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_4-7"/>
+       <position name="posArapuca7-Lat-4" unit="cm" 
+         x="60.02"
+	 y="745" 
+	 z="-1646.15"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_4-7"/>
+       <position name="posOpArapuca7-Lat-4" unit="cm" 
+         x="60.02"
+	 y="744.26" 
+	 z="-1646.15"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_5-0"/>
+       <position name="posArapuca0-Lat-5" unit="cm" 
+         x="285.02"
+	 y="-745" 
+	 z="-1346.85"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_5-0"/>
+       <position name="posOpArapuca0-Lat-5" unit="cm" 
+         x="285.02"
+	 y="-744.26" 
+	 z="-1346.85"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_5-1"/>
+       <position name="posArapuca1-Lat-5" unit="cm" 
+         x="210.02"
+	 y="-745" 
+	 z="-1346.85"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_5-1"/>
+       <position name="posOpArapuca1-Lat-5" unit="cm" 
+         x="210.02"
+	 y="-744.26" 
+	 z="-1346.85"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_5-2"/>
+       <position name="posArapuca2-Lat-5" unit="cm" 
+         x="135.02"
+	 y="-745" 
+	 z="-1346.85"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_5-2"/>
+       <position name="posOpArapuca2-Lat-5" unit="cm" 
+         x="135.02"
+	 y="-744.26" 
+	 z="-1346.85"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_5-3"/>
+       <position name="posArapuca3-Lat-5" unit="cm" 
+         x="60.02"
+	 y="-745" 
+	 z="-1346.85"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_5-3"/>
+       <position name="posOpArapuca3-Lat-5" unit="cm" 
+         x="60.02"
+	 y="-744.26" 
+	 z="-1346.85"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_5-4"/>
+       <position name="posArapuca4-Lat-5" unit="cm" 
+         x="285.02"
+	 y="745" 
+	 z="-1346.85"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_5-4"/>
+       <position name="posOpArapuca4-Lat-5" unit="cm" 
+         x="285.02"
+	 y="744.26" 
+	 z="-1346.85"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_5-5"/>
+       <position name="posArapuca5-Lat-5" unit="cm" 
+         x="210.02"
+	 y="745" 
+	 z="-1346.85"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_5-5"/>
+       <position name="posOpArapuca5-Lat-5" unit="cm" 
+         x="210.02"
+	 y="744.26" 
+	 z="-1346.85"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_5-6"/>
+       <position name="posArapuca6-Lat-5" unit="cm" 
+         x="135.02"
+	 y="745" 
+	 z="-1346.85"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_5-6"/>
+       <position name="posOpArapuca6-Lat-5" unit="cm" 
+         x="135.02"
+	 y="744.26" 
+	 z="-1346.85"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_5-7"/>
+       <position name="posArapuca7-Lat-5" unit="cm" 
+         x="60.02"
+	 y="745" 
+	 z="-1346.85"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_5-7"/>
+       <position name="posOpArapuca7-Lat-5" unit="cm" 
+         x="60.02"
+	 y="744.26" 
+	 z="-1346.85"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_6-0"/>
+       <position name="posArapuca0-Lat-6" unit="cm" 
+         x="285.02"
+	 y="-745" 
+	 z="-1047.55"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_6-0"/>
+       <position name="posOpArapuca0-Lat-6" unit="cm" 
+         x="285.02"
+	 y="-744.26" 
+	 z="-1047.55"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_6-1"/>
+       <position name="posArapuca1-Lat-6" unit="cm" 
+         x="210.02"
+	 y="-745" 
+	 z="-1047.55"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_6-1"/>
+       <position name="posOpArapuca1-Lat-6" unit="cm" 
+         x="210.02"
+	 y="-744.26" 
+	 z="-1047.55"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_6-2"/>
+       <position name="posArapuca2-Lat-6" unit="cm" 
+         x="135.02"
+	 y="-745" 
+	 z="-1047.55"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_6-2"/>
+       <position name="posOpArapuca2-Lat-6" unit="cm" 
+         x="135.02"
+	 y="-744.26" 
+	 z="-1047.55"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_6-3"/>
+       <position name="posArapuca3-Lat-6" unit="cm" 
+         x="60.02"
+	 y="-745" 
+	 z="-1047.55"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_6-3"/>
+       <position name="posOpArapuca3-Lat-6" unit="cm" 
+         x="60.02"
+	 y="-744.26" 
+	 z="-1047.55"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_6-4"/>
+       <position name="posArapuca4-Lat-6" unit="cm" 
+         x="285.02"
+	 y="745" 
+	 z="-1047.55"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_6-4"/>
+       <position name="posOpArapuca4-Lat-6" unit="cm" 
+         x="285.02"
+	 y="744.26" 
+	 z="-1047.55"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_6-5"/>
+       <position name="posArapuca5-Lat-6" unit="cm" 
+         x="210.02"
+	 y="745" 
+	 z="-1047.55"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_6-5"/>
+       <position name="posOpArapuca5-Lat-6" unit="cm" 
+         x="210.02"
+	 y="744.26" 
+	 z="-1047.55"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_6-6"/>
+       <position name="posArapuca6-Lat-6" unit="cm" 
+         x="135.02"
+	 y="745" 
+	 z="-1047.55"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_6-6"/>
+       <position name="posOpArapuca6-Lat-6" unit="cm" 
+         x="135.02"
+	 y="744.26" 
+	 z="-1047.55"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_6-7"/>
+       <position name="posArapuca7-Lat-6" unit="cm" 
+         x="60.02"
+	 y="745" 
+	 z="-1047.55"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_6-7"/>
+       <position name="posOpArapuca7-Lat-6" unit="cm" 
+         x="60.02"
+	 y="744.26" 
+	 z="-1047.55"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_7-0"/>
+       <position name="posArapuca0-Lat-7" unit="cm" 
+         x="285.02"
+	 y="-745" 
+	 z="-748.25"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_7-0"/>
+       <position name="posOpArapuca0-Lat-7" unit="cm" 
+         x="285.02"
+	 y="-744.26" 
+	 z="-748.25"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_7-1"/>
+       <position name="posArapuca1-Lat-7" unit="cm" 
+         x="210.02"
+	 y="-745" 
+	 z="-748.25"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_7-1"/>
+       <position name="posOpArapuca1-Lat-7" unit="cm" 
+         x="210.02"
+	 y="-744.26" 
+	 z="-748.25"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_7-2"/>
+       <position name="posArapuca2-Lat-7" unit="cm" 
+         x="135.02"
+	 y="-745" 
+	 z="-748.25"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_7-2"/>
+       <position name="posOpArapuca2-Lat-7" unit="cm" 
+         x="135.02"
+	 y="-744.26" 
+	 z="-748.25"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_7-3"/>
+       <position name="posArapuca3-Lat-7" unit="cm" 
+         x="60.02"
+	 y="-745" 
+	 z="-748.25"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_7-3"/>
+       <position name="posOpArapuca3-Lat-7" unit="cm" 
+         x="60.02"
+	 y="-744.26" 
+	 z="-748.25"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_7-4"/>
+       <position name="posArapuca4-Lat-7" unit="cm" 
+         x="285.02"
+	 y="745" 
+	 z="-748.25"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_7-4"/>
+       <position name="posOpArapuca4-Lat-7" unit="cm" 
+         x="285.02"
+	 y="744.26" 
+	 z="-748.25"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_7-5"/>
+       <position name="posArapuca5-Lat-7" unit="cm" 
+         x="210.02"
+	 y="745" 
+	 z="-748.25"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_7-5"/>
+       <position name="posOpArapuca5-Lat-7" unit="cm" 
+         x="210.02"
+	 y="744.26" 
+	 z="-748.25"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_7-6"/>
+       <position name="posArapuca6-Lat-7" unit="cm" 
+         x="135.02"
+	 y="745" 
+	 z="-748.25"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_7-6"/>
+       <position name="posOpArapuca6-Lat-7" unit="cm" 
+         x="135.02"
+	 y="744.26" 
+	 z="-748.25"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_7-7"/>
+       <position name="posArapuca7-Lat-7" unit="cm" 
+         x="60.02"
+	 y="745" 
+	 z="-748.25"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_7-7"/>
+       <position name="posOpArapuca7-Lat-7" unit="cm" 
+         x="60.02"
+	 y="744.26" 
+	 z="-748.25"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_8-0"/>
+       <position name="posArapuca0-Lat-8" unit="cm" 
+         x="285.02"
+	 y="-745" 
+	 z="-448.95"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_8-0"/>
+       <position name="posOpArapuca0-Lat-8" unit="cm" 
+         x="285.02"
+	 y="-744.26" 
+	 z="-448.95"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_8-1"/>
+       <position name="posArapuca1-Lat-8" unit="cm" 
+         x="210.02"
+	 y="-745" 
+	 z="-448.95"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_8-1"/>
+       <position name="posOpArapuca1-Lat-8" unit="cm" 
+         x="210.02"
+	 y="-744.26" 
+	 z="-448.95"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_8-2"/>
+       <position name="posArapuca2-Lat-8" unit="cm" 
+         x="135.02"
+	 y="-745" 
+	 z="-448.95"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_8-2"/>
+       <position name="posOpArapuca2-Lat-8" unit="cm" 
+         x="135.02"
+	 y="-744.26" 
+	 z="-448.95"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_8-3"/>
+       <position name="posArapuca3-Lat-8" unit="cm" 
+         x="60.02"
+	 y="-745" 
+	 z="-448.95"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_8-3"/>
+       <position name="posOpArapuca3-Lat-8" unit="cm" 
+         x="60.02"
+	 y="-744.26" 
+	 z="-448.95"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_8-4"/>
+       <position name="posArapuca4-Lat-8" unit="cm" 
+         x="285.02"
+	 y="745" 
+	 z="-448.95"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_8-4"/>
+       <position name="posOpArapuca4-Lat-8" unit="cm" 
+         x="285.02"
+	 y="744.26" 
+	 z="-448.95"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_8-5"/>
+       <position name="posArapuca5-Lat-8" unit="cm" 
+         x="210.02"
+	 y="745" 
+	 z="-448.95"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_8-5"/>
+       <position name="posOpArapuca5-Lat-8" unit="cm" 
+         x="210.02"
+	 y="744.26" 
+	 z="-448.95"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_8-6"/>
+       <position name="posArapuca6-Lat-8" unit="cm" 
+         x="135.02"
+	 y="745" 
+	 z="-448.95"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_8-6"/>
+       <position name="posOpArapuca6-Lat-8" unit="cm" 
+         x="135.02"
+	 y="744.26" 
+	 z="-448.95"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_8-7"/>
+       <position name="posArapuca7-Lat-8" unit="cm" 
+         x="60.02"
+	 y="745" 
+	 z="-448.95"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_8-7"/>
+       <position name="posOpArapuca7-Lat-8" unit="cm" 
+         x="60.02"
+	 y="744.26" 
+	 z="-448.95"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_9-0"/>
+       <position name="posArapuca0-Lat-9" unit="cm" 
+         x="285.02"
+	 y="-745" 
+	 z="-149.65"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_9-0"/>
+       <position name="posOpArapuca0-Lat-9" unit="cm" 
+         x="285.02"
+	 y="-744.26" 
+	 z="-149.65"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_9-1"/>
+       <position name="posArapuca1-Lat-9" unit="cm" 
+         x="210.02"
+	 y="-745" 
+	 z="-149.65"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_9-1"/>
+       <position name="posOpArapuca1-Lat-9" unit="cm" 
+         x="210.02"
+	 y="-744.26" 
+	 z="-149.65"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_9-2"/>
+       <position name="posArapuca2-Lat-9" unit="cm" 
+         x="135.02"
+	 y="-745" 
+	 z="-149.65"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_9-2"/>
+       <position name="posOpArapuca2-Lat-9" unit="cm" 
+         x="135.02"
+	 y="-744.26" 
+	 z="-149.65"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_9-3"/>
+       <position name="posArapuca3-Lat-9" unit="cm" 
+         x="60.02"
+	 y="-745" 
+	 z="-149.65"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_9-3"/>
+       <position name="posOpArapuca3-Lat-9" unit="cm" 
+         x="60.02"
+	 y="-744.26" 
+	 z="-149.65"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_9-4"/>
+       <position name="posArapuca4-Lat-9" unit="cm" 
+         x="285.02"
+	 y="745" 
+	 z="-149.65"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_9-4"/>
+       <position name="posOpArapuca4-Lat-9" unit="cm" 
+         x="285.02"
+	 y="744.26" 
+	 z="-149.65"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_9-5"/>
+       <position name="posArapuca5-Lat-9" unit="cm" 
+         x="210.02"
+	 y="745" 
+	 z="-149.65"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_9-5"/>
+       <position name="posOpArapuca5-Lat-9" unit="cm" 
+         x="210.02"
+	 y="744.26" 
+	 z="-149.65"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_9-6"/>
+       <position name="posArapuca6-Lat-9" unit="cm" 
+         x="135.02"
+	 y="745" 
+	 z="-149.65"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_9-6"/>
+       <position name="posOpArapuca6-Lat-9" unit="cm" 
+         x="135.02"
+	 y="744.26" 
+	 z="-149.65"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_9-7"/>
+       <position name="posArapuca7-Lat-9" unit="cm" 
+         x="60.02"
+	 y="745" 
+	 z="-149.65"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_9-7"/>
+       <position name="posOpArapuca7-Lat-9" unit="cm" 
+         x="60.02"
+	 y="744.26" 
+	 z="-149.65"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_10-0"/>
+       <position name="posArapuca0-Lat-10" unit="cm" 
+         x="285.02"
+	 y="-745" 
+	 z="149.65"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_10-0"/>
+       <position name="posOpArapuca0-Lat-10" unit="cm" 
+         x="285.02"
+	 y="-744.26" 
+	 z="149.65"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_10-1"/>
+       <position name="posArapuca1-Lat-10" unit="cm" 
+         x="210.02"
+	 y="-745" 
+	 z="149.65"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_10-1"/>
+       <position name="posOpArapuca1-Lat-10" unit="cm" 
+         x="210.02"
+	 y="-744.26" 
+	 z="149.65"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_10-2"/>
+       <position name="posArapuca2-Lat-10" unit="cm" 
+         x="135.02"
+	 y="-745" 
+	 z="149.65"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_10-2"/>
+       <position name="posOpArapuca2-Lat-10" unit="cm" 
+         x="135.02"
+	 y="-744.26" 
+	 z="149.65"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_10-3"/>
+       <position name="posArapuca3-Lat-10" unit="cm" 
+         x="60.02"
+	 y="-745" 
+	 z="149.65"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_10-3"/>
+       <position name="posOpArapuca3-Lat-10" unit="cm" 
+         x="60.02"
+	 y="-744.26" 
+	 z="149.65"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_10-4"/>
+       <position name="posArapuca4-Lat-10" unit="cm" 
+         x="285.02"
+	 y="745" 
+	 z="149.65"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_10-4"/>
+       <position name="posOpArapuca4-Lat-10" unit="cm" 
+         x="285.02"
+	 y="744.26" 
+	 z="149.65"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_10-5"/>
+       <position name="posArapuca5-Lat-10" unit="cm" 
+         x="210.02"
+	 y="745" 
+	 z="149.65"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_10-5"/>
+       <position name="posOpArapuca5-Lat-10" unit="cm" 
+         x="210.02"
+	 y="744.26" 
+	 z="149.65"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_10-6"/>
+       <position name="posArapuca6-Lat-10" unit="cm" 
+         x="135.02"
+	 y="745" 
+	 z="149.65"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_10-6"/>
+       <position name="posOpArapuca6-Lat-10" unit="cm" 
+         x="135.02"
+	 y="744.26" 
+	 z="149.65"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_10-7"/>
+       <position name="posArapuca7-Lat-10" unit="cm" 
+         x="60.02"
+	 y="745" 
+	 z="149.65"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_10-7"/>
+       <position name="posOpArapuca7-Lat-10" unit="cm" 
+         x="60.02"
+	 y="744.26" 
+	 z="149.65"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_11-0"/>
+       <position name="posArapuca0-Lat-11" unit="cm" 
+         x="285.02"
+	 y="-745" 
+	 z="448.95"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_11-0"/>
+       <position name="posOpArapuca0-Lat-11" unit="cm" 
+         x="285.02"
+	 y="-744.26" 
+	 z="448.95"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_11-1"/>
+       <position name="posArapuca1-Lat-11" unit="cm" 
+         x="210.02"
+	 y="-745" 
+	 z="448.95"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_11-1"/>
+       <position name="posOpArapuca1-Lat-11" unit="cm" 
+         x="210.02"
+	 y="-744.26" 
+	 z="448.95"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_11-2"/>
+       <position name="posArapuca2-Lat-11" unit="cm" 
+         x="135.02"
+	 y="-745" 
+	 z="448.95"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_11-2"/>
+       <position name="posOpArapuca2-Lat-11" unit="cm" 
+         x="135.02"
+	 y="-744.26" 
+	 z="448.95"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_11-3"/>
+       <position name="posArapuca3-Lat-11" unit="cm" 
+         x="60.02"
+	 y="-745" 
+	 z="448.95"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_11-3"/>
+       <position name="posOpArapuca3-Lat-11" unit="cm" 
+         x="60.02"
+	 y="-744.26" 
+	 z="448.95"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_11-4"/>
+       <position name="posArapuca4-Lat-11" unit="cm" 
+         x="285.02"
+	 y="745" 
+	 z="448.95"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_11-4"/>
+       <position name="posOpArapuca4-Lat-11" unit="cm" 
+         x="285.02"
+	 y="744.26" 
+	 z="448.95"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_11-5"/>
+       <position name="posArapuca5-Lat-11" unit="cm" 
+         x="210.02"
+	 y="745" 
+	 z="448.95"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_11-5"/>
+       <position name="posOpArapuca5-Lat-11" unit="cm" 
+         x="210.02"
+	 y="744.26" 
+	 z="448.95"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_11-6"/>
+       <position name="posArapuca6-Lat-11" unit="cm" 
+         x="135.02"
+	 y="745" 
+	 z="448.95"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_11-6"/>
+       <position name="posOpArapuca6-Lat-11" unit="cm" 
+         x="135.02"
+	 y="744.26" 
+	 z="448.95"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_11-7"/>
+       <position name="posArapuca7-Lat-11" unit="cm" 
+         x="60.02"
+	 y="745" 
+	 z="448.95"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_11-7"/>
+       <position name="posOpArapuca7-Lat-11" unit="cm" 
+         x="60.02"
+	 y="744.26" 
+	 z="448.95"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_12-0"/>
+       <position name="posArapuca0-Lat-12" unit="cm" 
+         x="285.02"
+	 y="-745" 
+	 z="748.25"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_12-0"/>
+       <position name="posOpArapuca0-Lat-12" unit="cm" 
+         x="285.02"
+	 y="-744.26" 
+	 z="748.25"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_12-1"/>
+       <position name="posArapuca1-Lat-12" unit="cm" 
+         x="210.02"
+	 y="-745" 
+	 z="748.25"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_12-1"/>
+       <position name="posOpArapuca1-Lat-12" unit="cm" 
+         x="210.02"
+	 y="-744.26" 
+	 z="748.25"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_12-2"/>
+       <position name="posArapuca2-Lat-12" unit="cm" 
+         x="135.02"
+	 y="-745" 
+	 z="748.25"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_12-2"/>
+       <position name="posOpArapuca2-Lat-12" unit="cm" 
+         x="135.02"
+	 y="-744.26" 
+	 z="748.25"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_12-3"/>
+       <position name="posArapuca3-Lat-12" unit="cm" 
+         x="60.02"
+	 y="-745" 
+	 z="748.25"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_12-3"/>
+       <position name="posOpArapuca3-Lat-12" unit="cm" 
+         x="60.02"
+	 y="-744.26" 
+	 z="748.25"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_12-4"/>
+       <position name="posArapuca4-Lat-12" unit="cm" 
+         x="285.02"
+	 y="745" 
+	 z="748.25"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_12-4"/>
+       <position name="posOpArapuca4-Lat-12" unit="cm" 
+         x="285.02"
+	 y="744.26" 
+	 z="748.25"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_12-5"/>
+       <position name="posArapuca5-Lat-12" unit="cm" 
+         x="210.02"
+	 y="745" 
+	 z="748.25"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_12-5"/>
+       <position name="posOpArapuca5-Lat-12" unit="cm" 
+         x="210.02"
+	 y="744.26" 
+	 z="748.25"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_12-6"/>
+       <position name="posArapuca6-Lat-12" unit="cm" 
+         x="135.02"
+	 y="745" 
+	 z="748.25"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_12-6"/>
+       <position name="posOpArapuca6-Lat-12" unit="cm" 
+         x="135.02"
+	 y="744.26" 
+	 z="748.25"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_12-7"/>
+       <position name="posArapuca7-Lat-12" unit="cm" 
+         x="60.02"
+	 y="745" 
+	 z="748.25"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_12-7"/>
+       <position name="posOpArapuca7-Lat-12" unit="cm" 
+         x="60.02"
+	 y="744.26" 
+	 z="748.25"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_13-0"/>
+       <position name="posArapuca0-Lat-13" unit="cm" 
+         x="285.02"
+	 y="-745" 
+	 z="1047.55"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_13-0"/>
+       <position name="posOpArapuca0-Lat-13" unit="cm" 
+         x="285.02"
+	 y="-744.26" 
+	 z="1047.55"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_13-1"/>
+       <position name="posArapuca1-Lat-13" unit="cm" 
+         x="210.02"
+	 y="-745" 
+	 z="1047.55"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_13-1"/>
+       <position name="posOpArapuca1-Lat-13" unit="cm" 
+         x="210.02"
+	 y="-744.26" 
+	 z="1047.55"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_13-2"/>
+       <position name="posArapuca2-Lat-13" unit="cm" 
+         x="135.02"
+	 y="-745" 
+	 z="1047.55"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_13-2"/>
+       <position name="posOpArapuca2-Lat-13" unit="cm" 
+         x="135.02"
+	 y="-744.26" 
+	 z="1047.55"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_13-3"/>
+       <position name="posArapuca3-Lat-13" unit="cm" 
+         x="60.02"
+	 y="-745" 
+	 z="1047.55"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_13-3"/>
+       <position name="posOpArapuca3-Lat-13" unit="cm" 
+         x="60.02"
+	 y="-744.26" 
+	 z="1047.55"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_13-4"/>
+       <position name="posArapuca4-Lat-13" unit="cm" 
+         x="285.02"
+	 y="745" 
+	 z="1047.55"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_13-4"/>
+       <position name="posOpArapuca4-Lat-13" unit="cm" 
+         x="285.02"
+	 y="744.26" 
+	 z="1047.55"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_13-5"/>
+       <position name="posArapuca5-Lat-13" unit="cm" 
+         x="210.02"
+	 y="745" 
+	 z="1047.55"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_13-5"/>
+       <position name="posOpArapuca5-Lat-13" unit="cm" 
+         x="210.02"
+	 y="744.26" 
+	 z="1047.55"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_13-6"/>
+       <position name="posArapuca6-Lat-13" unit="cm" 
+         x="135.02"
+	 y="745" 
+	 z="1047.55"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_13-6"/>
+       <position name="posOpArapuca6-Lat-13" unit="cm" 
+         x="135.02"
+	 y="744.26" 
+	 z="1047.55"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_13-7"/>
+       <position name="posArapuca7-Lat-13" unit="cm" 
+         x="60.02"
+	 y="745" 
+	 z="1047.55"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_13-7"/>
+       <position name="posOpArapuca7-Lat-13" unit="cm" 
+         x="60.02"
+	 y="744.26" 
+	 z="1047.55"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_14-0"/>
+       <position name="posArapuca0-Lat-14" unit="cm" 
+         x="285.02"
+	 y="-745" 
+	 z="1346.85"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_14-0"/>
+       <position name="posOpArapuca0-Lat-14" unit="cm" 
+         x="285.02"
+	 y="-744.26" 
+	 z="1346.85"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_14-1"/>
+       <position name="posArapuca1-Lat-14" unit="cm" 
+         x="210.02"
+	 y="-745" 
+	 z="1346.85"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_14-1"/>
+       <position name="posOpArapuca1-Lat-14" unit="cm" 
+         x="210.02"
+	 y="-744.26" 
+	 z="1346.85"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_14-2"/>
+       <position name="posArapuca2-Lat-14" unit="cm" 
+         x="135.02"
+	 y="-745" 
+	 z="1346.85"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_14-2"/>
+       <position name="posOpArapuca2-Lat-14" unit="cm" 
+         x="135.02"
+	 y="-744.26" 
+	 z="1346.85"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_14-3"/>
+       <position name="posArapuca3-Lat-14" unit="cm" 
+         x="60.02"
+	 y="-745" 
+	 z="1346.85"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_14-3"/>
+       <position name="posOpArapuca3-Lat-14" unit="cm" 
+         x="60.02"
+	 y="-744.26" 
+	 z="1346.85"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_14-4"/>
+       <position name="posArapuca4-Lat-14" unit="cm" 
+         x="285.02"
+	 y="745" 
+	 z="1346.85"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_14-4"/>
+       <position name="posOpArapuca4-Lat-14" unit="cm" 
+         x="285.02"
+	 y="744.26" 
+	 z="1346.85"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_14-5"/>
+       <position name="posArapuca5-Lat-14" unit="cm" 
+         x="210.02"
+	 y="745" 
+	 z="1346.85"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_14-5"/>
+       <position name="posOpArapuca5-Lat-14" unit="cm" 
+         x="210.02"
+	 y="744.26" 
+	 z="1346.85"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_14-6"/>
+       <position name="posArapuca6-Lat-14" unit="cm" 
+         x="135.02"
+	 y="745" 
+	 z="1346.85"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_14-6"/>
+       <position name="posOpArapuca6-Lat-14" unit="cm" 
+         x="135.02"
+	 y="744.26" 
+	 z="1346.85"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_14-7"/>
+       <position name="posArapuca7-Lat-14" unit="cm" 
+         x="60.02"
+	 y="745" 
+	 z="1346.85"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_14-7"/>
+       <position name="posOpArapuca7-Lat-14" unit="cm" 
+         x="60.02"
+	 y="744.26" 
+	 z="1346.85"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_15-0"/>
+       <position name="posArapuca0-Lat-15" unit="cm" 
+         x="285.02"
+	 y="-745" 
+	 z="1646.15"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_15-0"/>
+       <position name="posOpArapuca0-Lat-15" unit="cm" 
+         x="285.02"
+	 y="-744.26" 
+	 z="1646.15"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_15-1"/>
+       <position name="posArapuca1-Lat-15" unit="cm" 
+         x="210.02"
+	 y="-745" 
+	 z="1646.15"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_15-1"/>
+       <position name="posOpArapuca1-Lat-15" unit="cm" 
+         x="210.02"
+	 y="-744.26" 
+	 z="1646.15"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_15-2"/>
+       <position name="posArapuca2-Lat-15" unit="cm" 
+         x="135.02"
+	 y="-745" 
+	 z="1646.15"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_15-2"/>
+       <position name="posOpArapuca2-Lat-15" unit="cm" 
+         x="135.02"
+	 y="-744.26" 
+	 z="1646.15"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_15-3"/>
+       <position name="posArapuca3-Lat-15" unit="cm" 
+         x="60.02"
+	 y="-745" 
+	 z="1646.15"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_15-3"/>
+       <position name="posOpArapuca3-Lat-15" unit="cm" 
+         x="60.02"
+	 y="-744.26" 
+	 z="1646.15"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_15-4"/>
+       <position name="posArapuca4-Lat-15" unit="cm" 
+         x="285.02"
+	 y="745" 
+	 z="1646.15"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_15-4"/>
+       <position name="posOpArapuca4-Lat-15" unit="cm" 
+         x="285.02"
+	 y="744.26" 
+	 z="1646.15"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_15-5"/>
+       <position name="posArapuca5-Lat-15" unit="cm" 
+         x="210.02"
+	 y="745" 
+	 z="1646.15"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_15-5"/>
+       <position name="posOpArapuca5-Lat-15" unit="cm" 
+         x="210.02"
+	 y="744.26" 
+	 z="1646.15"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_15-6"/>
+       <position name="posArapuca6-Lat-15" unit="cm" 
+         x="135.02"
+	 y="745" 
+	 z="1646.15"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_15-6"/>
+       <position name="posOpArapuca6-Lat-15" unit="cm" 
+         x="135.02"
+	 y="744.26" 
+	 z="1646.15"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_15-7"/>
+       <position name="posArapuca7-Lat-15" unit="cm" 
+         x="60.02"
+	 y="745" 
+	 z="1646.15"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_15-7"/>
+       <position name="posOpArapuca7-Lat-15" unit="cm" 
+         x="60.02"
+	 y="744.26" 
+	 z="1646.15"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_16-0"/>
+       <position name="posArapuca0-Lat-16" unit="cm" 
+         x="285.02"
+	 y="-745" 
+	 z="1945.45"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_16-0"/>
+       <position name="posOpArapuca0-Lat-16" unit="cm" 
+         x="285.02"
+	 y="-744.26" 
+	 z="1945.45"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_16-1"/>
+       <position name="posArapuca1-Lat-16" unit="cm" 
+         x="210.02"
+	 y="-745" 
+	 z="1945.45"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_16-1"/>
+       <position name="posOpArapuca1-Lat-16" unit="cm" 
+         x="210.02"
+	 y="-744.26" 
+	 z="1945.45"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_16-2"/>
+       <position name="posArapuca2-Lat-16" unit="cm" 
+         x="135.02"
+	 y="-745" 
+	 z="1945.45"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_16-2"/>
+       <position name="posOpArapuca2-Lat-16" unit="cm" 
+         x="135.02"
+	 y="-744.26" 
+	 z="1945.45"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_16-3"/>
+       <position name="posArapuca3-Lat-16" unit="cm" 
+         x="60.02"
+	 y="-745" 
+	 z="1945.45"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_16-3"/>
+       <position name="posOpArapuca3-Lat-16" unit="cm" 
+         x="60.02"
+	 y="-744.26" 
+	 z="1945.45"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_16-4"/>
+       <position name="posArapuca4-Lat-16" unit="cm" 
+         x="285.02"
+	 y="745" 
+	 z="1945.45"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_16-4"/>
+       <position name="posOpArapuca4-Lat-16" unit="cm" 
+         x="285.02"
+	 y="744.26" 
+	 z="1945.45"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_16-5"/>
+       <position name="posArapuca5-Lat-16" unit="cm" 
+         x="210.02"
+	 y="745" 
+	 z="1945.45"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_16-5"/>
+       <position name="posOpArapuca5-Lat-16" unit="cm" 
+         x="210.02"
+	 y="744.26" 
+	 z="1945.45"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_16-6"/>
+       <position name="posArapuca6-Lat-16" unit="cm" 
+         x="135.02"
+	 y="745" 
+	 z="1945.45"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_16-6"/>
+       <position name="posOpArapuca6-Lat-16" unit="cm" 
+         x="135.02"
+	 y="744.26" 
+	 z="1945.45"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_16-7"/>
+       <position name="posArapuca7-Lat-16" unit="cm" 
+         x="60.02"
+	 y="745" 
+	 z="1945.45"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_16-7"/>
+       <position name="posOpArapuca7-Lat-16" unit="cm" 
+         x="60.02"
+	 y="744.26" 
+	 z="1945.45"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_17-0"/>
+       <position name="posArapuca0-Lat-17" unit="cm" 
+         x="285.02"
+	 y="-745" 
+	 z="2244.75"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_17-0"/>
+       <position name="posOpArapuca0-Lat-17" unit="cm" 
+         x="285.02"
+	 y="-744.26" 
+	 z="2244.75"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_17-1"/>
+       <position name="posArapuca1-Lat-17" unit="cm" 
+         x="210.02"
+	 y="-745" 
+	 z="2244.75"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_17-1"/>
+       <position name="posOpArapuca1-Lat-17" unit="cm" 
+         x="210.02"
+	 y="-744.26" 
+	 z="2244.75"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_17-2"/>
+       <position name="posArapuca2-Lat-17" unit="cm" 
+         x="135.02"
+	 y="-745" 
+	 z="2244.75"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_17-2"/>
+       <position name="posOpArapuca2-Lat-17" unit="cm" 
+         x="135.02"
+	 y="-744.26" 
+	 z="2244.75"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_17-3"/>
+       <position name="posArapuca3-Lat-17" unit="cm" 
+         x="60.02"
+	 y="-745" 
+	 z="2244.75"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_17-3"/>
+       <position name="posOpArapuca3-Lat-17" unit="cm" 
+         x="60.02"
+	 y="-744.26" 
+	 z="2244.75"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_17-4"/>
+       <position name="posArapuca4-Lat-17" unit="cm" 
+         x="285.02"
+	 y="745" 
+	 z="2244.75"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_17-4"/>
+       <position name="posOpArapuca4-Lat-17" unit="cm" 
+         x="285.02"
+	 y="744.26" 
+	 z="2244.75"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_17-5"/>
+       <position name="posArapuca5-Lat-17" unit="cm" 
+         x="210.02"
+	 y="745" 
+	 z="2244.75"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_17-5"/>
+       <position name="posOpArapuca5-Lat-17" unit="cm" 
+         x="210.02"
+	 y="744.26" 
+	 z="2244.75"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_17-6"/>
+       <position name="posArapuca6-Lat-17" unit="cm" 
+         x="135.02"
+	 y="745" 
+	 z="2244.75"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_17-6"/>
+       <position name="posOpArapuca6-Lat-17" unit="cm" 
+         x="135.02"
+	 y="744.26" 
+	 z="2244.75"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_17-7"/>
+       <position name="posArapuca7-Lat-17" unit="cm" 
+         x="60.02"
+	 y="745" 
+	 z="2244.75"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_17-7"/>
+       <position name="posOpArapuca7-Lat-17" unit="cm" 
+         x="60.02"
+	 y="744.26" 
+	 z="2244.75"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_18-0"/>
+       <position name="posArapuca0-Lat-18" unit="cm" 
+         x="285.02"
+	 y="-745" 
+	 z="2544.05"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_18-0"/>
+       <position name="posOpArapuca0-Lat-18" unit="cm" 
+         x="285.02"
+	 y="-744.26" 
+	 z="2544.05"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_18-1"/>
+       <position name="posArapuca1-Lat-18" unit="cm" 
+         x="210.02"
+	 y="-745" 
+	 z="2544.05"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_18-1"/>
+       <position name="posOpArapuca1-Lat-18" unit="cm" 
+         x="210.02"
+	 y="-744.26" 
+	 z="2544.05"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_18-2"/>
+       <position name="posArapuca2-Lat-18" unit="cm" 
+         x="135.02"
+	 y="-745" 
+	 z="2544.05"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_18-2"/>
+       <position name="posOpArapuca2-Lat-18" unit="cm" 
+         x="135.02"
+	 y="-744.26" 
+	 z="2544.05"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_18-3"/>
+       <position name="posArapuca3-Lat-18" unit="cm" 
+         x="60.02"
+	 y="-745" 
+	 z="2544.05"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_18-3"/>
+       <position name="posOpArapuca3-Lat-18" unit="cm" 
+         x="60.02"
+	 y="-744.26" 
+	 z="2544.05"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_18-4"/>
+       <position name="posArapuca4-Lat-18" unit="cm" 
+         x="285.02"
+	 y="745" 
+	 z="2544.05"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_18-4"/>
+       <position name="posOpArapuca4-Lat-18" unit="cm" 
+         x="285.02"
+	 y="744.26" 
+	 z="2544.05"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_18-5"/>
+       <position name="posArapuca5-Lat-18" unit="cm" 
+         x="210.02"
+	 y="745" 
+	 z="2544.05"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_18-5"/>
+       <position name="posOpArapuca5-Lat-18" unit="cm" 
+         x="210.02"
+	 y="744.26" 
+	 z="2544.05"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_18-6"/>
+       <position name="posArapuca6-Lat-18" unit="cm" 
+         x="135.02"
+	 y="745" 
+	 z="2544.05"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_18-6"/>
+       <position name="posOpArapuca6-Lat-18" unit="cm" 
+         x="135.02"
+	 y="744.26" 
+	 z="2544.05"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_18-7"/>
+       <position name="posArapuca7-Lat-18" unit="cm" 
+         x="60.02"
+	 y="745" 
+	 z="2544.05"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_18-7"/>
+       <position name="posOpArapuca7-Lat-18" unit="cm" 
+         x="60.02"
+	 y="744.26" 
+	 z="2544.05"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_19-0"/>
+       <position name="posArapuca0-Lat-19" unit="cm" 
+         x="285.02"
+	 y="-745" 
+	 z="2843.35"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_19-0"/>
+       <position name="posOpArapuca0-Lat-19" unit="cm" 
+         x="285.02"
+	 y="-744.26" 
+	 z="2843.35"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_19-1"/>
+       <position name="posArapuca1-Lat-19" unit="cm" 
+         x="210.02"
+	 y="-745" 
+	 z="2843.35"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_19-1"/>
+       <position name="posOpArapuca1-Lat-19" unit="cm" 
+         x="210.02"
+	 y="-744.26" 
+	 z="2843.35"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_19-2"/>
+       <position name="posArapuca2-Lat-19" unit="cm" 
+         x="135.02"
+	 y="-745" 
+	 z="2843.35"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_19-2"/>
+       <position name="posOpArapuca2-Lat-19" unit="cm" 
+         x="135.02"
+	 y="-744.26" 
+	 z="2843.35"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_19-3"/>
+       <position name="posArapuca3-Lat-19" unit="cm" 
+         x="60.02"
+	 y="-745" 
+	 z="2843.35"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_19-3"/>
+       <position name="posOpArapuca3-Lat-19" unit="cm" 
+         x="60.02"
+	 y="-744.26" 
+	 z="2843.35"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_19-4"/>
+       <position name="posArapuca4-Lat-19" unit="cm" 
+         x="285.02"
+	 y="745" 
+	 z="2843.35"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_19-4"/>
+       <position name="posOpArapuca4-Lat-19" unit="cm" 
+         x="285.02"
+	 y="744.26" 
+	 z="2843.35"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_19-5"/>
+       <position name="posArapuca5-Lat-19" unit="cm" 
+         x="210.02"
+	 y="745" 
+	 z="2843.35"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_19-5"/>
+       <position name="posOpArapuca5-Lat-19" unit="cm" 
+         x="210.02"
+	 y="744.26" 
+	 z="2843.35"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_19-6"/>
+       <position name="posArapuca6-Lat-19" unit="cm" 
+         x="135.02"
+	 y="745" 
+	 z="2843.35"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_19-6"/>
+       <position name="posOpArapuca6-Lat-19" unit="cm" 
+         x="135.02"
+	 y="744.26" 
+	 z="2843.35"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_19-7"/>
+       <position name="posArapuca7-Lat-19" unit="cm" 
+         x="60.02"
+	 y="745" 
+	 z="2843.35"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_19-7"/>
+       <position name="posOpArapuca7-Lat-19" unit="cm" 
+         x="60.02"
+	 y="744.26" 
+	 z="2843.35"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapuca"/>
-       <position name="posArapuca0-ShortLat-2" unit="cm" 
+       <position name="posArapuca0-ShortLat-19" unit="cm" 
          x="285.02"
 	 y="-220" 
-	 z="-545.95"/>
+	 z="-3090"/>
        <rotationref ref="rMinus90AboutX"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapuca"/>
-       <position name="posArapuca1-ShortLat-2" unit="cm" 
+       <position name="posArapuca1-ShortLat-19" unit="cm" 
          x="210.02"
 	 y="-220" 
-	 z="-545.95"/>
+	 z="-3090"/>
        <rotationref ref="rMinus90AboutX"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapuca"/>
-       <position name="posArapuca2-ShortLat-2" unit="cm" 
+       <position name="posArapuca2-ShortLat-19" unit="cm" 
          x="135.02"
 	 y="-220" 
-	 z="-545.95"/>
+	 z="-3090"/>
        <rotationref ref="rMinus90AboutX"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapuca"/>
-       <position name="posArapuca3-ShortLat-2" unit="cm" 
+       <position name="posArapuca3-ShortLat-19" unit="cm" 
          x="60.02"
 	 y="-220" 
-	 z="-545.95"/>
+	 z="-3090"/>
        <rotationref ref="rMinus90AboutX"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapuca"/>
-       <position name="posArapuca4-ShortLat-2" unit="cm" 
+       <position name="posArapuca4-ShortLat-19" unit="cm" 
          x="285.02"
 	 y="-220" 
-	 z="545.95"/>
+	 z="3090"/>
        <rotationref ref="rPlus90AboutX"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapuca"/>
-       <position name="posArapuca5-ShortLat-2" unit="cm" 
+       <position name="posArapuca5-ShortLat-19" unit="cm" 
          x="210.02"
 	 y="-220" 
-	 z="545.95"/>
+	 z="3090"/>
        <rotationref ref="rPlus90AboutX"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapuca"/>
-       <position name="posArapuca6-ShortLat-2" unit="cm" 
+       <position name="posArapuca6-ShortLat-19" unit="cm" 
          x="135.02"
 	 y="-220" 
-	 z="545.95"/>
+	 z="3090"/>
        <rotationref ref="rPlus90AboutX"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapuca"/>
-       <position name="posArapuca7-ShortLat-2" unit="cm" 
+       <position name="posArapuca7-ShortLat-19" unit="cm" 
          x="60.02"
 	 y="-220" 
-	 z="545.95"/>
+	 z="3090"/>
        <rotationref ref="rPlus90AboutX"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapuca"/>
-       <position name="posArapuca0-ShortLat-2" unit="cm" 
+       <position name="posArapuca0-ShortLat-19" unit="cm" 
          x="285.02"
 	 y="220" 
-	 z="-545.95"/>
+	 z="-3090"/>
        <rotationref ref="rMinus90AboutX"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapuca"/>
-       <position name="posArapuca1-ShortLat-2" unit="cm" 
+       <position name="posArapuca1-ShortLat-19" unit="cm" 
          x="210.02"
 	 y="220" 
-	 z="-545.95"/>
+	 z="-3090"/>
        <rotationref ref="rMinus90AboutX"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapuca"/>
-       <position name="posArapuca2-ShortLat-2" unit="cm" 
+       <position name="posArapuca2-ShortLat-19" unit="cm" 
          x="135.02"
 	 y="220" 
-	 z="-545.95"/>
+	 z="-3090"/>
        <rotationref ref="rMinus90AboutX"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapuca"/>
-       <position name="posArapuca3-ShortLat-2" unit="cm" 
+       <position name="posArapuca3-ShortLat-19" unit="cm" 
          x="60.02"
 	 y="220" 
-	 z="-545.95"/>
+	 z="-3090"/>
        <rotationref ref="rMinus90AboutX"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapuca"/>
-       <position name="posArapuca4-ShortLat-2" unit="cm" 
+       <position name="posArapuca4-ShortLat-19" unit="cm" 
          x="285.02"
 	 y="220" 
-	 z="545.95"/>
+	 z="3090"/>
        <rotationref ref="rPlus90AboutX"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapuca"/>
-       <position name="posArapuca5-ShortLat-2" unit="cm" 
+       <position name="posArapuca5-ShortLat-19" unit="cm" 
          x="210.02"
 	 y="220" 
-	 z="545.95"/>
+	 z="3090"/>
        <rotationref ref="rPlus90AboutX"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapuca"/>
-       <position name="posArapuca6-ShortLat-2" unit="cm" 
+       <position name="posArapuca6-ShortLat-19" unit="cm" 
          x="135.02"
 	 y="220" 
-	 z="545.95"/>
+	 z="3090"/>
        <rotationref ref="rPlus90AboutX"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapuca"/>
-       <position name="posArapuca7-ShortLat-2" unit="cm" 
+       <position name="posArapuca7-ShortLat-19" unit="cm" 
          x="60.02"
 	 y="220" 
-	 z="545.95"/>
+	 z="3090"/>
        <rotationref ref="rPlus90AboutX"/>
      </physvol>
     </volume>
@@ -41657,7 +53013,7 @@
 
       <physvol>
         <volumeref ref="volDetEnclosure"/>
-	<position name="posDetEnclosure" unit="cm" x="50.03" y="-1.13686837721616e-13" z="448.95"/>
+	<position name="posDetEnclosure" unit="cm" x="50.03" y="-1.13686837721616e-13" z="2993"/>
       </physvol>
 
     </volume>

--- a/dunecore/Geometry/gdml/dunevd10kt_3view_30deg_v5_refactored_1x8x20ref.gdml
+++ b/dunecore/Geometry/gdml/dunevd10kt_3view_30deg_v5_refactored_1x8x20ref.gdml
@@ -397,6 +397,24 @@
      <tube name="FieldShaperLongtube" rmin="0.5" rmax="2.285" z="5986" deltaphi="360" startphi="0" aunit="deg" lunit="cm"/>
      <tube name="FieldShaperLongtubeSlim" rmin="0.5" rmax="0.75" z="5986" deltaphi="360" startphi="0" aunit="deg" lunit="cm"/>
      <tube name="FieldShaperShorttube" rmin="0.5" rmax="2.285" z="1348" deltaphi="360" startphi="0" aunit="deg" lunit="cm"/>
+     <tube name="FieldShaperShorttubeWindowSlim" rmin="0.5" rmax="0.75" z="670" deltaphi="360" startphi="0" aunit="deg" lunit="cm"/>
+     <tube name="FieldShaperShorttubeWindowNotSlim" rmin="0.5" rmax="2.285" z="339" deltaphi="360" startphi="0" aunit="deg" lunit="cm"/>
+
+
+    <union name="FSunionWindow1">
+      <first ref="FieldShaperShorttubeWindowSlim"/>
+      <second ref="FieldShaperShorttubeWindowNotSlim"/>
+      <position name="posFieldShaperShortTube_shift1" unit="cm" x="0" y="0" z="504.5"/>
+    </union>
+
+    <union name="FieldShaperShorttubeSlim">
+      <first ref="FSunionWindow1"/>
+      <second ref="FieldShaperShorttubeWindowNotSlim"/>
+      <position name="posFieldShaperShortTube_shift2" unit="cm" x="0" y="0" z="-504.5"/>
+    </union>
+
+
+
 
     <union name="FSunion1">
       <first ref="FieldShaperLongtube"/>
@@ -455,7 +473,7 @@
 
     <union name="FSunionSlim2">
       <first ref="FSunionSlim1"/>
-      <second ref="FieldShaperShorttube"/>
+      <second ref="FieldShaperShorttubeSlim"/>
    		<position name="esquinapos9" unit="cm" x="-676.3" y="0" z="2995.3"/>
    		<rotationref ref="rPlus90AboutY"/>
     </union>
@@ -482,7 +500,7 @@
 
     <union name="FSunionSlim6">
       <first ref="FSunionSlim5"/>
-      <second ref="FieldShaperShorttube"/>
+      <second ref="FieldShaperShorttubeSlim"/>
    		<position name="esquinapos12" unit="cm" x="-676.3" y="0" z="-2995.3"/>
 		<rotationref ref="rPlus90AboutY"/>
     </union>
@@ -38906,10 +38924,6 @@
       <colorref ref="green"/>
     </volume>
 
-    <volume name="volArapucaShortLat">
-      <materialref ref="G10"/>
-      <solidref ref="ArapucaWalls"/>
-    </volume>
     <volume name="volOpDetSensitive">
       <materialref ref="LAr"/>
       <solidref ref="ArapucaAcceptanceWindow"/>
@@ -38933,3846 +38947,6 @@
       </physvol>
     </volume>
 
-    <volume name="volArapucaDouble_0-0-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-0-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-0-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-0-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-0-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-0-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-0-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-0-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-1-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-1-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-1-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-1-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-1-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-1-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-1-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-1-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-2-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-2-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-2-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-2-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-2-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-2-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-2-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-2-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-3-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-3-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-3-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-3-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-3-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-3-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-3-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-3-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-4-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-4-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-4-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-4-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-4-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-4-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-4-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-4-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-5-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-5-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-5-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-5-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-5-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-5-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-5-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-5-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-6-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-6-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-6-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-6-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-6-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-6-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-6-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-6-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-7-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-7-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-7-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-7-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-7-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-7-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-7-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-7-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-8-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-8-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-8-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-8-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-8-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-8-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-8-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-8-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-9-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-9-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-9-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-9-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-9-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-9-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-9-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-9-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-10-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-10-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-10-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-10-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-10-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-10-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-10-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-10-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-11-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-11-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-11-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-11-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-11-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-11-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-11-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-11-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-12-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-12-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-12-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-12-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-12-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-12-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-12-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-12-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-13-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-13-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-13-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-13-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-13-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-13-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-13-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-13-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-14-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-14-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-14-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-14-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-14-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-14-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-14-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-14-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-15-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-15-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-15-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-15-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-15-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-15-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-15-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-15-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-16-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-16-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-16-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-16-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-16-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-16-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-16-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-16-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-17-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-17-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-17-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-17-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-17-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-17-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-17-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-17-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-18-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-18-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-18-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-18-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-18-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-18-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-18-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-18-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-19-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-19-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-19-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-19-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-19-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-19-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-19-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-19-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-0-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-0-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-0-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-0-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-0-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-0-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-0-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-0-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-1-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-1-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-1-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-1-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-1-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-1-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-1-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-1-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-2-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-2-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-2-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-2-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-2-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-2-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-2-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-2-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-3-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-3-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-3-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-3-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-3-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-3-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-3-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-3-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-4-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-4-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-4-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-4-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-4-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-4-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-4-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-4-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-5-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-5-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-5-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-5-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-5-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-5-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-5-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-5-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-6-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-6-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-6-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-6-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-6-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-6-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-6-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-6-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-7-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-7-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-7-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-7-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-7-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-7-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-7-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-7-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-8-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-8-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-8-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-8-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-8-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-8-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-8-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-8-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-9-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-9-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-9-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-9-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-9-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-9-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-9-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-9-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-10-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-10-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-10-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-10-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-10-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-10-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-10-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-10-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-11-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-11-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-11-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-11-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-11-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-11-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-11-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-11-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-12-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-12-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-12-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-12-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-12-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-12-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-12-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-12-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-13-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-13-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-13-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-13-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-13-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-13-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-13-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-13-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-14-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-14-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-14-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-14-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-14-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-14-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-14-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-14-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-15-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-15-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-15-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-15-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-15-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-15-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-15-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-15-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-16-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-16-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-16-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-16-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-16-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-16-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-16-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-16-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-17-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-17-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-17-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-17-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-17-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-17-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-17-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-17-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-18-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-18-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-18-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-18-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-18-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-18-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-18-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-18-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-19-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-19-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-19-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-19-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-19-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-19-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-19-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-19-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-0-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-0-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-0-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-0-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-0-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-0-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-0-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-0-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-1-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-1-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-1-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-1-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-1-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-1-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-1-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-1-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-2-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-2-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-2-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-2-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-2-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-2-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-2-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-2-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-3-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-3-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-3-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-3-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-3-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-3-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-3-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-3-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-4-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-4-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-4-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-4-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-4-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-4-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-4-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-4-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-5-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-5-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-5-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-5-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-5-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-5-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-5-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-5-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-6-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-6-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-6-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-6-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-6-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-6-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-6-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-6-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-7-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-7-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-7-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-7-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-7-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-7-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-7-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-7-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-8-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-8-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-8-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-8-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-8-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-8-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-8-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-8-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-9-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-9-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-9-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-9-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-9-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-9-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-9-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-9-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-10-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-10-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-10-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-10-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-10-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-10-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-10-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-10-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-11-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-11-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-11-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-11-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-11-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-11-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-11-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-11-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-12-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-12-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-12-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-12-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-12-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-12-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-12-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-12-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-13-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-13-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-13-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-13-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-13-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-13-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-13-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-13-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-14-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-14-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-14-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-14-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-14-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-14-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-14-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-14-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-15-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-15-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-15-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-15-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-15-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-15-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-15-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-15-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-16-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-16-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-16-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-16-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-16-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-16-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-16-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-16-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-17-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-17-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-17-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-17-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-17-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-17-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-17-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-17-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-18-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-18-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-18-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-18-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-18-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-18-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-18-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-18-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-19-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-19-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-19-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-19-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-19-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-19-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-19-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-19-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-0-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-0-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-0-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-0-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-0-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-0-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-0-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-0-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-1-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-1-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-1-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-1-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-1-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-1-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-1-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-1-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-2-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-2-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-2-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-2-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-2-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-2-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-2-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-2-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-3-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-3-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-3-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-3-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-3-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-3-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-3-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-3-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-4-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-4-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-4-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-4-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-4-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-4-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-4-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-4-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-5-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-5-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-5-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-5-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-5-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-5-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-5-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-5-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-6-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-6-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-6-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-6-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-6-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-6-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-6-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-6-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-7-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-7-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-7-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-7-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-7-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-7-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-7-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-7-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-8-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-8-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-8-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-8-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-8-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-8-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-8-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-8-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-9-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-9-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-9-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-9-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-9-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-9-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-9-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-9-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-10-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-10-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-10-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-10-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-10-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-10-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-10-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-10-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-11-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-11-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-11-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-11-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-11-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-11-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-11-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-11-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-12-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-12-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-12-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-12-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-12-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-12-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-12-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-12-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-13-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-13-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-13-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-13-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-13-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-13-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-13-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-13-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-14-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-14-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-14-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-14-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-14-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-14-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-14-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-14-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-15-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-15-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-15-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-15-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-15-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-15-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-15-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-15-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-16-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-16-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-16-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-16-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-16-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-16-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-16-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-16-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-17-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-17-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-17-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-17-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-17-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-17-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-17-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-17-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-18-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-18-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-18-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-18-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-18-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-18-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-18-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-18-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-19-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-19-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-19-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-19-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-19-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-19-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-19-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-19-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_0-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_0-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_0-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_0-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_0-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_0-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_0-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_0-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_0-4">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_0-4">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_0-5">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_0-5">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_0-6">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_0-6">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_0-7">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_0-7">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_1-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_1-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_1-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_1-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_1-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_1-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_1-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_1-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_1-4">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_1-4">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_1-5">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_1-5">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_1-6">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_1-6">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_1-7">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_1-7">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_2-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_2-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_2-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_2-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_2-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_2-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_2-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_2-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_2-4">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_2-4">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_2-5">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_2-5">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_2-6">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_2-6">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_2-7">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_2-7">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_3-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_3-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_3-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_3-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_3-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_3-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_3-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_3-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_3-4">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_3-4">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_3-5">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_3-5">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_3-6">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_3-6">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_3-7">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_3-7">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_4-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_4-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_4-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_4-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_4-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_4-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_4-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_4-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_4-4">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_4-4">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_4-5">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_4-5">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_4-6">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_4-6">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_4-7">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_4-7">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_5-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_5-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_5-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_5-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_5-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_5-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_5-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_5-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_5-4">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_5-4">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_5-5">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_5-5">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_5-6">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_5-6">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_5-7">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_5-7">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_6-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_6-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_6-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_6-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_6-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_6-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_6-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_6-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_6-4">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_6-4">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_6-5">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_6-5">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_6-6">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_6-6">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_6-7">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_6-7">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_7-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_7-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_7-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_7-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_7-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_7-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_7-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_7-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_7-4">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_7-4">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_7-5">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_7-5">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_7-6">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_7-6">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_7-7">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_7-7">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_8-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_8-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_8-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_8-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_8-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_8-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_8-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_8-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_8-4">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_8-4">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_8-5">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_8-5">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_8-6">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_8-6">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_8-7">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_8-7">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_9-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_9-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_9-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_9-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_9-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_9-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_9-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_9-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_9-4">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_9-4">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_9-5">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_9-5">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_9-6">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_9-6">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_9-7">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_9-7">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_10-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_10-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_10-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_10-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_10-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_10-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_10-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_10-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_10-4">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_10-4">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_10-5">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_10-5">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_10-6">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_10-6">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_10-7">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_10-7">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_11-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_11-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_11-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_11-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_11-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_11-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_11-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_11-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_11-4">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_11-4">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_11-5">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_11-5">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_11-6">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_11-6">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_11-7">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_11-7">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_12-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_12-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_12-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_12-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_12-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_12-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_12-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_12-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_12-4">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_12-4">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_12-5">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_12-5">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_12-6">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_12-6">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_12-7">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_12-7">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_13-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_13-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_13-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_13-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_13-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_13-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_13-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_13-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_13-4">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_13-4">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_13-5">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_13-5">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_13-6">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_13-6">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_13-7">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_13-7">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_14-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_14-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_14-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_14-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_14-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_14-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_14-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_14-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_14-4">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_14-4">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_14-5">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_14-5">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_14-6">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_14-6">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_14-7">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_14-7">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_15-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_15-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_15-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_15-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_15-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_15-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_15-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_15-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_15-4">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_15-4">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_15-5">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_15-5">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_15-6">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_15-6">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_15-7">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_15-7">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_16-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_16-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_16-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_16-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_16-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_16-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_16-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_16-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_16-4">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_16-4">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_16-5">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_16-5">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_16-6">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_16-6">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_16-7">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_16-7">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_17-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_17-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_17-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_17-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_17-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_17-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_17-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_17-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_17-4">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_17-4">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_17-5">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_17-5">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_17-6">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_17-6">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_17-7">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_17-7">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_18-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_18-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_18-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_18-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_18-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_18-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_18-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_18-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_18-4">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_18-4">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_18-5">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_18-5">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_18-6">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_18-6">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_18-7">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_18-7">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_19-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_19-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_19-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_19-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_19-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_19-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_19-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_19-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_19-4">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_19-4">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_19-5">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_19-5">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_19-6">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_19-6">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_19-7">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_19-7">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
 
     <volume name="volCryostat">
       <materialref ref="LAr" />
@@ -45650,7 +41824,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>    
      <physvol>
-       <volumeref ref="volArapucaDouble_0-0-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-0-0" unit="cm" 
          x="-328.03"
 	 y="-633.2" 
@@ -45658,14 +41832,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-0"/>
-       <position name="posOpArapucaDouble0-Frame-0-0" unit="cm" 
-         x="-327.29"
-	 y="-633.2" 
-	 z="-2805.85"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-0-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-0-0" unit="cm" 
          x="-328.03"
 	 y="-542.5" 
@@ -45673,14 +41840,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-1"/>
-       <position name="posOpArapucaDouble1-Frame-0-0" unit="cm" 
-         x="-327.29"
-	 y="-542.5" 
-	 z="-2951.85"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-0-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-0-0" unit="cm" 
          x="-328.03"
 	 y="-468.5" 
@@ -45688,14 +41848,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-2"/>
-       <position name="posOpArapucaDouble2-Frame-0-0" unit="cm" 
-         x="-327.29"
-	 y="-468.5" 
-	 z="-2734.85"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-0-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-0-0" unit="cm" 
          x="-328.03"
 	 y="-377.8" 
@@ -45703,14 +41856,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-3"/>
-       <position name="posOpArapucaDouble3-Frame-0-0" unit="cm" 
-         x="-327.29"
-	 y="-377.8" 
-	 z="-2880.85"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-1-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-0-1" unit="cm" 
          x="-328.03"
 	 y="-633.2" 
@@ -45718,14 +41864,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-0"/>
-       <position name="posOpArapucaDouble0-Frame-0-1" unit="cm" 
-         x="-327.29"
-	 y="-633.2" 
-	 z="-2506.55"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-1-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-0-1" unit="cm" 
          x="-328.03"
 	 y="-542.5" 
@@ -45733,14 +41872,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-1"/>
-       <position name="posOpArapucaDouble1-Frame-0-1" unit="cm" 
-         x="-327.29"
-	 y="-542.5" 
-	 z="-2652.55"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-1-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-0-1" unit="cm" 
          x="-328.03"
 	 y="-468.5" 
@@ -45748,14 +41880,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-2"/>
-       <position name="posOpArapucaDouble2-Frame-0-1" unit="cm" 
-         x="-327.29"
-	 y="-468.5" 
-	 z="-2435.55"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-1-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-0-1" unit="cm" 
          x="-328.03"
 	 y="-377.8" 
@@ -45763,14 +41888,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-3"/>
-       <position name="posOpArapucaDouble3-Frame-0-1" unit="cm" 
-         x="-327.29"
-	 y="-377.8" 
-	 z="-2581.55"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-2-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-0-2" unit="cm" 
          x="-328.03"
 	 y="-633.2" 
@@ -45778,14 +41896,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-0"/>
-       <position name="posOpArapucaDouble0-Frame-0-2" unit="cm" 
-         x="-327.29"
-	 y="-633.2" 
-	 z="-2207.25"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-2-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-0-2" unit="cm" 
          x="-328.03"
 	 y="-542.5" 
@@ -45793,14 +41904,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-1"/>
-       <position name="posOpArapucaDouble1-Frame-0-2" unit="cm" 
-         x="-327.29"
-	 y="-542.5" 
-	 z="-2353.25"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-2-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-0-2" unit="cm" 
          x="-328.03"
 	 y="-468.5" 
@@ -45808,14 +41912,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-2"/>
-       <position name="posOpArapucaDouble2-Frame-0-2" unit="cm" 
-         x="-327.29"
-	 y="-468.5" 
-	 z="-2136.25"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-2-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-0-2" unit="cm" 
          x="-328.03"
 	 y="-377.8" 
@@ -45823,14 +41920,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-3"/>
-       <position name="posOpArapucaDouble3-Frame-0-2" unit="cm" 
-         x="-327.29"
-	 y="-377.8" 
-	 z="-2282.25"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-3-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-0-3" unit="cm" 
          x="-328.03"
 	 y="-633.2" 
@@ -45838,14 +41928,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-3-0"/>
-       <position name="posOpArapucaDouble0-Frame-0-3" unit="cm" 
-         x="-327.29"
-	 y="-633.2" 
-	 z="-1907.95"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-3-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-0-3" unit="cm" 
          x="-328.03"
 	 y="-542.5" 
@@ -45853,14 +41936,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-3-1"/>
-       <position name="posOpArapucaDouble1-Frame-0-3" unit="cm" 
-         x="-327.29"
-	 y="-542.5" 
-	 z="-2053.95"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-3-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-0-3" unit="cm" 
          x="-328.03"
 	 y="-468.5" 
@@ -45868,14 +41944,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-3-2"/>
-       <position name="posOpArapucaDouble2-Frame-0-3" unit="cm" 
-         x="-327.29"
-	 y="-468.5" 
-	 z="-1836.95"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-3-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-0-3" unit="cm" 
          x="-328.03"
 	 y="-377.8" 
@@ -45883,14 +41952,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-3-3"/>
-       <position name="posOpArapucaDouble3-Frame-0-3" unit="cm" 
-         x="-327.29"
-	 y="-377.8" 
-	 z="-1982.95"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-4-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-0-4" unit="cm" 
          x="-328.03"
 	 y="-633.2" 
@@ -45898,14 +41960,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-4-0"/>
-       <position name="posOpArapucaDouble0-Frame-0-4" unit="cm" 
-         x="-327.29"
-	 y="-633.2" 
-	 z="-1608.65"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-4-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-0-4" unit="cm" 
          x="-328.03"
 	 y="-542.5" 
@@ -45913,14 +41968,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-4-1"/>
-       <position name="posOpArapucaDouble1-Frame-0-4" unit="cm" 
-         x="-327.29"
-	 y="-542.5" 
-	 z="-1754.65"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-4-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-0-4" unit="cm" 
          x="-328.03"
 	 y="-468.5" 
@@ -45928,14 +41976,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-4-2"/>
-       <position name="posOpArapucaDouble2-Frame-0-4" unit="cm" 
-         x="-327.29"
-	 y="-468.5" 
-	 z="-1537.65"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-4-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-0-4" unit="cm" 
          x="-328.03"
 	 y="-377.8" 
@@ -45943,14 +41984,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-4-3"/>
-       <position name="posOpArapucaDouble3-Frame-0-4" unit="cm" 
-         x="-327.29"
-	 y="-377.8" 
-	 z="-1683.65"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-5-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-0-5" unit="cm" 
          x="-328.03"
 	 y="-633.2" 
@@ -45958,14 +41992,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-5-0"/>
-       <position name="posOpArapucaDouble0-Frame-0-5" unit="cm" 
-         x="-327.29"
-	 y="-633.2" 
-	 z="-1309.35"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-5-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-0-5" unit="cm" 
          x="-328.03"
 	 y="-542.5" 
@@ -45973,14 +42000,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-5-1"/>
-       <position name="posOpArapucaDouble1-Frame-0-5" unit="cm" 
-         x="-327.29"
-	 y="-542.5" 
-	 z="-1455.35"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-5-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-0-5" unit="cm" 
          x="-328.03"
 	 y="-468.5" 
@@ -45988,14 +42008,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-5-2"/>
-       <position name="posOpArapucaDouble2-Frame-0-5" unit="cm" 
-         x="-327.29"
-	 y="-468.5" 
-	 z="-1238.35"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-5-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-0-5" unit="cm" 
          x="-328.03"
 	 y="-377.8" 
@@ -46003,14 +42016,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-5-3"/>
-       <position name="posOpArapucaDouble3-Frame-0-5" unit="cm" 
-         x="-327.29"
-	 y="-377.8" 
-	 z="-1384.35"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-6-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-0-6" unit="cm" 
          x="-328.03"
 	 y="-633.2" 
@@ -46018,14 +42024,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-6-0"/>
-       <position name="posOpArapucaDouble0-Frame-0-6" unit="cm" 
-         x="-327.29"
-	 y="-633.2" 
-	 z="-1010.05"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-6-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-0-6" unit="cm" 
          x="-328.03"
 	 y="-542.5" 
@@ -46033,14 +42032,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-6-1"/>
-       <position name="posOpArapucaDouble1-Frame-0-6" unit="cm" 
-         x="-327.29"
-	 y="-542.5" 
-	 z="-1156.05"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-6-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-0-6" unit="cm" 
          x="-328.03"
 	 y="-468.5" 
@@ -46048,14 +42040,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-6-2"/>
-       <position name="posOpArapucaDouble2-Frame-0-6" unit="cm" 
-         x="-327.29"
-	 y="-468.5" 
-	 z="-939.05"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-6-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-0-6" unit="cm" 
          x="-328.03"
 	 y="-377.8" 
@@ -46063,14 +42048,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-6-3"/>
-       <position name="posOpArapucaDouble3-Frame-0-6" unit="cm" 
-         x="-327.29"
-	 y="-377.8" 
-	 z="-1085.05"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-7-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-0-7" unit="cm" 
          x="-328.03"
 	 y="-633.2" 
@@ -46078,14 +42056,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-7-0"/>
-       <position name="posOpArapucaDouble0-Frame-0-7" unit="cm" 
-         x="-327.29"
-	 y="-633.2" 
-	 z="-710.75"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-7-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-0-7" unit="cm" 
          x="-328.03"
 	 y="-542.5" 
@@ -46093,14 +42064,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-7-1"/>
-       <position name="posOpArapucaDouble1-Frame-0-7" unit="cm" 
-         x="-327.29"
-	 y="-542.5" 
-	 z="-856.75"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-7-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-0-7" unit="cm" 
          x="-328.03"
 	 y="-468.5" 
@@ -46108,14 +42072,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-7-2"/>
-       <position name="posOpArapucaDouble2-Frame-0-7" unit="cm" 
-         x="-327.29"
-	 y="-468.5" 
-	 z="-639.75"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-7-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-0-7" unit="cm" 
          x="-328.03"
 	 y="-377.8" 
@@ -46123,14 +42080,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-7-3"/>
-       <position name="posOpArapucaDouble3-Frame-0-7" unit="cm" 
-         x="-327.29"
-	 y="-377.8" 
-	 z="-785.75"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-8-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-0-8" unit="cm" 
          x="-328.03"
 	 y="-633.2" 
@@ -46138,14 +42088,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-8-0"/>
-       <position name="posOpArapucaDouble0-Frame-0-8" unit="cm" 
-         x="-327.29"
-	 y="-633.2" 
-	 z="-411.45"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-8-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-0-8" unit="cm" 
          x="-328.03"
 	 y="-542.5" 
@@ -46153,14 +42096,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-8-1"/>
-       <position name="posOpArapucaDouble1-Frame-0-8" unit="cm" 
-         x="-327.29"
-	 y="-542.5" 
-	 z="-557.45"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-8-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-0-8" unit="cm" 
          x="-328.03"
 	 y="-468.5" 
@@ -46168,14 +42104,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-8-2"/>
-       <position name="posOpArapucaDouble2-Frame-0-8" unit="cm" 
-         x="-327.29"
-	 y="-468.5" 
-	 z="-340.45"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-8-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-0-8" unit="cm" 
          x="-328.03"
 	 y="-377.8" 
@@ -46183,14 +42112,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-8-3"/>
-       <position name="posOpArapucaDouble3-Frame-0-8" unit="cm" 
-         x="-327.29"
-	 y="-377.8" 
-	 z="-486.45"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-9-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-0-9" unit="cm" 
          x="-328.03"
 	 y="-633.2" 
@@ -46198,14 +42120,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-9-0"/>
-       <position name="posOpArapucaDouble0-Frame-0-9" unit="cm" 
-         x="-327.29"
-	 y="-633.2" 
-	 z="-112.15"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-9-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-0-9" unit="cm" 
          x="-328.03"
 	 y="-542.5" 
@@ -46213,14 +42128,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-9-1"/>
-       <position name="posOpArapucaDouble1-Frame-0-9" unit="cm" 
-         x="-327.29"
-	 y="-542.5" 
-	 z="-258.15"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-9-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-0-9" unit="cm" 
          x="-328.03"
 	 y="-468.5" 
@@ -46228,14 +42136,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-9-2"/>
-       <position name="posOpArapucaDouble2-Frame-0-9" unit="cm" 
-         x="-327.29"
-	 y="-468.5" 
-	 z="-41.1499999999997"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-9-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-0-9" unit="cm" 
          x="-328.03"
 	 y="-377.8" 
@@ -46243,14 +42144,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-9-3"/>
-       <position name="posOpArapucaDouble3-Frame-0-9" unit="cm" 
-         x="-327.29"
-	 y="-377.8" 
-	 z="-187.15"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-10-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-0-10" unit="cm" 
          x="-328.03"
 	 y="-633.2" 
@@ -46258,14 +42152,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-10-0"/>
-       <position name="posOpArapucaDouble0-Frame-0-10" unit="cm" 
-         x="-327.29"
-	 y="-633.2" 
-	 z="187.15"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-10-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-0-10" unit="cm" 
          x="-328.03"
 	 y="-542.5" 
@@ -46273,14 +42160,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-10-1"/>
-       <position name="posOpArapucaDouble1-Frame-0-10" unit="cm" 
-         x="-327.29"
-	 y="-542.5" 
-	 z="41.1500000000003"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-10-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-0-10" unit="cm" 
          x="-328.03"
 	 y="-468.5" 
@@ -46288,14 +42168,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-10-2"/>
-       <position name="posOpArapucaDouble2-Frame-0-10" unit="cm" 
-         x="-327.29"
-	 y="-468.5" 
-	 z="258.15"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-10-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-0-10" unit="cm" 
          x="-328.03"
 	 y="-377.8" 
@@ -46303,14 +42176,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-10-3"/>
-       <position name="posOpArapucaDouble3-Frame-0-10" unit="cm" 
-         x="-327.29"
-	 y="-377.8" 
-	 z="112.15"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-11-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-0-11" unit="cm" 
          x="-328.03"
 	 y="-633.2" 
@@ -46318,14 +42184,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-11-0"/>
-       <position name="posOpArapucaDouble0-Frame-0-11" unit="cm" 
-         x="-327.29"
-	 y="-633.2" 
-	 z="486.45"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-11-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-0-11" unit="cm" 
          x="-328.03"
 	 y="-542.5" 
@@ -46333,14 +42192,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-11-1"/>
-       <position name="posOpArapucaDouble1-Frame-0-11" unit="cm" 
-         x="-327.29"
-	 y="-542.5" 
-	 z="340.45"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-11-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-0-11" unit="cm" 
          x="-328.03"
 	 y="-468.5" 
@@ -46348,14 +42200,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-11-2"/>
-       <position name="posOpArapucaDouble2-Frame-0-11" unit="cm" 
-         x="-327.29"
-	 y="-468.5" 
-	 z="557.45"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-11-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-0-11" unit="cm" 
          x="-328.03"
 	 y="-377.8" 
@@ -46363,14 +42208,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-11-3"/>
-       <position name="posOpArapucaDouble3-Frame-0-11" unit="cm" 
-         x="-327.29"
-	 y="-377.8" 
-	 z="411.45"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-12-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-0-12" unit="cm" 
          x="-328.03"
 	 y="-633.2" 
@@ -46378,14 +42216,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-12-0"/>
-       <position name="posOpArapucaDouble0-Frame-0-12" unit="cm" 
-         x="-327.29"
-	 y="-633.2" 
-	 z="785.75"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-12-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-0-12" unit="cm" 
          x="-328.03"
 	 y="-542.5" 
@@ -46393,14 +42224,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-12-1"/>
-       <position name="posOpArapucaDouble1-Frame-0-12" unit="cm" 
-         x="-327.29"
-	 y="-542.5" 
-	 z="639.75"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-12-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-0-12" unit="cm" 
          x="-328.03"
 	 y="-468.5" 
@@ -46408,14 +42232,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-12-2"/>
-       <position name="posOpArapucaDouble2-Frame-0-12" unit="cm" 
-         x="-327.29"
-	 y="-468.5" 
-	 z="856.75"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-12-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-0-12" unit="cm" 
          x="-328.03"
 	 y="-377.8" 
@@ -46423,14 +42240,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-12-3"/>
-       <position name="posOpArapucaDouble3-Frame-0-12" unit="cm" 
-         x="-327.29"
-	 y="-377.8" 
-	 z="710.75"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-13-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-0-13" unit="cm" 
          x="-328.03"
 	 y="-633.2" 
@@ -46438,14 +42248,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-13-0"/>
-       <position name="posOpArapucaDouble0-Frame-0-13" unit="cm" 
-         x="-327.29"
-	 y="-633.2" 
-	 z="1085.05"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-13-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-0-13" unit="cm" 
          x="-328.03"
 	 y="-542.5" 
@@ -46453,14 +42256,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-13-1"/>
-       <position name="posOpArapucaDouble1-Frame-0-13" unit="cm" 
-         x="-327.29"
-	 y="-542.5" 
-	 z="939.05"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-13-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-0-13" unit="cm" 
          x="-328.03"
 	 y="-468.5" 
@@ -46468,14 +42264,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-13-2"/>
-       <position name="posOpArapucaDouble2-Frame-0-13" unit="cm" 
-         x="-327.29"
-	 y="-468.5" 
-	 z="1156.05"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-13-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-0-13" unit="cm" 
          x="-328.03"
 	 y="-377.8" 
@@ -46483,14 +42272,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-13-3"/>
-       <position name="posOpArapucaDouble3-Frame-0-13" unit="cm" 
-         x="-327.29"
-	 y="-377.8" 
-	 z="1010.05"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-14-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-0-14" unit="cm" 
          x="-328.03"
 	 y="-633.2" 
@@ -46498,14 +42280,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-14-0"/>
-       <position name="posOpArapucaDouble0-Frame-0-14" unit="cm" 
-         x="-327.29"
-	 y="-633.2" 
-	 z="1384.35"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-14-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-0-14" unit="cm" 
          x="-328.03"
 	 y="-542.5" 
@@ -46513,14 +42288,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-14-1"/>
-       <position name="posOpArapucaDouble1-Frame-0-14" unit="cm" 
-         x="-327.29"
-	 y="-542.5" 
-	 z="1238.35"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-14-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-0-14" unit="cm" 
          x="-328.03"
 	 y="-468.5" 
@@ -46528,14 +42296,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-14-2"/>
-       <position name="posOpArapucaDouble2-Frame-0-14" unit="cm" 
-         x="-327.29"
-	 y="-468.5" 
-	 z="1455.35"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-14-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-0-14" unit="cm" 
          x="-328.03"
 	 y="-377.8" 
@@ -46543,14 +42304,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-14-3"/>
-       <position name="posOpArapucaDouble3-Frame-0-14" unit="cm" 
-         x="-327.29"
-	 y="-377.8" 
-	 z="1309.35"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-15-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-0-15" unit="cm" 
          x="-328.03"
 	 y="-633.2" 
@@ -46558,14 +42312,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-15-0"/>
-       <position name="posOpArapucaDouble0-Frame-0-15" unit="cm" 
-         x="-327.29"
-	 y="-633.2" 
-	 z="1683.65"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-15-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-0-15" unit="cm" 
          x="-328.03"
 	 y="-542.5" 
@@ -46573,14 +42320,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-15-1"/>
-       <position name="posOpArapucaDouble1-Frame-0-15" unit="cm" 
-         x="-327.29"
-	 y="-542.5" 
-	 z="1537.65"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-15-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-0-15" unit="cm" 
          x="-328.03"
 	 y="-468.5" 
@@ -46588,14 +42328,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-15-2"/>
-       <position name="posOpArapucaDouble2-Frame-0-15" unit="cm" 
-         x="-327.29"
-	 y="-468.5" 
-	 z="1754.65"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-15-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-0-15" unit="cm" 
          x="-328.03"
 	 y="-377.8" 
@@ -46603,14 +42336,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-15-3"/>
-       <position name="posOpArapucaDouble3-Frame-0-15" unit="cm" 
-         x="-327.29"
-	 y="-377.8" 
-	 z="1608.65"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-16-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-0-16" unit="cm" 
          x="-328.03"
 	 y="-633.2" 
@@ -46618,14 +42344,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-16-0"/>
-       <position name="posOpArapucaDouble0-Frame-0-16" unit="cm" 
-         x="-327.29"
-	 y="-633.2" 
-	 z="1982.95"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-16-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-0-16" unit="cm" 
          x="-328.03"
 	 y="-542.5" 
@@ -46633,14 +42352,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-16-1"/>
-       <position name="posOpArapucaDouble1-Frame-0-16" unit="cm" 
-         x="-327.29"
-	 y="-542.5" 
-	 z="1836.95"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-16-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-0-16" unit="cm" 
          x="-328.03"
 	 y="-468.5" 
@@ -46648,14 +42360,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-16-2"/>
-       <position name="posOpArapucaDouble2-Frame-0-16" unit="cm" 
-         x="-327.29"
-	 y="-468.5" 
-	 z="2053.95"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-16-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-0-16" unit="cm" 
          x="-328.03"
 	 y="-377.8" 
@@ -46663,14 +42368,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-16-3"/>
-       <position name="posOpArapucaDouble3-Frame-0-16" unit="cm" 
-         x="-327.29"
-	 y="-377.8" 
-	 z="1907.95"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-17-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-0-17" unit="cm" 
          x="-328.03"
 	 y="-633.2" 
@@ -46678,14 +42376,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-17-0"/>
-       <position name="posOpArapucaDouble0-Frame-0-17" unit="cm" 
-         x="-327.29"
-	 y="-633.2" 
-	 z="2282.25"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-17-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-0-17" unit="cm" 
          x="-328.03"
 	 y="-542.5" 
@@ -46693,14 +42384,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-17-1"/>
-       <position name="posOpArapucaDouble1-Frame-0-17" unit="cm" 
-         x="-327.29"
-	 y="-542.5" 
-	 z="2136.25"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-17-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-0-17" unit="cm" 
          x="-328.03"
 	 y="-468.5" 
@@ -46708,14 +42392,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-17-2"/>
-       <position name="posOpArapucaDouble2-Frame-0-17" unit="cm" 
-         x="-327.29"
-	 y="-468.5" 
-	 z="2353.25"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-17-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-0-17" unit="cm" 
          x="-328.03"
 	 y="-377.8" 
@@ -46723,14 +42400,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-17-3"/>
-       <position name="posOpArapucaDouble3-Frame-0-17" unit="cm" 
-         x="-327.29"
-	 y="-377.8" 
-	 z="2207.25"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-18-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-0-18" unit="cm" 
          x="-328.03"
 	 y="-633.2" 
@@ -46738,14 +42408,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-18-0"/>
-       <position name="posOpArapucaDouble0-Frame-0-18" unit="cm" 
-         x="-327.29"
-	 y="-633.2" 
-	 z="2581.55"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-18-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-0-18" unit="cm" 
          x="-328.03"
 	 y="-542.5" 
@@ -46753,14 +42416,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-18-1"/>
-       <position name="posOpArapucaDouble1-Frame-0-18" unit="cm" 
-         x="-327.29"
-	 y="-542.5" 
-	 z="2435.55"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-18-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-0-18" unit="cm" 
          x="-328.03"
 	 y="-468.5" 
@@ -46768,14 +42424,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-18-2"/>
-       <position name="posOpArapucaDouble2-Frame-0-18" unit="cm" 
-         x="-327.29"
-	 y="-468.5" 
-	 z="2652.55"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-18-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-0-18" unit="cm" 
          x="-328.03"
 	 y="-377.8" 
@@ -46783,14 +42432,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-18-3"/>
-       <position name="posOpArapucaDouble3-Frame-0-18" unit="cm" 
-         x="-327.29"
-	 y="-377.8" 
-	 z="2506.55"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-19-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-0-19" unit="cm" 
          x="-328.03"
 	 y="-633.2" 
@@ -46798,14 +42440,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-19-0"/>
-       <position name="posOpArapucaDouble0-Frame-0-19" unit="cm" 
-         x="-327.29"
-	 y="-633.2" 
-	 z="2880.85"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-19-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-0-19" unit="cm" 
          x="-328.03"
 	 y="-542.5" 
@@ -46813,14 +42448,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-19-1"/>
-       <position name="posOpArapucaDouble1-Frame-0-19" unit="cm" 
-         x="-327.29"
-	 y="-542.5" 
-	 z="2734.85"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-19-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-0-19" unit="cm" 
          x="-328.03"
 	 y="-468.5" 
@@ -46828,14 +42456,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-19-2"/>
-       <position name="posOpArapucaDouble2-Frame-0-19" unit="cm" 
-         x="-327.29"
-	 y="-468.5" 
-	 z="2951.85"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-19-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-0-19" unit="cm" 
          x="-328.03"
 	 y="-377.8" 
@@ -46843,14 +42464,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-19-3"/>
-       <position name="posOpArapucaDouble3-Frame-0-19" unit="cm" 
-         x="-327.29"
-	 y="-377.8" 
-	 z="2805.85"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-0-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-1-0" unit="cm" 
          x="-328.03"
 	 y="-296.2" 
@@ -46858,14 +42472,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-0"/>
-       <position name="posOpArapucaDouble0-Frame-1-0" unit="cm" 
-         x="-327.29"
-	 y="-296.2" 
-	 z="-2805.85"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-0-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-1-0" unit="cm" 
          x="-328.03"
 	 y="-205.5" 
@@ -46873,14 +42480,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-1"/>
-       <position name="posOpArapucaDouble1-Frame-1-0" unit="cm" 
-         x="-327.29"
-	 y="-205.5" 
-	 z="-2951.85"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-0-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-1-0" unit="cm" 
          x="-328.03"
 	 y="-131.5" 
@@ -46888,14 +42488,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-2"/>
-       <position name="posOpArapucaDouble2-Frame-1-0" unit="cm" 
-         x="-327.29"
-	 y="-131.5" 
-	 z="-2734.85"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-0-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-1-0" unit="cm" 
          x="-328.03"
 	 y="-40.8" 
@@ -46903,14 +42496,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-3"/>
-       <position name="posOpArapucaDouble3-Frame-1-0" unit="cm" 
-         x="-327.29"
-	 y="-40.8" 
-	 z="-2880.85"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-1-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-1-1" unit="cm" 
          x="-328.03"
 	 y="-296.2" 
@@ -46918,14 +42504,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-0"/>
-       <position name="posOpArapucaDouble0-Frame-1-1" unit="cm" 
-         x="-327.29"
-	 y="-296.2" 
-	 z="-2506.55"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-1-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-1-1" unit="cm" 
          x="-328.03"
 	 y="-205.5" 
@@ -46933,14 +42512,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-1"/>
-       <position name="posOpArapucaDouble1-Frame-1-1" unit="cm" 
-         x="-327.29"
-	 y="-205.5" 
-	 z="-2652.55"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-1-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-1-1" unit="cm" 
          x="-328.03"
 	 y="-131.5" 
@@ -46948,14 +42520,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-2"/>
-       <position name="posOpArapucaDouble2-Frame-1-1" unit="cm" 
-         x="-327.29"
-	 y="-131.5" 
-	 z="-2435.55"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-1-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-1-1" unit="cm" 
          x="-328.03"
 	 y="-40.8" 
@@ -46963,14 +42528,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-3"/>
-       <position name="posOpArapucaDouble3-Frame-1-1" unit="cm" 
-         x="-327.29"
-	 y="-40.8" 
-	 z="-2581.55"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-2-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-1-2" unit="cm" 
          x="-328.03"
 	 y="-296.2" 
@@ -46978,14 +42536,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-0"/>
-       <position name="posOpArapucaDouble0-Frame-1-2" unit="cm" 
-         x="-327.29"
-	 y="-296.2" 
-	 z="-2207.25"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-2-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-1-2" unit="cm" 
          x="-328.03"
 	 y="-205.5" 
@@ -46993,14 +42544,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-1"/>
-       <position name="posOpArapucaDouble1-Frame-1-2" unit="cm" 
-         x="-327.29"
-	 y="-205.5" 
-	 z="-2353.25"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-2-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-1-2" unit="cm" 
          x="-328.03"
 	 y="-131.5" 
@@ -47008,14 +42552,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-2"/>
-       <position name="posOpArapucaDouble2-Frame-1-2" unit="cm" 
-         x="-327.29"
-	 y="-131.5" 
-	 z="-2136.25"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-2-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-1-2" unit="cm" 
          x="-328.03"
 	 y="-40.8" 
@@ -47023,14 +42560,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-3"/>
-       <position name="posOpArapucaDouble3-Frame-1-2" unit="cm" 
-         x="-327.29"
-	 y="-40.8" 
-	 z="-2282.25"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-3-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-1-3" unit="cm" 
          x="-328.03"
 	 y="-296.2" 
@@ -47038,14 +42568,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-3-0"/>
-       <position name="posOpArapucaDouble0-Frame-1-3" unit="cm" 
-         x="-327.29"
-	 y="-296.2" 
-	 z="-1907.95"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-3-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-1-3" unit="cm" 
          x="-328.03"
 	 y="-205.5" 
@@ -47053,14 +42576,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-3-1"/>
-       <position name="posOpArapucaDouble1-Frame-1-3" unit="cm" 
-         x="-327.29"
-	 y="-205.5" 
-	 z="-2053.95"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-3-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-1-3" unit="cm" 
          x="-328.03"
 	 y="-131.5" 
@@ -47068,14 +42584,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-3-2"/>
-       <position name="posOpArapucaDouble2-Frame-1-3" unit="cm" 
-         x="-327.29"
-	 y="-131.5" 
-	 z="-1836.95"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-3-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-1-3" unit="cm" 
          x="-328.03"
 	 y="-40.8" 
@@ -47083,14 +42592,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-3-3"/>
-       <position name="posOpArapucaDouble3-Frame-1-3" unit="cm" 
-         x="-327.29"
-	 y="-40.8" 
-	 z="-1982.95"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-4-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-1-4" unit="cm" 
          x="-328.03"
 	 y="-296.2" 
@@ -47098,14 +42600,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-4-0"/>
-       <position name="posOpArapucaDouble0-Frame-1-4" unit="cm" 
-         x="-327.29"
-	 y="-296.2" 
-	 z="-1608.65"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-4-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-1-4" unit="cm" 
          x="-328.03"
 	 y="-205.5" 
@@ -47113,14 +42608,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-4-1"/>
-       <position name="posOpArapucaDouble1-Frame-1-4" unit="cm" 
-         x="-327.29"
-	 y="-205.5" 
-	 z="-1754.65"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-4-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-1-4" unit="cm" 
          x="-328.03"
 	 y="-131.5" 
@@ -47128,14 +42616,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-4-2"/>
-       <position name="posOpArapucaDouble2-Frame-1-4" unit="cm" 
-         x="-327.29"
-	 y="-131.5" 
-	 z="-1537.65"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-4-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-1-4" unit="cm" 
          x="-328.03"
 	 y="-40.8" 
@@ -47143,14 +42624,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-4-3"/>
-       <position name="posOpArapucaDouble3-Frame-1-4" unit="cm" 
-         x="-327.29"
-	 y="-40.8" 
-	 z="-1683.65"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-5-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-1-5" unit="cm" 
          x="-328.03"
 	 y="-296.2" 
@@ -47158,14 +42632,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-5-0"/>
-       <position name="posOpArapucaDouble0-Frame-1-5" unit="cm" 
-         x="-327.29"
-	 y="-296.2" 
-	 z="-1309.35"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-5-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-1-5" unit="cm" 
          x="-328.03"
 	 y="-205.5" 
@@ -47173,14 +42640,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-5-1"/>
-       <position name="posOpArapucaDouble1-Frame-1-5" unit="cm" 
-         x="-327.29"
-	 y="-205.5" 
-	 z="-1455.35"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-5-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-1-5" unit="cm" 
          x="-328.03"
 	 y="-131.5" 
@@ -47188,14 +42648,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-5-2"/>
-       <position name="posOpArapucaDouble2-Frame-1-5" unit="cm" 
-         x="-327.29"
-	 y="-131.5" 
-	 z="-1238.35"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-5-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-1-5" unit="cm" 
          x="-328.03"
 	 y="-40.8" 
@@ -47203,14 +42656,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-5-3"/>
-       <position name="posOpArapucaDouble3-Frame-1-5" unit="cm" 
-         x="-327.29"
-	 y="-40.8" 
-	 z="-1384.35"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-6-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-1-6" unit="cm" 
          x="-328.03"
 	 y="-296.2" 
@@ -47218,14 +42664,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-6-0"/>
-       <position name="posOpArapucaDouble0-Frame-1-6" unit="cm" 
-         x="-327.29"
-	 y="-296.2" 
-	 z="-1010.05"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-6-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-1-6" unit="cm" 
          x="-328.03"
 	 y="-205.5" 
@@ -47233,14 +42672,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-6-1"/>
-       <position name="posOpArapucaDouble1-Frame-1-6" unit="cm" 
-         x="-327.29"
-	 y="-205.5" 
-	 z="-1156.05"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-6-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-1-6" unit="cm" 
          x="-328.03"
 	 y="-131.5" 
@@ -47248,14 +42680,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-6-2"/>
-       <position name="posOpArapucaDouble2-Frame-1-6" unit="cm" 
-         x="-327.29"
-	 y="-131.5" 
-	 z="-939.05"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-6-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-1-6" unit="cm" 
          x="-328.03"
 	 y="-40.8" 
@@ -47263,14 +42688,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-6-3"/>
-       <position name="posOpArapucaDouble3-Frame-1-6" unit="cm" 
-         x="-327.29"
-	 y="-40.8" 
-	 z="-1085.05"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-7-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-1-7" unit="cm" 
          x="-328.03"
 	 y="-296.2" 
@@ -47278,14 +42696,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-7-0"/>
-       <position name="posOpArapucaDouble0-Frame-1-7" unit="cm" 
-         x="-327.29"
-	 y="-296.2" 
-	 z="-710.75"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-7-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-1-7" unit="cm" 
          x="-328.03"
 	 y="-205.5" 
@@ -47293,14 +42704,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-7-1"/>
-       <position name="posOpArapucaDouble1-Frame-1-7" unit="cm" 
-         x="-327.29"
-	 y="-205.5" 
-	 z="-856.75"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-7-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-1-7" unit="cm" 
          x="-328.03"
 	 y="-131.5" 
@@ -47308,14 +42712,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-7-2"/>
-       <position name="posOpArapucaDouble2-Frame-1-7" unit="cm" 
-         x="-327.29"
-	 y="-131.5" 
-	 z="-639.75"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-7-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-1-7" unit="cm" 
          x="-328.03"
 	 y="-40.8" 
@@ -47323,14 +42720,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-7-3"/>
-       <position name="posOpArapucaDouble3-Frame-1-7" unit="cm" 
-         x="-327.29"
-	 y="-40.8" 
-	 z="-785.75"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-8-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-1-8" unit="cm" 
          x="-328.03"
 	 y="-296.2" 
@@ -47338,14 +42728,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-8-0"/>
-       <position name="posOpArapucaDouble0-Frame-1-8" unit="cm" 
-         x="-327.29"
-	 y="-296.2" 
-	 z="-411.45"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-8-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-1-8" unit="cm" 
          x="-328.03"
 	 y="-205.5" 
@@ -47353,14 +42736,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-8-1"/>
-       <position name="posOpArapucaDouble1-Frame-1-8" unit="cm" 
-         x="-327.29"
-	 y="-205.5" 
-	 z="-557.45"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-8-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-1-8" unit="cm" 
          x="-328.03"
 	 y="-131.5" 
@@ -47368,14 +42744,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-8-2"/>
-       <position name="posOpArapucaDouble2-Frame-1-8" unit="cm" 
-         x="-327.29"
-	 y="-131.5" 
-	 z="-340.45"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-8-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-1-8" unit="cm" 
          x="-328.03"
 	 y="-40.8" 
@@ -47383,14 +42752,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-8-3"/>
-       <position name="posOpArapucaDouble3-Frame-1-8" unit="cm" 
-         x="-327.29"
-	 y="-40.8" 
-	 z="-486.45"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-9-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-1-9" unit="cm" 
          x="-328.03"
 	 y="-296.2" 
@@ -47398,14 +42760,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-9-0"/>
-       <position name="posOpArapucaDouble0-Frame-1-9" unit="cm" 
-         x="-327.29"
-	 y="-296.2" 
-	 z="-112.15"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-9-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-1-9" unit="cm" 
          x="-328.03"
 	 y="-205.5" 
@@ -47413,14 +42768,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-9-1"/>
-       <position name="posOpArapucaDouble1-Frame-1-9" unit="cm" 
-         x="-327.29"
-	 y="-205.5" 
-	 z="-258.15"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-9-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-1-9" unit="cm" 
          x="-328.03"
 	 y="-131.5" 
@@ -47428,14 +42776,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-9-2"/>
-       <position name="posOpArapucaDouble2-Frame-1-9" unit="cm" 
-         x="-327.29"
-	 y="-131.5" 
-	 z="-41.1499999999997"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-9-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-1-9" unit="cm" 
          x="-328.03"
 	 y="-40.8" 
@@ -47443,14 +42784,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-9-3"/>
-       <position name="posOpArapucaDouble3-Frame-1-9" unit="cm" 
-         x="-327.29"
-	 y="-40.8" 
-	 z="-187.15"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-10-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-1-10" unit="cm" 
          x="-328.03"
 	 y="-296.2" 
@@ -47458,14 +42792,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-10-0"/>
-       <position name="posOpArapucaDouble0-Frame-1-10" unit="cm" 
-         x="-327.29"
-	 y="-296.2" 
-	 z="187.15"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-10-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-1-10" unit="cm" 
          x="-328.03"
 	 y="-205.5" 
@@ -47473,14 +42800,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-10-1"/>
-       <position name="posOpArapucaDouble1-Frame-1-10" unit="cm" 
-         x="-327.29"
-	 y="-205.5" 
-	 z="41.1500000000003"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-10-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-1-10" unit="cm" 
          x="-328.03"
 	 y="-131.5" 
@@ -47488,14 +42808,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-10-2"/>
-       <position name="posOpArapucaDouble2-Frame-1-10" unit="cm" 
-         x="-327.29"
-	 y="-131.5" 
-	 z="258.15"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-10-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-1-10" unit="cm" 
          x="-328.03"
 	 y="-40.8" 
@@ -47503,14 +42816,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-10-3"/>
-       <position name="posOpArapucaDouble3-Frame-1-10" unit="cm" 
-         x="-327.29"
-	 y="-40.8" 
-	 z="112.15"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-11-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-1-11" unit="cm" 
          x="-328.03"
 	 y="-296.2" 
@@ -47518,14 +42824,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-11-0"/>
-       <position name="posOpArapucaDouble0-Frame-1-11" unit="cm" 
-         x="-327.29"
-	 y="-296.2" 
-	 z="486.45"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-11-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-1-11" unit="cm" 
          x="-328.03"
 	 y="-205.5" 
@@ -47533,14 +42832,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-11-1"/>
-       <position name="posOpArapucaDouble1-Frame-1-11" unit="cm" 
-         x="-327.29"
-	 y="-205.5" 
-	 z="340.45"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-11-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-1-11" unit="cm" 
          x="-328.03"
 	 y="-131.5" 
@@ -47548,14 +42840,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-11-2"/>
-       <position name="posOpArapucaDouble2-Frame-1-11" unit="cm" 
-         x="-327.29"
-	 y="-131.5" 
-	 z="557.45"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-11-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-1-11" unit="cm" 
          x="-328.03"
 	 y="-40.8" 
@@ -47563,14 +42848,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-11-3"/>
-       <position name="posOpArapucaDouble3-Frame-1-11" unit="cm" 
-         x="-327.29"
-	 y="-40.8" 
-	 z="411.45"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-12-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-1-12" unit="cm" 
          x="-328.03"
 	 y="-296.2" 
@@ -47578,14 +42856,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-12-0"/>
-       <position name="posOpArapucaDouble0-Frame-1-12" unit="cm" 
-         x="-327.29"
-	 y="-296.2" 
-	 z="785.75"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-12-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-1-12" unit="cm" 
          x="-328.03"
 	 y="-205.5" 
@@ -47593,14 +42864,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-12-1"/>
-       <position name="posOpArapucaDouble1-Frame-1-12" unit="cm" 
-         x="-327.29"
-	 y="-205.5" 
-	 z="639.75"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-12-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-1-12" unit="cm" 
          x="-328.03"
 	 y="-131.5" 
@@ -47608,14 +42872,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-12-2"/>
-       <position name="posOpArapucaDouble2-Frame-1-12" unit="cm" 
-         x="-327.29"
-	 y="-131.5" 
-	 z="856.75"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-12-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-1-12" unit="cm" 
          x="-328.03"
 	 y="-40.8" 
@@ -47623,14 +42880,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-12-3"/>
-       <position name="posOpArapucaDouble3-Frame-1-12" unit="cm" 
-         x="-327.29"
-	 y="-40.8" 
-	 z="710.75"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-13-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-1-13" unit="cm" 
          x="-328.03"
 	 y="-296.2" 
@@ -47638,14 +42888,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-13-0"/>
-       <position name="posOpArapucaDouble0-Frame-1-13" unit="cm" 
-         x="-327.29"
-	 y="-296.2" 
-	 z="1085.05"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-13-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-1-13" unit="cm" 
          x="-328.03"
 	 y="-205.5" 
@@ -47653,14 +42896,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-13-1"/>
-       <position name="posOpArapucaDouble1-Frame-1-13" unit="cm" 
-         x="-327.29"
-	 y="-205.5" 
-	 z="939.05"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-13-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-1-13" unit="cm" 
          x="-328.03"
 	 y="-131.5" 
@@ -47668,14 +42904,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-13-2"/>
-       <position name="posOpArapucaDouble2-Frame-1-13" unit="cm" 
-         x="-327.29"
-	 y="-131.5" 
-	 z="1156.05"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-13-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-1-13" unit="cm" 
          x="-328.03"
 	 y="-40.8" 
@@ -47683,14 +42912,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-13-3"/>
-       <position name="posOpArapucaDouble3-Frame-1-13" unit="cm" 
-         x="-327.29"
-	 y="-40.8" 
-	 z="1010.05"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-14-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-1-14" unit="cm" 
          x="-328.03"
 	 y="-296.2" 
@@ -47698,14 +42920,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-14-0"/>
-       <position name="posOpArapucaDouble0-Frame-1-14" unit="cm" 
-         x="-327.29"
-	 y="-296.2" 
-	 z="1384.35"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-14-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-1-14" unit="cm" 
          x="-328.03"
 	 y="-205.5" 
@@ -47713,14 +42928,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-14-1"/>
-       <position name="posOpArapucaDouble1-Frame-1-14" unit="cm" 
-         x="-327.29"
-	 y="-205.5" 
-	 z="1238.35"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-14-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-1-14" unit="cm" 
          x="-328.03"
 	 y="-131.5" 
@@ -47728,14 +42936,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-14-2"/>
-       <position name="posOpArapucaDouble2-Frame-1-14" unit="cm" 
-         x="-327.29"
-	 y="-131.5" 
-	 z="1455.35"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-14-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-1-14" unit="cm" 
          x="-328.03"
 	 y="-40.8" 
@@ -47743,14 +42944,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-14-3"/>
-       <position name="posOpArapucaDouble3-Frame-1-14" unit="cm" 
-         x="-327.29"
-	 y="-40.8" 
-	 z="1309.35"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-15-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-1-15" unit="cm" 
          x="-328.03"
 	 y="-296.2" 
@@ -47758,14 +42952,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-15-0"/>
-       <position name="posOpArapucaDouble0-Frame-1-15" unit="cm" 
-         x="-327.29"
-	 y="-296.2" 
-	 z="1683.65"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-15-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-1-15" unit="cm" 
          x="-328.03"
 	 y="-205.5" 
@@ -47773,14 +42960,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-15-1"/>
-       <position name="posOpArapucaDouble1-Frame-1-15" unit="cm" 
-         x="-327.29"
-	 y="-205.5" 
-	 z="1537.65"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-15-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-1-15" unit="cm" 
          x="-328.03"
 	 y="-131.5" 
@@ -47788,14 +42968,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-15-2"/>
-       <position name="posOpArapucaDouble2-Frame-1-15" unit="cm" 
-         x="-327.29"
-	 y="-131.5" 
-	 z="1754.65"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-15-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-1-15" unit="cm" 
          x="-328.03"
 	 y="-40.8" 
@@ -47803,14 +42976,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-15-3"/>
-       <position name="posOpArapucaDouble3-Frame-1-15" unit="cm" 
-         x="-327.29"
-	 y="-40.8" 
-	 z="1608.65"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-16-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-1-16" unit="cm" 
          x="-328.03"
 	 y="-296.2" 
@@ -47818,14 +42984,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-16-0"/>
-       <position name="posOpArapucaDouble0-Frame-1-16" unit="cm" 
-         x="-327.29"
-	 y="-296.2" 
-	 z="1982.95"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-16-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-1-16" unit="cm" 
          x="-328.03"
 	 y="-205.5" 
@@ -47833,14 +42992,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-16-1"/>
-       <position name="posOpArapucaDouble1-Frame-1-16" unit="cm" 
-         x="-327.29"
-	 y="-205.5" 
-	 z="1836.95"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-16-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-1-16" unit="cm" 
          x="-328.03"
 	 y="-131.5" 
@@ -47848,14 +43000,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-16-2"/>
-       <position name="posOpArapucaDouble2-Frame-1-16" unit="cm" 
-         x="-327.29"
-	 y="-131.5" 
-	 z="2053.95"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-16-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-1-16" unit="cm" 
          x="-328.03"
 	 y="-40.8" 
@@ -47863,14 +43008,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-16-3"/>
-       <position name="posOpArapucaDouble3-Frame-1-16" unit="cm" 
-         x="-327.29"
-	 y="-40.8" 
-	 z="1907.95"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-17-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-1-17" unit="cm" 
          x="-328.03"
 	 y="-296.2" 
@@ -47878,14 +43016,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-17-0"/>
-       <position name="posOpArapucaDouble0-Frame-1-17" unit="cm" 
-         x="-327.29"
-	 y="-296.2" 
-	 z="2282.25"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-17-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-1-17" unit="cm" 
          x="-328.03"
 	 y="-205.5" 
@@ -47893,14 +43024,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-17-1"/>
-       <position name="posOpArapucaDouble1-Frame-1-17" unit="cm" 
-         x="-327.29"
-	 y="-205.5" 
-	 z="2136.25"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-17-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-1-17" unit="cm" 
          x="-328.03"
 	 y="-131.5" 
@@ -47908,14 +43032,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-17-2"/>
-       <position name="posOpArapucaDouble2-Frame-1-17" unit="cm" 
-         x="-327.29"
-	 y="-131.5" 
-	 z="2353.25"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-17-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-1-17" unit="cm" 
          x="-328.03"
 	 y="-40.8" 
@@ -47923,14 +43040,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-17-3"/>
-       <position name="posOpArapucaDouble3-Frame-1-17" unit="cm" 
-         x="-327.29"
-	 y="-40.8" 
-	 z="2207.25"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-18-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-1-18" unit="cm" 
          x="-328.03"
 	 y="-296.2" 
@@ -47938,14 +43048,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-18-0"/>
-       <position name="posOpArapucaDouble0-Frame-1-18" unit="cm" 
-         x="-327.29"
-	 y="-296.2" 
-	 z="2581.55"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-18-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-1-18" unit="cm" 
          x="-328.03"
 	 y="-205.5" 
@@ -47953,14 +43056,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-18-1"/>
-       <position name="posOpArapucaDouble1-Frame-1-18" unit="cm" 
-         x="-327.29"
-	 y="-205.5" 
-	 z="2435.55"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-18-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-1-18" unit="cm" 
          x="-328.03"
 	 y="-131.5" 
@@ -47968,14 +43064,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-18-2"/>
-       <position name="posOpArapucaDouble2-Frame-1-18" unit="cm" 
-         x="-327.29"
-	 y="-131.5" 
-	 z="2652.55"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-18-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-1-18" unit="cm" 
          x="-328.03"
 	 y="-40.8" 
@@ -47983,14 +43072,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-18-3"/>
-       <position name="posOpArapucaDouble3-Frame-1-18" unit="cm" 
-         x="-327.29"
-	 y="-40.8" 
-	 z="2506.55"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-19-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-1-19" unit="cm" 
          x="-328.03"
 	 y="-296.2" 
@@ -47998,14 +43080,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-19-0"/>
-       <position name="posOpArapucaDouble0-Frame-1-19" unit="cm" 
-         x="-327.29"
-	 y="-296.2" 
-	 z="2880.85"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-19-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-1-19" unit="cm" 
          x="-328.03"
 	 y="-205.5" 
@@ -48013,14 +43088,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-19-1"/>
-       <position name="posOpArapucaDouble1-Frame-1-19" unit="cm" 
-         x="-327.29"
-	 y="-205.5" 
-	 z="2734.85"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-19-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-1-19" unit="cm" 
          x="-328.03"
 	 y="-131.5" 
@@ -48028,14 +43096,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-19-2"/>
-       <position name="posOpArapucaDouble2-Frame-1-19" unit="cm" 
-         x="-327.29"
-	 y="-131.5" 
-	 z="2951.85"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-19-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-1-19" unit="cm" 
          x="-328.03"
 	 y="-40.8" 
@@ -48043,14 +43104,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-19-3"/>
-       <position name="posOpArapucaDouble3-Frame-1-19" unit="cm" 
-         x="-327.29"
-	 y="-40.8" 
-	 z="2805.85"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-0-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-2-0" unit="cm" 
          x="-328.03"
 	 y="40.8" 
@@ -48058,14 +43112,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-0"/>
-       <position name="posOpArapucaDouble0-Frame-2-0" unit="cm" 
-         x="-327.29"
-	 y="40.8" 
-	 z="-2805.85"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-0-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-2-0" unit="cm" 
          x="-328.03"
 	 y="131.5" 
@@ -48073,14 +43120,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-1"/>
-       <position name="posOpArapucaDouble1-Frame-2-0" unit="cm" 
-         x="-327.29"
-	 y="131.5" 
-	 z="-2951.85"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-0-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-2-0" unit="cm" 
          x="-328.03"
 	 y="205.5" 
@@ -48088,14 +43128,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-2"/>
-       <position name="posOpArapucaDouble2-Frame-2-0" unit="cm" 
-         x="-327.29"
-	 y="205.5" 
-	 z="-2734.85"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-0-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-2-0" unit="cm" 
          x="-328.03"
 	 y="296.2" 
@@ -48103,14 +43136,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-3"/>
-       <position name="posOpArapucaDouble3-Frame-2-0" unit="cm" 
-         x="-327.29"
-	 y="296.2" 
-	 z="-2880.85"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-1-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-2-1" unit="cm" 
          x="-328.03"
 	 y="40.8" 
@@ -48118,14 +43144,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-0"/>
-       <position name="posOpArapucaDouble0-Frame-2-1" unit="cm" 
-         x="-327.29"
-	 y="40.8" 
-	 z="-2506.55"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-1-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-2-1" unit="cm" 
          x="-328.03"
 	 y="131.5" 
@@ -48133,14 +43152,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-1"/>
-       <position name="posOpArapucaDouble1-Frame-2-1" unit="cm" 
-         x="-327.29"
-	 y="131.5" 
-	 z="-2652.55"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-1-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-2-1" unit="cm" 
          x="-328.03"
 	 y="205.5" 
@@ -48148,14 +43160,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-2"/>
-       <position name="posOpArapucaDouble2-Frame-2-1" unit="cm" 
-         x="-327.29"
-	 y="205.5" 
-	 z="-2435.55"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-1-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-2-1" unit="cm" 
          x="-328.03"
 	 y="296.2" 
@@ -48163,14 +43168,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-3"/>
-       <position name="posOpArapucaDouble3-Frame-2-1" unit="cm" 
-         x="-327.29"
-	 y="296.2" 
-	 z="-2581.55"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-2-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-2-2" unit="cm" 
          x="-328.03"
 	 y="40.8" 
@@ -48178,14 +43176,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-0"/>
-       <position name="posOpArapucaDouble0-Frame-2-2" unit="cm" 
-         x="-327.29"
-	 y="40.8" 
-	 z="-2207.25"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-2-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-2-2" unit="cm" 
          x="-328.03"
 	 y="131.5" 
@@ -48193,14 +43184,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-1"/>
-       <position name="posOpArapucaDouble1-Frame-2-2" unit="cm" 
-         x="-327.29"
-	 y="131.5" 
-	 z="-2353.25"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-2-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-2-2" unit="cm" 
          x="-328.03"
 	 y="205.5" 
@@ -48208,14 +43192,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-2"/>
-       <position name="posOpArapucaDouble2-Frame-2-2" unit="cm" 
-         x="-327.29"
-	 y="205.5" 
-	 z="-2136.25"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-2-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-2-2" unit="cm" 
          x="-328.03"
 	 y="296.2" 
@@ -48223,14 +43200,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-3"/>
-       <position name="posOpArapucaDouble3-Frame-2-2" unit="cm" 
-         x="-327.29"
-	 y="296.2" 
-	 z="-2282.25"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-3-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-2-3" unit="cm" 
          x="-328.03"
 	 y="40.8" 
@@ -48238,14 +43208,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-3-0"/>
-       <position name="posOpArapucaDouble0-Frame-2-3" unit="cm" 
-         x="-327.29"
-	 y="40.8" 
-	 z="-1907.95"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-3-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-2-3" unit="cm" 
          x="-328.03"
 	 y="131.5" 
@@ -48253,14 +43216,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-3-1"/>
-       <position name="posOpArapucaDouble1-Frame-2-3" unit="cm" 
-         x="-327.29"
-	 y="131.5" 
-	 z="-2053.95"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-3-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-2-3" unit="cm" 
          x="-328.03"
 	 y="205.5" 
@@ -48268,14 +43224,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-3-2"/>
-       <position name="posOpArapucaDouble2-Frame-2-3" unit="cm" 
-         x="-327.29"
-	 y="205.5" 
-	 z="-1836.95"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-3-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-2-3" unit="cm" 
          x="-328.03"
 	 y="296.2" 
@@ -48283,14 +43232,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-3-3"/>
-       <position name="posOpArapucaDouble3-Frame-2-3" unit="cm" 
-         x="-327.29"
-	 y="296.2" 
-	 z="-1982.95"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-4-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-2-4" unit="cm" 
          x="-328.03"
 	 y="40.8" 
@@ -48298,14 +43240,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-4-0"/>
-       <position name="posOpArapucaDouble0-Frame-2-4" unit="cm" 
-         x="-327.29"
-	 y="40.8" 
-	 z="-1608.65"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-4-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-2-4" unit="cm" 
          x="-328.03"
 	 y="131.5" 
@@ -48313,14 +43248,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-4-1"/>
-       <position name="posOpArapucaDouble1-Frame-2-4" unit="cm" 
-         x="-327.29"
-	 y="131.5" 
-	 z="-1754.65"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-4-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-2-4" unit="cm" 
          x="-328.03"
 	 y="205.5" 
@@ -48328,14 +43256,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-4-2"/>
-       <position name="posOpArapucaDouble2-Frame-2-4" unit="cm" 
-         x="-327.29"
-	 y="205.5" 
-	 z="-1537.65"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-4-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-2-4" unit="cm" 
          x="-328.03"
 	 y="296.2" 
@@ -48343,14 +43264,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-4-3"/>
-       <position name="posOpArapucaDouble3-Frame-2-4" unit="cm" 
-         x="-327.29"
-	 y="296.2" 
-	 z="-1683.65"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-5-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-2-5" unit="cm" 
          x="-328.03"
 	 y="40.8" 
@@ -48358,14 +43272,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-5-0"/>
-       <position name="posOpArapucaDouble0-Frame-2-5" unit="cm" 
-         x="-327.29"
-	 y="40.8" 
-	 z="-1309.35"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-5-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-2-5" unit="cm" 
          x="-328.03"
 	 y="131.5" 
@@ -48373,14 +43280,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-5-1"/>
-       <position name="posOpArapucaDouble1-Frame-2-5" unit="cm" 
-         x="-327.29"
-	 y="131.5" 
-	 z="-1455.35"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-5-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-2-5" unit="cm" 
          x="-328.03"
 	 y="205.5" 
@@ -48388,14 +43288,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-5-2"/>
-       <position name="posOpArapucaDouble2-Frame-2-5" unit="cm" 
-         x="-327.29"
-	 y="205.5" 
-	 z="-1238.35"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-5-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-2-5" unit="cm" 
          x="-328.03"
 	 y="296.2" 
@@ -48403,14 +43296,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-5-3"/>
-       <position name="posOpArapucaDouble3-Frame-2-5" unit="cm" 
-         x="-327.29"
-	 y="296.2" 
-	 z="-1384.35"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-6-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-2-6" unit="cm" 
          x="-328.03"
 	 y="40.8" 
@@ -48418,14 +43304,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-6-0"/>
-       <position name="posOpArapucaDouble0-Frame-2-6" unit="cm" 
-         x="-327.29"
-	 y="40.8" 
-	 z="-1010.05"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-6-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-2-6" unit="cm" 
          x="-328.03"
 	 y="131.5" 
@@ -48433,14 +43312,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-6-1"/>
-       <position name="posOpArapucaDouble1-Frame-2-6" unit="cm" 
-         x="-327.29"
-	 y="131.5" 
-	 z="-1156.05"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-6-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-2-6" unit="cm" 
          x="-328.03"
 	 y="205.5" 
@@ -48448,14 +43320,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-6-2"/>
-       <position name="posOpArapucaDouble2-Frame-2-6" unit="cm" 
-         x="-327.29"
-	 y="205.5" 
-	 z="-939.05"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-6-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-2-6" unit="cm" 
          x="-328.03"
 	 y="296.2" 
@@ -48463,14 +43328,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-6-3"/>
-       <position name="posOpArapucaDouble3-Frame-2-6" unit="cm" 
-         x="-327.29"
-	 y="296.2" 
-	 z="-1085.05"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-7-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-2-7" unit="cm" 
          x="-328.03"
 	 y="40.8" 
@@ -48478,14 +43336,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-7-0"/>
-       <position name="posOpArapucaDouble0-Frame-2-7" unit="cm" 
-         x="-327.29"
-	 y="40.8" 
-	 z="-710.75"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-7-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-2-7" unit="cm" 
          x="-328.03"
 	 y="131.5" 
@@ -48493,14 +43344,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-7-1"/>
-       <position name="posOpArapucaDouble1-Frame-2-7" unit="cm" 
-         x="-327.29"
-	 y="131.5" 
-	 z="-856.75"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-7-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-2-7" unit="cm" 
          x="-328.03"
 	 y="205.5" 
@@ -48508,14 +43352,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-7-2"/>
-       <position name="posOpArapucaDouble2-Frame-2-7" unit="cm" 
-         x="-327.29"
-	 y="205.5" 
-	 z="-639.75"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-7-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-2-7" unit="cm" 
          x="-328.03"
 	 y="296.2" 
@@ -48523,14 +43360,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-7-3"/>
-       <position name="posOpArapucaDouble3-Frame-2-7" unit="cm" 
-         x="-327.29"
-	 y="296.2" 
-	 z="-785.75"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-8-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-2-8" unit="cm" 
          x="-328.03"
 	 y="40.8" 
@@ -48538,14 +43368,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-8-0"/>
-       <position name="posOpArapucaDouble0-Frame-2-8" unit="cm" 
-         x="-327.29"
-	 y="40.8" 
-	 z="-411.45"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-8-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-2-8" unit="cm" 
          x="-328.03"
 	 y="131.5" 
@@ -48553,14 +43376,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-8-1"/>
-       <position name="posOpArapucaDouble1-Frame-2-8" unit="cm" 
-         x="-327.29"
-	 y="131.5" 
-	 z="-557.45"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-8-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-2-8" unit="cm" 
          x="-328.03"
 	 y="205.5" 
@@ -48568,14 +43384,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-8-2"/>
-       <position name="posOpArapucaDouble2-Frame-2-8" unit="cm" 
-         x="-327.29"
-	 y="205.5" 
-	 z="-340.45"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-8-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-2-8" unit="cm" 
          x="-328.03"
 	 y="296.2" 
@@ -48583,14 +43392,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-8-3"/>
-       <position name="posOpArapucaDouble3-Frame-2-8" unit="cm" 
-         x="-327.29"
-	 y="296.2" 
-	 z="-486.45"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-9-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-2-9" unit="cm" 
          x="-328.03"
 	 y="40.8" 
@@ -48598,14 +43400,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-9-0"/>
-       <position name="posOpArapucaDouble0-Frame-2-9" unit="cm" 
-         x="-327.29"
-	 y="40.8" 
-	 z="-112.15"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-9-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-2-9" unit="cm" 
          x="-328.03"
 	 y="131.5" 
@@ -48613,14 +43408,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-9-1"/>
-       <position name="posOpArapucaDouble1-Frame-2-9" unit="cm" 
-         x="-327.29"
-	 y="131.5" 
-	 z="-258.15"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-9-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-2-9" unit="cm" 
          x="-328.03"
 	 y="205.5" 
@@ -48628,14 +43416,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-9-2"/>
-       <position name="posOpArapucaDouble2-Frame-2-9" unit="cm" 
-         x="-327.29"
-	 y="205.5" 
-	 z="-41.1499999999997"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-9-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-2-9" unit="cm" 
          x="-328.03"
 	 y="296.2" 
@@ -48643,14 +43424,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-9-3"/>
-       <position name="posOpArapucaDouble3-Frame-2-9" unit="cm" 
-         x="-327.29"
-	 y="296.2" 
-	 z="-187.15"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-10-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-2-10" unit="cm" 
          x="-328.03"
 	 y="40.8" 
@@ -48658,14 +43432,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-10-0"/>
-       <position name="posOpArapucaDouble0-Frame-2-10" unit="cm" 
-         x="-327.29"
-	 y="40.8" 
-	 z="187.15"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-10-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-2-10" unit="cm" 
          x="-328.03"
 	 y="131.5" 
@@ -48673,14 +43440,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-10-1"/>
-       <position name="posOpArapucaDouble1-Frame-2-10" unit="cm" 
-         x="-327.29"
-	 y="131.5" 
-	 z="41.1500000000003"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-10-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-2-10" unit="cm" 
          x="-328.03"
 	 y="205.5" 
@@ -48688,14 +43448,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-10-2"/>
-       <position name="posOpArapucaDouble2-Frame-2-10" unit="cm" 
-         x="-327.29"
-	 y="205.5" 
-	 z="258.15"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-10-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-2-10" unit="cm" 
          x="-328.03"
 	 y="296.2" 
@@ -48703,14 +43456,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-10-3"/>
-       <position name="posOpArapucaDouble3-Frame-2-10" unit="cm" 
-         x="-327.29"
-	 y="296.2" 
-	 z="112.15"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-11-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-2-11" unit="cm" 
          x="-328.03"
 	 y="40.8" 
@@ -48718,14 +43464,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-11-0"/>
-       <position name="posOpArapucaDouble0-Frame-2-11" unit="cm" 
-         x="-327.29"
-	 y="40.8" 
-	 z="486.45"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-11-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-2-11" unit="cm" 
          x="-328.03"
 	 y="131.5" 
@@ -48733,14 +43472,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-11-1"/>
-       <position name="posOpArapucaDouble1-Frame-2-11" unit="cm" 
-         x="-327.29"
-	 y="131.5" 
-	 z="340.45"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-11-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-2-11" unit="cm" 
          x="-328.03"
 	 y="205.5" 
@@ -48748,14 +43480,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-11-2"/>
-       <position name="posOpArapucaDouble2-Frame-2-11" unit="cm" 
-         x="-327.29"
-	 y="205.5" 
-	 z="557.45"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-11-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-2-11" unit="cm" 
          x="-328.03"
 	 y="296.2" 
@@ -48763,14 +43488,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-11-3"/>
-       <position name="posOpArapucaDouble3-Frame-2-11" unit="cm" 
-         x="-327.29"
-	 y="296.2" 
-	 z="411.45"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-12-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-2-12" unit="cm" 
          x="-328.03"
 	 y="40.8" 
@@ -48778,14 +43496,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-12-0"/>
-       <position name="posOpArapucaDouble0-Frame-2-12" unit="cm" 
-         x="-327.29"
-	 y="40.8" 
-	 z="785.75"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-12-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-2-12" unit="cm" 
          x="-328.03"
 	 y="131.5" 
@@ -48793,14 +43504,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-12-1"/>
-       <position name="posOpArapucaDouble1-Frame-2-12" unit="cm" 
-         x="-327.29"
-	 y="131.5" 
-	 z="639.75"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-12-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-2-12" unit="cm" 
          x="-328.03"
 	 y="205.5" 
@@ -48808,14 +43512,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-12-2"/>
-       <position name="posOpArapucaDouble2-Frame-2-12" unit="cm" 
-         x="-327.29"
-	 y="205.5" 
-	 z="856.75"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-12-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-2-12" unit="cm" 
          x="-328.03"
 	 y="296.2" 
@@ -48823,14 +43520,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-12-3"/>
-       <position name="posOpArapucaDouble3-Frame-2-12" unit="cm" 
-         x="-327.29"
-	 y="296.2" 
-	 z="710.75"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-13-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-2-13" unit="cm" 
          x="-328.03"
 	 y="40.8" 
@@ -48838,14 +43528,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-13-0"/>
-       <position name="posOpArapucaDouble0-Frame-2-13" unit="cm" 
-         x="-327.29"
-	 y="40.8" 
-	 z="1085.05"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-13-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-2-13" unit="cm" 
          x="-328.03"
 	 y="131.5" 
@@ -48853,14 +43536,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-13-1"/>
-       <position name="posOpArapucaDouble1-Frame-2-13" unit="cm" 
-         x="-327.29"
-	 y="131.5" 
-	 z="939.05"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-13-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-2-13" unit="cm" 
          x="-328.03"
 	 y="205.5" 
@@ -48868,14 +43544,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-13-2"/>
-       <position name="posOpArapucaDouble2-Frame-2-13" unit="cm" 
-         x="-327.29"
-	 y="205.5" 
-	 z="1156.05"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-13-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-2-13" unit="cm" 
          x="-328.03"
 	 y="296.2" 
@@ -48883,14 +43552,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-13-3"/>
-       <position name="posOpArapucaDouble3-Frame-2-13" unit="cm" 
-         x="-327.29"
-	 y="296.2" 
-	 z="1010.05"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-14-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-2-14" unit="cm" 
          x="-328.03"
 	 y="40.8" 
@@ -48898,14 +43560,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-14-0"/>
-       <position name="posOpArapucaDouble0-Frame-2-14" unit="cm" 
-         x="-327.29"
-	 y="40.8" 
-	 z="1384.35"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-14-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-2-14" unit="cm" 
          x="-328.03"
 	 y="131.5" 
@@ -48913,14 +43568,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-14-1"/>
-       <position name="posOpArapucaDouble1-Frame-2-14" unit="cm" 
-         x="-327.29"
-	 y="131.5" 
-	 z="1238.35"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-14-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-2-14" unit="cm" 
          x="-328.03"
 	 y="205.5" 
@@ -48928,14 +43576,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-14-2"/>
-       <position name="posOpArapucaDouble2-Frame-2-14" unit="cm" 
-         x="-327.29"
-	 y="205.5" 
-	 z="1455.35"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-14-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-2-14" unit="cm" 
          x="-328.03"
 	 y="296.2" 
@@ -48943,14 +43584,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-14-3"/>
-       <position name="posOpArapucaDouble3-Frame-2-14" unit="cm" 
-         x="-327.29"
-	 y="296.2" 
-	 z="1309.35"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-15-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-2-15" unit="cm" 
          x="-328.03"
 	 y="40.8" 
@@ -48958,14 +43592,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-15-0"/>
-       <position name="posOpArapucaDouble0-Frame-2-15" unit="cm" 
-         x="-327.29"
-	 y="40.8" 
-	 z="1683.65"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-15-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-2-15" unit="cm" 
          x="-328.03"
 	 y="131.5" 
@@ -48973,14 +43600,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-15-1"/>
-       <position name="posOpArapucaDouble1-Frame-2-15" unit="cm" 
-         x="-327.29"
-	 y="131.5" 
-	 z="1537.65"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-15-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-2-15" unit="cm" 
          x="-328.03"
 	 y="205.5" 
@@ -48988,14 +43608,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-15-2"/>
-       <position name="posOpArapucaDouble2-Frame-2-15" unit="cm" 
-         x="-327.29"
-	 y="205.5" 
-	 z="1754.65"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-15-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-2-15" unit="cm" 
          x="-328.03"
 	 y="296.2" 
@@ -49003,14 +43616,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-15-3"/>
-       <position name="posOpArapucaDouble3-Frame-2-15" unit="cm" 
-         x="-327.29"
-	 y="296.2" 
-	 z="1608.65"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-16-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-2-16" unit="cm" 
          x="-328.03"
 	 y="40.8" 
@@ -49018,14 +43624,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-16-0"/>
-       <position name="posOpArapucaDouble0-Frame-2-16" unit="cm" 
-         x="-327.29"
-	 y="40.8" 
-	 z="1982.95"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-16-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-2-16" unit="cm" 
          x="-328.03"
 	 y="131.5" 
@@ -49033,14 +43632,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-16-1"/>
-       <position name="posOpArapucaDouble1-Frame-2-16" unit="cm" 
-         x="-327.29"
-	 y="131.5" 
-	 z="1836.95"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-16-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-2-16" unit="cm" 
          x="-328.03"
 	 y="205.5" 
@@ -49048,14 +43640,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-16-2"/>
-       <position name="posOpArapucaDouble2-Frame-2-16" unit="cm" 
-         x="-327.29"
-	 y="205.5" 
-	 z="2053.95"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-16-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-2-16" unit="cm" 
          x="-328.03"
 	 y="296.2" 
@@ -49063,14 +43648,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-16-3"/>
-       <position name="posOpArapucaDouble3-Frame-2-16" unit="cm" 
-         x="-327.29"
-	 y="296.2" 
-	 z="1907.95"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-17-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-2-17" unit="cm" 
          x="-328.03"
 	 y="40.8" 
@@ -49078,14 +43656,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-17-0"/>
-       <position name="posOpArapucaDouble0-Frame-2-17" unit="cm" 
-         x="-327.29"
-	 y="40.8" 
-	 z="2282.25"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-17-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-2-17" unit="cm" 
          x="-328.03"
 	 y="131.5" 
@@ -49093,14 +43664,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-17-1"/>
-       <position name="posOpArapucaDouble1-Frame-2-17" unit="cm" 
-         x="-327.29"
-	 y="131.5" 
-	 z="2136.25"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-17-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-2-17" unit="cm" 
          x="-328.03"
 	 y="205.5" 
@@ -49108,14 +43672,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-17-2"/>
-       <position name="posOpArapucaDouble2-Frame-2-17" unit="cm" 
-         x="-327.29"
-	 y="205.5" 
-	 z="2353.25"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-17-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-2-17" unit="cm" 
          x="-328.03"
 	 y="296.2" 
@@ -49123,14 +43680,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-17-3"/>
-       <position name="posOpArapucaDouble3-Frame-2-17" unit="cm" 
-         x="-327.29"
-	 y="296.2" 
-	 z="2207.25"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-18-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-2-18" unit="cm" 
          x="-328.03"
 	 y="40.8" 
@@ -49138,14 +43688,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-18-0"/>
-       <position name="posOpArapucaDouble0-Frame-2-18" unit="cm" 
-         x="-327.29"
-	 y="40.8" 
-	 z="2581.55"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-18-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-2-18" unit="cm" 
          x="-328.03"
 	 y="131.5" 
@@ -49153,14 +43696,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-18-1"/>
-       <position name="posOpArapucaDouble1-Frame-2-18" unit="cm" 
-         x="-327.29"
-	 y="131.5" 
-	 z="2435.55"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-18-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-2-18" unit="cm" 
          x="-328.03"
 	 y="205.5" 
@@ -49168,14 +43704,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-18-2"/>
-       <position name="posOpArapucaDouble2-Frame-2-18" unit="cm" 
-         x="-327.29"
-	 y="205.5" 
-	 z="2652.55"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-18-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-2-18" unit="cm" 
          x="-328.03"
 	 y="296.2" 
@@ -49183,14 +43712,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-18-3"/>
-       <position name="posOpArapucaDouble3-Frame-2-18" unit="cm" 
-         x="-327.29"
-	 y="296.2" 
-	 z="2506.55"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-19-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-2-19" unit="cm" 
          x="-328.03"
 	 y="40.8" 
@@ -49198,14 +43720,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-19-0"/>
-       <position name="posOpArapucaDouble0-Frame-2-19" unit="cm" 
-         x="-327.29"
-	 y="40.8" 
-	 z="2880.85"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-19-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-2-19" unit="cm" 
          x="-328.03"
 	 y="131.5" 
@@ -49213,14 +43728,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-19-1"/>
-       <position name="posOpArapucaDouble1-Frame-2-19" unit="cm" 
-         x="-327.29"
-	 y="131.5" 
-	 z="2734.85"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-19-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-2-19" unit="cm" 
          x="-328.03"
 	 y="205.5" 
@@ -49228,14 +43736,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-19-2"/>
-       <position name="posOpArapucaDouble2-Frame-2-19" unit="cm" 
-         x="-327.29"
-	 y="205.5" 
-	 z="2951.85"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-19-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-2-19" unit="cm" 
          x="-328.03"
 	 y="296.2" 
@@ -49243,14 +43744,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-19-3"/>
-       <position name="posOpArapucaDouble3-Frame-2-19" unit="cm" 
-         x="-327.29"
-	 y="296.2" 
-	 z="2805.85"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-0-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-3-0" unit="cm" 
          x="-328.03"
 	 y="377.8" 
@@ -49258,14 +43752,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-0"/>
-       <position name="posOpArapucaDouble0-Frame-3-0" unit="cm" 
-         x="-327.29"
-	 y="377.8" 
-	 z="-2805.85"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-0-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-3-0" unit="cm" 
          x="-328.03"
 	 y="468.5" 
@@ -49273,14 +43760,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-1"/>
-       <position name="posOpArapucaDouble1-Frame-3-0" unit="cm" 
-         x="-327.29"
-	 y="468.5" 
-	 z="-2951.85"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-0-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-3-0" unit="cm" 
          x="-328.03"
 	 y="542.5" 
@@ -49288,14 +43768,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-2"/>
-       <position name="posOpArapucaDouble2-Frame-3-0" unit="cm" 
-         x="-327.29"
-	 y="542.5" 
-	 z="-2734.85"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-0-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-3-0" unit="cm" 
          x="-328.03"
 	 y="633.2" 
@@ -49303,14 +43776,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-3"/>
-       <position name="posOpArapucaDouble3-Frame-3-0" unit="cm" 
-         x="-327.29"
-	 y="633.2" 
-	 z="-2880.85"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-1-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-3-1" unit="cm" 
          x="-328.03"
 	 y="377.8" 
@@ -49318,14 +43784,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-0"/>
-       <position name="posOpArapucaDouble0-Frame-3-1" unit="cm" 
-         x="-327.29"
-	 y="377.8" 
-	 z="-2506.55"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-1-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-3-1" unit="cm" 
          x="-328.03"
 	 y="468.5" 
@@ -49333,14 +43792,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-1"/>
-       <position name="posOpArapucaDouble1-Frame-3-1" unit="cm" 
-         x="-327.29"
-	 y="468.5" 
-	 z="-2652.55"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-1-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-3-1" unit="cm" 
          x="-328.03"
 	 y="542.5" 
@@ -49348,14 +43800,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-2"/>
-       <position name="posOpArapucaDouble2-Frame-3-1" unit="cm" 
-         x="-327.29"
-	 y="542.5" 
-	 z="-2435.55"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-1-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-3-1" unit="cm" 
          x="-328.03"
 	 y="633.2" 
@@ -49363,14 +43808,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-3"/>
-       <position name="posOpArapucaDouble3-Frame-3-1" unit="cm" 
-         x="-327.29"
-	 y="633.2" 
-	 z="-2581.55"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-2-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-3-2" unit="cm" 
          x="-328.03"
 	 y="377.8" 
@@ -49378,14 +43816,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-0"/>
-       <position name="posOpArapucaDouble0-Frame-3-2" unit="cm" 
-         x="-327.29"
-	 y="377.8" 
-	 z="-2207.25"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-2-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-3-2" unit="cm" 
          x="-328.03"
 	 y="468.5" 
@@ -49393,14 +43824,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-1"/>
-       <position name="posOpArapucaDouble1-Frame-3-2" unit="cm" 
-         x="-327.29"
-	 y="468.5" 
-	 z="-2353.25"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-2-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-3-2" unit="cm" 
          x="-328.03"
 	 y="542.5" 
@@ -49408,14 +43832,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-2"/>
-       <position name="posOpArapucaDouble2-Frame-3-2" unit="cm" 
-         x="-327.29"
-	 y="542.5" 
-	 z="-2136.25"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-2-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-3-2" unit="cm" 
          x="-328.03"
 	 y="633.2" 
@@ -49423,14 +43840,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-3"/>
-       <position name="posOpArapucaDouble3-Frame-3-2" unit="cm" 
-         x="-327.29"
-	 y="633.2" 
-	 z="-2282.25"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-3-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-3-3" unit="cm" 
          x="-328.03"
 	 y="377.8" 
@@ -49438,14 +43848,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-3-0"/>
-       <position name="posOpArapucaDouble0-Frame-3-3" unit="cm" 
-         x="-327.29"
-	 y="377.8" 
-	 z="-1907.95"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-3-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-3-3" unit="cm" 
          x="-328.03"
 	 y="468.5" 
@@ -49453,14 +43856,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-3-1"/>
-       <position name="posOpArapucaDouble1-Frame-3-3" unit="cm" 
-         x="-327.29"
-	 y="468.5" 
-	 z="-2053.95"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-3-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-3-3" unit="cm" 
          x="-328.03"
 	 y="542.5" 
@@ -49468,14 +43864,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-3-2"/>
-       <position name="posOpArapucaDouble2-Frame-3-3" unit="cm" 
-         x="-327.29"
-	 y="542.5" 
-	 z="-1836.95"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-3-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-3-3" unit="cm" 
          x="-328.03"
 	 y="633.2" 
@@ -49483,14 +43872,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-3-3"/>
-       <position name="posOpArapucaDouble3-Frame-3-3" unit="cm" 
-         x="-327.29"
-	 y="633.2" 
-	 z="-1982.95"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-4-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-3-4" unit="cm" 
          x="-328.03"
 	 y="377.8" 
@@ -49498,14 +43880,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-4-0"/>
-       <position name="posOpArapucaDouble0-Frame-3-4" unit="cm" 
-         x="-327.29"
-	 y="377.8" 
-	 z="-1608.65"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-4-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-3-4" unit="cm" 
          x="-328.03"
 	 y="468.5" 
@@ -49513,14 +43888,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-4-1"/>
-       <position name="posOpArapucaDouble1-Frame-3-4" unit="cm" 
-         x="-327.29"
-	 y="468.5" 
-	 z="-1754.65"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-4-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-3-4" unit="cm" 
          x="-328.03"
 	 y="542.5" 
@@ -49528,14 +43896,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-4-2"/>
-       <position name="posOpArapucaDouble2-Frame-3-4" unit="cm" 
-         x="-327.29"
-	 y="542.5" 
-	 z="-1537.65"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-4-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-3-4" unit="cm" 
          x="-328.03"
 	 y="633.2" 
@@ -49543,14 +43904,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-4-3"/>
-       <position name="posOpArapucaDouble3-Frame-3-4" unit="cm" 
-         x="-327.29"
-	 y="633.2" 
-	 z="-1683.65"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-5-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-3-5" unit="cm" 
          x="-328.03"
 	 y="377.8" 
@@ -49558,14 +43912,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-5-0"/>
-       <position name="posOpArapucaDouble0-Frame-3-5" unit="cm" 
-         x="-327.29"
-	 y="377.8" 
-	 z="-1309.35"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-5-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-3-5" unit="cm" 
          x="-328.03"
 	 y="468.5" 
@@ -49573,14 +43920,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-5-1"/>
-       <position name="posOpArapucaDouble1-Frame-3-5" unit="cm" 
-         x="-327.29"
-	 y="468.5" 
-	 z="-1455.35"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-5-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-3-5" unit="cm" 
          x="-328.03"
 	 y="542.5" 
@@ -49588,14 +43928,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-5-2"/>
-       <position name="posOpArapucaDouble2-Frame-3-5" unit="cm" 
-         x="-327.29"
-	 y="542.5" 
-	 z="-1238.35"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-5-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-3-5" unit="cm" 
          x="-328.03"
 	 y="633.2" 
@@ -49603,14 +43936,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-5-3"/>
-       <position name="posOpArapucaDouble3-Frame-3-5" unit="cm" 
-         x="-327.29"
-	 y="633.2" 
-	 z="-1384.35"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-6-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-3-6" unit="cm" 
          x="-328.03"
 	 y="377.8" 
@@ -49618,14 +43944,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-6-0"/>
-       <position name="posOpArapucaDouble0-Frame-3-6" unit="cm" 
-         x="-327.29"
-	 y="377.8" 
-	 z="-1010.05"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-6-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-3-6" unit="cm" 
          x="-328.03"
 	 y="468.5" 
@@ -49633,14 +43952,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-6-1"/>
-       <position name="posOpArapucaDouble1-Frame-3-6" unit="cm" 
-         x="-327.29"
-	 y="468.5" 
-	 z="-1156.05"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-6-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-3-6" unit="cm" 
          x="-328.03"
 	 y="542.5" 
@@ -49648,14 +43960,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-6-2"/>
-       <position name="posOpArapucaDouble2-Frame-3-6" unit="cm" 
-         x="-327.29"
-	 y="542.5" 
-	 z="-939.05"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-6-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-3-6" unit="cm" 
          x="-328.03"
 	 y="633.2" 
@@ -49663,14 +43968,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-6-3"/>
-       <position name="posOpArapucaDouble3-Frame-3-6" unit="cm" 
-         x="-327.29"
-	 y="633.2" 
-	 z="-1085.05"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-7-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-3-7" unit="cm" 
          x="-328.03"
 	 y="377.8" 
@@ -49678,14 +43976,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-7-0"/>
-       <position name="posOpArapucaDouble0-Frame-3-7" unit="cm" 
-         x="-327.29"
-	 y="377.8" 
-	 z="-710.75"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-7-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-3-7" unit="cm" 
          x="-328.03"
 	 y="468.5" 
@@ -49693,14 +43984,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-7-1"/>
-       <position name="posOpArapucaDouble1-Frame-3-7" unit="cm" 
-         x="-327.29"
-	 y="468.5" 
-	 z="-856.75"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-7-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-3-7" unit="cm" 
          x="-328.03"
 	 y="542.5" 
@@ -49708,14 +43992,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-7-2"/>
-       <position name="posOpArapucaDouble2-Frame-3-7" unit="cm" 
-         x="-327.29"
-	 y="542.5" 
-	 z="-639.75"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-7-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-3-7" unit="cm" 
          x="-328.03"
 	 y="633.2" 
@@ -49723,14 +44000,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-7-3"/>
-       <position name="posOpArapucaDouble3-Frame-3-7" unit="cm" 
-         x="-327.29"
-	 y="633.2" 
-	 z="-785.75"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-8-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-3-8" unit="cm" 
          x="-328.03"
 	 y="377.8" 
@@ -49738,14 +44008,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-8-0"/>
-       <position name="posOpArapucaDouble0-Frame-3-8" unit="cm" 
-         x="-327.29"
-	 y="377.8" 
-	 z="-411.45"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-8-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-3-8" unit="cm" 
          x="-328.03"
 	 y="468.5" 
@@ -49753,14 +44016,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-8-1"/>
-       <position name="posOpArapucaDouble1-Frame-3-8" unit="cm" 
-         x="-327.29"
-	 y="468.5" 
-	 z="-557.45"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-8-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-3-8" unit="cm" 
          x="-328.03"
 	 y="542.5" 
@@ -49768,14 +44024,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-8-2"/>
-       <position name="posOpArapucaDouble2-Frame-3-8" unit="cm" 
-         x="-327.29"
-	 y="542.5" 
-	 z="-340.45"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-8-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-3-8" unit="cm" 
          x="-328.03"
 	 y="633.2" 
@@ -49783,14 +44032,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-8-3"/>
-       <position name="posOpArapucaDouble3-Frame-3-8" unit="cm" 
-         x="-327.29"
-	 y="633.2" 
-	 z="-486.45"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-9-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-3-9" unit="cm" 
          x="-328.03"
 	 y="377.8" 
@@ -49798,14 +44040,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-9-0"/>
-       <position name="posOpArapucaDouble0-Frame-3-9" unit="cm" 
-         x="-327.29"
-	 y="377.8" 
-	 z="-112.15"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-9-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-3-9" unit="cm" 
          x="-328.03"
 	 y="468.5" 
@@ -49813,14 +44048,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-9-1"/>
-       <position name="posOpArapucaDouble1-Frame-3-9" unit="cm" 
-         x="-327.29"
-	 y="468.5" 
-	 z="-258.15"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-9-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-3-9" unit="cm" 
          x="-328.03"
 	 y="542.5" 
@@ -49828,14 +44056,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-9-2"/>
-       <position name="posOpArapucaDouble2-Frame-3-9" unit="cm" 
-         x="-327.29"
-	 y="542.5" 
-	 z="-41.1499999999997"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-9-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-3-9" unit="cm" 
          x="-328.03"
 	 y="633.2" 
@@ -49843,14 +44064,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-9-3"/>
-       <position name="posOpArapucaDouble3-Frame-3-9" unit="cm" 
-         x="-327.29"
-	 y="633.2" 
-	 z="-187.15"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-10-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-3-10" unit="cm" 
          x="-328.03"
 	 y="377.8" 
@@ -49858,14 +44072,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-10-0"/>
-       <position name="posOpArapucaDouble0-Frame-3-10" unit="cm" 
-         x="-327.29"
-	 y="377.8" 
-	 z="187.15"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-10-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-3-10" unit="cm" 
          x="-328.03"
 	 y="468.5" 
@@ -49873,14 +44080,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-10-1"/>
-       <position name="posOpArapucaDouble1-Frame-3-10" unit="cm" 
-         x="-327.29"
-	 y="468.5" 
-	 z="41.1500000000003"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-10-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-3-10" unit="cm" 
          x="-328.03"
 	 y="542.5" 
@@ -49888,14 +44088,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-10-2"/>
-       <position name="posOpArapucaDouble2-Frame-3-10" unit="cm" 
-         x="-327.29"
-	 y="542.5" 
-	 z="258.15"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-10-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-3-10" unit="cm" 
          x="-328.03"
 	 y="633.2" 
@@ -49903,14 +44096,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-10-3"/>
-       <position name="posOpArapucaDouble3-Frame-3-10" unit="cm" 
-         x="-327.29"
-	 y="633.2" 
-	 z="112.15"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-11-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-3-11" unit="cm" 
          x="-328.03"
 	 y="377.8" 
@@ -49918,14 +44104,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-11-0"/>
-       <position name="posOpArapucaDouble0-Frame-3-11" unit="cm" 
-         x="-327.29"
-	 y="377.8" 
-	 z="486.45"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-11-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-3-11" unit="cm" 
          x="-328.03"
 	 y="468.5" 
@@ -49933,14 +44112,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-11-1"/>
-       <position name="posOpArapucaDouble1-Frame-3-11" unit="cm" 
-         x="-327.29"
-	 y="468.5" 
-	 z="340.45"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-11-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-3-11" unit="cm" 
          x="-328.03"
 	 y="542.5" 
@@ -49948,14 +44120,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-11-2"/>
-       <position name="posOpArapucaDouble2-Frame-3-11" unit="cm" 
-         x="-327.29"
-	 y="542.5" 
-	 z="557.45"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-11-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-3-11" unit="cm" 
          x="-328.03"
 	 y="633.2" 
@@ -49963,14 +44128,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-11-3"/>
-       <position name="posOpArapucaDouble3-Frame-3-11" unit="cm" 
-         x="-327.29"
-	 y="633.2" 
-	 z="411.45"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-12-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-3-12" unit="cm" 
          x="-328.03"
 	 y="377.8" 
@@ -49978,14 +44136,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-12-0"/>
-       <position name="posOpArapucaDouble0-Frame-3-12" unit="cm" 
-         x="-327.29"
-	 y="377.8" 
-	 z="785.75"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-12-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-3-12" unit="cm" 
          x="-328.03"
 	 y="468.5" 
@@ -49993,14 +44144,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-12-1"/>
-       <position name="posOpArapucaDouble1-Frame-3-12" unit="cm" 
-         x="-327.29"
-	 y="468.5" 
-	 z="639.75"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-12-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-3-12" unit="cm" 
          x="-328.03"
 	 y="542.5" 
@@ -50008,14 +44152,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-12-2"/>
-       <position name="posOpArapucaDouble2-Frame-3-12" unit="cm" 
-         x="-327.29"
-	 y="542.5" 
-	 z="856.75"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-12-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-3-12" unit="cm" 
          x="-328.03"
 	 y="633.2" 
@@ -50023,14 +44160,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-12-3"/>
-       <position name="posOpArapucaDouble3-Frame-3-12" unit="cm" 
-         x="-327.29"
-	 y="633.2" 
-	 z="710.75"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-13-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-3-13" unit="cm" 
          x="-328.03"
 	 y="377.8" 
@@ -50038,14 +44168,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-13-0"/>
-       <position name="posOpArapucaDouble0-Frame-3-13" unit="cm" 
-         x="-327.29"
-	 y="377.8" 
-	 z="1085.05"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-13-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-3-13" unit="cm" 
          x="-328.03"
 	 y="468.5" 
@@ -50053,14 +44176,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-13-1"/>
-       <position name="posOpArapucaDouble1-Frame-3-13" unit="cm" 
-         x="-327.29"
-	 y="468.5" 
-	 z="939.05"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-13-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-3-13" unit="cm" 
          x="-328.03"
 	 y="542.5" 
@@ -50068,14 +44184,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-13-2"/>
-       <position name="posOpArapucaDouble2-Frame-3-13" unit="cm" 
-         x="-327.29"
-	 y="542.5" 
-	 z="1156.05"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-13-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-3-13" unit="cm" 
          x="-328.03"
 	 y="633.2" 
@@ -50083,14 +44192,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-13-3"/>
-       <position name="posOpArapucaDouble3-Frame-3-13" unit="cm" 
-         x="-327.29"
-	 y="633.2" 
-	 z="1010.05"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-14-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-3-14" unit="cm" 
          x="-328.03"
 	 y="377.8" 
@@ -50098,14 +44200,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-14-0"/>
-       <position name="posOpArapucaDouble0-Frame-3-14" unit="cm" 
-         x="-327.29"
-	 y="377.8" 
-	 z="1384.35"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-14-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-3-14" unit="cm" 
          x="-328.03"
 	 y="468.5" 
@@ -50113,14 +44208,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-14-1"/>
-       <position name="posOpArapucaDouble1-Frame-3-14" unit="cm" 
-         x="-327.29"
-	 y="468.5" 
-	 z="1238.35"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-14-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-3-14" unit="cm" 
          x="-328.03"
 	 y="542.5" 
@@ -50128,14 +44216,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-14-2"/>
-       <position name="posOpArapucaDouble2-Frame-3-14" unit="cm" 
-         x="-327.29"
-	 y="542.5" 
-	 z="1455.35"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-14-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-3-14" unit="cm" 
          x="-328.03"
 	 y="633.2" 
@@ -50143,14 +44224,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-14-3"/>
-       <position name="posOpArapucaDouble3-Frame-3-14" unit="cm" 
-         x="-327.29"
-	 y="633.2" 
-	 z="1309.35"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-15-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-3-15" unit="cm" 
          x="-328.03"
 	 y="377.8" 
@@ -50158,14 +44232,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-15-0"/>
-       <position name="posOpArapucaDouble0-Frame-3-15" unit="cm" 
-         x="-327.29"
-	 y="377.8" 
-	 z="1683.65"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-15-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-3-15" unit="cm" 
          x="-328.03"
 	 y="468.5" 
@@ -50173,14 +44240,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-15-1"/>
-       <position name="posOpArapucaDouble1-Frame-3-15" unit="cm" 
-         x="-327.29"
-	 y="468.5" 
-	 z="1537.65"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-15-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-3-15" unit="cm" 
          x="-328.03"
 	 y="542.5" 
@@ -50188,14 +44248,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-15-2"/>
-       <position name="posOpArapucaDouble2-Frame-3-15" unit="cm" 
-         x="-327.29"
-	 y="542.5" 
-	 z="1754.65"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-15-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-3-15" unit="cm" 
          x="-328.03"
 	 y="633.2" 
@@ -50203,14 +44256,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-15-3"/>
-       <position name="posOpArapucaDouble3-Frame-3-15" unit="cm" 
-         x="-327.29"
-	 y="633.2" 
-	 z="1608.65"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-16-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-3-16" unit="cm" 
          x="-328.03"
 	 y="377.8" 
@@ -50218,14 +44264,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-16-0"/>
-       <position name="posOpArapucaDouble0-Frame-3-16" unit="cm" 
-         x="-327.29"
-	 y="377.8" 
-	 z="1982.95"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-16-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-3-16" unit="cm" 
          x="-328.03"
 	 y="468.5" 
@@ -50233,14 +44272,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-16-1"/>
-       <position name="posOpArapucaDouble1-Frame-3-16" unit="cm" 
-         x="-327.29"
-	 y="468.5" 
-	 z="1836.95"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-16-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-3-16" unit="cm" 
          x="-328.03"
 	 y="542.5" 
@@ -50248,14 +44280,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-16-2"/>
-       <position name="posOpArapucaDouble2-Frame-3-16" unit="cm" 
-         x="-327.29"
-	 y="542.5" 
-	 z="2053.95"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-16-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-3-16" unit="cm" 
          x="-328.03"
 	 y="633.2" 
@@ -50263,14 +44288,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-16-3"/>
-       <position name="posOpArapucaDouble3-Frame-3-16" unit="cm" 
-         x="-327.29"
-	 y="633.2" 
-	 z="1907.95"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-17-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-3-17" unit="cm" 
          x="-328.03"
 	 y="377.8" 
@@ -50278,14 +44296,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-17-0"/>
-       <position name="posOpArapucaDouble0-Frame-3-17" unit="cm" 
-         x="-327.29"
-	 y="377.8" 
-	 z="2282.25"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-17-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-3-17" unit="cm" 
          x="-328.03"
 	 y="468.5" 
@@ -50293,14 +44304,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-17-1"/>
-       <position name="posOpArapucaDouble1-Frame-3-17" unit="cm" 
-         x="-327.29"
-	 y="468.5" 
-	 z="2136.25"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-17-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-3-17" unit="cm" 
          x="-328.03"
 	 y="542.5" 
@@ -50308,14 +44312,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-17-2"/>
-       <position name="posOpArapucaDouble2-Frame-3-17" unit="cm" 
-         x="-327.29"
-	 y="542.5" 
-	 z="2353.25"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-17-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-3-17" unit="cm" 
          x="-328.03"
 	 y="633.2" 
@@ -50323,14 +44320,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-17-3"/>
-       <position name="posOpArapucaDouble3-Frame-3-17" unit="cm" 
-         x="-327.29"
-	 y="633.2" 
-	 z="2207.25"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-18-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-3-18" unit="cm" 
          x="-328.03"
 	 y="377.8" 
@@ -50338,14 +44328,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-18-0"/>
-       <position name="posOpArapucaDouble0-Frame-3-18" unit="cm" 
-         x="-327.29"
-	 y="377.8" 
-	 z="2581.55"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-18-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-3-18" unit="cm" 
          x="-328.03"
 	 y="468.5" 
@@ -50353,14 +44336,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-18-1"/>
-       <position name="posOpArapucaDouble1-Frame-3-18" unit="cm" 
-         x="-327.29"
-	 y="468.5" 
-	 z="2435.55"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-18-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-3-18" unit="cm" 
          x="-328.03"
 	 y="542.5" 
@@ -50368,14 +44344,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-18-2"/>
-       <position name="posOpArapucaDouble2-Frame-3-18" unit="cm" 
-         x="-327.29"
-	 y="542.5" 
-	 z="2652.55"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-18-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-3-18" unit="cm" 
          x="-328.03"
 	 y="633.2" 
@@ -50383,14 +44352,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-18-3"/>
-       <position name="posOpArapucaDouble3-Frame-3-18" unit="cm" 
-         x="-327.29"
-	 y="633.2" 
-	 z="2506.55"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-19-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-3-19" unit="cm" 
          x="-328.03"
 	 y="377.8" 
@@ -50398,14 +44360,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-19-0"/>
-       <position name="posOpArapucaDouble0-Frame-3-19" unit="cm" 
-         x="-327.29"
-	 y="377.8" 
-	 z="2880.85"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-19-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-3-19" unit="cm" 
          x="-328.03"
 	 y="468.5" 
@@ -50413,14 +44368,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-19-1"/>
-       <position name="posOpArapucaDouble1-Frame-3-19" unit="cm" 
-         x="-327.29"
-	 y="468.5" 
-	 z="2734.85"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-19-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-3-19" unit="cm" 
          x="-328.03"
 	 y="542.5" 
@@ -50428,14 +44376,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-19-2"/>
-       <position name="posOpArapucaDouble2-Frame-3-19" unit="cm" 
-         x="-327.29"
-	 y="542.5" 
-	 z="2951.85"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-19-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-3-19" unit="cm" 
          x="-328.03"
 	 y="633.2" 
@@ -50443,14 +44384,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-19-3"/>
-       <position name="posOpArapucaDouble3-Frame-3-19" unit="cm" 
-         x="-327.29"
-	 y="633.2" 
-	 z="2805.85"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_0-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca0-Lat-0" unit="cm" 
          x="285.02"
 	 y="-745" 
@@ -50458,14 +44392,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_0-0"/>
-       <position name="posOpArapuca0-Lat-0" unit="cm" 
-         x="285.02"
-	 y="-744.26" 
-	 z="-2843.35"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_0-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca1-Lat-0" unit="cm" 
          x="210.02"
 	 y="-745" 
@@ -50473,14 +44400,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_0-1"/>
-       <position name="posOpArapuca1-Lat-0" unit="cm" 
-         x="210.02"
-	 y="-744.26" 
-	 z="-2843.35"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_0-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca2-Lat-0" unit="cm" 
          x="135.02"
 	 y="-745" 
@@ -50488,14 +44408,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_0-2"/>
-       <position name="posOpArapuca2-Lat-0" unit="cm" 
-         x="135.02"
-	 y="-744.26" 
-	 z="-2843.35"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_0-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca3-Lat-0" unit="cm" 
          x="60.02"
 	 y="-745" 
@@ -50503,14 +44416,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_0-3"/>
-       <position name="posOpArapuca3-Lat-0" unit="cm" 
-         x="60.02"
-	 y="-744.26" 
-	 z="-2843.35"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_0-4"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca4-Lat-0" unit="cm" 
          x="285.02"
 	 y="745" 
@@ -50518,14 +44424,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_0-4"/>
-       <position name="posOpArapuca4-Lat-0" unit="cm" 
-         x="285.02"
-	 y="744.26" 
-	 z="-2843.35"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_0-5"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca5-Lat-0" unit="cm" 
          x="210.02"
 	 y="745" 
@@ -50533,14 +44432,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_0-5"/>
-       <position name="posOpArapuca5-Lat-0" unit="cm" 
-         x="210.02"
-	 y="744.26" 
-	 z="-2843.35"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_0-6"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca6-Lat-0" unit="cm" 
          x="135.02"
 	 y="745" 
@@ -50548,14 +44440,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_0-6"/>
-       <position name="posOpArapuca6-Lat-0" unit="cm" 
-         x="135.02"
-	 y="744.26" 
-	 z="-2843.35"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_0-7"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca7-Lat-0" unit="cm" 
          x="60.02"
 	 y="745" 
@@ -50563,14 +44448,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_0-7"/>
-       <position name="posOpArapuca7-Lat-0" unit="cm" 
-         x="60.02"
-	 y="744.26" 
-	 z="-2843.35"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_1-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca0-Lat-1" unit="cm" 
          x="285.02"
 	 y="-745" 
@@ -50578,14 +44456,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_1-0"/>
-       <position name="posOpArapuca0-Lat-1" unit="cm" 
-         x="285.02"
-	 y="-744.26" 
-	 z="-2544.05"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_1-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca1-Lat-1" unit="cm" 
          x="210.02"
 	 y="-745" 
@@ -50593,14 +44464,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_1-1"/>
-       <position name="posOpArapuca1-Lat-1" unit="cm" 
-         x="210.02"
-	 y="-744.26" 
-	 z="-2544.05"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_1-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca2-Lat-1" unit="cm" 
          x="135.02"
 	 y="-745" 
@@ -50608,14 +44472,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_1-2"/>
-       <position name="posOpArapuca2-Lat-1" unit="cm" 
-         x="135.02"
-	 y="-744.26" 
-	 z="-2544.05"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_1-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca3-Lat-1" unit="cm" 
          x="60.02"
 	 y="-745" 
@@ -50623,14 +44480,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_1-3"/>
-       <position name="posOpArapuca3-Lat-1" unit="cm" 
-         x="60.02"
-	 y="-744.26" 
-	 z="-2544.05"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_1-4"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca4-Lat-1" unit="cm" 
          x="285.02"
 	 y="745" 
@@ -50638,14 +44488,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_1-4"/>
-       <position name="posOpArapuca4-Lat-1" unit="cm" 
-         x="285.02"
-	 y="744.26" 
-	 z="-2544.05"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_1-5"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca5-Lat-1" unit="cm" 
          x="210.02"
 	 y="745" 
@@ -50653,14 +44496,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_1-5"/>
-       <position name="posOpArapuca5-Lat-1" unit="cm" 
-         x="210.02"
-	 y="744.26" 
-	 z="-2544.05"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_1-6"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca6-Lat-1" unit="cm" 
          x="135.02"
 	 y="745" 
@@ -50668,14 +44504,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_1-6"/>
-       <position name="posOpArapuca6-Lat-1" unit="cm" 
-         x="135.02"
-	 y="744.26" 
-	 z="-2544.05"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_1-7"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca7-Lat-1" unit="cm" 
          x="60.02"
 	 y="745" 
@@ -50683,14 +44512,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_1-7"/>
-       <position name="posOpArapuca7-Lat-1" unit="cm" 
-         x="60.02"
-	 y="744.26" 
-	 z="-2544.05"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_2-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca0-Lat-2" unit="cm" 
          x="285.02"
 	 y="-745" 
@@ -50698,14 +44520,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_2-0"/>
-       <position name="posOpArapuca0-Lat-2" unit="cm" 
-         x="285.02"
-	 y="-744.26" 
-	 z="-2244.75"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_2-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca1-Lat-2" unit="cm" 
          x="210.02"
 	 y="-745" 
@@ -50713,14 +44528,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_2-1"/>
-       <position name="posOpArapuca1-Lat-2" unit="cm" 
-         x="210.02"
-	 y="-744.26" 
-	 z="-2244.75"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_2-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca2-Lat-2" unit="cm" 
          x="135.02"
 	 y="-745" 
@@ -50728,14 +44536,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_2-2"/>
-       <position name="posOpArapuca2-Lat-2" unit="cm" 
-         x="135.02"
-	 y="-744.26" 
-	 z="-2244.75"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_2-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca3-Lat-2" unit="cm" 
          x="60.02"
 	 y="-745" 
@@ -50743,14 +44544,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_2-3"/>
-       <position name="posOpArapuca3-Lat-2" unit="cm" 
-         x="60.02"
-	 y="-744.26" 
-	 z="-2244.75"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_2-4"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca4-Lat-2" unit="cm" 
          x="285.02"
 	 y="745" 
@@ -50758,14 +44552,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_2-4"/>
-       <position name="posOpArapuca4-Lat-2" unit="cm" 
-         x="285.02"
-	 y="744.26" 
-	 z="-2244.75"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_2-5"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca5-Lat-2" unit="cm" 
          x="210.02"
 	 y="745" 
@@ -50773,14 +44560,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_2-5"/>
-       <position name="posOpArapuca5-Lat-2" unit="cm" 
-         x="210.02"
-	 y="744.26" 
-	 z="-2244.75"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_2-6"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca6-Lat-2" unit="cm" 
          x="135.02"
 	 y="745" 
@@ -50788,14 +44568,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_2-6"/>
-       <position name="posOpArapuca6-Lat-2" unit="cm" 
-         x="135.02"
-	 y="744.26" 
-	 z="-2244.75"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_2-7"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca7-Lat-2" unit="cm" 
          x="60.02"
 	 y="745" 
@@ -50803,14 +44576,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_2-7"/>
-       <position name="posOpArapuca7-Lat-2" unit="cm" 
-         x="60.02"
-	 y="744.26" 
-	 z="-2244.75"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_3-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca0-Lat-3" unit="cm" 
          x="285.02"
 	 y="-745" 
@@ -50818,14 +44584,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_3-0"/>
-       <position name="posOpArapuca0-Lat-3" unit="cm" 
-         x="285.02"
-	 y="-744.26" 
-	 z="-1945.45"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_3-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca1-Lat-3" unit="cm" 
          x="210.02"
 	 y="-745" 
@@ -50833,14 +44592,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_3-1"/>
-       <position name="posOpArapuca1-Lat-3" unit="cm" 
-         x="210.02"
-	 y="-744.26" 
-	 z="-1945.45"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_3-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca2-Lat-3" unit="cm" 
          x="135.02"
 	 y="-745" 
@@ -50848,14 +44600,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_3-2"/>
-       <position name="posOpArapuca2-Lat-3" unit="cm" 
-         x="135.02"
-	 y="-744.26" 
-	 z="-1945.45"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_3-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca3-Lat-3" unit="cm" 
          x="60.02"
 	 y="-745" 
@@ -50863,14 +44608,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_3-3"/>
-       <position name="posOpArapuca3-Lat-3" unit="cm" 
-         x="60.02"
-	 y="-744.26" 
-	 z="-1945.45"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_3-4"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca4-Lat-3" unit="cm" 
          x="285.02"
 	 y="745" 
@@ -50878,14 +44616,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_3-4"/>
-       <position name="posOpArapuca4-Lat-3" unit="cm" 
-         x="285.02"
-	 y="744.26" 
-	 z="-1945.45"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_3-5"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca5-Lat-3" unit="cm" 
          x="210.02"
 	 y="745" 
@@ -50893,14 +44624,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_3-5"/>
-       <position name="posOpArapuca5-Lat-3" unit="cm" 
-         x="210.02"
-	 y="744.26" 
-	 z="-1945.45"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_3-6"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca6-Lat-3" unit="cm" 
          x="135.02"
 	 y="745" 
@@ -50908,14 +44632,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_3-6"/>
-       <position name="posOpArapuca6-Lat-3" unit="cm" 
-         x="135.02"
-	 y="744.26" 
-	 z="-1945.45"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_3-7"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca7-Lat-3" unit="cm" 
          x="60.02"
 	 y="745" 
@@ -50923,14 +44640,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_3-7"/>
-       <position name="posOpArapuca7-Lat-3" unit="cm" 
-         x="60.02"
-	 y="744.26" 
-	 z="-1945.45"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_4-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca0-Lat-4" unit="cm" 
          x="285.02"
 	 y="-745" 
@@ -50938,14 +44648,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_4-0"/>
-       <position name="posOpArapuca0-Lat-4" unit="cm" 
-         x="285.02"
-	 y="-744.26" 
-	 z="-1646.15"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_4-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca1-Lat-4" unit="cm" 
          x="210.02"
 	 y="-745" 
@@ -50953,14 +44656,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_4-1"/>
-       <position name="posOpArapuca1-Lat-4" unit="cm" 
-         x="210.02"
-	 y="-744.26" 
-	 z="-1646.15"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_4-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca2-Lat-4" unit="cm" 
          x="135.02"
 	 y="-745" 
@@ -50968,14 +44664,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_4-2"/>
-       <position name="posOpArapuca2-Lat-4" unit="cm" 
-         x="135.02"
-	 y="-744.26" 
-	 z="-1646.15"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_4-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca3-Lat-4" unit="cm" 
          x="60.02"
 	 y="-745" 
@@ -50983,14 +44672,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_4-3"/>
-       <position name="posOpArapuca3-Lat-4" unit="cm" 
-         x="60.02"
-	 y="-744.26" 
-	 z="-1646.15"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_4-4"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca4-Lat-4" unit="cm" 
          x="285.02"
 	 y="745" 
@@ -50998,14 +44680,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_4-4"/>
-       <position name="posOpArapuca4-Lat-4" unit="cm" 
-         x="285.02"
-	 y="744.26" 
-	 z="-1646.15"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_4-5"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca5-Lat-4" unit="cm" 
          x="210.02"
 	 y="745" 
@@ -51013,14 +44688,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_4-5"/>
-       <position name="posOpArapuca5-Lat-4" unit="cm" 
-         x="210.02"
-	 y="744.26" 
-	 z="-1646.15"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_4-6"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca6-Lat-4" unit="cm" 
          x="135.02"
 	 y="745" 
@@ -51028,14 +44696,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_4-6"/>
-       <position name="posOpArapuca6-Lat-4" unit="cm" 
-         x="135.02"
-	 y="744.26" 
-	 z="-1646.15"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_4-7"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca7-Lat-4" unit="cm" 
          x="60.02"
 	 y="745" 
@@ -51043,14 +44704,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_4-7"/>
-       <position name="posOpArapuca7-Lat-4" unit="cm" 
-         x="60.02"
-	 y="744.26" 
-	 z="-1646.15"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_5-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca0-Lat-5" unit="cm" 
          x="285.02"
 	 y="-745" 
@@ -51058,14 +44712,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_5-0"/>
-       <position name="posOpArapuca0-Lat-5" unit="cm" 
-         x="285.02"
-	 y="-744.26" 
-	 z="-1346.85"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_5-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca1-Lat-5" unit="cm" 
          x="210.02"
 	 y="-745" 
@@ -51073,14 +44720,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_5-1"/>
-       <position name="posOpArapuca1-Lat-5" unit="cm" 
-         x="210.02"
-	 y="-744.26" 
-	 z="-1346.85"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_5-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca2-Lat-5" unit="cm" 
          x="135.02"
 	 y="-745" 
@@ -51088,14 +44728,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_5-2"/>
-       <position name="posOpArapuca2-Lat-5" unit="cm" 
-         x="135.02"
-	 y="-744.26" 
-	 z="-1346.85"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_5-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca3-Lat-5" unit="cm" 
          x="60.02"
 	 y="-745" 
@@ -51103,14 +44736,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_5-3"/>
-       <position name="posOpArapuca3-Lat-5" unit="cm" 
-         x="60.02"
-	 y="-744.26" 
-	 z="-1346.85"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_5-4"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca4-Lat-5" unit="cm" 
          x="285.02"
 	 y="745" 
@@ -51118,14 +44744,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_5-4"/>
-       <position name="posOpArapuca4-Lat-5" unit="cm" 
-         x="285.02"
-	 y="744.26" 
-	 z="-1346.85"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_5-5"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca5-Lat-5" unit="cm" 
          x="210.02"
 	 y="745" 
@@ -51133,14 +44752,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_5-5"/>
-       <position name="posOpArapuca5-Lat-5" unit="cm" 
-         x="210.02"
-	 y="744.26" 
-	 z="-1346.85"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_5-6"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca6-Lat-5" unit="cm" 
          x="135.02"
 	 y="745" 
@@ -51148,14 +44760,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_5-6"/>
-       <position name="posOpArapuca6-Lat-5" unit="cm" 
-         x="135.02"
-	 y="744.26" 
-	 z="-1346.85"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_5-7"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca7-Lat-5" unit="cm" 
          x="60.02"
 	 y="745" 
@@ -51163,14 +44768,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_5-7"/>
-       <position name="posOpArapuca7-Lat-5" unit="cm" 
-         x="60.02"
-	 y="744.26" 
-	 z="-1346.85"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_6-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca0-Lat-6" unit="cm" 
          x="285.02"
 	 y="-745" 
@@ -51178,14 +44776,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_6-0"/>
-       <position name="posOpArapuca0-Lat-6" unit="cm" 
-         x="285.02"
-	 y="-744.26" 
-	 z="-1047.55"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_6-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca1-Lat-6" unit="cm" 
          x="210.02"
 	 y="-745" 
@@ -51193,14 +44784,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_6-1"/>
-       <position name="posOpArapuca1-Lat-6" unit="cm" 
-         x="210.02"
-	 y="-744.26" 
-	 z="-1047.55"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_6-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca2-Lat-6" unit="cm" 
          x="135.02"
 	 y="-745" 
@@ -51208,14 +44792,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_6-2"/>
-       <position name="posOpArapuca2-Lat-6" unit="cm" 
-         x="135.02"
-	 y="-744.26" 
-	 z="-1047.55"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_6-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca3-Lat-6" unit="cm" 
          x="60.02"
 	 y="-745" 
@@ -51223,14 +44800,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_6-3"/>
-       <position name="posOpArapuca3-Lat-6" unit="cm" 
-         x="60.02"
-	 y="-744.26" 
-	 z="-1047.55"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_6-4"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca4-Lat-6" unit="cm" 
          x="285.02"
 	 y="745" 
@@ -51238,14 +44808,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_6-4"/>
-       <position name="posOpArapuca4-Lat-6" unit="cm" 
-         x="285.02"
-	 y="744.26" 
-	 z="-1047.55"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_6-5"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca5-Lat-6" unit="cm" 
          x="210.02"
 	 y="745" 
@@ -51253,14 +44816,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_6-5"/>
-       <position name="posOpArapuca5-Lat-6" unit="cm" 
-         x="210.02"
-	 y="744.26" 
-	 z="-1047.55"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_6-6"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca6-Lat-6" unit="cm" 
          x="135.02"
 	 y="745" 
@@ -51268,14 +44824,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_6-6"/>
-       <position name="posOpArapuca6-Lat-6" unit="cm" 
-         x="135.02"
-	 y="744.26" 
-	 z="-1047.55"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_6-7"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca7-Lat-6" unit="cm" 
          x="60.02"
 	 y="745" 
@@ -51283,14 +44832,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_6-7"/>
-       <position name="posOpArapuca7-Lat-6" unit="cm" 
-         x="60.02"
-	 y="744.26" 
-	 z="-1047.55"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_7-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca0-Lat-7" unit="cm" 
          x="285.02"
 	 y="-745" 
@@ -51298,14 +44840,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_7-0"/>
-       <position name="posOpArapuca0-Lat-7" unit="cm" 
-         x="285.02"
-	 y="-744.26" 
-	 z="-748.25"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_7-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca1-Lat-7" unit="cm" 
          x="210.02"
 	 y="-745" 
@@ -51313,14 +44848,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_7-1"/>
-       <position name="posOpArapuca1-Lat-7" unit="cm" 
-         x="210.02"
-	 y="-744.26" 
-	 z="-748.25"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_7-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca2-Lat-7" unit="cm" 
          x="135.02"
 	 y="-745" 
@@ -51328,14 +44856,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_7-2"/>
-       <position name="posOpArapuca2-Lat-7" unit="cm" 
-         x="135.02"
-	 y="-744.26" 
-	 z="-748.25"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_7-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca3-Lat-7" unit="cm" 
          x="60.02"
 	 y="-745" 
@@ -51343,14 +44864,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_7-3"/>
-       <position name="posOpArapuca3-Lat-7" unit="cm" 
-         x="60.02"
-	 y="-744.26" 
-	 z="-748.25"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_7-4"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca4-Lat-7" unit="cm" 
          x="285.02"
 	 y="745" 
@@ -51358,14 +44872,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_7-4"/>
-       <position name="posOpArapuca4-Lat-7" unit="cm" 
-         x="285.02"
-	 y="744.26" 
-	 z="-748.25"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_7-5"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca5-Lat-7" unit="cm" 
          x="210.02"
 	 y="745" 
@@ -51373,14 +44880,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_7-5"/>
-       <position name="posOpArapuca5-Lat-7" unit="cm" 
-         x="210.02"
-	 y="744.26" 
-	 z="-748.25"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_7-6"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca6-Lat-7" unit="cm" 
          x="135.02"
 	 y="745" 
@@ -51388,14 +44888,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_7-6"/>
-       <position name="posOpArapuca6-Lat-7" unit="cm" 
-         x="135.02"
-	 y="744.26" 
-	 z="-748.25"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_7-7"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca7-Lat-7" unit="cm" 
          x="60.02"
 	 y="745" 
@@ -51403,14 +44896,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_7-7"/>
-       <position name="posOpArapuca7-Lat-7" unit="cm" 
-         x="60.02"
-	 y="744.26" 
-	 z="-748.25"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_8-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca0-Lat-8" unit="cm" 
          x="285.02"
 	 y="-745" 
@@ -51418,14 +44904,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_8-0"/>
-       <position name="posOpArapuca0-Lat-8" unit="cm" 
-         x="285.02"
-	 y="-744.26" 
-	 z="-448.95"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_8-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca1-Lat-8" unit="cm" 
          x="210.02"
 	 y="-745" 
@@ -51433,14 +44912,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_8-1"/>
-       <position name="posOpArapuca1-Lat-8" unit="cm" 
-         x="210.02"
-	 y="-744.26" 
-	 z="-448.95"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_8-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca2-Lat-8" unit="cm" 
          x="135.02"
 	 y="-745" 
@@ -51448,14 +44920,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_8-2"/>
-       <position name="posOpArapuca2-Lat-8" unit="cm" 
-         x="135.02"
-	 y="-744.26" 
-	 z="-448.95"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_8-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca3-Lat-8" unit="cm" 
          x="60.02"
 	 y="-745" 
@@ -51463,14 +44928,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_8-3"/>
-       <position name="posOpArapuca3-Lat-8" unit="cm" 
-         x="60.02"
-	 y="-744.26" 
-	 z="-448.95"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_8-4"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca4-Lat-8" unit="cm" 
          x="285.02"
 	 y="745" 
@@ -51478,14 +44936,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_8-4"/>
-       <position name="posOpArapuca4-Lat-8" unit="cm" 
-         x="285.02"
-	 y="744.26" 
-	 z="-448.95"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_8-5"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca5-Lat-8" unit="cm" 
          x="210.02"
 	 y="745" 
@@ -51493,14 +44944,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_8-5"/>
-       <position name="posOpArapuca5-Lat-8" unit="cm" 
-         x="210.02"
-	 y="744.26" 
-	 z="-448.95"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_8-6"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca6-Lat-8" unit="cm" 
          x="135.02"
 	 y="745" 
@@ -51508,14 +44952,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_8-6"/>
-       <position name="posOpArapuca6-Lat-8" unit="cm" 
-         x="135.02"
-	 y="744.26" 
-	 z="-448.95"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_8-7"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca7-Lat-8" unit="cm" 
          x="60.02"
 	 y="745" 
@@ -51523,14 +44960,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_8-7"/>
-       <position name="posOpArapuca7-Lat-8" unit="cm" 
-         x="60.02"
-	 y="744.26" 
-	 z="-448.95"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_9-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca0-Lat-9" unit="cm" 
          x="285.02"
 	 y="-745" 
@@ -51538,14 +44968,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_9-0"/>
-       <position name="posOpArapuca0-Lat-9" unit="cm" 
-         x="285.02"
-	 y="-744.26" 
-	 z="-149.65"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_9-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca1-Lat-9" unit="cm" 
          x="210.02"
 	 y="-745" 
@@ -51553,14 +44976,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_9-1"/>
-       <position name="posOpArapuca1-Lat-9" unit="cm" 
-         x="210.02"
-	 y="-744.26" 
-	 z="-149.65"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_9-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca2-Lat-9" unit="cm" 
          x="135.02"
 	 y="-745" 
@@ -51568,14 +44984,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_9-2"/>
-       <position name="posOpArapuca2-Lat-9" unit="cm" 
-         x="135.02"
-	 y="-744.26" 
-	 z="-149.65"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_9-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca3-Lat-9" unit="cm" 
          x="60.02"
 	 y="-745" 
@@ -51583,14 +44992,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_9-3"/>
-       <position name="posOpArapuca3-Lat-9" unit="cm" 
-         x="60.02"
-	 y="-744.26" 
-	 z="-149.65"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_9-4"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca4-Lat-9" unit="cm" 
          x="285.02"
 	 y="745" 
@@ -51598,14 +45000,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_9-4"/>
-       <position name="posOpArapuca4-Lat-9" unit="cm" 
-         x="285.02"
-	 y="744.26" 
-	 z="-149.65"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_9-5"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca5-Lat-9" unit="cm" 
          x="210.02"
 	 y="745" 
@@ -51613,14 +45008,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_9-5"/>
-       <position name="posOpArapuca5-Lat-9" unit="cm" 
-         x="210.02"
-	 y="744.26" 
-	 z="-149.65"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_9-6"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca6-Lat-9" unit="cm" 
          x="135.02"
 	 y="745" 
@@ -51628,14 +45016,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_9-6"/>
-       <position name="posOpArapuca6-Lat-9" unit="cm" 
-         x="135.02"
-	 y="744.26" 
-	 z="-149.65"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_9-7"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca7-Lat-9" unit="cm" 
          x="60.02"
 	 y="745" 
@@ -51643,14 +45024,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_9-7"/>
-       <position name="posOpArapuca7-Lat-9" unit="cm" 
-         x="60.02"
-	 y="744.26" 
-	 z="-149.65"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_10-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca0-Lat-10" unit="cm" 
          x="285.02"
 	 y="-745" 
@@ -51658,14 +45032,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_10-0"/>
-       <position name="posOpArapuca0-Lat-10" unit="cm" 
-         x="285.02"
-	 y="-744.26" 
-	 z="149.65"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_10-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca1-Lat-10" unit="cm" 
          x="210.02"
 	 y="-745" 
@@ -51673,14 +45040,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_10-1"/>
-       <position name="posOpArapuca1-Lat-10" unit="cm" 
-         x="210.02"
-	 y="-744.26" 
-	 z="149.65"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_10-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca2-Lat-10" unit="cm" 
          x="135.02"
 	 y="-745" 
@@ -51688,14 +45048,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_10-2"/>
-       <position name="posOpArapuca2-Lat-10" unit="cm" 
-         x="135.02"
-	 y="-744.26" 
-	 z="149.65"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_10-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca3-Lat-10" unit="cm" 
          x="60.02"
 	 y="-745" 
@@ -51703,14 +45056,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_10-3"/>
-       <position name="posOpArapuca3-Lat-10" unit="cm" 
-         x="60.02"
-	 y="-744.26" 
-	 z="149.65"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_10-4"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca4-Lat-10" unit="cm" 
          x="285.02"
 	 y="745" 
@@ -51718,14 +45064,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_10-4"/>
-       <position name="posOpArapuca4-Lat-10" unit="cm" 
-         x="285.02"
-	 y="744.26" 
-	 z="149.65"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_10-5"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca5-Lat-10" unit="cm" 
          x="210.02"
 	 y="745" 
@@ -51733,14 +45072,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_10-5"/>
-       <position name="posOpArapuca5-Lat-10" unit="cm" 
-         x="210.02"
-	 y="744.26" 
-	 z="149.65"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_10-6"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca6-Lat-10" unit="cm" 
          x="135.02"
 	 y="745" 
@@ -51748,14 +45080,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_10-6"/>
-       <position name="posOpArapuca6-Lat-10" unit="cm" 
-         x="135.02"
-	 y="744.26" 
-	 z="149.65"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_10-7"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca7-Lat-10" unit="cm" 
          x="60.02"
 	 y="745" 
@@ -51763,14 +45088,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_10-7"/>
-       <position name="posOpArapuca7-Lat-10" unit="cm" 
-         x="60.02"
-	 y="744.26" 
-	 z="149.65"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_11-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca0-Lat-11" unit="cm" 
          x="285.02"
 	 y="-745" 
@@ -51778,14 +45096,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_11-0"/>
-       <position name="posOpArapuca0-Lat-11" unit="cm" 
-         x="285.02"
-	 y="-744.26" 
-	 z="448.95"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_11-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca1-Lat-11" unit="cm" 
          x="210.02"
 	 y="-745" 
@@ -51793,14 +45104,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_11-1"/>
-       <position name="posOpArapuca1-Lat-11" unit="cm" 
-         x="210.02"
-	 y="-744.26" 
-	 z="448.95"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_11-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca2-Lat-11" unit="cm" 
          x="135.02"
 	 y="-745" 
@@ -51808,14 +45112,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_11-2"/>
-       <position name="posOpArapuca2-Lat-11" unit="cm" 
-         x="135.02"
-	 y="-744.26" 
-	 z="448.95"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_11-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca3-Lat-11" unit="cm" 
          x="60.02"
 	 y="-745" 
@@ -51823,14 +45120,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_11-3"/>
-       <position name="posOpArapuca3-Lat-11" unit="cm" 
-         x="60.02"
-	 y="-744.26" 
-	 z="448.95"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_11-4"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca4-Lat-11" unit="cm" 
          x="285.02"
 	 y="745" 
@@ -51838,14 +45128,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_11-4"/>
-       <position name="posOpArapuca4-Lat-11" unit="cm" 
-         x="285.02"
-	 y="744.26" 
-	 z="448.95"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_11-5"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca5-Lat-11" unit="cm" 
          x="210.02"
 	 y="745" 
@@ -51853,14 +45136,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_11-5"/>
-       <position name="posOpArapuca5-Lat-11" unit="cm" 
-         x="210.02"
-	 y="744.26" 
-	 z="448.95"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_11-6"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca6-Lat-11" unit="cm" 
          x="135.02"
 	 y="745" 
@@ -51868,14 +45144,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_11-6"/>
-       <position name="posOpArapuca6-Lat-11" unit="cm" 
-         x="135.02"
-	 y="744.26" 
-	 z="448.95"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_11-7"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca7-Lat-11" unit="cm" 
          x="60.02"
 	 y="745" 
@@ -51883,14 +45152,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_11-7"/>
-       <position name="posOpArapuca7-Lat-11" unit="cm" 
-         x="60.02"
-	 y="744.26" 
-	 z="448.95"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_12-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca0-Lat-12" unit="cm" 
          x="285.02"
 	 y="-745" 
@@ -51898,14 +45160,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_12-0"/>
-       <position name="posOpArapuca0-Lat-12" unit="cm" 
-         x="285.02"
-	 y="-744.26" 
-	 z="748.25"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_12-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca1-Lat-12" unit="cm" 
          x="210.02"
 	 y="-745" 
@@ -51913,14 +45168,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_12-1"/>
-       <position name="posOpArapuca1-Lat-12" unit="cm" 
-         x="210.02"
-	 y="-744.26" 
-	 z="748.25"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_12-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca2-Lat-12" unit="cm" 
          x="135.02"
 	 y="-745" 
@@ -51928,14 +45176,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_12-2"/>
-       <position name="posOpArapuca2-Lat-12" unit="cm" 
-         x="135.02"
-	 y="-744.26" 
-	 z="748.25"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_12-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca3-Lat-12" unit="cm" 
          x="60.02"
 	 y="-745" 
@@ -51943,14 +45184,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_12-3"/>
-       <position name="posOpArapuca3-Lat-12" unit="cm" 
-         x="60.02"
-	 y="-744.26" 
-	 z="748.25"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_12-4"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca4-Lat-12" unit="cm" 
          x="285.02"
 	 y="745" 
@@ -51958,14 +45192,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_12-4"/>
-       <position name="posOpArapuca4-Lat-12" unit="cm" 
-         x="285.02"
-	 y="744.26" 
-	 z="748.25"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_12-5"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca5-Lat-12" unit="cm" 
          x="210.02"
 	 y="745" 
@@ -51973,14 +45200,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_12-5"/>
-       <position name="posOpArapuca5-Lat-12" unit="cm" 
-         x="210.02"
-	 y="744.26" 
-	 z="748.25"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_12-6"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca6-Lat-12" unit="cm" 
          x="135.02"
 	 y="745" 
@@ -51988,14 +45208,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_12-6"/>
-       <position name="posOpArapuca6-Lat-12" unit="cm" 
-         x="135.02"
-	 y="744.26" 
-	 z="748.25"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_12-7"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca7-Lat-12" unit="cm" 
          x="60.02"
 	 y="745" 
@@ -52003,14 +45216,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_12-7"/>
-       <position name="posOpArapuca7-Lat-12" unit="cm" 
-         x="60.02"
-	 y="744.26" 
-	 z="748.25"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_13-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca0-Lat-13" unit="cm" 
          x="285.02"
 	 y="-745" 
@@ -52018,14 +45224,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_13-0"/>
-       <position name="posOpArapuca0-Lat-13" unit="cm" 
-         x="285.02"
-	 y="-744.26" 
-	 z="1047.55"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_13-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca1-Lat-13" unit="cm" 
          x="210.02"
 	 y="-745" 
@@ -52033,14 +45232,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_13-1"/>
-       <position name="posOpArapuca1-Lat-13" unit="cm" 
-         x="210.02"
-	 y="-744.26" 
-	 z="1047.55"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_13-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca2-Lat-13" unit="cm" 
          x="135.02"
 	 y="-745" 
@@ -52048,14 +45240,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_13-2"/>
-       <position name="posOpArapuca2-Lat-13" unit="cm" 
-         x="135.02"
-	 y="-744.26" 
-	 z="1047.55"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_13-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca3-Lat-13" unit="cm" 
          x="60.02"
 	 y="-745" 
@@ -52063,14 +45248,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_13-3"/>
-       <position name="posOpArapuca3-Lat-13" unit="cm" 
-         x="60.02"
-	 y="-744.26" 
-	 z="1047.55"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_13-4"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca4-Lat-13" unit="cm" 
          x="285.02"
 	 y="745" 
@@ -52078,14 +45256,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_13-4"/>
-       <position name="posOpArapuca4-Lat-13" unit="cm" 
-         x="285.02"
-	 y="744.26" 
-	 z="1047.55"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_13-5"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca5-Lat-13" unit="cm" 
          x="210.02"
 	 y="745" 
@@ -52093,14 +45264,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_13-5"/>
-       <position name="posOpArapuca5-Lat-13" unit="cm" 
-         x="210.02"
-	 y="744.26" 
-	 z="1047.55"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_13-6"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca6-Lat-13" unit="cm" 
          x="135.02"
 	 y="745" 
@@ -52108,14 +45272,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_13-6"/>
-       <position name="posOpArapuca6-Lat-13" unit="cm" 
-         x="135.02"
-	 y="744.26" 
-	 z="1047.55"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_13-7"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca7-Lat-13" unit="cm" 
          x="60.02"
 	 y="745" 
@@ -52123,14 +45280,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_13-7"/>
-       <position name="posOpArapuca7-Lat-13" unit="cm" 
-         x="60.02"
-	 y="744.26" 
-	 z="1047.55"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_14-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca0-Lat-14" unit="cm" 
          x="285.02"
 	 y="-745" 
@@ -52138,14 +45288,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_14-0"/>
-       <position name="posOpArapuca0-Lat-14" unit="cm" 
-         x="285.02"
-	 y="-744.26" 
-	 z="1346.85"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_14-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca1-Lat-14" unit="cm" 
          x="210.02"
 	 y="-745" 
@@ -52153,14 +45296,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_14-1"/>
-       <position name="posOpArapuca1-Lat-14" unit="cm" 
-         x="210.02"
-	 y="-744.26" 
-	 z="1346.85"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_14-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca2-Lat-14" unit="cm" 
          x="135.02"
 	 y="-745" 
@@ -52168,14 +45304,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_14-2"/>
-       <position name="posOpArapuca2-Lat-14" unit="cm" 
-         x="135.02"
-	 y="-744.26" 
-	 z="1346.85"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_14-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca3-Lat-14" unit="cm" 
          x="60.02"
 	 y="-745" 
@@ -52183,14 +45312,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_14-3"/>
-       <position name="posOpArapuca3-Lat-14" unit="cm" 
-         x="60.02"
-	 y="-744.26" 
-	 z="1346.85"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_14-4"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca4-Lat-14" unit="cm" 
          x="285.02"
 	 y="745" 
@@ -52198,14 +45320,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_14-4"/>
-       <position name="posOpArapuca4-Lat-14" unit="cm" 
-         x="285.02"
-	 y="744.26" 
-	 z="1346.85"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_14-5"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca5-Lat-14" unit="cm" 
          x="210.02"
 	 y="745" 
@@ -52213,14 +45328,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_14-5"/>
-       <position name="posOpArapuca5-Lat-14" unit="cm" 
-         x="210.02"
-	 y="744.26" 
-	 z="1346.85"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_14-6"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca6-Lat-14" unit="cm" 
          x="135.02"
 	 y="745" 
@@ -52228,14 +45336,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_14-6"/>
-       <position name="posOpArapuca6-Lat-14" unit="cm" 
-         x="135.02"
-	 y="744.26" 
-	 z="1346.85"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_14-7"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca7-Lat-14" unit="cm" 
          x="60.02"
 	 y="745" 
@@ -52243,14 +45344,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_14-7"/>
-       <position name="posOpArapuca7-Lat-14" unit="cm" 
-         x="60.02"
-	 y="744.26" 
-	 z="1346.85"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_15-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca0-Lat-15" unit="cm" 
          x="285.02"
 	 y="-745" 
@@ -52258,14 +45352,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_15-0"/>
-       <position name="posOpArapuca0-Lat-15" unit="cm" 
-         x="285.02"
-	 y="-744.26" 
-	 z="1646.15"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_15-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca1-Lat-15" unit="cm" 
          x="210.02"
 	 y="-745" 
@@ -52273,14 +45360,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_15-1"/>
-       <position name="posOpArapuca1-Lat-15" unit="cm" 
-         x="210.02"
-	 y="-744.26" 
-	 z="1646.15"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_15-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca2-Lat-15" unit="cm" 
          x="135.02"
 	 y="-745" 
@@ -52288,14 +45368,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_15-2"/>
-       <position name="posOpArapuca2-Lat-15" unit="cm" 
-         x="135.02"
-	 y="-744.26" 
-	 z="1646.15"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_15-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca3-Lat-15" unit="cm" 
          x="60.02"
 	 y="-745" 
@@ -52303,14 +45376,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_15-3"/>
-       <position name="posOpArapuca3-Lat-15" unit="cm" 
-         x="60.02"
-	 y="-744.26" 
-	 z="1646.15"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_15-4"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca4-Lat-15" unit="cm" 
          x="285.02"
 	 y="745" 
@@ -52318,14 +45384,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_15-4"/>
-       <position name="posOpArapuca4-Lat-15" unit="cm" 
-         x="285.02"
-	 y="744.26" 
-	 z="1646.15"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_15-5"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca5-Lat-15" unit="cm" 
          x="210.02"
 	 y="745" 
@@ -52333,14 +45392,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_15-5"/>
-       <position name="posOpArapuca5-Lat-15" unit="cm" 
-         x="210.02"
-	 y="744.26" 
-	 z="1646.15"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_15-6"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca6-Lat-15" unit="cm" 
          x="135.02"
 	 y="745" 
@@ -52348,14 +45400,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_15-6"/>
-       <position name="posOpArapuca6-Lat-15" unit="cm" 
-         x="135.02"
-	 y="744.26" 
-	 z="1646.15"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_15-7"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca7-Lat-15" unit="cm" 
          x="60.02"
 	 y="745" 
@@ -52363,14 +45408,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_15-7"/>
-       <position name="posOpArapuca7-Lat-15" unit="cm" 
-         x="60.02"
-	 y="744.26" 
-	 z="1646.15"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_16-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca0-Lat-16" unit="cm" 
          x="285.02"
 	 y="-745" 
@@ -52378,14 +45416,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_16-0"/>
-       <position name="posOpArapuca0-Lat-16" unit="cm" 
-         x="285.02"
-	 y="-744.26" 
-	 z="1945.45"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_16-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca1-Lat-16" unit="cm" 
          x="210.02"
 	 y="-745" 
@@ -52393,14 +45424,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_16-1"/>
-       <position name="posOpArapuca1-Lat-16" unit="cm" 
-         x="210.02"
-	 y="-744.26" 
-	 z="1945.45"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_16-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca2-Lat-16" unit="cm" 
          x="135.02"
 	 y="-745" 
@@ -52408,14 +45432,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_16-2"/>
-       <position name="posOpArapuca2-Lat-16" unit="cm" 
-         x="135.02"
-	 y="-744.26" 
-	 z="1945.45"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_16-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca3-Lat-16" unit="cm" 
          x="60.02"
 	 y="-745" 
@@ -52423,14 +45440,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_16-3"/>
-       <position name="posOpArapuca3-Lat-16" unit="cm" 
-         x="60.02"
-	 y="-744.26" 
-	 z="1945.45"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_16-4"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca4-Lat-16" unit="cm" 
          x="285.02"
 	 y="745" 
@@ -52438,14 +45448,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_16-4"/>
-       <position name="posOpArapuca4-Lat-16" unit="cm" 
-         x="285.02"
-	 y="744.26" 
-	 z="1945.45"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_16-5"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca5-Lat-16" unit="cm" 
          x="210.02"
 	 y="745" 
@@ -52453,14 +45456,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_16-5"/>
-       <position name="posOpArapuca5-Lat-16" unit="cm" 
-         x="210.02"
-	 y="744.26" 
-	 z="1945.45"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_16-6"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca6-Lat-16" unit="cm" 
          x="135.02"
 	 y="745" 
@@ -52468,14 +45464,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_16-6"/>
-       <position name="posOpArapuca6-Lat-16" unit="cm" 
-         x="135.02"
-	 y="744.26" 
-	 z="1945.45"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_16-7"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca7-Lat-16" unit="cm" 
          x="60.02"
 	 y="745" 
@@ -52483,14 +45472,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_16-7"/>
-       <position name="posOpArapuca7-Lat-16" unit="cm" 
-         x="60.02"
-	 y="744.26" 
-	 z="1945.45"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_17-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca0-Lat-17" unit="cm" 
          x="285.02"
 	 y="-745" 
@@ -52498,14 +45480,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_17-0"/>
-       <position name="posOpArapuca0-Lat-17" unit="cm" 
-         x="285.02"
-	 y="-744.26" 
-	 z="2244.75"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_17-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca1-Lat-17" unit="cm" 
          x="210.02"
 	 y="-745" 
@@ -52513,14 +45488,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_17-1"/>
-       <position name="posOpArapuca1-Lat-17" unit="cm" 
-         x="210.02"
-	 y="-744.26" 
-	 z="2244.75"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_17-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca2-Lat-17" unit="cm" 
          x="135.02"
 	 y="-745" 
@@ -52528,14 +45496,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_17-2"/>
-       <position name="posOpArapuca2-Lat-17" unit="cm" 
-         x="135.02"
-	 y="-744.26" 
-	 z="2244.75"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_17-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca3-Lat-17" unit="cm" 
          x="60.02"
 	 y="-745" 
@@ -52543,14 +45504,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_17-3"/>
-       <position name="posOpArapuca3-Lat-17" unit="cm" 
-         x="60.02"
-	 y="-744.26" 
-	 z="2244.75"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_17-4"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca4-Lat-17" unit="cm" 
          x="285.02"
 	 y="745" 
@@ -52558,14 +45512,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_17-4"/>
-       <position name="posOpArapuca4-Lat-17" unit="cm" 
-         x="285.02"
-	 y="744.26" 
-	 z="2244.75"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_17-5"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca5-Lat-17" unit="cm" 
          x="210.02"
 	 y="745" 
@@ -52573,14 +45520,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_17-5"/>
-       <position name="posOpArapuca5-Lat-17" unit="cm" 
-         x="210.02"
-	 y="744.26" 
-	 z="2244.75"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_17-6"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca6-Lat-17" unit="cm" 
          x="135.02"
 	 y="745" 
@@ -52588,14 +45528,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_17-6"/>
-       <position name="posOpArapuca6-Lat-17" unit="cm" 
-         x="135.02"
-	 y="744.26" 
-	 z="2244.75"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_17-7"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca7-Lat-17" unit="cm" 
          x="60.02"
 	 y="745" 
@@ -52603,14 +45536,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_17-7"/>
-       <position name="posOpArapuca7-Lat-17" unit="cm" 
-         x="60.02"
-	 y="744.26" 
-	 z="2244.75"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_18-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca0-Lat-18" unit="cm" 
          x="285.02"
 	 y="-745" 
@@ -52618,14 +45544,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_18-0"/>
-       <position name="posOpArapuca0-Lat-18" unit="cm" 
-         x="285.02"
-	 y="-744.26" 
-	 z="2544.05"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_18-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca1-Lat-18" unit="cm" 
          x="210.02"
 	 y="-745" 
@@ -52633,14 +45552,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_18-1"/>
-       <position name="posOpArapuca1-Lat-18" unit="cm" 
-         x="210.02"
-	 y="-744.26" 
-	 z="2544.05"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_18-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca2-Lat-18" unit="cm" 
          x="135.02"
 	 y="-745" 
@@ -52648,14 +45560,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_18-2"/>
-       <position name="posOpArapuca2-Lat-18" unit="cm" 
-         x="135.02"
-	 y="-744.26" 
-	 z="2544.05"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_18-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca3-Lat-18" unit="cm" 
          x="60.02"
 	 y="-745" 
@@ -52663,14 +45568,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_18-3"/>
-       <position name="posOpArapuca3-Lat-18" unit="cm" 
-         x="60.02"
-	 y="-744.26" 
-	 z="2544.05"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_18-4"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca4-Lat-18" unit="cm" 
          x="285.02"
 	 y="745" 
@@ -52678,14 +45576,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_18-4"/>
-       <position name="posOpArapuca4-Lat-18" unit="cm" 
-         x="285.02"
-	 y="744.26" 
-	 z="2544.05"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_18-5"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca5-Lat-18" unit="cm" 
          x="210.02"
 	 y="745" 
@@ -52693,14 +45584,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_18-5"/>
-       <position name="posOpArapuca5-Lat-18" unit="cm" 
-         x="210.02"
-	 y="744.26" 
-	 z="2544.05"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_18-6"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca6-Lat-18" unit="cm" 
          x="135.02"
 	 y="745" 
@@ -52708,14 +45592,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_18-6"/>
-       <position name="posOpArapuca6-Lat-18" unit="cm" 
-         x="135.02"
-	 y="744.26" 
-	 z="2544.05"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_18-7"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca7-Lat-18" unit="cm" 
          x="60.02"
 	 y="745" 
@@ -52723,14 +45600,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_18-7"/>
-       <position name="posOpArapuca7-Lat-18" unit="cm" 
-         x="60.02"
-	 y="744.26" 
-	 z="2544.05"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_19-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca0-Lat-19" unit="cm" 
          x="285.02"
 	 y="-745" 
@@ -52738,14 +45608,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_19-0"/>
-       <position name="posOpArapuca0-Lat-19" unit="cm" 
-         x="285.02"
-	 y="-744.26" 
-	 z="2843.35"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_19-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca1-Lat-19" unit="cm" 
          x="210.02"
 	 y="-745" 
@@ -52753,14 +45616,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_19-1"/>
-       <position name="posOpArapuca1-Lat-19" unit="cm" 
-         x="210.02"
-	 y="-744.26" 
-	 z="2843.35"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_19-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca2-Lat-19" unit="cm" 
          x="135.02"
 	 y="-745" 
@@ -52768,14 +45624,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_19-2"/>
-       <position name="posOpArapuca2-Lat-19" unit="cm" 
-         x="135.02"
-	 y="-744.26" 
-	 z="2843.35"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_19-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca3-Lat-19" unit="cm" 
          x="60.02"
 	 y="-745" 
@@ -52783,14 +45632,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_19-3"/>
-       <position name="posOpArapuca3-Lat-19" unit="cm" 
-         x="60.02"
-	 y="-744.26" 
-	 z="2843.35"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_19-4"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca4-Lat-19" unit="cm" 
          x="285.02"
 	 y="745" 
@@ -52798,14 +45640,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_19-4"/>
-       <position name="posOpArapuca4-Lat-19" unit="cm" 
-         x="285.02"
-	 y="744.26" 
-	 z="2843.35"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_19-5"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca5-Lat-19" unit="cm" 
          x="210.02"
 	 y="745" 
@@ -52813,14 +45648,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_19-5"/>
-       <position name="posOpArapuca5-Lat-19" unit="cm" 
-         x="210.02"
-	 y="744.26" 
-	 z="2843.35"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_19-6"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca6-Lat-19" unit="cm" 
          x="135.02"
 	 y="745" 
@@ -52828,14 +45656,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_19-6"/>
-       <position name="posOpArapuca6-Lat-19" unit="cm" 
-         x="135.02"
-	 y="744.26" 
-	 z="2843.35"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_19-7"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca7-Lat-19" unit="cm" 
          x="60.02"
 	 y="745" 
@@ -52843,15 +45664,8 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_19-7"/>
-       <position name="posOpArapuca7-Lat-19" unit="cm" 
-         x="60.02"
-	 y="744.26" 
-	 z="2843.35"/>
-     </physvol>
-     <physvol>
        <volumeref ref="volArapuca"/>
-       <position name="posArapuca0-ShortLat-19" unit="cm" 
+       <position name="posArapuca0-ShortLat-220" unit="cm" 
          x="285.02"
 	 y="-220" 
 	 z="-3090"/>
@@ -52859,7 +45673,7 @@
      </physvol>
      <physvol>
        <volumeref ref="volArapuca"/>
-       <position name="posArapuca1-ShortLat-19" unit="cm" 
+       <position name="posArapuca1-ShortLat-220" unit="cm" 
          x="210.02"
 	 y="-220" 
 	 z="-3090"/>
@@ -52867,7 +45681,7 @@
      </physvol>
      <physvol>
        <volumeref ref="volArapuca"/>
-       <position name="posArapuca2-ShortLat-19" unit="cm" 
+       <position name="posArapuca2-ShortLat-220" unit="cm" 
          x="135.02"
 	 y="-220" 
 	 z="-3090"/>
@@ -52875,7 +45689,7 @@
      </physvol>
      <physvol>
        <volumeref ref="volArapuca"/>
-       <position name="posArapuca3-ShortLat-19" unit="cm" 
+       <position name="posArapuca3-ShortLat-220" unit="cm" 
          x="60.02"
 	 y="-220" 
 	 z="-3090"/>
@@ -52883,7 +45697,7 @@
      </physvol>
      <physvol>
        <volumeref ref="volArapuca"/>
-       <position name="posArapuca4-ShortLat-19" unit="cm" 
+       <position name="posArapuca4-ShortLat-220" unit="cm" 
          x="285.02"
 	 y="-220" 
 	 z="3090"/>
@@ -52891,7 +45705,7 @@
      </physvol>
      <physvol>
        <volumeref ref="volArapuca"/>
-       <position name="posArapuca5-ShortLat-19" unit="cm" 
+       <position name="posArapuca5-ShortLat-220" unit="cm" 
          x="210.02"
 	 y="-220" 
 	 z="3090"/>
@@ -52899,7 +45713,7 @@
      </physvol>
      <physvol>
        <volumeref ref="volArapuca"/>
-       <position name="posArapuca6-ShortLat-19" unit="cm" 
+       <position name="posArapuca6-ShortLat-220" unit="cm" 
          x="135.02"
 	 y="-220" 
 	 z="3090"/>
@@ -52907,7 +45721,7 @@
      </physvol>
      <physvol>
        <volumeref ref="volArapuca"/>
-       <position name="posArapuca7-ShortLat-19" unit="cm" 
+       <position name="posArapuca7-ShortLat-220" unit="cm" 
          x="60.02"
 	 y="-220" 
 	 z="3090"/>
@@ -52915,7 +45729,7 @@
      </physvol>
      <physvol>
        <volumeref ref="volArapuca"/>
-       <position name="posArapuca0-ShortLat-19" unit="cm" 
+       <position name="posArapuca0-ShortLat220" unit="cm" 
          x="285.02"
 	 y="220" 
 	 z="-3090"/>
@@ -52923,7 +45737,7 @@
      </physvol>
      <physvol>
        <volumeref ref="volArapuca"/>
-       <position name="posArapuca1-ShortLat-19" unit="cm" 
+       <position name="posArapuca1-ShortLat220" unit="cm" 
          x="210.02"
 	 y="220" 
 	 z="-3090"/>
@@ -52931,7 +45745,7 @@
      </physvol>
      <physvol>
        <volumeref ref="volArapuca"/>
-       <position name="posArapuca2-ShortLat-19" unit="cm" 
+       <position name="posArapuca2-ShortLat220" unit="cm" 
          x="135.02"
 	 y="220" 
 	 z="-3090"/>
@@ -52939,7 +45753,7 @@
      </physvol>
      <physvol>
        <volumeref ref="volArapuca"/>
-       <position name="posArapuca3-ShortLat-19" unit="cm" 
+       <position name="posArapuca3-ShortLat220" unit="cm" 
          x="60.02"
 	 y="220" 
 	 z="-3090"/>
@@ -52947,7 +45761,7 @@
      </physvol>
      <physvol>
        <volumeref ref="volArapuca"/>
-       <position name="posArapuca4-ShortLat-19" unit="cm" 
+       <position name="posArapuca4-ShortLat220" unit="cm" 
          x="285.02"
 	 y="220" 
 	 z="3090"/>
@@ -52955,7 +45769,7 @@
      </physvol>
      <physvol>
        <volumeref ref="volArapuca"/>
-       <position name="posArapuca5-ShortLat-19" unit="cm" 
+       <position name="posArapuca5-ShortLat220" unit="cm" 
          x="210.02"
 	 y="220" 
 	 z="3090"/>
@@ -52963,7 +45777,7 @@
      </physvol>
      <physvol>
        <volumeref ref="volArapuca"/>
-       <position name="posArapuca6-ShortLat-19" unit="cm" 
+       <position name="posArapuca6-ShortLat220" unit="cm" 
          x="135.02"
 	 y="220" 
 	 z="3090"/>
@@ -52971,7 +45785,7 @@
      </physvol>
      <physvol>
        <volumeref ref="volArapuca"/>
-       <position name="posArapuca7-ShortLat-19" unit="cm" 
+       <position name="posArapuca7-ShortLat220" unit="cm" 
          x="60.02"
 	 y="220" 
 	 z="3090"/>

--- a/dunecore/Geometry/gdml/dunevd10kt_3view_30deg_v5_refactored_1x8x20ref_nowires.gdml
+++ b/dunecore/Geometry/gdml/dunevd10kt_3view_30deg_v5_refactored_1x8x20ref_nowires.gdml
@@ -1,0 +1,15062 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<gdml_simple_extension xmlns:gdml_simple_extension="http://www.example.org"
+                       xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"          
+                       xs:noNamespaceSchemaLocation="RefactoredGDMLSchema/SimpleExtension.xsd"> 
+
+
+<extension>
+   <color name="magenta"     R="0.0"  G="1.0"  B="0.0"  A="1.0" />
+   <color name="green"       R="0.0"  G="1.0"  B="0.0"  A="1.0" />
+   <color name="red"         R="1.0"  G="0.0"  B="0.0"  A="1.0" />
+   <color name="blue"        R="0.0"  G="0.0"  B="1.0"  A="1.0" />
+   <color name="yellow"      R="1.0"  G="1.0"  B="0.0"  A="1.0" />    
+</extension>
+<define>
+
+<!--
+
+
+
+-->
+
+   <position name="posCryoInDetEnc"     unit="cm" x="-50" y="0" z="0"/>
+   <position name="posCenter"           unit="cm" x="0" y="0" z="0"/>
+   <rotation name="rUWireAboutX"        unit="deg" x="150" y="0" z="0"/>
+   <rotation name="rVWireAboutX"        unit="deg" x="30" y="0" z="0"/>
+   <rotation name="rPlus90AboutX"       unit="deg" x="90" y="0" z="0"/>
+   <rotation name="rPlus90AboutY"       unit="deg" x="0" y="90" z="0"/>
+   <rotation name="rPlus90AboutXPlus90AboutY" unit="deg" x="90" y="90" z="0"/>
+   <rotation name="rMinus90AboutX"      unit="deg" x="270" y="0" z="0"/>
+   <rotation name="rMinus90AboutY"      unit="deg" x="0" y="270" z="0"/>
+   <rotation name="rMinus90AboutYMinus90AboutX"       unit="deg" x="270" y="270" z="0"/>
+   <rotation name="rPlus180AboutX"	unit="deg" x="180" y="0"   z="0"/>
+   <rotation name="rPlus180AboutY"	unit="deg" x="0" y="180"   z="0"/>
+   <rotation name="rPlus180AboutXPlus180AboutY"	unit="deg" x="180" y="180"   z="0"/>
+   <rotation name="rIdentity"		unit="deg" x="0" y="0"   z="0"/>
+   <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+   <rotation name="rPlus90AboutXPlus180AboutY" unit="deg" x="90" y="180" z="0" />
+   <rotation name="rPlus90AboutXMinux90AboutY" unit="deg" x="90" y="270" z="0" />
+   <rotation name="rPlus90AboutZ" unit="deg" x="0" y="0" z="90" />
+</define>
+<materials>
+  <element name="videRef" formula="VACUUM" Z="1">  <atom value="1"/> </element>
+  <element name="copper" formula="Cu" Z="29">  <atom value="63.546"/>  </element>
+  <element name="beryllium" formula="Be" Z="4">  <atom value="9.0121831"/>  </element>
+  <element name="bromine" formula="Br" Z="35"> <atom value="79.904"/> </element>
+  <element name="hydrogen" formula="H" Z="1">  <atom value="1.0079"/> </element>
+  <element name="nitrogen" formula="N" Z="7">  <atom value="14.0067"/> </element>
+  <element name="oxygen" formula="O" Z="8">  <atom value="15.999"/> </element>
+  <element name="aluminum" formula="Al" Z="13"> <atom value="26.9815"/>  </element>
+  <element name="silicon" formula="Si" Z="14"> <atom value="28.0855"/>  </element>
+  <element name="carbon" formula="C" Z="6">  <atom value="12.0107"/>  </element>
+  <element name="potassium" formula="K" Z="19"> <atom value="39.0983"/>  </element>
+  <element name="chromium" formula="Cr" Z="24"> <atom value="51.9961"/>  </element>
+  <element name="iron" formula="Fe" Z="26"> <atom value="55.8450"/>  </element>
+  <element name="nickel" formula="Ni" Z="28"> <atom value="58.6934"/>  </element>
+  <element name="calcium" formula="Ca" Z="20"> <atom value="40.078"/>   </element>
+  <element name="magnesium" formula="Mg" Z="12"> <atom value="24.305"/>   </element>
+  <element name="sodium" formula="Na" Z="11"> <atom value="22.99"/>    </element>
+  <element name="titanium" formula="Ti" Z="22"> <atom value="47.867"/>   </element>
+  <element name="argon" formula="Ar" Z="18"> <atom value="39.9480"/>  </element>
+  <element name="sulphur" formula="S" Z="16"> <atom value="32.065"/>  </element>
+  <element name="phosphorus" formula="P" Z="15"> <atom value="30.973"/>  </element>
+
+  <material name="Vacuum" formula="Vacuum">
+   <D value="1.e-25" unit="g/cm3"/>
+   <fraction n="1.0" ref="videRef"/>
+  </material>
+
+  <material name="ALUMINUM_Al" formula="ALUMINUM_Al">
+   <D value="2.6990" unit="g/cm3"/>
+   <fraction n="1.0000" ref="aluminum"/>
+  </material>
+
+  <material name="SILICON_Si" formula="SILICON_Si">
+   <D value="2.3300" unit="g/cm3"/>
+   <fraction n="1.0000" ref="silicon"/>
+  </material>
+
+  <material name="epoxy_resin" formula="C38H40O6Br4">
+   <D value="1.1250" unit="g/cm3"/>
+   <composite n="38" ref="carbon"/>
+   <composite n="40" ref="hydrogen"/>
+   <composite n="6" ref="oxygen"/>
+   <composite n="4" ref="bromine"/>
+  </material>
+
+  <material name="SiO2" formula="SiO2">
+   <D value="2.2" unit="g/cm3"/>
+   <composite n="1" ref="silicon"/>
+   <composite n="2" ref="oxygen"/>
+  </material>
+
+  <material name="Al2O3" formula="Al2O3">
+   <D value="3.97" unit="g/cm3"/>
+   <composite n="2" ref="aluminum"/>
+   <composite n="3" ref="oxygen"/>
+  </material>
+
+  <material name="Fe2O3" formula="Fe2O3">
+   <D value="5.24" unit="g/cm3"/>
+   <composite n="2" ref="iron"/>
+   <composite n="3" ref="oxygen"/>
+  </material>
+
+  <material name="CaO" formula="CaO">
+   <D value="3.35" unit="g/cm3"/>
+   <composite n="1" ref="calcium"/>
+   <composite n="1" ref="oxygen"/>
+  </material>
+
+  <material name="Delrin" formula="CH2O">
+    <D value="1.41" unit="g/cm3"/>
+    <composite n="1" ref="carbon"/>
+    <composite n="2" ref="hydrogen"/>
+    <composite n="1" ref="oxygen"/>
+  </material>
+
+  <material name="MgO" formula="MgO">
+   <D value="3.58" unit="g/cm3"/>
+   <composite n="1" ref="magnesium"/>
+   <composite n="1" ref="oxygen"/>
+  </material>
+
+  <material name="Na2O" formula="Na2O">
+   <D value="2.27" unit="g/cm3"/>
+   <composite n="2" ref="sodium"/>
+   <composite n="1" ref="oxygen"/>
+  </material>
+
+  <material name="TiO2" formula="TiO2">
+   <D value="4.23" unit="g/cm3"/>
+   <composite n="1" ref="titanium"/>
+   <composite n="2" ref="oxygen"/>
+  </material>
+
+  <material name="FeO" formula="FeO">
+   <D value="5.745" unit="g/cm3"/>
+   <composite n="1" ref="iron"/>
+   <composite n="1" ref="oxygen"/>
+  </material>
+
+  <material name="CO2" formula="CO2">
+   <D value="1.562" unit="g/cm3"/>
+   <composite n="1" ref="iron"/>
+   <composite n="2" ref="oxygen"/>
+  </material>
+
+  <material name="P2O5" formula="P2O5">
+   <D value="1.562" unit="g/cm3"/>
+   <composite n="2" ref="phosphorus"/>
+   <composite n="5" ref="oxygen"/>
+  </material>
+
+  <material formula=" " name="DUSEL_Rock">
+    <D value="2.82" unit="g/cm3"/>
+    <fraction n="0.5267" ref="SiO2"/>
+    <fraction n="0.1174" ref="FeO"/>
+    <fraction n="0.1025" ref="Al2O3"/>
+    <fraction n="0.0473" ref="MgO"/>
+    <fraction n="0.0422" ref="CO2"/>
+    <fraction n="0.0382" ref="CaO"/>
+    <fraction n="0.0240" ref="carbon"/>
+    <fraction n="0.0186" ref="sulphur"/>
+    <fraction n="0.0053" ref="Na2O"/>
+    <fraction n="0.00070" ref="P2O5"/>
+    <fraction n="0.0771" ref="oxygen"/>
+  </material> 
+
+  <material formula="Air" name="Air">
+   <D value="0.001205" unit="g/cm3"/>
+   <fraction n="0.781154" ref="nitrogen"/>
+   <fraction n="0.209476" ref="oxygen"/>
+   <fraction n="0.00934" ref="argon"/>
+  </material>
+
+  <material name="fibrous_glass">
+   <D value="2.74351" unit="g/cm3"/>
+   <fraction n="0.600" ref="SiO2"/>
+   <fraction n="0.118" ref="Al2O3"/>
+   <fraction n="0.001" ref="Fe2O3"/>
+   <fraction n="0.224" ref="CaO"/>
+   <fraction n="0.034" ref="MgO"/>
+   <fraction n="0.010" ref="Na2O"/>
+   <fraction n="0.013" ref="TiO2"/>
+  </material>
+
+  <!-- density referenced from EHN1-Cold Cryostats Technical Requirements:
+       https://edms.cern.ch/document/1543254 -->
+  <material name="FD_foam">
+   <D value="0.09" unit="g/cm3"/>
+   <fraction n="0.95" ref="Air"/>
+   <fraction n="0.05" ref="fibrous_glass"/>
+  </material>
+
+  <!-- Foam density is 70 kg / m^3 for the 3x1x1 -->
+  <material name="foam_3x1x1dp">
+   <D value="0.07" unit="g/cm3"/>
+   <fraction n="0.95" ref="Air"/>
+   <fraction n="0.05" ref="fibrous_glass"/>
+  </material>
+
+  <!-- Copied from protodune_v4.gdml -->
+  <material name="foam_protoDUNEdp">
+   <D value="0.135" unit="g/cm3"/>
+   <composite n="17" ref="carbon"/>
+   <composite n="16" ref="hydrogen"/>
+   <composite n="2" ref="nitrogen"/>
+   <composite n="4" ref="oxygen"/>
+  </material>
+
+  <material name="FR4">
+   <D value="1.98281" unit="g/cm3"/>
+   <fraction n="0.47" ref="epoxy_resin"/>
+   <fraction n="0.53" ref="fibrous_glass"/>
+  </material>
+
+  <material name="STEEL_STAINLESS_Fe7Cr2Ni" formula="STEEL_STAINLESS_Fe7Cr2Ni">
+   <D value="7.9300" unit="g/cm3"/>
+   <fraction n="0.0010" ref="carbon"/>
+   <fraction n="0.1792" ref="chromium"/>
+   <fraction n="0.7298" ref="iron"/>
+   <fraction n="0.0900" ref="nickel"/>
+  </material>
+
+  <material name="Copper_Beryllium_alloy25" formula="Copper_Beryllium_alloy25">
+   <D value="8.26" unit="g/cm3"/>
+   <fraction n="0.981" ref="copper"/>
+   <fraction n="0.019" ref="beryllium"/>
+  </material>
+
+  <material name="LAr" formula="LAr">
+   <D value="1.40" unit="g/cm3"/>
+   <fraction n="1.0000" ref="argon"/>
+  </material>
+
+  <material name="ArGas" formula="ArGas">
+   <D value="0.00166" unit="g/cm3"/>
+   <fraction n="1.0" ref="argon"/>
+  </material>
+
+  <material formula=" " name="G10">
+   <D value="1.7" unit="g/cm3"/>
+   <fraction n="0.2805" ref="silicon"/>
+   <fraction n="0.3954" ref="oxygen"/>
+   <fraction n="0.2990" ref="carbon"/>
+   <fraction n="0.0251" ref="hydrogen"/>
+  </material>
+
+  <material formula=" " name="Granite">
+   <D value="2.7" unit="g/cm3"/>
+   <fraction n="0.438" ref="oxygen"/>
+   <fraction n="0.257" ref="silicon"/>
+   <fraction n="0.222" ref="sodium"/>
+   <fraction n="0.049" ref="aluminum"/>
+   <fraction n="0.019" ref="iron"/>
+   <fraction n="0.015" ref="potassium"/>
+  </material>
+
+  <material formula=" " name="ShotRock">
+   <D value="1.62" unit="g/cm3"/>
+   <fraction n="0.438" ref="oxygen"/>
+   <fraction n="0.257" ref="silicon"/>
+   <fraction n="0.222" ref="sodium"/>
+   <fraction n="0.049" ref="aluminum"/>
+   <fraction n="0.019" ref="iron"/>
+   <fraction n="0.015" ref="potassium"/>
+  </material>
+
+  <material formula=" " name="Dirt">
+   <D value="1.7" unit="g/cm3"/>
+   <fraction n="0.438" ref="oxygen"/>
+   <fraction n="0.257" ref="silicon"/>
+   <fraction n="0.222" ref="sodium"/>
+   <fraction n="0.049" ref="aluminum"/>
+   <fraction n="0.019" ref="iron"/>
+   <fraction n="0.015" ref="potassium"/>
+  </material>
+
+  <material formula=" " name="Concrete">
+   <D value="2.3" unit="g/cm3"/>
+   <fraction n="0.530" ref="oxygen"/>
+   <fraction n="0.335" ref="silicon"/>
+   <fraction n="0.060" ref="calcium"/>
+   <fraction n="0.015" ref="sodium"/>
+   <fraction n="0.020" ref="iron"/>
+   <fraction n="0.040" ref="aluminum"/>
+  </material>
+
+  <material formula="H2O" name="Water">
+   <D value="1.0" unit="g/cm3"/>
+   <fraction n="0.1119" ref="hydrogen"/>
+   <fraction n="0.8881" ref="oxygen"/>
+  </material>
+
+  <material formula="Ti" name="Titanium">
+   <D value="4.506" unit="g/cm3"/>
+   <fraction n="1." ref="titanium"/>
+  </material>
+
+  <material name="TPB" formula="TPB">
+   <D value="1.40" unit="g/cm3"/>
+   <fraction n="1.0000" ref="argon"/>
+  </material>
+
+  <material name="Glass">
+   <D value="2.74351" unit="g/cm3"/>
+   <fraction n="0.600" ref="SiO2"/>
+   <fraction n="0.118" ref="Al2O3"/>
+   <fraction n="0.001" ref="Fe2O3"/>
+   <fraction n="0.224" ref="CaO"/>
+   <fraction n="0.034" ref="MgO"/>
+   <fraction n="0.010" ref="Na2O"/>
+   <fraction n="0.013" ref="TiO2"/>
+  </material>
+
+  <material name="Acrylic">
+   <D value="1.19" unit="g/cm3"/>
+   <fraction n="0.600" ref="carbon"/>
+   <fraction n="0.320" ref="oxygen"/>
+   <fraction n="0.080" ref="hydrogen"/>
+  </material>
+
+  <material name="NiGas1atm80K">
+   <D value="0.0039" unit="g/cm3"/>
+   <fraction n="1.000" ref="nitrogen"/>
+  </material>
+
+  <material name="NiGas">
+   <D value="0.001165" unit="g/cm3"/>
+   <fraction n="1.000" ref="nitrogen"/>
+  </material>
+
+  <material name="PolyurethaneFoam">
+   <D value="0.088" unit="g/cm3"/>
+   <composite n="17" ref="carbon"/>
+   <composite n="16" ref="hydrogen"/>
+   <composite n="2" ref="nitrogen"/>
+   <composite n="4" ref="oxygen"/>
+  </material>
+
+  <material name="ProtoDUNEFoam">
+   <D value="0.135" unit="g/cm3"/>
+   <composite n="17" ref="carbon"/>
+   <composite n="16" ref="hydrogen"/>
+   <composite n="2" ref="nitrogen"/>
+   <composite n="4" ref="oxygen"/>
+  </material>
+
+  <material name="LightPolyurethaneFoam">
+   <D value="0.009" unit="g/cm3"/>
+   <composite n="17" ref="carbon"/>
+   <composite n="16" ref="hydrogen"/>
+   <composite n="2" ref="nitrogen"/>
+   <composite n="4" ref="oxygen"/>
+  </material>
+
+  <material name="ProtoDUNEBWFoam">
+   <D value="0.021" unit="g/cm3"/>
+   <composite n="17" ref="carbon"/>
+   <composite n="16" ref="hydrogen"/>
+   <composite n="2" ref="nitrogen"/>
+   <composite n="4" ref="oxygen"/>
+  </material>
+
+  <material name="GlassWool">
+   <D value="0.035" unit="g/cm3"/>
+   <fraction n="0.65" ref="SiO2"/>
+   <fraction n="0.09" ref="Al2O3"/>
+   <fraction n="0.07" ref="CaO"/>
+   <fraction n="0.03" ref="MgO"/>
+   <fraction n="0.16" ref="Na2O"/>
+  </material>
+
+  <material name="Polystyrene">
+   <D value="1.06" unit="g/cm3"/>
+   <composite n="8" ref="carbon"/>
+   <composite n="8" ref="hydrogen"/>
+  </material>
+
+
+
+  <!-- preliminary values -->
+  <material name="AirSteelMixture" formula="AirSteelMixture">
+   <D value=" 0.001205*(1-0.5) + 7.9300*0.5 " unit="g/cm3"/>
+   <fraction n="0.5" ref="STEEL_STAINLESS_Fe7Cr2Ni"/>
+   <fraction n="0.5"   ref="Air"/>
+  </material>
+  <material name="vm2000" formula="vm2000">
+    <D value="1.2" unit="g/cm3"/>
+    <composite n="2" ref="carbon"/>
+    <composite n="4" ref="hydrogen"/>
+  </material>
+
+</materials>
+<solids>
+     <torus name="FieldShaperCorner" rmin="0.5" rmax="2.285" rtor="2.3" deltaphi="90" startphi="0" aunit="deg" lunit="cm"/>
+     <tube name="FieldShaperLongtube" rmin="0.5" rmax="2.285" z="5986" deltaphi="360" startphi="0" aunit="deg" lunit="cm"/>
+     <tube name="FieldShaperLongtubeSlim" rmin="0.5" rmax="0.75" z="5986" deltaphi="360" startphi="0" aunit="deg" lunit="cm"/>
+     <tube name="FieldShaperShorttube" rmin="0.5" rmax="2.285" z="1348" deltaphi="360" startphi="0" aunit="deg" lunit="cm"/>
+
+    <union name="FSunion1">
+      <first ref="FieldShaperLongtube"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos1" unit="cm" x="-2.3" y="0" z="2993"/>
+		<rotationref ref="rPlus90AboutX"/>
+    </union>
+
+    <union name="FSunion2">
+      <first ref="FSunion1"/>
+      <second ref="FieldShaperShorttube"/>
+   		<position name="esquinapos2" unit="cm" x="-676.3" y="0" z="2995.3"/>
+   		<rotationref ref="rPlus90AboutY"/>
+    </union>
+
+    <union name="FSunion3">
+      <first ref="FSunion2"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos3" unit="cm" x="-1350.3" y="0" z="2993"/>
+		<rotationref ref="rPlus90AboutXMinux90AboutY"/>
+    </union>
+
+    <union name="FSunion4">
+      <first ref="FSunion3"/>
+      <second ref="FieldShaperLongtube"/>
+   		<position name="esquinapos4" unit="cm" x="-1352.6" y="0" z="0"/>
+    </union>
+
+    <union name="FSunion5">
+      <first ref="FSunion4"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos5" unit="cm" x="-1350.3" y="0" z="-2993"/>
+		<rotationref ref="rPlus90AboutXPlus180AboutY"/>
+    </union>
+
+    <union name="FSunion6">
+      <first ref="FSunion5"/>
+      <second ref="FieldShaperShorttube"/>
+   		<position name="esquinapos6" unit="cm" x="-676.3" y="0" z="-2995.3"/>
+		<rotationref ref="rPlus90AboutY"/>
+    </union>
+
+    <union name="FieldShaperSolid">
+      <first ref="FSunion6"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos7" unit="cm" x="-2.3" y="0" z="-2993"/>
+		<rotationref ref="rPlus90AboutXPlus90AboutY"/>
+    </union>
+    
+    <union name="FSunionSlim1">
+      <first ref="FieldShaperLongtubeSlim"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos8" unit="cm" x="-2.3" y="0" z="2993"/>
+		<rotationref ref="rPlus90AboutX"/>
+    </union>
+
+    <union name="FSunionSlim2">
+      <first ref="FSunionSlim1"/>
+      <second ref="FieldShaperShorttube"/>
+   		<position name="esquinapos9" unit="cm" x="-676.3" y="0" z="2995.3"/>
+   		<rotationref ref="rPlus90AboutY"/>
+    </union>
+
+    <union name="FSunionSlim3">
+      <first ref="FSunionSlim2"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos10" unit="cm" x="-1350.3" y="0" z="2993"/>
+		<rotationref ref="rPlus90AboutXMinux90AboutY"/>
+    </union>
+
+    <union name="FSunionSlim4">
+      <first ref="FSunionSlim3"/>
+      <second ref="FieldShaperLongtubeSlim"/>
+   		<position name="esquinapos4" unit="cm" x="-1352.6" y="0" z="0"/>
+    </union>
+
+    <union name="FSunionSlim5">
+      <first ref="FSunionSlim4"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos11" unit="cm" x="-1350.3" y="0" z="-2993"/>
+		<rotationref ref="rPlus90AboutXPlus180AboutY"/>
+    </union>
+
+    <union name="FSunionSlim6">
+      <first ref="FSunionSlim5"/>
+      <second ref="FieldShaperShorttube"/>
+   		<position name="esquinapos12" unit="cm" x="-676.3" y="0" z="-2995.3"/>
+		<rotationref ref="rPlus90AboutY"/>
+    </union>
+
+    <union name="FieldShaperSolidSlim">
+      <first ref="FSunionSlim6"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos13" unit="cm" x="-2.3" y="0" z="-2993"/>
+		<rotationref ref="rPlus90AboutXPlus90AboutY"/>
+    </union>
+    
+
+   <box name="CRM"
+      x="650.06" 
+      y="168.5" 
+      z="149.65"
+      lunit="cm"/>
+   <box name="CRMActive" 
+      x="650"
+      y="168.5"
+      z="149.65"
+      lunit="cm"/>
+   <box name="CRMUPlane" 
+      x="0.02" 
+      y="167.9" 
+      z="149"
+      lunit="cm"/>
+   <box name="CRMVPlane" 
+      x="0.02" 
+      y="167.9" 
+      z="149"
+      lunit="cm"/>
+   <box name="CRMZPlane" 
+      x="0.02"
+      y="167.9"
+      z="149"
+      lunit="cm"/>
+
+
+
+
+    <box name="ArapucaOut" lunit="cm"
+      x="65"
+      y="2.5"
+      z="65"/>
+
+    <box name="ArapucaIn" lunit="cm"
+      x="60"
+      y="2.5"
+      z="60"/>
+
+     <subtraction name="ArapucaWalls">
+      <first  ref="ArapucaOut"/>
+      <second ref="ArapucaIn"/>
+      <position name="posArapucaSub" x="0" y="1.25" z="0." unit="cm"/>
+      </subtraction>
+
+    <box name="ArapucaAcceptanceWindow" lunit="cm"
+      x="60"
+      y="1"
+      z="60"/>
+
+    <box name="ArapucaDoubleIn" lunit="cm"
+      x="60"
+      y="3.5"
+      z="60"/>
+
+     <subtraction name="ArapucaDoubleWalls">
+      <first  ref="ArapucaOut"/>
+      <second ref="ArapucaDoubleIn"/>
+      <position name="posArapucaDoubleSub" x="0" y="0" z="0" unit="cm"/>
+      </subtraction>
+
+    <box name="ArapucaDoubleAcceptanceWindow" lunit="cm"
+      x="2.48"
+      y="60"
+      z="60"/>
+
+    <box name="ArapucaCathodeAcceptanceWindow" lunit="cm"
+      x="1"
+      y="60"
+      z="60"/>
+
+
+    <box name="Cryostat" lunit="cm" 
+      x="850.3" 
+      y="1510.24" 
+      z="6200.24"/>
+
+    <box name="ArgonInterior" lunit="cm" 
+      x="850.06"
+      y="1510"
+      z="6200"/>
+
+    <box name="GaseousArgon" lunit="cm" 
+      x="100 - 0.01"
+      y="1510"
+      z="6200"/>
+
+    <box name="ExternalAuxOut" lunit="cm" 
+      x="850.06 - 99.9999999999999"
+      y="1510 - 2*2.5 - 2*10"
+      z="6200"/>
+
+    <box name="ExternalAuxIn" lunit="cm" 
+      x="850.06"
+      y="1359.17"
+      z="6200 + 1"/>
+
+   <subtraction name="ExternalActive">
+      <first ref="ExternalAuxOut"/>
+      <second ref="ExternalAuxIn"/>
+    </subtraction>
+
+    <subtraction name="SteelShell">
+      <first ref="Cryostat"/>
+      <second ref="ArgonInterior"/>
+    </subtraction>
+
+
+
+    <box name="CathodeBlock" lunit="cm"
+      x="4"
+      y="337"
+      z="299.3" />
+
+    <box name="CathodeVoid" lunit="cm"
+      x="5"
+      y="76.35"
+      z="67" />
+
+    <subtraction name="Cathode1">
+      <first ref="CathodeBlock"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub1" x="0" y="-122.525" z="-108.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode2">
+      <first ref="Cathode1"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub2" x="0" y="-122.525" z="-37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode3">
+      <first ref="Cathode2"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub3" x="0" y="-122.525" z="37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode4">
+      <first ref="Cathode3"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub4" x="0" y="-122.525" z="108.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode5">
+      <first ref="Cathode4"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub5" x="0" y="-42.175" z="-108.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode6">
+      <first ref="Cathode5"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub6" x="0" y="-42.175" z="-37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode7">
+      <first ref="Cathode6"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub7" x="0" y="-42.175" z="37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode8">
+      <first ref="Cathode7"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub8" x="0" y="-42.175" z="108.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode9">
+      <first ref="Cathode8"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub9" x="0" y="42.175" z="-108.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode10">
+      <first ref="Cathode9"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub10" x="0" y="42.175" z="-37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode11">
+      <first ref="Cathode10"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub11" x="0" y="42.175" z="37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode12">
+      <first ref="Cathode11"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub12" x="0" y="42.175" z="108.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode13">
+      <first ref="Cathode12"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub13" x="0" y="122.525" z="-108.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode14">
+      <first ref="Cathode13"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub14" x="0" y="122.525" z="-37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode15">
+      <first ref="Cathode14"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub15" x="0" y="122.525" z="37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="CathodeGrid">
+      <first ref="Cathode15"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub16" x="0" y="122.525" z="108.5" unit="cm"/>
+    </subtraction>
+
+   <box name="AnodePlate" 
+      x="0.01"
+      y="337"
+      z="299.3"
+      lunit="cm"/>
+
+    <box name="FoamPadBlock" lunit="cm"
+      x="1010.3"
+      y="1670.24"
+      z="6360.24" />
+
+    <subtraction name="FoamPadding">
+      <first ref="FoamPadBlock"/>
+      <second ref="Cryostat"/>
+      <positionref ref="posCenter"/>
+    </subtraction>
+
+    <box name="SteelSupportBlock" lunit="cm"
+      x="1210.3"
+      y="1870.24"
+      z="6560.24" />
+
+    <subtraction name="SteelSupport">
+      <first ref="SteelSupportBlock"/>
+      <second ref="FoamPadBlock"/>
+      <positionref ref="posCenter"/>
+    </subtraction>
+
+    <box name="DetEnclosure" lunit="cm" 
+      x="1310.3"
+      y="2070.24"
+      z="6760.24"/>
+
+
+    <box name="World" lunit="cm" 
+      x="9310.3" 
+      y="10070.24" 
+      z="14760.24"/>
+</solids>
+<structure>
+<volume name="volFieldShaper">
+  <materialref ref="ALUMINUM_Al"/>
+  <solidref ref="FieldShaperSolid"/>
+</volume>
+<volume name="volFieldShaperSlim">
+  <materialref ref="ALUMINUM_Al"/>
+  <solidref ref="FieldShaperSolidSlim"/>
+</volume>
+
+
+    <volume name="volTPCActive">
+      <materialref ref="LAr"/>
+      <solidref ref="CRMActive"/>
+      <auxiliary auxtype="SensDet" auxvalue="SimEnergyDeposit"/>
+      <auxiliary auxtype="StepLimit" auxunit="cm" auxvalue="0.5*cm"/>
+      <auxiliary auxtype="Efield" auxunit="V/cm" auxvalue="500*V/cm"/>
+      <colorref ref="blue"/>
+    </volume>
+   <volume name="volTPCPlaneU0">
+     <materialref ref="LAr"/>
+     <solidref ref="CRMUPlane"/>
+   </volume>
+  <volume name="volTPCPlaneV0">
+    <materialref ref="LAr"/>
+    <solidref ref="CRMVPlane"/>
+  </volume>
+  <volume name="volTPCPlaneZ0">
+    <materialref ref="LAr"/>
+    <solidref ref="CRMZPlane"/>
+  </volume>
+   <volume name="volTPC0">
+     <materialref ref="LAr"/>
+       <solidref ref="CRM"/>
+       <physvol>
+       <volumeref ref="volTPCPlaneU0"/>
+       <position name="posPlaneU0" unit="cm" 
+         x="324.98" y="0.3" z="0.275"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCPlaneV0"/>
+       <position name="posPlaneY0" unit="cm" 
+         x="325" y="0.3" z="0.275"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCPlaneZ0"/>
+       <position name="posPlaneZ0" unit="cm" 
+         x="325.02" y="0.3" z="0.275"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCActive"/>
+       <position name="posActive0" unit="cm" 
+        x="-0.03" y="" z="0"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+   </volume>
+ 
+   <volume name="volTPCPlaneU1">
+     <materialref ref="LAr"/>
+     <solidref ref="CRMUPlane"/>
+   </volume>
+  <volume name="volTPCPlaneV1">
+    <materialref ref="LAr"/>
+    <solidref ref="CRMVPlane"/>
+  </volume>
+  <volume name="volTPCPlaneZ1">
+    <materialref ref="LAr"/>
+    <solidref ref="CRMZPlane"/>
+  </volume>
+   <volume name="volTPC1">
+     <materialref ref="LAr"/>
+       <solidref ref="CRM"/>
+       <physvol>
+       <volumeref ref="volTPCPlaneU1"/>
+       <position name="posPlaneU1" unit="cm" 
+         x="324.98" y="-0.3" z="0.275"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCPlaneV1"/>
+       <position name="posPlaneY1" unit="cm" 
+         x="325" y="-0.3" z="0.275"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCPlaneZ1"/>
+       <position name="posPlaneZ1" unit="cm" 
+         x="325.02" y="-0.3" z="0.275"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCActive"/>
+       <position name="posActive1" unit="cm" 
+        x="-0.03" y="" z="0"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+   </volume>
+ 
+   <volume name="volTPCPlaneU2">
+     <materialref ref="LAr"/>
+     <solidref ref="CRMUPlane"/>
+   </volume>
+  <volume name="volTPCPlaneV2">
+    <materialref ref="LAr"/>
+    <solidref ref="CRMVPlane"/>
+  </volume>
+  <volume name="volTPCPlaneZ2">
+    <materialref ref="LAr"/>
+    <solidref ref="CRMZPlane"/>
+  </volume>
+   <volume name="volTPC2">
+     <materialref ref="LAr"/>
+       <solidref ref="CRM"/>
+       <physvol>
+       <volumeref ref="volTPCPlaneU2"/>
+       <position name="posPlaneU2" unit="cm" 
+         x="324.98" y="0.3" z="-0.275"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCPlaneV2"/>
+       <position name="posPlaneY2" unit="cm" 
+         x="325" y="0.3" z="-0.275"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCPlaneZ2"/>
+       <position name="posPlaneZ2" unit="cm" 
+         x="325.02" y="0.3" z="-0.275"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCActive"/>
+       <position name="posActive2" unit="cm" 
+        x="-0.03" y="" z="0"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+   </volume>
+ 
+   <volume name="volTPCPlaneU3">
+     <materialref ref="LAr"/>
+     <solidref ref="CRMUPlane"/>
+   </volume>
+  <volume name="volTPCPlaneV3">
+    <materialref ref="LAr"/>
+    <solidref ref="CRMVPlane"/>
+  </volume>
+  <volume name="volTPCPlaneZ3">
+    <materialref ref="LAr"/>
+    <solidref ref="CRMZPlane"/>
+  </volume>
+   <volume name="volTPC3">
+     <materialref ref="LAr"/>
+       <solidref ref="CRM"/>
+       <physvol>
+       <volumeref ref="volTPCPlaneU3"/>
+       <position name="posPlaneU3" unit="cm" 
+         x="324.98" y="-0.3" z="-0.275"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCPlaneV3"/>
+       <position name="posPlaneY3" unit="cm" 
+         x="325" y="-0.3" z="-0.275"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCPlaneZ3"/>
+       <position name="posPlaneZ3" unit="cm" 
+         x="325.02" y="-0.3" z="-0.275"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCActive"/>
+       <position name="posActive3" unit="cm" 
+        x="-0.03" y="" z="0"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+   </volume>
+ 
+    <volume name="volSteelShell">
+      <materialref ref="STEEL_STAINLESS_Fe7Cr2Ni" />
+      <solidref ref="SteelShell" />
+    </volume>
+    <volume name="volCathodeGrid">
+      <materialref ref="G10" />
+      <solidref ref="CathodeGrid" />
+    </volume>
+    <volume name="volAnodePlate">
+     <materialref ref="vm2000"/>
+     <solidref ref="AnodePlate"/>
+    </volume>
+    <volume name="volGaseousArgon">
+      <materialref ref="ArGas"/>
+      <solidref ref="GaseousArgon"/>
+    </volume>
+    <volume name="volExternalActive">
+      <materialref ref="LAr"/>
+      <solidref ref="ExternalActive"/>
+      <auxiliary auxtype="SensDet" auxvalue="SimEnergyDeposit"/>
+      <auxiliary auxtype="StepLimit" auxunit="cm" auxvalue="0.5208*cm"/>
+      <auxiliary auxtype="Efield" auxunit="V/cm" auxvalue="0*V/cm"/>
+      <colorref ref="green"/>
+    </volume>
+
+    <volume name="volArapucaShortLat">
+      <materialref ref="G10"/>
+      <solidref ref="ArapucaWalls"/>
+    </volume>
+    <volume name="volOpDetSensitive">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+
+    <volume name="Arapuca">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+
+    <volume name="volArapuca">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaOut"/>
+      <physvol>
+        <volumeref ref="Arapuca"/>
+        <positionref ref="posCenter"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volOpDetSensitive"/>
+        <position name="opdetshift" unit="cm" x="0" y="0.5" z="0"/>
+      </physvol>
+    </volume>
+
+    <volume name="volArapucaDouble_0-0-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-0-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-0-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-0-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-0-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-0-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-0-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-0-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-1-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-1-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-1-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-1-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-1-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-1-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-1-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-1-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-2-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-2-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-2-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-2-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-2-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-2-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-2-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-2-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-3-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-3-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-3-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-3-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-3-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-3-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-3-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-3-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-4-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-4-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-4-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-4-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-4-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-4-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-4-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-4-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-5-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-5-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-5-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-5-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-5-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-5-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-5-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-5-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-6-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-6-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-6-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-6-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-6-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-6-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-6-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-6-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-7-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-7-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-7-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-7-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-7-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-7-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-7-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-7-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-8-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-8-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-8-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-8-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-8-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-8-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-8-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-8-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-9-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-9-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-9-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-9-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-9-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-9-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-9-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-9-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-10-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-10-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-10-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-10-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-10-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-10-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-10-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-10-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-11-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-11-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-11-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-11-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-11-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-11-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-11-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-11-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-12-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-12-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-12-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-12-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-12-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-12-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-12-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-12-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-13-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-13-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-13-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-13-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-13-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-13-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-13-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-13-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-14-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-14-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-14-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-14-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-14-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-14-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-14-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-14-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-15-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-15-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-15-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-15-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-15-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-15-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-15-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-15-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-16-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-16-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-16-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-16-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-16-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-16-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-16-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-16-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-17-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-17-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-17-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-17-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-17-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-17-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-17-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-17-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-18-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-18-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-18-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-18-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-18-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-18-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-18-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-18-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-19-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-19-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-19-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-19-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-19-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-19-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_0-19-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_0-19-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-0-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-0-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-0-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-0-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-0-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-0-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-0-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-0-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-1-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-1-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-1-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-1-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-1-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-1-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-1-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-1-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-2-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-2-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-2-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-2-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-2-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-2-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-2-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-2-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-3-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-3-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-3-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-3-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-3-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-3-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-3-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-3-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-4-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-4-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-4-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-4-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-4-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-4-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-4-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-4-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-5-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-5-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-5-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-5-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-5-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-5-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-5-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-5-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-6-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-6-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-6-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-6-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-6-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-6-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-6-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-6-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-7-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-7-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-7-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-7-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-7-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-7-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-7-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-7-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-8-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-8-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-8-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-8-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-8-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-8-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-8-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-8-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-9-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-9-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-9-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-9-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-9-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-9-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-9-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-9-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-10-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-10-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-10-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-10-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-10-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-10-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-10-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-10-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-11-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-11-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-11-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-11-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-11-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-11-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-11-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-11-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-12-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-12-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-12-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-12-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-12-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-12-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-12-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-12-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-13-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-13-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-13-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-13-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-13-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-13-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-13-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-13-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-14-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-14-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-14-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-14-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-14-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-14-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-14-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-14-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-15-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-15-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-15-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-15-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-15-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-15-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-15-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-15-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-16-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-16-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-16-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-16-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-16-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-16-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-16-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-16-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-17-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-17-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-17-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-17-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-17-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-17-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-17-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-17-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-18-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-18-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-18-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-18-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-18-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-18-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-18-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-18-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-19-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-19-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-19-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-19-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-19-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-19-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_1-19-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_1-19-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-0-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-0-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-0-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-0-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-0-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-0-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-0-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-0-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-1-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-1-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-1-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-1-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-1-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-1-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-1-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-1-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-2-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-2-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-2-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-2-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-2-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-2-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-2-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-2-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-3-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-3-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-3-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-3-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-3-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-3-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-3-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-3-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-4-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-4-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-4-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-4-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-4-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-4-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-4-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-4-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-5-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-5-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-5-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-5-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-5-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-5-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-5-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-5-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-6-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-6-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-6-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-6-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-6-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-6-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-6-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-6-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-7-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-7-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-7-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-7-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-7-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-7-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-7-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-7-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-8-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-8-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-8-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-8-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-8-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-8-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-8-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-8-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-9-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-9-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-9-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-9-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-9-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-9-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-9-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-9-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-10-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-10-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-10-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-10-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-10-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-10-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-10-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-10-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-11-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-11-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-11-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-11-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-11-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-11-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-11-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-11-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-12-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-12-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-12-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-12-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-12-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-12-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-12-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-12-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-13-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-13-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-13-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-13-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-13-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-13-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-13-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-13-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-14-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-14-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-14-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-14-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-14-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-14-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-14-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-14-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-15-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-15-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-15-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-15-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-15-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-15-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-15-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-15-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-16-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-16-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-16-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-16-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-16-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-16-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-16-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-16-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-17-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-17-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-17-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-17-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-17-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-17-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-17-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-17-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-18-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-18-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-18-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-18-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-18-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-18-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-18-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-18-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-19-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-19-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-19-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-19-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-19-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-19-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_2-19-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_2-19-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-0-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-0-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-0-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-0-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-0-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-0-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-0-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-0-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-1-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-1-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-1-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-1-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-1-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-1-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-1-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-1-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-2-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-2-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-2-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-2-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-2-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-2-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-2-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-2-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-3-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-3-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-3-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-3-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-3-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-3-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-3-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-3-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-4-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-4-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-4-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-4-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-4-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-4-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-4-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-4-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-5-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-5-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-5-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-5-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-5-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-5-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-5-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-5-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-6-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-6-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-6-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-6-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-6-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-6-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-6-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-6-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-7-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-7-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-7-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-7-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-7-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-7-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-7-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-7-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-8-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-8-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-8-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-8-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-8-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-8-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-8-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-8-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-9-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-9-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-9-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-9-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-9-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-9-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-9-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-9-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-10-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-10-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-10-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-10-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-10-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-10-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-10-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-10-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-11-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-11-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-11-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-11-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-11-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-11-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-11-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-11-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-12-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-12-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-12-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-12-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-12-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-12-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-12-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-12-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-13-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-13-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-13-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-13-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-13-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-13-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-13-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-13-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-14-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-14-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-14-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-14-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-14-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-14-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-14-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-14-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-15-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-15-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-15-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-15-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-15-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-15-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-15-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-15-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-16-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-16-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-16-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-16-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-16-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-16-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-16-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-16-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-17-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-17-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-17-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-17-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-17-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-17-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-17-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-17-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-18-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-18-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-18-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-18-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-18-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-18-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-18-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-18-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-19-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-19-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-19-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-19-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-19-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-19-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaDouble_3-19-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_3-19-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_0-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_0-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_0-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_0-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_0-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_0-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_0-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_0-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_0-4">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_0-4">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_0-5">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_0-5">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_0-6">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_0-6">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_0-7">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_0-7">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_1-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_1-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_1-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_1-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_1-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_1-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_1-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_1-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_1-4">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_1-4">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_1-5">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_1-5">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_1-6">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_1-6">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_1-7">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_1-7">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_2-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_2-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_2-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_2-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_2-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_2-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_2-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_2-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_2-4">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_2-4">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_2-5">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_2-5">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_2-6">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_2-6">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_2-7">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_2-7">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_3-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_3-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_3-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_3-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_3-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_3-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_3-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_3-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_3-4">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_3-4">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_3-5">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_3-5">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_3-6">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_3-6">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_3-7">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_3-7">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_4-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_4-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_4-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_4-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_4-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_4-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_4-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_4-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_4-4">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_4-4">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_4-5">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_4-5">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_4-6">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_4-6">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_4-7">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_4-7">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_5-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_5-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_5-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_5-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_5-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_5-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_5-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_5-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_5-4">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_5-4">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_5-5">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_5-5">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_5-6">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_5-6">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_5-7">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_5-7">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_6-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_6-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_6-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_6-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_6-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_6-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_6-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_6-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_6-4">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_6-4">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_6-5">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_6-5">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_6-6">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_6-6">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_6-7">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_6-7">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_7-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_7-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_7-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_7-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_7-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_7-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_7-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_7-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_7-4">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_7-4">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_7-5">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_7-5">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_7-6">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_7-6">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_7-7">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_7-7">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_8-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_8-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_8-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_8-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_8-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_8-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_8-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_8-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_8-4">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_8-4">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_8-5">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_8-5">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_8-6">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_8-6">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_8-7">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_8-7">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_9-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_9-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_9-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_9-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_9-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_9-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_9-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_9-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_9-4">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_9-4">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_9-5">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_9-5">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_9-6">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_9-6">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_9-7">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_9-7">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_10-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_10-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_10-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_10-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_10-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_10-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_10-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_10-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_10-4">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_10-4">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_10-5">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_10-5">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_10-6">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_10-6">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_10-7">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_10-7">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_11-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_11-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_11-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_11-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_11-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_11-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_11-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_11-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_11-4">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_11-4">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_11-5">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_11-5">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_11-6">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_11-6">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_11-7">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_11-7">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_12-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_12-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_12-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_12-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_12-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_12-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_12-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_12-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_12-4">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_12-4">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_12-5">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_12-5">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_12-6">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_12-6">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_12-7">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_12-7">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_13-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_13-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_13-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_13-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_13-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_13-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_13-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_13-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_13-4">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_13-4">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_13-5">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_13-5">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_13-6">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_13-6">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_13-7">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_13-7">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_14-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_14-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_14-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_14-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_14-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_14-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_14-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_14-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_14-4">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_14-4">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_14-5">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_14-5">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_14-6">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_14-6">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_14-7">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_14-7">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_15-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_15-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_15-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_15-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_15-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_15-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_15-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_15-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_15-4">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_15-4">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_15-5">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_15-5">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_15-6">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_15-6">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_15-7">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_15-7">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_16-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_16-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_16-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_16-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_16-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_16-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_16-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_16-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_16-4">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_16-4">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_16-5">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_16-5">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_16-6">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_16-6">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_16-7">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_16-7">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_17-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_17-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_17-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_17-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_17-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_17-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_17-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_17-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_17-4">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_17-4">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_17-5">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_17-5">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_17-6">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_17-6">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_17-7">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_17-7">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_18-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_18-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_18-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_18-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_18-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_18-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_18-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_18-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_18-4">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_18-4">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_18-5">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_18-5">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_18-6">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_18-6">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_18-7">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_18-7">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_19-0">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_19-0">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_19-1">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_19-1">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_19-2">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_19-2">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_19-3">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_19-3">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_19-4">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_19-4">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_19-5">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_19-5">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_19-6">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_19-6">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+    <volume name="volArapucaLat_19-7">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_19-7">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+
+    <volume name="volCryostat">
+      <materialref ref="LAr" />
+      <solidref ref="Cryostat" />
+      <physvol>
+        <volumeref ref="volGaseousArgon"/>
+        <position name="posGaseousArgon" unit="cm" x="375.035" y="0" z="0"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volSteelShell"/>
+        <position name="posSteelShell" unit="cm" x="0" y="0" z="0"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volExternalActive"/>
+        <position name="posExternalActive" unit="cm" x="-99.9999999999999/2" y="0" z="0"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-0" unit="cm"
+           x="0" y="-589.75" z="-2918.175"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-1" unit="cm"
+           x="0" y="-421.25" z="-2918.175"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-2" unit="cm"
+           x="0" y="-252.75" z="-2918.175"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-3" unit="cm"
+           x="0" y="-84.25" z="-2918.175"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-4" unit="cm"
+           x="0" y="84.25" z="-2918.175"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-5" unit="cm"
+           x="0" y="252.75" z="-2918.175"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-6" unit="cm"
+           x="0" y="421.25" z="-2918.175"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-7" unit="cm"
+           x="0" y="589.75" z="-2918.175"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-8" unit="cm"
+           x="0" y="-589.75" z="-2768.525"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-9" unit="cm"
+           x="0" y="-421.25" z="-2768.525"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-10" unit="cm"
+           x="0" y="-252.75" z="-2768.525"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-11" unit="cm"
+           x="0" y="-84.25" z="-2768.525"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-12" unit="cm"
+           x="0" y="84.25" z="-2768.525"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-13" unit="cm"
+           x="0" y="252.75" z="-2768.525"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-14" unit="cm"
+           x="0" y="421.25" z="-2768.525"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-15" unit="cm"
+           x="0" y="589.75" z="-2768.525"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-16" unit="cm"
+           x="0" y="-589.75" z="-2618.875"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-17" unit="cm"
+           x="0" y="-421.25" z="-2618.875"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-18" unit="cm"
+           x="0" y="-252.75" z="-2618.875"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-19" unit="cm"
+           x="0" y="-84.25" z="-2618.875"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-20" unit="cm"
+           x="0" y="84.25" z="-2618.875"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-21" unit="cm"
+           x="0" y="252.75" z="-2618.875"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-22" unit="cm"
+           x="0" y="421.25" z="-2618.875"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-23" unit="cm"
+           x="0" y="589.75" z="-2618.875"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-24" unit="cm"
+           x="0" y="-589.75" z="-2469.225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-25" unit="cm"
+           x="0" y="-421.25" z="-2469.225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-26" unit="cm"
+           x="0" y="-252.75" z="-2469.225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-27" unit="cm"
+           x="0" y="-84.25" z="-2469.225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-28" unit="cm"
+           x="0" y="84.25" z="-2469.225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-29" unit="cm"
+           x="0" y="252.75" z="-2469.225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-30" unit="cm"
+           x="0" y="421.25" z="-2469.225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-31" unit="cm"
+           x="0" y="589.75" z="-2469.225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-32" unit="cm"
+           x="0" y="-589.75" z="-2319.575"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-33" unit="cm"
+           x="0" y="-421.25" z="-2319.575"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-34" unit="cm"
+           x="0" y="-252.75" z="-2319.575"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-35" unit="cm"
+           x="0" y="-84.25" z="-2319.575"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-36" unit="cm"
+           x="0" y="84.25" z="-2319.575"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-37" unit="cm"
+           x="0" y="252.75" z="-2319.575"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-38" unit="cm"
+           x="0" y="421.25" z="-2319.575"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-39" unit="cm"
+           x="0" y="589.75" z="-2319.575"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-40" unit="cm"
+           x="0" y="-589.75" z="-2169.925"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-41" unit="cm"
+           x="0" y="-421.25" z="-2169.925"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-42" unit="cm"
+           x="0" y="-252.75" z="-2169.925"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-43" unit="cm"
+           x="0" y="-84.25" z="-2169.925"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-44" unit="cm"
+           x="0" y="84.25" z="-2169.925"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-45" unit="cm"
+           x="0" y="252.75" z="-2169.925"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-46" unit="cm"
+           x="0" y="421.25" z="-2169.925"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-47" unit="cm"
+           x="0" y="589.75" z="-2169.925"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-48" unit="cm"
+           x="0" y="-589.75" z="-2020.275"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-49" unit="cm"
+           x="0" y="-421.25" z="-2020.275"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-50" unit="cm"
+           x="0" y="-252.75" z="-2020.275"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-51" unit="cm"
+           x="0" y="-84.25" z="-2020.275"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-52" unit="cm"
+           x="0" y="84.25" z="-2020.275"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-53" unit="cm"
+           x="0" y="252.75" z="-2020.275"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-54" unit="cm"
+           x="0" y="421.25" z="-2020.275"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-55" unit="cm"
+           x="0" y="589.75" z="-2020.275"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-56" unit="cm"
+           x="0" y="-589.75" z="-1870.625"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-57" unit="cm"
+           x="0" y="-421.25" z="-1870.625"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-58" unit="cm"
+           x="0" y="-252.75" z="-1870.625"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-59" unit="cm"
+           x="0" y="-84.25" z="-1870.625"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-60" unit="cm"
+           x="0" y="84.25" z="-1870.625"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-61" unit="cm"
+           x="0" y="252.75" z="-1870.625"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-62" unit="cm"
+           x="0" y="421.25" z="-1870.625"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-63" unit="cm"
+           x="0" y="589.75" z="-1870.625"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-64" unit="cm"
+           x="0" y="-589.75" z="-1720.975"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-65" unit="cm"
+           x="0" y="-421.25" z="-1720.975"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-66" unit="cm"
+           x="0" y="-252.75" z="-1720.975"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-67" unit="cm"
+           x="0" y="-84.25" z="-1720.975"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-68" unit="cm"
+           x="0" y="84.25" z="-1720.975"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-69" unit="cm"
+           x="0" y="252.75" z="-1720.975"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-70" unit="cm"
+           x="0" y="421.25" z="-1720.975"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-71" unit="cm"
+           x="0" y="589.75" z="-1720.975"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-72" unit="cm"
+           x="0" y="-589.75" z="-1571.325"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-73" unit="cm"
+           x="0" y="-421.25" z="-1571.325"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-74" unit="cm"
+           x="0" y="-252.75" z="-1571.325"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-75" unit="cm"
+           x="0" y="-84.25" z="-1571.325"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-76" unit="cm"
+           x="0" y="84.25" z="-1571.325"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-77" unit="cm"
+           x="0" y="252.75" z="-1571.325"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-78" unit="cm"
+           x="0" y="421.25" z="-1571.325"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-79" unit="cm"
+           x="0" y="589.75" z="-1571.325"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-80" unit="cm"
+           x="0" y="-589.75" z="-1421.675"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-81" unit="cm"
+           x="0" y="-421.25" z="-1421.675"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-82" unit="cm"
+           x="0" y="-252.75" z="-1421.675"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-83" unit="cm"
+           x="0" y="-84.25" z="-1421.675"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-84" unit="cm"
+           x="0" y="84.25" z="-1421.675"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-85" unit="cm"
+           x="0" y="252.75" z="-1421.675"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-86" unit="cm"
+           x="0" y="421.25" z="-1421.675"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-87" unit="cm"
+           x="0" y="589.75" z="-1421.675"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-88" unit="cm"
+           x="0" y="-589.75" z="-1272.025"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-89" unit="cm"
+           x="0" y="-421.25" z="-1272.025"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-90" unit="cm"
+           x="0" y="-252.75" z="-1272.025"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-91" unit="cm"
+           x="0" y="-84.25" z="-1272.025"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-92" unit="cm"
+           x="0" y="84.25" z="-1272.025"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-93" unit="cm"
+           x="0" y="252.75" z="-1272.025"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-94" unit="cm"
+           x="0" y="421.25" z="-1272.025"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-95" unit="cm"
+           x="0" y="589.75" z="-1272.025"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-96" unit="cm"
+           x="0" y="-589.75" z="-1122.375"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-97" unit="cm"
+           x="0" y="-421.25" z="-1122.375"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-98" unit="cm"
+           x="0" y="-252.75" z="-1122.375"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-99" unit="cm"
+           x="0" y="-84.25" z="-1122.375"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-100" unit="cm"
+           x="0" y="84.25" z="-1122.375"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-101" unit="cm"
+           x="0" y="252.75" z="-1122.375"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-102" unit="cm"
+           x="0" y="421.25" z="-1122.375"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-103" unit="cm"
+           x="0" y="589.75" z="-1122.375"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-104" unit="cm"
+           x="0" y="-589.75" z="-972.725"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-105" unit="cm"
+           x="0" y="-421.25" z="-972.725"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-106" unit="cm"
+           x="0" y="-252.75" z="-972.725"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-107" unit="cm"
+           x="0" y="-84.25" z="-972.725"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-108" unit="cm"
+           x="0" y="84.25" z="-972.725"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-109" unit="cm"
+           x="0" y="252.75" z="-972.725"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-110" unit="cm"
+           x="0" y="421.25" z="-972.725"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-111" unit="cm"
+           x="0" y="589.75" z="-972.725"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-112" unit="cm"
+           x="0" y="-589.75" z="-823.075"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-113" unit="cm"
+           x="0" y="-421.25" z="-823.075"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-114" unit="cm"
+           x="0" y="-252.75" z="-823.075"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-115" unit="cm"
+           x="0" y="-84.25" z="-823.075"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-116" unit="cm"
+           x="0" y="84.25" z="-823.075"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-117" unit="cm"
+           x="0" y="252.75" z="-823.075"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-118" unit="cm"
+           x="0" y="421.25" z="-823.075"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-119" unit="cm"
+           x="0" y="589.75" z="-823.075"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-120" unit="cm"
+           x="0" y="-589.75" z="-673.425"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-121" unit="cm"
+           x="0" y="-421.25" z="-673.425"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-122" unit="cm"
+           x="0" y="-252.75" z="-673.425"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-123" unit="cm"
+           x="0" y="-84.25" z="-673.425"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-124" unit="cm"
+           x="0" y="84.25" z="-673.425"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-125" unit="cm"
+           x="0" y="252.75" z="-673.425"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-126" unit="cm"
+           x="0" y="421.25" z="-673.425"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-127" unit="cm"
+           x="0" y="589.75" z="-673.425"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-128" unit="cm"
+           x="0" y="-589.75" z="-523.775"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-129" unit="cm"
+           x="0" y="-421.25" z="-523.775"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-130" unit="cm"
+           x="0" y="-252.75" z="-523.775"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-131" unit="cm"
+           x="0" y="-84.25" z="-523.775"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-132" unit="cm"
+           x="0" y="84.25" z="-523.775"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-133" unit="cm"
+           x="0" y="252.75" z="-523.775"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-134" unit="cm"
+           x="0" y="421.25" z="-523.775"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-135" unit="cm"
+           x="0" y="589.75" z="-523.775"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-136" unit="cm"
+           x="0" y="-589.75" z="-374.125"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-137" unit="cm"
+           x="0" y="-421.25" z="-374.125"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-138" unit="cm"
+           x="0" y="-252.75" z="-374.125"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-139" unit="cm"
+           x="0" y="-84.25" z="-374.125"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-140" unit="cm"
+           x="0" y="84.25" z="-374.125"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-141" unit="cm"
+           x="0" y="252.75" z="-374.125"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-142" unit="cm"
+           x="0" y="421.25" z="-374.125"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-143" unit="cm"
+           x="0" y="589.75" z="-374.125"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-144" unit="cm"
+           x="0" y="-589.75" z="-224.475"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-145" unit="cm"
+           x="0" y="-421.25" z="-224.475"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-146" unit="cm"
+           x="0" y="-252.75" z="-224.475"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-147" unit="cm"
+           x="0" y="-84.25" z="-224.475"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-148" unit="cm"
+           x="0" y="84.25" z="-224.475"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-149" unit="cm"
+           x="0" y="252.75" z="-224.475"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-150" unit="cm"
+           x="0" y="421.25" z="-224.475"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-151" unit="cm"
+           x="0" y="589.75" z="-224.475"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-152" unit="cm"
+           x="0" y="-589.75" z="-74.8249999999997"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-153" unit="cm"
+           x="0" y="-421.25" z="-74.8249999999997"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-154" unit="cm"
+           x="0" y="-252.75" z="-74.8249999999997"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-155" unit="cm"
+           x="0" y="-84.25" z="-74.8249999999997"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-156" unit="cm"
+           x="0" y="84.25" z="-74.8249999999997"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-157" unit="cm"
+           x="0" y="252.75" z="-74.8249999999997"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-158" unit="cm"
+           x="0" y="421.25" z="-74.8249999999997"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-159" unit="cm"
+           x="0" y="589.75" z="-74.8249999999997"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-160" unit="cm"
+           x="0" y="-589.75" z="74.8250000000003"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-161" unit="cm"
+           x="0" y="-421.25" z="74.8250000000003"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-162" unit="cm"
+           x="0" y="-252.75" z="74.8250000000003"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-163" unit="cm"
+           x="0" y="-84.25" z="74.8250000000003"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-164" unit="cm"
+           x="0" y="84.25" z="74.8250000000003"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-165" unit="cm"
+           x="0" y="252.75" z="74.8250000000003"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-166" unit="cm"
+           x="0" y="421.25" z="74.8250000000003"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-167" unit="cm"
+           x="0" y="589.75" z="74.8250000000003"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-168" unit="cm"
+           x="0" y="-589.75" z="224.475"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-169" unit="cm"
+           x="0" y="-421.25" z="224.475"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-170" unit="cm"
+           x="0" y="-252.75" z="224.475"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-171" unit="cm"
+           x="0" y="-84.25" z="224.475"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-172" unit="cm"
+           x="0" y="84.25" z="224.475"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-173" unit="cm"
+           x="0" y="252.75" z="224.475"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-174" unit="cm"
+           x="0" y="421.25" z="224.475"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-175" unit="cm"
+           x="0" y="589.75" z="224.475"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-176" unit="cm"
+           x="0" y="-589.75" z="374.125"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-177" unit="cm"
+           x="0" y="-421.25" z="374.125"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-178" unit="cm"
+           x="0" y="-252.75" z="374.125"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-179" unit="cm"
+           x="0" y="-84.25" z="374.125"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-180" unit="cm"
+           x="0" y="84.25" z="374.125"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-181" unit="cm"
+           x="0" y="252.75" z="374.125"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-182" unit="cm"
+           x="0" y="421.25" z="374.125"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-183" unit="cm"
+           x="0" y="589.75" z="374.125"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-184" unit="cm"
+           x="0" y="-589.75" z="523.775"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-185" unit="cm"
+           x="0" y="-421.25" z="523.775"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-186" unit="cm"
+           x="0" y="-252.75" z="523.775"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-187" unit="cm"
+           x="0" y="-84.25" z="523.775"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-188" unit="cm"
+           x="0" y="84.25" z="523.775"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-189" unit="cm"
+           x="0" y="252.75" z="523.775"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-190" unit="cm"
+           x="0" y="421.25" z="523.775"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-191" unit="cm"
+           x="0" y="589.75" z="523.775"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-192" unit="cm"
+           x="0" y="-589.75" z="673.425"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-193" unit="cm"
+           x="0" y="-421.25" z="673.425"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-194" unit="cm"
+           x="0" y="-252.75" z="673.425"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-195" unit="cm"
+           x="0" y="-84.25" z="673.425"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-196" unit="cm"
+           x="0" y="84.25" z="673.425"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-197" unit="cm"
+           x="0" y="252.75" z="673.425"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-198" unit="cm"
+           x="0" y="421.25" z="673.425"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-199" unit="cm"
+           x="0" y="589.75" z="673.425"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-200" unit="cm"
+           x="0" y="-589.75" z="823.075"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-201" unit="cm"
+           x="0" y="-421.25" z="823.075"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-202" unit="cm"
+           x="0" y="-252.75" z="823.075"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-203" unit="cm"
+           x="0" y="-84.25" z="823.075"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-204" unit="cm"
+           x="0" y="84.25" z="823.075"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-205" unit="cm"
+           x="0" y="252.75" z="823.075"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-206" unit="cm"
+           x="0" y="421.25" z="823.075"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-207" unit="cm"
+           x="0" y="589.75" z="823.075"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-208" unit="cm"
+           x="0" y="-589.75" z="972.725"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-209" unit="cm"
+           x="0" y="-421.25" z="972.725"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-210" unit="cm"
+           x="0" y="-252.75" z="972.725"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-211" unit="cm"
+           x="0" y="-84.25" z="972.725"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-212" unit="cm"
+           x="0" y="84.25" z="972.725"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-213" unit="cm"
+           x="0" y="252.75" z="972.725"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-214" unit="cm"
+           x="0" y="421.25" z="972.725"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-215" unit="cm"
+           x="0" y="589.75" z="972.725"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-216" unit="cm"
+           x="0" y="-589.75" z="1122.375"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-217" unit="cm"
+           x="0" y="-421.25" z="1122.375"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-218" unit="cm"
+           x="0" y="-252.75" z="1122.375"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-219" unit="cm"
+           x="0" y="-84.25" z="1122.375"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-220" unit="cm"
+           x="0" y="84.25" z="1122.375"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-221" unit="cm"
+           x="0" y="252.75" z="1122.375"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-222" unit="cm"
+           x="0" y="421.25" z="1122.375"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-223" unit="cm"
+           x="0" y="589.75" z="1122.375"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-224" unit="cm"
+           x="0" y="-589.75" z="1272.025"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-225" unit="cm"
+           x="0" y="-421.25" z="1272.025"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-226" unit="cm"
+           x="0" y="-252.75" z="1272.025"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-227" unit="cm"
+           x="0" y="-84.25" z="1272.025"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-228" unit="cm"
+           x="0" y="84.25" z="1272.025"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-229" unit="cm"
+           x="0" y="252.75" z="1272.025"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-230" unit="cm"
+           x="0" y="421.25" z="1272.025"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-231" unit="cm"
+           x="0" y="589.75" z="1272.025"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-232" unit="cm"
+           x="0" y="-589.75" z="1421.675"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-233" unit="cm"
+           x="0" y="-421.25" z="1421.675"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-234" unit="cm"
+           x="0" y="-252.75" z="1421.675"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-235" unit="cm"
+           x="0" y="-84.25" z="1421.675"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-236" unit="cm"
+           x="0" y="84.25" z="1421.675"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-237" unit="cm"
+           x="0" y="252.75" z="1421.675"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-238" unit="cm"
+           x="0" y="421.25" z="1421.675"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-239" unit="cm"
+           x="0" y="589.75" z="1421.675"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-240" unit="cm"
+           x="0" y="-589.75" z="1571.325"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-241" unit="cm"
+           x="0" y="-421.25" z="1571.325"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-242" unit="cm"
+           x="0" y="-252.75" z="1571.325"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-243" unit="cm"
+           x="0" y="-84.25" z="1571.325"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-244" unit="cm"
+           x="0" y="84.25" z="1571.325"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-245" unit="cm"
+           x="0" y="252.75" z="1571.325"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-246" unit="cm"
+           x="0" y="421.25" z="1571.325"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-247" unit="cm"
+           x="0" y="589.75" z="1571.325"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-248" unit="cm"
+           x="0" y="-589.75" z="1720.975"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-249" unit="cm"
+           x="0" y="-421.25" z="1720.975"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-250" unit="cm"
+           x="0" y="-252.75" z="1720.975"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-251" unit="cm"
+           x="0" y="-84.25" z="1720.975"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-252" unit="cm"
+           x="0" y="84.25" z="1720.975"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-253" unit="cm"
+           x="0" y="252.75" z="1720.975"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-254" unit="cm"
+           x="0" y="421.25" z="1720.975"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-255" unit="cm"
+           x="0" y="589.75" z="1720.975"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-256" unit="cm"
+           x="0" y="-589.75" z="1870.625"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-257" unit="cm"
+           x="0" y="-421.25" z="1870.625"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-258" unit="cm"
+           x="0" y="-252.75" z="1870.625"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-259" unit="cm"
+           x="0" y="-84.25" z="1870.625"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-260" unit="cm"
+           x="0" y="84.25" z="1870.625"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-261" unit="cm"
+           x="0" y="252.75" z="1870.625"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-262" unit="cm"
+           x="0" y="421.25" z="1870.625"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-263" unit="cm"
+           x="0" y="589.75" z="1870.625"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-264" unit="cm"
+           x="0" y="-589.75" z="2020.275"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-265" unit="cm"
+           x="0" y="-421.25" z="2020.275"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-266" unit="cm"
+           x="0" y="-252.75" z="2020.275"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-267" unit="cm"
+           x="0" y="-84.25" z="2020.275"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-268" unit="cm"
+           x="0" y="84.25" z="2020.275"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-269" unit="cm"
+           x="0" y="252.75" z="2020.275"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-270" unit="cm"
+           x="0" y="421.25" z="2020.275"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-271" unit="cm"
+           x="0" y="589.75" z="2020.275"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-272" unit="cm"
+           x="0" y="-589.75" z="2169.925"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-273" unit="cm"
+           x="0" y="-421.25" z="2169.925"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-274" unit="cm"
+           x="0" y="-252.75" z="2169.925"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-275" unit="cm"
+           x="0" y="-84.25" z="2169.925"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-276" unit="cm"
+           x="0" y="84.25" z="2169.925"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-277" unit="cm"
+           x="0" y="252.75" z="2169.925"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-278" unit="cm"
+           x="0" y="421.25" z="2169.925"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-279" unit="cm"
+           x="0" y="589.75" z="2169.925"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-280" unit="cm"
+           x="0" y="-589.75" z="2319.575"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-281" unit="cm"
+           x="0" y="-421.25" z="2319.575"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-282" unit="cm"
+           x="0" y="-252.75" z="2319.575"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-283" unit="cm"
+           x="0" y="-84.25" z="2319.575"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-284" unit="cm"
+           x="0" y="84.25" z="2319.575"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-285" unit="cm"
+           x="0" y="252.75" z="2319.575"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-286" unit="cm"
+           x="0" y="421.25" z="2319.575"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-287" unit="cm"
+           x="0" y="589.75" z="2319.575"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-288" unit="cm"
+           x="0" y="-589.75" z="2469.225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-289" unit="cm"
+           x="0" y="-421.25" z="2469.225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-290" unit="cm"
+           x="0" y="-252.75" z="2469.225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-291" unit="cm"
+           x="0" y="-84.25" z="2469.225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-292" unit="cm"
+           x="0" y="84.25" z="2469.225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-293" unit="cm"
+           x="0" y="252.75" z="2469.225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-294" unit="cm"
+           x="0" y="421.25" z="2469.225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-295" unit="cm"
+           x="0" y="589.75" z="2469.225"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-296" unit="cm"
+           x="0" y="-589.75" z="2618.875"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-297" unit="cm"
+           x="0" y="-421.25" z="2618.875"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-298" unit="cm"
+           x="0" y="-252.75" z="2618.875"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-299" unit="cm"
+           x="0" y="-84.25" z="2618.875"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-300" unit="cm"
+           x="0" y="84.25" z="2618.875"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-301" unit="cm"
+           x="0" y="252.75" z="2618.875"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-302" unit="cm"
+           x="0" y="421.25" z="2618.875"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-303" unit="cm"
+           x="0" y="589.75" z="2618.875"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-304" unit="cm"
+           x="0" y="-589.75" z="2768.525"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-305" unit="cm"
+           x="0" y="-421.25" z="2768.525"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-306" unit="cm"
+           x="0" y="-252.75" z="2768.525"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-307" unit="cm"
+           x="0" y="-84.25" z="2768.525"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-308" unit="cm"
+           x="0" y="84.25" z="2768.525"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-309" unit="cm"
+           x="0" y="252.75" z="2768.525"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC0"/>
+	<position name="posTopTPC-310" unit="cm"
+           x="0" y="421.25" z="2768.525"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC1"/>
+	<position name="posTopTPC-311" unit="cm"
+           x="0" y="589.75" z="2768.525"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-312" unit="cm"
+           x="0" y="-589.75" z="2918.175"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-313" unit="cm"
+           x="0" y="-421.25" z="2918.175"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-314" unit="cm"
+           x="0" y="-252.75" z="2918.175"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-315" unit="cm"
+           x="0" y="-84.25" z="2918.175"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-316" unit="cm"
+           x="0" y="84.25" z="2918.175"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-317" unit="cm"
+           x="0" y="252.75" z="2918.175"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC2"/>
+	<position name="posTopTPC-318" unit="cm"
+           x="0" y="421.25" z="2918.175"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC3"/>
+	<position name="posTopTPC-319" unit="cm"
+           x="0" y="589.75" z="2918.175"/>
+      </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper0" unit="cm"  x="-322.03" y="-676.3" z="0" />
+     <rotationref ref="rPlus90AboutZ"/>
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper1" unit="cm"  x="-316.03" y="-676.3" z="0" />
+     <rotationref ref="rPlus90AboutZ"/>
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper2" unit="cm"  x="-310.03" y="-676.3" z="0" />
+     <rotationref ref="rPlus90AboutZ"/>
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper3" unit="cm"  x="-304.03" y="-676.3" z="0" />
+     <rotationref ref="rPlus90AboutZ"/>
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper4" unit="cm"  x="-298.03" y="-676.3" z="0" />
+     <rotationref ref="rPlus90AboutZ"/>
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper5" unit="cm"  x="-292.03" y="-676.3" z="0" />
+     <rotationref ref="rPlus90AboutZ"/>
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper6" unit="cm"  x="-286.03" y="-676.3" z="0" />
+     <rotationref ref="rPlus90AboutZ"/>
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper7" unit="cm"  x="-280.03" y="-676.3" z="0" />
+     <rotationref ref="rPlus90AboutZ"/>
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper8" unit="cm"  x="-274.03" y="-676.3" z="0" />
+     <rotationref ref="rPlus90AboutZ"/>
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper9" unit="cm"  x="-268.03" y="-676.3" z="0" />
+     <rotationref ref="rPlus90AboutZ"/>
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper10" unit="cm"  x="-262.03" y="-676.3" z="0" />
+     <rotationref ref="rPlus90AboutZ"/>
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper11" unit="cm"  x="-256.03" y="-676.3" z="0" />
+     <rotationref ref="rPlus90AboutZ"/>
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper12" unit="cm"  x="-250.03" y="-676.3" z="0" />
+     <rotationref ref="rPlus90AboutZ"/>
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper13" unit="cm"  x="-244.03" y="-676.3" z="0" />
+     <rotationref ref="rPlus90AboutZ"/>
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper14" unit="cm"  x="-238.03" y="-676.3" z="0" />
+     <rotationref ref="rPlus90AboutZ"/>
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper15" unit="cm"  x="-232.03" y="-676.3" z="0" />
+     <rotationref ref="rPlus90AboutZ"/>
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper16" unit="cm"  x="-226.03" y="-676.3" z="0" />
+     <rotationref ref="rPlus90AboutZ"/>
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper17" unit="cm"  x="-220.03" y="-676.3" z="0" />
+     <rotationref ref="rPlus90AboutZ"/>
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper18" unit="cm"  x="-214.03" y="-676.3" z="0" />
+     <rotationref ref="rPlus90AboutZ"/>
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper19" unit="cm"  x="-208.03" y="-676.3" z="0" />
+     <rotationref ref="rPlus90AboutZ"/>
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper20" unit="cm"  x="-202.03" y="-676.3" z="0" />
+     <rotationref ref="rPlus90AboutZ"/>
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper21" unit="cm"  x="-196.03" y="-676.3" z="0" />
+     <rotationref ref="rPlus90AboutZ"/>
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper22" unit="cm"  x="-190.03" y="-676.3" z="0" />
+     <rotationref ref="rPlus90AboutZ"/>
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper23" unit="cm"  x="-184.03" y="-676.3" z="0" />
+     <rotationref ref="rPlus90AboutZ"/>
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper24" unit="cm"  x="-178.03" y="-676.3" z="0" />
+     <rotationref ref="rPlus90AboutZ"/>
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper25" unit="cm"  x="-172.03" y="-676.3" z="0" />
+     <rotationref ref="rPlus90AboutZ"/>
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper26" unit="cm"  x="-166.03" y="-676.3" z="0" />
+     <rotationref ref="rPlus90AboutZ"/>
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper27" unit="cm"  x="-160.03" y="-676.3" z="0" />
+     <rotationref ref="rPlus90AboutZ"/>
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper28" unit="cm"  x="-154.03" y="-676.3" z="0" />
+     <rotationref ref="rPlus90AboutZ"/>
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper29" unit="cm"  x="-148.03" y="-676.3" z="0" />
+     <rotationref ref="rPlus90AboutZ"/>
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper30" unit="cm"  x="-142.03" y="-676.3" z="0" />
+     <rotationref ref="rPlus90AboutZ"/>
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper31" unit="cm"  x="-136.03" y="-676.3" z="0" />
+     <rotationref ref="rPlus90AboutZ"/>
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper32" unit="cm"  x="-130.03" y="-676.3" z="0" />
+     <rotationref ref="rPlus90AboutZ"/>
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper33" unit="cm"  x="-124.03" y="-676.3" z="0" />
+     <rotationref ref="rPlus90AboutZ"/>
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper34" unit="cm"  x="-118.03" y="-676.3" z="0" />
+     <rotationref ref="rPlus90AboutZ"/>
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper35" unit="cm"  x="-112.03" y="-676.3" z="0" />
+     <rotationref ref="rPlus90AboutZ"/>
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper36" unit="cm"  x="-106.03" y="-676.3" z="0" />
+     <rotationref ref="rPlus90AboutZ"/>
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper37" unit="cm"  x="-100.03" y="-676.3" z="0" />
+     <rotationref ref="rPlus90AboutZ"/>
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper38" unit="cm"  x="-94.03" y="-676.3" z="0" />
+     <rotationref ref="rPlus90AboutZ"/>
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper39" unit="cm"  x="-88.03" y="-676.3" z="0" />
+     <rotationref ref="rPlus90AboutZ"/>
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper40" unit="cm"  x="-82.03" y="-676.3" z="0" />
+     <rotationref ref="rPlus90AboutZ"/>
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper41" unit="cm"  x="-76.03" y="-676.3" z="0" />
+     <rotationref ref="rPlus90AboutZ"/>
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper42" unit="cm"  x="-70.03" y="-676.3" z="0" />
+     <rotationref ref="rPlus90AboutZ"/>
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper43" unit="cm"  x="-64.03" y="-676.3" z="0" />
+     <rotationref ref="rPlus90AboutZ"/>
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper44" unit="cm"  x="-58.03" y="-676.3" z="0" />
+     <rotationref ref="rPlus90AboutZ"/>
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper45" unit="cm"  x="-52.03" y="-676.3" z="0" />
+     <rotationref ref="rPlus90AboutZ"/>
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper46" unit="cm"  x="-46.03" y="-676.3" z="0" />
+     <rotationref ref="rPlus90AboutZ"/>
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper47" unit="cm"  x="-40.03" y="-676.3" z="0" />
+     <rotationref ref="rPlus90AboutZ"/>
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper48" unit="cm"  x="-34.03" y="-676.3" z="0" />
+     <rotationref ref="rPlus90AboutZ"/>
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper49" unit="cm"  x="-28.03" y="-676.3" z="0" />
+     <rotationref ref="rPlus90AboutZ"/>
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper50" unit="cm"  x="-22.03" y="-676.3" z="0" />
+     <rotationref ref="rPlus90AboutZ"/>
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper51" unit="cm"  x="-16.03" y="-676.3" z="0" />
+     <rotationref ref="rPlus90AboutZ"/>
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper52" unit="cm"  x="-10.03" y="-676.3" z="0" />
+     <rotationref ref="rPlus90AboutZ"/>
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper53" unit="cm"  x="-4.03000000000002" y="-676.3" z="0" />
+     <rotationref ref="rPlus90AboutZ"/>
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper54" unit="cm"  x="1.96999999999998" y="-676.3" z="0" />
+     <rotationref ref="rPlus90AboutZ"/>
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper55" unit="cm"  x="7.96999999999998" y="-676.3" z="0" />
+     <rotationref ref="rPlus90AboutZ"/>
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper56" unit="cm"  x="13.97" y="-676.3" z="0" />
+     <rotationref ref="rPlus90AboutZ"/>
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper57" unit="cm"  x="19.97" y="-676.3" z="0" />
+     <rotationref ref="rPlus90AboutZ"/>
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper58" unit="cm"  x="25.97" y="-676.3" z="0" />
+     <rotationref ref="rPlus90AboutZ"/>
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper59" unit="cm"  x="31.97" y="-676.3" z="0" />
+     <rotationref ref="rPlus90AboutZ"/>
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper60" unit="cm"  x="37.97" y="-676.3" z="0" />
+     <rotationref ref="rPlus90AboutZ"/>
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper61" unit="cm"  x="43.97" y="-676.3" z="0" />
+     <rotationref ref="rPlus90AboutZ"/>
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper62" unit="cm"  x="49.97" y="-676.3" z="0" />
+     <rotationref ref="rPlus90AboutZ"/>
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper63" unit="cm"  x="55.97" y="-676.3" z="0" />
+     <rotationref ref="rPlus90AboutZ"/>
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper64" unit="cm"  x="61.97" y="-676.3" z="0" />
+     <rotationref ref="rPlus90AboutZ"/>
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper65" unit="cm"  x="67.97" y="-676.3" z="0" />
+     <rotationref ref="rPlus90AboutZ"/>
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper66" unit="cm"  x="73.97" y="-676.3" z="0" />
+     <rotationref ref="rPlus90AboutZ"/>
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper67" unit="cm"  x="79.97" y="-676.3" z="0" />
+     <rotationref ref="rPlus90AboutZ"/>
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper68" unit="cm"  x="85.97" y="-676.3" z="0" />
+     <rotationref ref="rPlus90AboutZ"/>
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper69" unit="cm"  x="91.97" y="-676.3" z="0" />
+     <rotationref ref="rPlus90AboutZ"/>
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper70" unit="cm"  x="97.97" y="-676.3" z="0" />
+     <rotationref ref="rPlus90AboutZ"/>
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper71" unit="cm"  x="103.97" y="-676.3" z="0" />
+     <rotationref ref="rPlus90AboutZ"/>
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper72" unit="cm"  x="109.97" y="-676.3" z="0" />
+     <rotationref ref="rPlus90AboutZ"/>
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper73" unit="cm"  x="115.97" y="-676.3" z="0" />
+     <rotationref ref="rPlus90AboutZ"/>
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper74" unit="cm"  x="121.97" y="-676.3" z="0" />
+     <rotationref ref="rPlus90AboutZ"/>
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper75" unit="cm"  x="127.97" y="-676.3" z="0" />
+     <rotationref ref="rPlus90AboutZ"/>
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper76" unit="cm"  x="133.97" y="-676.3" z="0" />
+     <rotationref ref="rPlus90AboutZ"/>
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper77" unit="cm"  x="139.97" y="-676.3" z="0" />
+     <rotationref ref="rPlus90AboutZ"/>
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper78" unit="cm"  x="145.97" y="-676.3" z="0" />
+     <rotationref ref="rPlus90AboutZ"/>
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper79" unit="cm"  x="151.97" y="-676.3" z="0" />
+     <rotationref ref="rPlus90AboutZ"/>
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper80" unit="cm"  x="157.97" y="-676.3" z="0" />
+     <rotationref ref="rPlus90AboutZ"/>
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper81" unit="cm"  x="163.97" y="-676.3" z="0" />
+     <rotationref ref="rPlus90AboutZ"/>
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper82" unit="cm"  x="169.97" y="-676.3" z="0" />
+     <rotationref ref="rPlus90AboutZ"/>
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper83" unit="cm"  x="175.97" y="-676.3" z="0" />
+     <rotationref ref="rPlus90AboutZ"/>
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper84" unit="cm"  x="181.97" y="-676.3" z="0" />
+     <rotationref ref="rPlus90AboutZ"/>
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper85" unit="cm"  x="187.97" y="-676.3" z="0" />
+     <rotationref ref="rPlus90AboutZ"/>
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper86" unit="cm"  x="193.97" y="-676.3" z="0" />
+     <rotationref ref="rPlus90AboutZ"/>
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper87" unit="cm"  x="199.97" y="-676.3" z="0" />
+     <rotationref ref="rPlus90AboutZ"/>
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper88" unit="cm"  x="205.97" y="-676.3" z="0" />
+     <rotationref ref="rPlus90AboutZ"/>
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper89" unit="cm"  x="211.97" y="-676.3" z="0" />
+     <rotationref ref="rPlus90AboutZ"/>
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper90" unit="cm"  x="217.97" y="-676.3" z="0" />
+     <rotationref ref="rPlus90AboutZ"/>
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper91" unit="cm"  x="223.97" y="-676.3" z="0" />
+     <rotationref ref="rPlus90AboutZ"/>
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper92" unit="cm"  x="229.97" y="-676.3" z="0" />
+     <rotationref ref="rPlus90AboutZ"/>
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper93" unit="cm"  x="235.97" y="-676.3" z="0" />
+     <rotationref ref="rPlus90AboutZ"/>
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper94" unit="cm"  x="241.97" y="-676.3" z="0" />
+     <rotationref ref="rPlus90AboutZ"/>
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper95" unit="cm"  x="247.97" y="-676.3" z="0" />
+     <rotationref ref="rPlus90AboutZ"/>
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper96" unit="cm"  x="253.97" y="-676.3" z="0" />
+     <rotationref ref="rPlus90AboutZ"/>
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper97" unit="cm"  x="259.97" y="-676.3" z="0" />
+     <rotationref ref="rPlus90AboutZ"/>
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper98" unit="cm"  x="265.97" y="-676.3" z="0" />
+     <rotationref ref="rPlus90AboutZ"/>
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper99" unit="cm"  x="271.97" y="-676.3" z="0" />
+     <rotationref ref="rPlus90AboutZ"/>
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper100" unit="cm"  x="277.97" y="-676.3" z="0" />
+     <rotationref ref="rPlus90AboutZ"/>
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper101" unit="cm"  x="283.97" y="-676.3" z="0" />
+     <rotationref ref="rPlus90AboutZ"/>
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper102" unit="cm"  x="289.97" y="-676.3" z="0" />
+     <rotationref ref="rPlus90AboutZ"/>
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper103" unit="cm"  x="295.97" y="-676.3" z="0" />
+     <rotationref ref="rPlus90AboutZ"/>
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper104" unit="cm"  x="301.97" y="-676.3" z="0" />
+     <rotationref ref="rPlus90AboutZ"/>
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper105" unit="cm"  x="307.97" y="-676.3" z="0" />
+     <rotationref ref="rPlus90AboutZ"/>
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper106" unit="cm"  x="313.97" y="-676.3" z="0" />
+     <rotationref ref="rPlus90AboutZ"/>
+  </physvol>
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper107" unit="cm"  x="319.97" y="-676.3" z="0" />
+     <rotationref ref="rPlus90AboutZ"/>
+  </physvol>
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-0" unit="cm" x="-328.03" y="-505.5" z="-2843.35"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-0" unit="cm" x="325.035" y="-505.5" z="-2843.35"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-1" unit="cm" x="-328.03" y="-168.5" z="-2843.35"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-1" unit="cm" x="325.035" y="-168.5" z="-2843.35"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-2" unit="cm" x="-328.03" y="168.5" z="-2843.35"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-2" unit="cm" x="325.035" y="168.5" z="-2843.35"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-3" unit="cm" x="-328.03" y="505.5" z="-2843.35"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-3" unit="cm" x="325.035" y="505.5" z="-2843.35"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-4" unit="cm" x="-328.03" y="-505.5" z="-2544.05"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-4" unit="cm" x="325.035" y="-505.5" z="-2544.05"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-5" unit="cm" x="-328.03" y="-168.5" z="-2544.05"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-5" unit="cm" x="325.035" y="-168.5" z="-2544.05"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-6" unit="cm" x="-328.03" y="168.5" z="-2544.05"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-6" unit="cm" x="325.035" y="168.5" z="-2544.05"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-7" unit="cm" x="-328.03" y="505.5" z="-2544.05"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-7" unit="cm" x="325.035" y="505.5" z="-2544.05"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-8" unit="cm" x="-328.03" y="-505.5" z="-2244.75"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-8" unit="cm" x="325.035" y="-505.5" z="-2244.75"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-9" unit="cm" x="-328.03" y="-168.5" z="-2244.75"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-9" unit="cm" x="325.035" y="-168.5" z="-2244.75"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-10" unit="cm" x="-328.03" y="168.5" z="-2244.75"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-10" unit="cm" x="325.035" y="168.5" z="-2244.75"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-11" unit="cm" x="-328.03" y="505.5" z="-2244.75"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-11" unit="cm" x="325.035" y="505.5" z="-2244.75"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-12" unit="cm" x="-328.03" y="-505.5" z="-1945.45"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-12" unit="cm" x="325.035" y="-505.5" z="-1945.45"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-13" unit="cm" x="-328.03" y="-168.5" z="-1945.45"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-13" unit="cm" x="325.035" y="-168.5" z="-1945.45"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-14" unit="cm" x="-328.03" y="168.5" z="-1945.45"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-14" unit="cm" x="325.035" y="168.5" z="-1945.45"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-15" unit="cm" x="-328.03" y="505.5" z="-1945.45"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-15" unit="cm" x="325.035" y="505.5" z="-1945.45"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-16" unit="cm" x="-328.03" y="-505.5" z="-1646.15"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-16" unit="cm" x="325.035" y="-505.5" z="-1646.15"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-17" unit="cm" x="-328.03" y="-168.5" z="-1646.15"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-17" unit="cm" x="325.035" y="-168.5" z="-1646.15"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-18" unit="cm" x="-328.03" y="168.5" z="-1646.15"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-18" unit="cm" x="325.035" y="168.5" z="-1646.15"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-19" unit="cm" x="-328.03" y="505.5" z="-1646.15"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-19" unit="cm" x="325.035" y="505.5" z="-1646.15"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-20" unit="cm" x="-328.03" y="-505.5" z="-1346.85"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-20" unit="cm" x="325.035" y="-505.5" z="-1346.85"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-21" unit="cm" x="-328.03" y="-168.5" z="-1346.85"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-21" unit="cm" x="325.035" y="-168.5" z="-1346.85"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-22" unit="cm" x="-328.03" y="168.5" z="-1346.85"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-22" unit="cm" x="325.035" y="168.5" z="-1346.85"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-23" unit="cm" x="-328.03" y="505.5" z="-1346.85"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-23" unit="cm" x="325.035" y="505.5" z="-1346.85"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-24" unit="cm" x="-328.03" y="-505.5" z="-1047.55"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-24" unit="cm" x="325.035" y="-505.5" z="-1047.55"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-25" unit="cm" x="-328.03" y="-168.5" z="-1047.55"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-25" unit="cm" x="325.035" y="-168.5" z="-1047.55"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-26" unit="cm" x="-328.03" y="168.5" z="-1047.55"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-26" unit="cm" x="325.035" y="168.5" z="-1047.55"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-27" unit="cm" x="-328.03" y="505.5" z="-1047.55"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-27" unit="cm" x="325.035" y="505.5" z="-1047.55"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-28" unit="cm" x="-328.03" y="-505.5" z="-748.25"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-28" unit="cm" x="325.035" y="-505.5" z="-748.25"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-29" unit="cm" x="-328.03" y="-168.5" z="-748.25"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-29" unit="cm" x="325.035" y="-168.5" z="-748.25"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-30" unit="cm" x="-328.03" y="168.5" z="-748.25"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-30" unit="cm" x="325.035" y="168.5" z="-748.25"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-31" unit="cm" x="-328.03" y="505.5" z="-748.25"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-31" unit="cm" x="325.035" y="505.5" z="-748.25"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-32" unit="cm" x="-328.03" y="-505.5" z="-448.95"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-32" unit="cm" x="325.035" y="-505.5" z="-448.95"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-33" unit="cm" x="-328.03" y="-168.5" z="-448.95"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-33" unit="cm" x="325.035" y="-168.5" z="-448.95"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-34" unit="cm" x="-328.03" y="168.5" z="-448.95"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-34" unit="cm" x="325.035" y="168.5" z="-448.95"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-35" unit="cm" x="-328.03" y="505.5" z="-448.95"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-35" unit="cm" x="325.035" y="505.5" z="-448.95"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-36" unit="cm" x="-328.03" y="-505.5" z="-149.65"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-36" unit="cm" x="325.035" y="-505.5" z="-149.65"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-37" unit="cm" x="-328.03" y="-168.5" z="-149.65"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-37" unit="cm" x="325.035" y="-168.5" z="-149.65"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-38" unit="cm" x="-328.03" y="168.5" z="-149.65"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-38" unit="cm" x="325.035" y="168.5" z="-149.65"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-39" unit="cm" x="-328.03" y="505.5" z="-149.65"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-39" unit="cm" x="325.035" y="505.5" z="-149.65"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-40" unit="cm" x="-328.03" y="-505.5" z="149.65"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-40" unit="cm" x="325.035" y="-505.5" z="149.65"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-41" unit="cm" x="-328.03" y="-168.5" z="149.65"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-41" unit="cm" x="325.035" y="-168.5" z="149.65"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-42" unit="cm" x="-328.03" y="168.5" z="149.65"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-42" unit="cm" x="325.035" y="168.5" z="149.65"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-43" unit="cm" x="-328.03" y="505.5" z="149.65"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-43" unit="cm" x="325.035" y="505.5" z="149.65"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-44" unit="cm" x="-328.03" y="-505.5" z="448.95"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-44" unit="cm" x="325.035" y="-505.5" z="448.95"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-45" unit="cm" x="-328.03" y="-168.5" z="448.95"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-45" unit="cm" x="325.035" y="-168.5" z="448.95"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-46" unit="cm" x="-328.03" y="168.5" z="448.95"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-46" unit="cm" x="325.035" y="168.5" z="448.95"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-47" unit="cm" x="-328.03" y="505.5" z="448.95"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-47" unit="cm" x="325.035" y="505.5" z="448.95"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-48" unit="cm" x="-328.03" y="-505.5" z="748.25"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-48" unit="cm" x="325.035" y="-505.5" z="748.25"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-49" unit="cm" x="-328.03" y="-168.5" z="748.25"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-49" unit="cm" x="325.035" y="-168.5" z="748.25"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-50" unit="cm" x="-328.03" y="168.5" z="748.25"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-50" unit="cm" x="325.035" y="168.5" z="748.25"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-51" unit="cm" x="-328.03" y="505.5" z="748.25"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-51" unit="cm" x="325.035" y="505.5" z="748.25"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-52" unit="cm" x="-328.03" y="-505.5" z="1047.55"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-52" unit="cm" x="325.035" y="-505.5" z="1047.55"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-53" unit="cm" x="-328.03" y="-168.5" z="1047.55"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-53" unit="cm" x="325.035" y="-168.5" z="1047.55"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-54" unit="cm" x="-328.03" y="168.5" z="1047.55"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-54" unit="cm" x="325.035" y="168.5" z="1047.55"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-55" unit="cm" x="-328.03" y="505.5" z="1047.55"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-55" unit="cm" x="325.035" y="505.5" z="1047.55"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-56" unit="cm" x="-328.03" y="-505.5" z="1346.85"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-56" unit="cm" x="325.035" y="-505.5" z="1346.85"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-57" unit="cm" x="-328.03" y="-168.5" z="1346.85"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-57" unit="cm" x="325.035" y="-168.5" z="1346.85"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-58" unit="cm" x="-328.03" y="168.5" z="1346.85"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-58" unit="cm" x="325.035" y="168.5" z="1346.85"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-59" unit="cm" x="-328.03" y="505.5" z="1346.85"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-59" unit="cm" x="325.035" y="505.5" z="1346.85"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-60" unit="cm" x="-328.03" y="-505.5" z="1646.15"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-60" unit="cm" x="325.035" y="-505.5" z="1646.15"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-61" unit="cm" x="-328.03" y="-168.5" z="1646.15"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-61" unit="cm" x="325.035" y="-168.5" z="1646.15"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-62" unit="cm" x="-328.03" y="168.5" z="1646.15"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-62" unit="cm" x="325.035" y="168.5" z="1646.15"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-63" unit="cm" x="-328.03" y="505.5" z="1646.15"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-63" unit="cm" x="325.035" y="505.5" z="1646.15"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-64" unit="cm" x="-328.03" y="-505.5" z="1945.45"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-64" unit="cm" x="325.035" y="-505.5" z="1945.45"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-65" unit="cm" x="-328.03" y="-168.5" z="1945.45"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-65" unit="cm" x="325.035" y="-168.5" z="1945.45"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-66" unit="cm" x="-328.03" y="168.5" z="1945.45"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-66" unit="cm" x="325.035" y="168.5" z="1945.45"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-67" unit="cm" x="-328.03" y="505.5" z="1945.45"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-67" unit="cm" x="325.035" y="505.5" z="1945.45"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-68" unit="cm" x="-328.03" y="-505.5" z="2244.75"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-68" unit="cm" x="325.035" y="-505.5" z="2244.75"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-69" unit="cm" x="-328.03" y="-168.5" z="2244.75"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-69" unit="cm" x="325.035" y="-168.5" z="2244.75"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-70" unit="cm" x="-328.03" y="168.5" z="2244.75"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-70" unit="cm" x="325.035" y="168.5" z="2244.75"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-71" unit="cm" x="-328.03" y="505.5" z="2244.75"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-71" unit="cm" x="325.035" y="505.5" z="2244.75"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-72" unit="cm" x="-328.03" y="-505.5" z="2544.05"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-72" unit="cm" x="325.035" y="-505.5" z="2544.05"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-73" unit="cm" x="-328.03" y="-168.5" z="2544.05"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-73" unit="cm" x="325.035" y="-168.5" z="2544.05"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-74" unit="cm" x="-328.03" y="168.5" z="2544.05"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-74" unit="cm" x="325.035" y="168.5" z="2544.05"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-75" unit="cm" x="-328.03" y="505.5" z="2544.05"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-75" unit="cm" x="325.035" y="505.5" z="2544.05"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-76" unit="cm" x="-328.03" y="-505.5" z="2843.35"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-76" unit="cm" x="325.035" y="-505.5" z="2843.35"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-77" unit="cm" x="-328.03" y="-168.5" z="2843.35"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-77" unit="cm" x="325.035" y="-168.5" z="2843.35"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-78" unit="cm" x="-328.03" y="168.5" z="2843.35"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-78" unit="cm" x="325.035" y="168.5" z="2843.35"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-79" unit="cm" x="-328.03" y="505.5" z="2843.35"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-79" unit="cm" x="325.035" y="505.5" z="2843.35"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-0-0"/>
+       <position name="posArapucaDouble0-Frame-0-0" unit="cm" 
+         x="-328.03"
+	 y="-633.2" 
+	 z="-2805.85"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-0"/>
+       <position name="posOpArapucaDouble0-Frame-0-0" unit="cm" 
+         x="-327.29"
+	 y="-633.2" 
+	 z="-2805.85"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-0-1"/>
+       <position name="posArapucaDouble1-Frame-0-0" unit="cm" 
+         x="-328.03"
+	 y="-542.5" 
+	 z="-2951.85"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-1"/>
+       <position name="posOpArapucaDouble1-Frame-0-0" unit="cm" 
+         x="-327.29"
+	 y="-542.5" 
+	 z="-2951.85"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-0-2"/>
+       <position name="posArapucaDouble2-Frame-0-0" unit="cm" 
+         x="-328.03"
+	 y="-468.5" 
+	 z="-2734.85"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-2"/>
+       <position name="posOpArapucaDouble2-Frame-0-0" unit="cm" 
+         x="-327.29"
+	 y="-468.5" 
+	 z="-2734.85"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-0-3"/>
+       <position name="posArapucaDouble3-Frame-0-0" unit="cm" 
+         x="-328.03"
+	 y="-377.8" 
+	 z="-2880.85"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-3"/>
+       <position name="posOpArapucaDouble3-Frame-0-0" unit="cm" 
+         x="-327.29"
+	 y="-377.8" 
+	 z="-2880.85"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-1-0"/>
+       <position name="posArapucaDouble0-Frame-0-1" unit="cm" 
+         x="-328.03"
+	 y="-633.2" 
+	 z="-2506.55"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-0"/>
+       <position name="posOpArapucaDouble0-Frame-0-1" unit="cm" 
+         x="-327.29"
+	 y="-633.2" 
+	 z="-2506.55"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-1-1"/>
+       <position name="posArapucaDouble1-Frame-0-1" unit="cm" 
+         x="-328.03"
+	 y="-542.5" 
+	 z="-2652.55"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-1"/>
+       <position name="posOpArapucaDouble1-Frame-0-1" unit="cm" 
+         x="-327.29"
+	 y="-542.5" 
+	 z="-2652.55"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-1-2"/>
+       <position name="posArapucaDouble2-Frame-0-1" unit="cm" 
+         x="-328.03"
+	 y="-468.5" 
+	 z="-2435.55"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-2"/>
+       <position name="posOpArapucaDouble2-Frame-0-1" unit="cm" 
+         x="-327.29"
+	 y="-468.5" 
+	 z="-2435.55"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-1-3"/>
+       <position name="posArapucaDouble3-Frame-0-1" unit="cm" 
+         x="-328.03"
+	 y="-377.8" 
+	 z="-2581.55"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-3"/>
+       <position name="posOpArapucaDouble3-Frame-0-1" unit="cm" 
+         x="-327.29"
+	 y="-377.8" 
+	 z="-2581.55"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-2-0"/>
+       <position name="posArapucaDouble0-Frame-0-2" unit="cm" 
+         x="-328.03"
+	 y="-633.2" 
+	 z="-2207.25"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-0"/>
+       <position name="posOpArapucaDouble0-Frame-0-2" unit="cm" 
+         x="-327.29"
+	 y="-633.2" 
+	 z="-2207.25"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-2-1"/>
+       <position name="posArapucaDouble1-Frame-0-2" unit="cm" 
+         x="-328.03"
+	 y="-542.5" 
+	 z="-2353.25"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-1"/>
+       <position name="posOpArapucaDouble1-Frame-0-2" unit="cm" 
+         x="-327.29"
+	 y="-542.5" 
+	 z="-2353.25"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-2-2"/>
+       <position name="posArapucaDouble2-Frame-0-2" unit="cm" 
+         x="-328.03"
+	 y="-468.5" 
+	 z="-2136.25"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-2"/>
+       <position name="posOpArapucaDouble2-Frame-0-2" unit="cm" 
+         x="-327.29"
+	 y="-468.5" 
+	 z="-2136.25"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-2-3"/>
+       <position name="posArapucaDouble3-Frame-0-2" unit="cm" 
+         x="-328.03"
+	 y="-377.8" 
+	 z="-2282.25"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-3"/>
+       <position name="posOpArapucaDouble3-Frame-0-2" unit="cm" 
+         x="-327.29"
+	 y="-377.8" 
+	 z="-2282.25"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-3-0"/>
+       <position name="posArapucaDouble0-Frame-0-3" unit="cm" 
+         x="-328.03"
+	 y="-633.2" 
+	 z="-1907.95"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-3-0"/>
+       <position name="posOpArapucaDouble0-Frame-0-3" unit="cm" 
+         x="-327.29"
+	 y="-633.2" 
+	 z="-1907.95"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-3-1"/>
+       <position name="posArapucaDouble1-Frame-0-3" unit="cm" 
+         x="-328.03"
+	 y="-542.5" 
+	 z="-2053.95"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-3-1"/>
+       <position name="posOpArapucaDouble1-Frame-0-3" unit="cm" 
+         x="-327.29"
+	 y="-542.5" 
+	 z="-2053.95"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-3-2"/>
+       <position name="posArapucaDouble2-Frame-0-3" unit="cm" 
+         x="-328.03"
+	 y="-468.5" 
+	 z="-1836.95"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-3-2"/>
+       <position name="posOpArapucaDouble2-Frame-0-3" unit="cm" 
+         x="-327.29"
+	 y="-468.5" 
+	 z="-1836.95"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-3-3"/>
+       <position name="posArapucaDouble3-Frame-0-3" unit="cm" 
+         x="-328.03"
+	 y="-377.8" 
+	 z="-1982.95"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-3-3"/>
+       <position name="posOpArapucaDouble3-Frame-0-3" unit="cm" 
+         x="-327.29"
+	 y="-377.8" 
+	 z="-1982.95"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-4-0"/>
+       <position name="posArapucaDouble0-Frame-0-4" unit="cm" 
+         x="-328.03"
+	 y="-633.2" 
+	 z="-1608.65"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-4-0"/>
+       <position name="posOpArapucaDouble0-Frame-0-4" unit="cm" 
+         x="-327.29"
+	 y="-633.2" 
+	 z="-1608.65"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-4-1"/>
+       <position name="posArapucaDouble1-Frame-0-4" unit="cm" 
+         x="-328.03"
+	 y="-542.5" 
+	 z="-1754.65"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-4-1"/>
+       <position name="posOpArapucaDouble1-Frame-0-4" unit="cm" 
+         x="-327.29"
+	 y="-542.5" 
+	 z="-1754.65"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-4-2"/>
+       <position name="posArapucaDouble2-Frame-0-4" unit="cm" 
+         x="-328.03"
+	 y="-468.5" 
+	 z="-1537.65"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-4-2"/>
+       <position name="posOpArapucaDouble2-Frame-0-4" unit="cm" 
+         x="-327.29"
+	 y="-468.5" 
+	 z="-1537.65"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-4-3"/>
+       <position name="posArapucaDouble3-Frame-0-4" unit="cm" 
+         x="-328.03"
+	 y="-377.8" 
+	 z="-1683.65"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-4-3"/>
+       <position name="posOpArapucaDouble3-Frame-0-4" unit="cm" 
+         x="-327.29"
+	 y="-377.8" 
+	 z="-1683.65"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-5-0"/>
+       <position name="posArapucaDouble0-Frame-0-5" unit="cm" 
+         x="-328.03"
+	 y="-633.2" 
+	 z="-1309.35"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-5-0"/>
+       <position name="posOpArapucaDouble0-Frame-0-5" unit="cm" 
+         x="-327.29"
+	 y="-633.2" 
+	 z="-1309.35"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-5-1"/>
+       <position name="posArapucaDouble1-Frame-0-5" unit="cm" 
+         x="-328.03"
+	 y="-542.5" 
+	 z="-1455.35"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-5-1"/>
+       <position name="posOpArapucaDouble1-Frame-0-5" unit="cm" 
+         x="-327.29"
+	 y="-542.5" 
+	 z="-1455.35"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-5-2"/>
+       <position name="posArapucaDouble2-Frame-0-5" unit="cm" 
+         x="-328.03"
+	 y="-468.5" 
+	 z="-1238.35"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-5-2"/>
+       <position name="posOpArapucaDouble2-Frame-0-5" unit="cm" 
+         x="-327.29"
+	 y="-468.5" 
+	 z="-1238.35"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-5-3"/>
+       <position name="posArapucaDouble3-Frame-0-5" unit="cm" 
+         x="-328.03"
+	 y="-377.8" 
+	 z="-1384.35"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-5-3"/>
+       <position name="posOpArapucaDouble3-Frame-0-5" unit="cm" 
+         x="-327.29"
+	 y="-377.8" 
+	 z="-1384.35"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-6-0"/>
+       <position name="posArapucaDouble0-Frame-0-6" unit="cm" 
+         x="-328.03"
+	 y="-633.2" 
+	 z="-1010.05"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-6-0"/>
+       <position name="posOpArapucaDouble0-Frame-0-6" unit="cm" 
+         x="-327.29"
+	 y="-633.2" 
+	 z="-1010.05"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-6-1"/>
+       <position name="posArapucaDouble1-Frame-0-6" unit="cm" 
+         x="-328.03"
+	 y="-542.5" 
+	 z="-1156.05"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-6-1"/>
+       <position name="posOpArapucaDouble1-Frame-0-6" unit="cm" 
+         x="-327.29"
+	 y="-542.5" 
+	 z="-1156.05"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-6-2"/>
+       <position name="posArapucaDouble2-Frame-0-6" unit="cm" 
+         x="-328.03"
+	 y="-468.5" 
+	 z="-939.05"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-6-2"/>
+       <position name="posOpArapucaDouble2-Frame-0-6" unit="cm" 
+         x="-327.29"
+	 y="-468.5" 
+	 z="-939.05"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-6-3"/>
+       <position name="posArapucaDouble3-Frame-0-6" unit="cm" 
+         x="-328.03"
+	 y="-377.8" 
+	 z="-1085.05"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-6-3"/>
+       <position name="posOpArapucaDouble3-Frame-0-6" unit="cm" 
+         x="-327.29"
+	 y="-377.8" 
+	 z="-1085.05"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-7-0"/>
+       <position name="posArapucaDouble0-Frame-0-7" unit="cm" 
+         x="-328.03"
+	 y="-633.2" 
+	 z="-710.75"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-7-0"/>
+       <position name="posOpArapucaDouble0-Frame-0-7" unit="cm" 
+         x="-327.29"
+	 y="-633.2" 
+	 z="-710.75"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-7-1"/>
+       <position name="posArapucaDouble1-Frame-0-7" unit="cm" 
+         x="-328.03"
+	 y="-542.5" 
+	 z="-856.75"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-7-1"/>
+       <position name="posOpArapucaDouble1-Frame-0-7" unit="cm" 
+         x="-327.29"
+	 y="-542.5" 
+	 z="-856.75"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-7-2"/>
+       <position name="posArapucaDouble2-Frame-0-7" unit="cm" 
+         x="-328.03"
+	 y="-468.5" 
+	 z="-639.75"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-7-2"/>
+       <position name="posOpArapucaDouble2-Frame-0-7" unit="cm" 
+         x="-327.29"
+	 y="-468.5" 
+	 z="-639.75"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-7-3"/>
+       <position name="posArapucaDouble3-Frame-0-7" unit="cm" 
+         x="-328.03"
+	 y="-377.8" 
+	 z="-785.75"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-7-3"/>
+       <position name="posOpArapucaDouble3-Frame-0-7" unit="cm" 
+         x="-327.29"
+	 y="-377.8" 
+	 z="-785.75"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-8-0"/>
+       <position name="posArapucaDouble0-Frame-0-8" unit="cm" 
+         x="-328.03"
+	 y="-633.2" 
+	 z="-411.45"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-8-0"/>
+       <position name="posOpArapucaDouble0-Frame-0-8" unit="cm" 
+         x="-327.29"
+	 y="-633.2" 
+	 z="-411.45"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-8-1"/>
+       <position name="posArapucaDouble1-Frame-0-8" unit="cm" 
+         x="-328.03"
+	 y="-542.5" 
+	 z="-557.45"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-8-1"/>
+       <position name="posOpArapucaDouble1-Frame-0-8" unit="cm" 
+         x="-327.29"
+	 y="-542.5" 
+	 z="-557.45"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-8-2"/>
+       <position name="posArapucaDouble2-Frame-0-8" unit="cm" 
+         x="-328.03"
+	 y="-468.5" 
+	 z="-340.45"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-8-2"/>
+       <position name="posOpArapucaDouble2-Frame-0-8" unit="cm" 
+         x="-327.29"
+	 y="-468.5" 
+	 z="-340.45"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-8-3"/>
+       <position name="posArapucaDouble3-Frame-0-8" unit="cm" 
+         x="-328.03"
+	 y="-377.8" 
+	 z="-486.45"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-8-3"/>
+       <position name="posOpArapucaDouble3-Frame-0-8" unit="cm" 
+         x="-327.29"
+	 y="-377.8" 
+	 z="-486.45"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-9-0"/>
+       <position name="posArapucaDouble0-Frame-0-9" unit="cm" 
+         x="-328.03"
+	 y="-633.2" 
+	 z="-112.15"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-9-0"/>
+       <position name="posOpArapucaDouble0-Frame-0-9" unit="cm" 
+         x="-327.29"
+	 y="-633.2" 
+	 z="-112.15"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-9-1"/>
+       <position name="posArapucaDouble1-Frame-0-9" unit="cm" 
+         x="-328.03"
+	 y="-542.5" 
+	 z="-258.15"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-9-1"/>
+       <position name="posOpArapucaDouble1-Frame-0-9" unit="cm" 
+         x="-327.29"
+	 y="-542.5" 
+	 z="-258.15"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-9-2"/>
+       <position name="posArapucaDouble2-Frame-0-9" unit="cm" 
+         x="-328.03"
+	 y="-468.5" 
+	 z="-41.1499999999997"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-9-2"/>
+       <position name="posOpArapucaDouble2-Frame-0-9" unit="cm" 
+         x="-327.29"
+	 y="-468.5" 
+	 z="-41.1499999999997"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-9-3"/>
+       <position name="posArapucaDouble3-Frame-0-9" unit="cm" 
+         x="-328.03"
+	 y="-377.8" 
+	 z="-187.15"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-9-3"/>
+       <position name="posOpArapucaDouble3-Frame-0-9" unit="cm" 
+         x="-327.29"
+	 y="-377.8" 
+	 z="-187.15"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-10-0"/>
+       <position name="posArapucaDouble0-Frame-0-10" unit="cm" 
+         x="-328.03"
+	 y="-633.2" 
+	 z="187.15"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-10-0"/>
+       <position name="posOpArapucaDouble0-Frame-0-10" unit="cm" 
+         x="-327.29"
+	 y="-633.2" 
+	 z="187.15"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-10-1"/>
+       <position name="posArapucaDouble1-Frame-0-10" unit="cm" 
+         x="-328.03"
+	 y="-542.5" 
+	 z="41.1500000000003"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-10-1"/>
+       <position name="posOpArapucaDouble1-Frame-0-10" unit="cm" 
+         x="-327.29"
+	 y="-542.5" 
+	 z="41.1500000000003"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-10-2"/>
+       <position name="posArapucaDouble2-Frame-0-10" unit="cm" 
+         x="-328.03"
+	 y="-468.5" 
+	 z="258.15"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-10-2"/>
+       <position name="posOpArapucaDouble2-Frame-0-10" unit="cm" 
+         x="-327.29"
+	 y="-468.5" 
+	 z="258.15"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-10-3"/>
+       <position name="posArapucaDouble3-Frame-0-10" unit="cm" 
+         x="-328.03"
+	 y="-377.8" 
+	 z="112.15"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-10-3"/>
+       <position name="posOpArapucaDouble3-Frame-0-10" unit="cm" 
+         x="-327.29"
+	 y="-377.8" 
+	 z="112.15"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-11-0"/>
+       <position name="posArapucaDouble0-Frame-0-11" unit="cm" 
+         x="-328.03"
+	 y="-633.2" 
+	 z="486.45"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-11-0"/>
+       <position name="posOpArapucaDouble0-Frame-0-11" unit="cm" 
+         x="-327.29"
+	 y="-633.2" 
+	 z="486.45"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-11-1"/>
+       <position name="posArapucaDouble1-Frame-0-11" unit="cm" 
+         x="-328.03"
+	 y="-542.5" 
+	 z="340.45"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-11-1"/>
+       <position name="posOpArapucaDouble1-Frame-0-11" unit="cm" 
+         x="-327.29"
+	 y="-542.5" 
+	 z="340.45"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-11-2"/>
+       <position name="posArapucaDouble2-Frame-0-11" unit="cm" 
+         x="-328.03"
+	 y="-468.5" 
+	 z="557.45"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-11-2"/>
+       <position name="posOpArapucaDouble2-Frame-0-11" unit="cm" 
+         x="-327.29"
+	 y="-468.5" 
+	 z="557.45"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-11-3"/>
+       <position name="posArapucaDouble3-Frame-0-11" unit="cm" 
+         x="-328.03"
+	 y="-377.8" 
+	 z="411.45"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-11-3"/>
+       <position name="posOpArapucaDouble3-Frame-0-11" unit="cm" 
+         x="-327.29"
+	 y="-377.8" 
+	 z="411.45"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-12-0"/>
+       <position name="posArapucaDouble0-Frame-0-12" unit="cm" 
+         x="-328.03"
+	 y="-633.2" 
+	 z="785.75"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-12-0"/>
+       <position name="posOpArapucaDouble0-Frame-0-12" unit="cm" 
+         x="-327.29"
+	 y="-633.2" 
+	 z="785.75"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-12-1"/>
+       <position name="posArapucaDouble1-Frame-0-12" unit="cm" 
+         x="-328.03"
+	 y="-542.5" 
+	 z="639.75"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-12-1"/>
+       <position name="posOpArapucaDouble1-Frame-0-12" unit="cm" 
+         x="-327.29"
+	 y="-542.5" 
+	 z="639.75"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-12-2"/>
+       <position name="posArapucaDouble2-Frame-0-12" unit="cm" 
+         x="-328.03"
+	 y="-468.5" 
+	 z="856.75"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-12-2"/>
+       <position name="posOpArapucaDouble2-Frame-0-12" unit="cm" 
+         x="-327.29"
+	 y="-468.5" 
+	 z="856.75"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-12-3"/>
+       <position name="posArapucaDouble3-Frame-0-12" unit="cm" 
+         x="-328.03"
+	 y="-377.8" 
+	 z="710.75"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-12-3"/>
+       <position name="posOpArapucaDouble3-Frame-0-12" unit="cm" 
+         x="-327.29"
+	 y="-377.8" 
+	 z="710.75"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-13-0"/>
+       <position name="posArapucaDouble0-Frame-0-13" unit="cm" 
+         x="-328.03"
+	 y="-633.2" 
+	 z="1085.05"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-13-0"/>
+       <position name="posOpArapucaDouble0-Frame-0-13" unit="cm" 
+         x="-327.29"
+	 y="-633.2" 
+	 z="1085.05"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-13-1"/>
+       <position name="posArapucaDouble1-Frame-0-13" unit="cm" 
+         x="-328.03"
+	 y="-542.5" 
+	 z="939.05"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-13-1"/>
+       <position name="posOpArapucaDouble1-Frame-0-13" unit="cm" 
+         x="-327.29"
+	 y="-542.5" 
+	 z="939.05"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-13-2"/>
+       <position name="posArapucaDouble2-Frame-0-13" unit="cm" 
+         x="-328.03"
+	 y="-468.5" 
+	 z="1156.05"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-13-2"/>
+       <position name="posOpArapucaDouble2-Frame-0-13" unit="cm" 
+         x="-327.29"
+	 y="-468.5" 
+	 z="1156.05"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-13-3"/>
+       <position name="posArapucaDouble3-Frame-0-13" unit="cm" 
+         x="-328.03"
+	 y="-377.8" 
+	 z="1010.05"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-13-3"/>
+       <position name="posOpArapucaDouble3-Frame-0-13" unit="cm" 
+         x="-327.29"
+	 y="-377.8" 
+	 z="1010.05"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-14-0"/>
+       <position name="posArapucaDouble0-Frame-0-14" unit="cm" 
+         x="-328.03"
+	 y="-633.2" 
+	 z="1384.35"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-14-0"/>
+       <position name="posOpArapucaDouble0-Frame-0-14" unit="cm" 
+         x="-327.29"
+	 y="-633.2" 
+	 z="1384.35"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-14-1"/>
+       <position name="posArapucaDouble1-Frame-0-14" unit="cm" 
+         x="-328.03"
+	 y="-542.5" 
+	 z="1238.35"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-14-1"/>
+       <position name="posOpArapucaDouble1-Frame-0-14" unit="cm" 
+         x="-327.29"
+	 y="-542.5" 
+	 z="1238.35"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-14-2"/>
+       <position name="posArapucaDouble2-Frame-0-14" unit="cm" 
+         x="-328.03"
+	 y="-468.5" 
+	 z="1455.35"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-14-2"/>
+       <position name="posOpArapucaDouble2-Frame-0-14" unit="cm" 
+         x="-327.29"
+	 y="-468.5" 
+	 z="1455.35"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-14-3"/>
+       <position name="posArapucaDouble3-Frame-0-14" unit="cm" 
+         x="-328.03"
+	 y="-377.8" 
+	 z="1309.35"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-14-3"/>
+       <position name="posOpArapucaDouble3-Frame-0-14" unit="cm" 
+         x="-327.29"
+	 y="-377.8" 
+	 z="1309.35"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-15-0"/>
+       <position name="posArapucaDouble0-Frame-0-15" unit="cm" 
+         x="-328.03"
+	 y="-633.2" 
+	 z="1683.65"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-15-0"/>
+       <position name="posOpArapucaDouble0-Frame-0-15" unit="cm" 
+         x="-327.29"
+	 y="-633.2" 
+	 z="1683.65"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-15-1"/>
+       <position name="posArapucaDouble1-Frame-0-15" unit="cm" 
+         x="-328.03"
+	 y="-542.5" 
+	 z="1537.65"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-15-1"/>
+       <position name="posOpArapucaDouble1-Frame-0-15" unit="cm" 
+         x="-327.29"
+	 y="-542.5" 
+	 z="1537.65"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-15-2"/>
+       <position name="posArapucaDouble2-Frame-0-15" unit="cm" 
+         x="-328.03"
+	 y="-468.5" 
+	 z="1754.65"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-15-2"/>
+       <position name="posOpArapucaDouble2-Frame-0-15" unit="cm" 
+         x="-327.29"
+	 y="-468.5" 
+	 z="1754.65"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-15-3"/>
+       <position name="posArapucaDouble3-Frame-0-15" unit="cm" 
+         x="-328.03"
+	 y="-377.8" 
+	 z="1608.65"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-15-3"/>
+       <position name="posOpArapucaDouble3-Frame-0-15" unit="cm" 
+         x="-327.29"
+	 y="-377.8" 
+	 z="1608.65"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-16-0"/>
+       <position name="posArapucaDouble0-Frame-0-16" unit="cm" 
+         x="-328.03"
+	 y="-633.2" 
+	 z="1982.95"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-16-0"/>
+       <position name="posOpArapucaDouble0-Frame-0-16" unit="cm" 
+         x="-327.29"
+	 y="-633.2" 
+	 z="1982.95"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-16-1"/>
+       <position name="posArapucaDouble1-Frame-0-16" unit="cm" 
+         x="-328.03"
+	 y="-542.5" 
+	 z="1836.95"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-16-1"/>
+       <position name="posOpArapucaDouble1-Frame-0-16" unit="cm" 
+         x="-327.29"
+	 y="-542.5" 
+	 z="1836.95"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-16-2"/>
+       <position name="posArapucaDouble2-Frame-0-16" unit="cm" 
+         x="-328.03"
+	 y="-468.5" 
+	 z="2053.95"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-16-2"/>
+       <position name="posOpArapucaDouble2-Frame-0-16" unit="cm" 
+         x="-327.29"
+	 y="-468.5" 
+	 z="2053.95"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-16-3"/>
+       <position name="posArapucaDouble3-Frame-0-16" unit="cm" 
+         x="-328.03"
+	 y="-377.8" 
+	 z="1907.95"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-16-3"/>
+       <position name="posOpArapucaDouble3-Frame-0-16" unit="cm" 
+         x="-327.29"
+	 y="-377.8" 
+	 z="1907.95"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-17-0"/>
+       <position name="posArapucaDouble0-Frame-0-17" unit="cm" 
+         x="-328.03"
+	 y="-633.2" 
+	 z="2282.25"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-17-0"/>
+       <position name="posOpArapucaDouble0-Frame-0-17" unit="cm" 
+         x="-327.29"
+	 y="-633.2" 
+	 z="2282.25"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-17-1"/>
+       <position name="posArapucaDouble1-Frame-0-17" unit="cm" 
+         x="-328.03"
+	 y="-542.5" 
+	 z="2136.25"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-17-1"/>
+       <position name="posOpArapucaDouble1-Frame-0-17" unit="cm" 
+         x="-327.29"
+	 y="-542.5" 
+	 z="2136.25"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-17-2"/>
+       <position name="posArapucaDouble2-Frame-0-17" unit="cm" 
+         x="-328.03"
+	 y="-468.5" 
+	 z="2353.25"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-17-2"/>
+       <position name="posOpArapucaDouble2-Frame-0-17" unit="cm" 
+         x="-327.29"
+	 y="-468.5" 
+	 z="2353.25"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-17-3"/>
+       <position name="posArapucaDouble3-Frame-0-17" unit="cm" 
+         x="-328.03"
+	 y="-377.8" 
+	 z="2207.25"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-17-3"/>
+       <position name="posOpArapucaDouble3-Frame-0-17" unit="cm" 
+         x="-327.29"
+	 y="-377.8" 
+	 z="2207.25"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-18-0"/>
+       <position name="posArapucaDouble0-Frame-0-18" unit="cm" 
+         x="-328.03"
+	 y="-633.2" 
+	 z="2581.55"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-18-0"/>
+       <position name="posOpArapucaDouble0-Frame-0-18" unit="cm" 
+         x="-327.29"
+	 y="-633.2" 
+	 z="2581.55"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-18-1"/>
+       <position name="posArapucaDouble1-Frame-0-18" unit="cm" 
+         x="-328.03"
+	 y="-542.5" 
+	 z="2435.55"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-18-1"/>
+       <position name="posOpArapucaDouble1-Frame-0-18" unit="cm" 
+         x="-327.29"
+	 y="-542.5" 
+	 z="2435.55"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-18-2"/>
+       <position name="posArapucaDouble2-Frame-0-18" unit="cm" 
+         x="-328.03"
+	 y="-468.5" 
+	 z="2652.55"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-18-2"/>
+       <position name="posOpArapucaDouble2-Frame-0-18" unit="cm" 
+         x="-327.29"
+	 y="-468.5" 
+	 z="2652.55"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-18-3"/>
+       <position name="posArapucaDouble3-Frame-0-18" unit="cm" 
+         x="-328.03"
+	 y="-377.8" 
+	 z="2506.55"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-18-3"/>
+       <position name="posOpArapucaDouble3-Frame-0-18" unit="cm" 
+         x="-327.29"
+	 y="-377.8" 
+	 z="2506.55"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-19-0"/>
+       <position name="posArapucaDouble0-Frame-0-19" unit="cm" 
+         x="-328.03"
+	 y="-633.2" 
+	 z="2880.85"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-19-0"/>
+       <position name="posOpArapucaDouble0-Frame-0-19" unit="cm" 
+         x="-327.29"
+	 y="-633.2" 
+	 z="2880.85"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-19-1"/>
+       <position name="posArapucaDouble1-Frame-0-19" unit="cm" 
+         x="-328.03"
+	 y="-542.5" 
+	 z="2734.85"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-19-1"/>
+       <position name="posOpArapucaDouble1-Frame-0-19" unit="cm" 
+         x="-327.29"
+	 y="-542.5" 
+	 z="2734.85"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-19-2"/>
+       <position name="posArapucaDouble2-Frame-0-19" unit="cm" 
+         x="-328.03"
+	 y="-468.5" 
+	 z="2951.85"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-19-2"/>
+       <position name="posOpArapucaDouble2-Frame-0-19" unit="cm" 
+         x="-327.29"
+	 y="-468.5" 
+	 z="2951.85"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_0-19-3"/>
+       <position name="posArapucaDouble3-Frame-0-19" unit="cm" 
+         x="-328.03"
+	 y="-377.8" 
+	 z="2805.85"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-19-3"/>
+       <position name="posOpArapucaDouble3-Frame-0-19" unit="cm" 
+         x="-327.29"
+	 y="-377.8" 
+	 z="2805.85"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-0-0"/>
+       <position name="posArapucaDouble0-Frame-1-0" unit="cm" 
+         x="-328.03"
+	 y="-296.2" 
+	 z="-2805.85"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-0"/>
+       <position name="posOpArapucaDouble0-Frame-1-0" unit="cm" 
+         x="-327.29"
+	 y="-296.2" 
+	 z="-2805.85"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-0-1"/>
+       <position name="posArapucaDouble1-Frame-1-0" unit="cm" 
+         x="-328.03"
+	 y="-205.5" 
+	 z="-2951.85"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-1"/>
+       <position name="posOpArapucaDouble1-Frame-1-0" unit="cm" 
+         x="-327.29"
+	 y="-205.5" 
+	 z="-2951.85"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-0-2"/>
+       <position name="posArapucaDouble2-Frame-1-0" unit="cm" 
+         x="-328.03"
+	 y="-131.5" 
+	 z="-2734.85"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-2"/>
+       <position name="posOpArapucaDouble2-Frame-1-0" unit="cm" 
+         x="-327.29"
+	 y="-131.5" 
+	 z="-2734.85"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-0-3"/>
+       <position name="posArapucaDouble3-Frame-1-0" unit="cm" 
+         x="-328.03"
+	 y="-40.8" 
+	 z="-2880.85"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-3"/>
+       <position name="posOpArapucaDouble3-Frame-1-0" unit="cm" 
+         x="-327.29"
+	 y="-40.8" 
+	 z="-2880.85"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-1-0"/>
+       <position name="posArapucaDouble0-Frame-1-1" unit="cm" 
+         x="-328.03"
+	 y="-296.2" 
+	 z="-2506.55"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-0"/>
+       <position name="posOpArapucaDouble0-Frame-1-1" unit="cm" 
+         x="-327.29"
+	 y="-296.2" 
+	 z="-2506.55"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-1-1"/>
+       <position name="posArapucaDouble1-Frame-1-1" unit="cm" 
+         x="-328.03"
+	 y="-205.5" 
+	 z="-2652.55"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-1"/>
+       <position name="posOpArapucaDouble1-Frame-1-1" unit="cm" 
+         x="-327.29"
+	 y="-205.5" 
+	 z="-2652.55"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-1-2"/>
+       <position name="posArapucaDouble2-Frame-1-1" unit="cm" 
+         x="-328.03"
+	 y="-131.5" 
+	 z="-2435.55"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-2"/>
+       <position name="posOpArapucaDouble2-Frame-1-1" unit="cm" 
+         x="-327.29"
+	 y="-131.5" 
+	 z="-2435.55"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-1-3"/>
+       <position name="posArapucaDouble3-Frame-1-1" unit="cm" 
+         x="-328.03"
+	 y="-40.8" 
+	 z="-2581.55"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-3"/>
+       <position name="posOpArapucaDouble3-Frame-1-1" unit="cm" 
+         x="-327.29"
+	 y="-40.8" 
+	 z="-2581.55"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-2-0"/>
+       <position name="posArapucaDouble0-Frame-1-2" unit="cm" 
+         x="-328.03"
+	 y="-296.2" 
+	 z="-2207.25"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-0"/>
+       <position name="posOpArapucaDouble0-Frame-1-2" unit="cm" 
+         x="-327.29"
+	 y="-296.2" 
+	 z="-2207.25"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-2-1"/>
+       <position name="posArapucaDouble1-Frame-1-2" unit="cm" 
+         x="-328.03"
+	 y="-205.5" 
+	 z="-2353.25"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-1"/>
+       <position name="posOpArapucaDouble1-Frame-1-2" unit="cm" 
+         x="-327.29"
+	 y="-205.5" 
+	 z="-2353.25"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-2-2"/>
+       <position name="posArapucaDouble2-Frame-1-2" unit="cm" 
+         x="-328.03"
+	 y="-131.5" 
+	 z="-2136.25"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-2"/>
+       <position name="posOpArapucaDouble2-Frame-1-2" unit="cm" 
+         x="-327.29"
+	 y="-131.5" 
+	 z="-2136.25"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-2-3"/>
+       <position name="posArapucaDouble3-Frame-1-2" unit="cm" 
+         x="-328.03"
+	 y="-40.8" 
+	 z="-2282.25"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-3"/>
+       <position name="posOpArapucaDouble3-Frame-1-2" unit="cm" 
+         x="-327.29"
+	 y="-40.8" 
+	 z="-2282.25"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-3-0"/>
+       <position name="posArapucaDouble0-Frame-1-3" unit="cm" 
+         x="-328.03"
+	 y="-296.2" 
+	 z="-1907.95"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-3-0"/>
+       <position name="posOpArapucaDouble0-Frame-1-3" unit="cm" 
+         x="-327.29"
+	 y="-296.2" 
+	 z="-1907.95"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-3-1"/>
+       <position name="posArapucaDouble1-Frame-1-3" unit="cm" 
+         x="-328.03"
+	 y="-205.5" 
+	 z="-2053.95"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-3-1"/>
+       <position name="posOpArapucaDouble1-Frame-1-3" unit="cm" 
+         x="-327.29"
+	 y="-205.5" 
+	 z="-2053.95"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-3-2"/>
+       <position name="posArapucaDouble2-Frame-1-3" unit="cm" 
+         x="-328.03"
+	 y="-131.5" 
+	 z="-1836.95"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-3-2"/>
+       <position name="posOpArapucaDouble2-Frame-1-3" unit="cm" 
+         x="-327.29"
+	 y="-131.5" 
+	 z="-1836.95"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-3-3"/>
+       <position name="posArapucaDouble3-Frame-1-3" unit="cm" 
+         x="-328.03"
+	 y="-40.8" 
+	 z="-1982.95"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-3-3"/>
+       <position name="posOpArapucaDouble3-Frame-1-3" unit="cm" 
+         x="-327.29"
+	 y="-40.8" 
+	 z="-1982.95"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-4-0"/>
+       <position name="posArapucaDouble0-Frame-1-4" unit="cm" 
+         x="-328.03"
+	 y="-296.2" 
+	 z="-1608.65"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-4-0"/>
+       <position name="posOpArapucaDouble0-Frame-1-4" unit="cm" 
+         x="-327.29"
+	 y="-296.2" 
+	 z="-1608.65"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-4-1"/>
+       <position name="posArapucaDouble1-Frame-1-4" unit="cm" 
+         x="-328.03"
+	 y="-205.5" 
+	 z="-1754.65"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-4-1"/>
+       <position name="posOpArapucaDouble1-Frame-1-4" unit="cm" 
+         x="-327.29"
+	 y="-205.5" 
+	 z="-1754.65"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-4-2"/>
+       <position name="posArapucaDouble2-Frame-1-4" unit="cm" 
+         x="-328.03"
+	 y="-131.5" 
+	 z="-1537.65"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-4-2"/>
+       <position name="posOpArapucaDouble2-Frame-1-4" unit="cm" 
+         x="-327.29"
+	 y="-131.5" 
+	 z="-1537.65"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-4-3"/>
+       <position name="posArapucaDouble3-Frame-1-4" unit="cm" 
+         x="-328.03"
+	 y="-40.8" 
+	 z="-1683.65"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-4-3"/>
+       <position name="posOpArapucaDouble3-Frame-1-4" unit="cm" 
+         x="-327.29"
+	 y="-40.8" 
+	 z="-1683.65"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-5-0"/>
+       <position name="posArapucaDouble0-Frame-1-5" unit="cm" 
+         x="-328.03"
+	 y="-296.2" 
+	 z="-1309.35"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-5-0"/>
+       <position name="posOpArapucaDouble0-Frame-1-5" unit="cm" 
+         x="-327.29"
+	 y="-296.2" 
+	 z="-1309.35"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-5-1"/>
+       <position name="posArapucaDouble1-Frame-1-5" unit="cm" 
+         x="-328.03"
+	 y="-205.5" 
+	 z="-1455.35"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-5-1"/>
+       <position name="posOpArapucaDouble1-Frame-1-5" unit="cm" 
+         x="-327.29"
+	 y="-205.5" 
+	 z="-1455.35"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-5-2"/>
+       <position name="posArapucaDouble2-Frame-1-5" unit="cm" 
+         x="-328.03"
+	 y="-131.5" 
+	 z="-1238.35"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-5-2"/>
+       <position name="posOpArapucaDouble2-Frame-1-5" unit="cm" 
+         x="-327.29"
+	 y="-131.5" 
+	 z="-1238.35"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-5-3"/>
+       <position name="posArapucaDouble3-Frame-1-5" unit="cm" 
+         x="-328.03"
+	 y="-40.8" 
+	 z="-1384.35"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-5-3"/>
+       <position name="posOpArapucaDouble3-Frame-1-5" unit="cm" 
+         x="-327.29"
+	 y="-40.8" 
+	 z="-1384.35"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-6-0"/>
+       <position name="posArapucaDouble0-Frame-1-6" unit="cm" 
+         x="-328.03"
+	 y="-296.2" 
+	 z="-1010.05"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-6-0"/>
+       <position name="posOpArapucaDouble0-Frame-1-6" unit="cm" 
+         x="-327.29"
+	 y="-296.2" 
+	 z="-1010.05"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-6-1"/>
+       <position name="posArapucaDouble1-Frame-1-6" unit="cm" 
+         x="-328.03"
+	 y="-205.5" 
+	 z="-1156.05"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-6-1"/>
+       <position name="posOpArapucaDouble1-Frame-1-6" unit="cm" 
+         x="-327.29"
+	 y="-205.5" 
+	 z="-1156.05"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-6-2"/>
+       <position name="posArapucaDouble2-Frame-1-6" unit="cm" 
+         x="-328.03"
+	 y="-131.5" 
+	 z="-939.05"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-6-2"/>
+       <position name="posOpArapucaDouble2-Frame-1-6" unit="cm" 
+         x="-327.29"
+	 y="-131.5" 
+	 z="-939.05"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-6-3"/>
+       <position name="posArapucaDouble3-Frame-1-6" unit="cm" 
+         x="-328.03"
+	 y="-40.8" 
+	 z="-1085.05"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-6-3"/>
+       <position name="posOpArapucaDouble3-Frame-1-6" unit="cm" 
+         x="-327.29"
+	 y="-40.8" 
+	 z="-1085.05"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-7-0"/>
+       <position name="posArapucaDouble0-Frame-1-7" unit="cm" 
+         x="-328.03"
+	 y="-296.2" 
+	 z="-710.75"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-7-0"/>
+       <position name="posOpArapucaDouble0-Frame-1-7" unit="cm" 
+         x="-327.29"
+	 y="-296.2" 
+	 z="-710.75"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-7-1"/>
+       <position name="posArapucaDouble1-Frame-1-7" unit="cm" 
+         x="-328.03"
+	 y="-205.5" 
+	 z="-856.75"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-7-1"/>
+       <position name="posOpArapucaDouble1-Frame-1-7" unit="cm" 
+         x="-327.29"
+	 y="-205.5" 
+	 z="-856.75"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-7-2"/>
+       <position name="posArapucaDouble2-Frame-1-7" unit="cm" 
+         x="-328.03"
+	 y="-131.5" 
+	 z="-639.75"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-7-2"/>
+       <position name="posOpArapucaDouble2-Frame-1-7" unit="cm" 
+         x="-327.29"
+	 y="-131.5" 
+	 z="-639.75"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-7-3"/>
+       <position name="posArapucaDouble3-Frame-1-7" unit="cm" 
+         x="-328.03"
+	 y="-40.8" 
+	 z="-785.75"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-7-3"/>
+       <position name="posOpArapucaDouble3-Frame-1-7" unit="cm" 
+         x="-327.29"
+	 y="-40.8" 
+	 z="-785.75"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-8-0"/>
+       <position name="posArapucaDouble0-Frame-1-8" unit="cm" 
+         x="-328.03"
+	 y="-296.2" 
+	 z="-411.45"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-8-0"/>
+       <position name="posOpArapucaDouble0-Frame-1-8" unit="cm" 
+         x="-327.29"
+	 y="-296.2" 
+	 z="-411.45"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-8-1"/>
+       <position name="posArapucaDouble1-Frame-1-8" unit="cm" 
+         x="-328.03"
+	 y="-205.5" 
+	 z="-557.45"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-8-1"/>
+       <position name="posOpArapucaDouble1-Frame-1-8" unit="cm" 
+         x="-327.29"
+	 y="-205.5" 
+	 z="-557.45"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-8-2"/>
+       <position name="posArapucaDouble2-Frame-1-8" unit="cm" 
+         x="-328.03"
+	 y="-131.5" 
+	 z="-340.45"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-8-2"/>
+       <position name="posOpArapucaDouble2-Frame-1-8" unit="cm" 
+         x="-327.29"
+	 y="-131.5" 
+	 z="-340.45"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-8-3"/>
+       <position name="posArapucaDouble3-Frame-1-8" unit="cm" 
+         x="-328.03"
+	 y="-40.8" 
+	 z="-486.45"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-8-3"/>
+       <position name="posOpArapucaDouble3-Frame-1-8" unit="cm" 
+         x="-327.29"
+	 y="-40.8" 
+	 z="-486.45"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-9-0"/>
+       <position name="posArapucaDouble0-Frame-1-9" unit="cm" 
+         x="-328.03"
+	 y="-296.2" 
+	 z="-112.15"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-9-0"/>
+       <position name="posOpArapucaDouble0-Frame-1-9" unit="cm" 
+         x="-327.29"
+	 y="-296.2" 
+	 z="-112.15"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-9-1"/>
+       <position name="posArapucaDouble1-Frame-1-9" unit="cm" 
+         x="-328.03"
+	 y="-205.5" 
+	 z="-258.15"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-9-1"/>
+       <position name="posOpArapucaDouble1-Frame-1-9" unit="cm" 
+         x="-327.29"
+	 y="-205.5" 
+	 z="-258.15"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-9-2"/>
+       <position name="posArapucaDouble2-Frame-1-9" unit="cm" 
+         x="-328.03"
+	 y="-131.5" 
+	 z="-41.1499999999997"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-9-2"/>
+       <position name="posOpArapucaDouble2-Frame-1-9" unit="cm" 
+         x="-327.29"
+	 y="-131.5" 
+	 z="-41.1499999999997"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-9-3"/>
+       <position name="posArapucaDouble3-Frame-1-9" unit="cm" 
+         x="-328.03"
+	 y="-40.8" 
+	 z="-187.15"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-9-3"/>
+       <position name="posOpArapucaDouble3-Frame-1-9" unit="cm" 
+         x="-327.29"
+	 y="-40.8" 
+	 z="-187.15"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-10-0"/>
+       <position name="posArapucaDouble0-Frame-1-10" unit="cm" 
+         x="-328.03"
+	 y="-296.2" 
+	 z="187.15"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-10-0"/>
+       <position name="posOpArapucaDouble0-Frame-1-10" unit="cm" 
+         x="-327.29"
+	 y="-296.2" 
+	 z="187.15"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-10-1"/>
+       <position name="posArapucaDouble1-Frame-1-10" unit="cm" 
+         x="-328.03"
+	 y="-205.5" 
+	 z="41.1500000000003"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-10-1"/>
+       <position name="posOpArapucaDouble1-Frame-1-10" unit="cm" 
+         x="-327.29"
+	 y="-205.5" 
+	 z="41.1500000000003"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-10-2"/>
+       <position name="posArapucaDouble2-Frame-1-10" unit="cm" 
+         x="-328.03"
+	 y="-131.5" 
+	 z="258.15"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-10-2"/>
+       <position name="posOpArapucaDouble2-Frame-1-10" unit="cm" 
+         x="-327.29"
+	 y="-131.5" 
+	 z="258.15"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-10-3"/>
+       <position name="posArapucaDouble3-Frame-1-10" unit="cm" 
+         x="-328.03"
+	 y="-40.8" 
+	 z="112.15"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-10-3"/>
+       <position name="posOpArapucaDouble3-Frame-1-10" unit="cm" 
+         x="-327.29"
+	 y="-40.8" 
+	 z="112.15"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-11-0"/>
+       <position name="posArapucaDouble0-Frame-1-11" unit="cm" 
+         x="-328.03"
+	 y="-296.2" 
+	 z="486.45"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-11-0"/>
+       <position name="posOpArapucaDouble0-Frame-1-11" unit="cm" 
+         x="-327.29"
+	 y="-296.2" 
+	 z="486.45"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-11-1"/>
+       <position name="posArapucaDouble1-Frame-1-11" unit="cm" 
+         x="-328.03"
+	 y="-205.5" 
+	 z="340.45"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-11-1"/>
+       <position name="posOpArapucaDouble1-Frame-1-11" unit="cm" 
+         x="-327.29"
+	 y="-205.5" 
+	 z="340.45"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-11-2"/>
+       <position name="posArapucaDouble2-Frame-1-11" unit="cm" 
+         x="-328.03"
+	 y="-131.5" 
+	 z="557.45"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-11-2"/>
+       <position name="posOpArapucaDouble2-Frame-1-11" unit="cm" 
+         x="-327.29"
+	 y="-131.5" 
+	 z="557.45"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-11-3"/>
+       <position name="posArapucaDouble3-Frame-1-11" unit="cm" 
+         x="-328.03"
+	 y="-40.8" 
+	 z="411.45"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-11-3"/>
+       <position name="posOpArapucaDouble3-Frame-1-11" unit="cm" 
+         x="-327.29"
+	 y="-40.8" 
+	 z="411.45"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-12-0"/>
+       <position name="posArapucaDouble0-Frame-1-12" unit="cm" 
+         x="-328.03"
+	 y="-296.2" 
+	 z="785.75"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-12-0"/>
+       <position name="posOpArapucaDouble0-Frame-1-12" unit="cm" 
+         x="-327.29"
+	 y="-296.2" 
+	 z="785.75"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-12-1"/>
+       <position name="posArapucaDouble1-Frame-1-12" unit="cm" 
+         x="-328.03"
+	 y="-205.5" 
+	 z="639.75"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-12-1"/>
+       <position name="posOpArapucaDouble1-Frame-1-12" unit="cm" 
+         x="-327.29"
+	 y="-205.5" 
+	 z="639.75"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-12-2"/>
+       <position name="posArapucaDouble2-Frame-1-12" unit="cm" 
+         x="-328.03"
+	 y="-131.5" 
+	 z="856.75"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-12-2"/>
+       <position name="posOpArapucaDouble2-Frame-1-12" unit="cm" 
+         x="-327.29"
+	 y="-131.5" 
+	 z="856.75"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-12-3"/>
+       <position name="posArapucaDouble3-Frame-1-12" unit="cm" 
+         x="-328.03"
+	 y="-40.8" 
+	 z="710.75"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-12-3"/>
+       <position name="posOpArapucaDouble3-Frame-1-12" unit="cm" 
+         x="-327.29"
+	 y="-40.8" 
+	 z="710.75"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-13-0"/>
+       <position name="posArapucaDouble0-Frame-1-13" unit="cm" 
+         x="-328.03"
+	 y="-296.2" 
+	 z="1085.05"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-13-0"/>
+       <position name="posOpArapucaDouble0-Frame-1-13" unit="cm" 
+         x="-327.29"
+	 y="-296.2" 
+	 z="1085.05"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-13-1"/>
+       <position name="posArapucaDouble1-Frame-1-13" unit="cm" 
+         x="-328.03"
+	 y="-205.5" 
+	 z="939.05"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-13-1"/>
+       <position name="posOpArapucaDouble1-Frame-1-13" unit="cm" 
+         x="-327.29"
+	 y="-205.5" 
+	 z="939.05"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-13-2"/>
+       <position name="posArapucaDouble2-Frame-1-13" unit="cm" 
+         x="-328.03"
+	 y="-131.5" 
+	 z="1156.05"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-13-2"/>
+       <position name="posOpArapucaDouble2-Frame-1-13" unit="cm" 
+         x="-327.29"
+	 y="-131.5" 
+	 z="1156.05"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-13-3"/>
+       <position name="posArapucaDouble3-Frame-1-13" unit="cm" 
+         x="-328.03"
+	 y="-40.8" 
+	 z="1010.05"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-13-3"/>
+       <position name="posOpArapucaDouble3-Frame-1-13" unit="cm" 
+         x="-327.29"
+	 y="-40.8" 
+	 z="1010.05"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-14-0"/>
+       <position name="posArapucaDouble0-Frame-1-14" unit="cm" 
+         x="-328.03"
+	 y="-296.2" 
+	 z="1384.35"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-14-0"/>
+       <position name="posOpArapucaDouble0-Frame-1-14" unit="cm" 
+         x="-327.29"
+	 y="-296.2" 
+	 z="1384.35"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-14-1"/>
+       <position name="posArapucaDouble1-Frame-1-14" unit="cm" 
+         x="-328.03"
+	 y="-205.5" 
+	 z="1238.35"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-14-1"/>
+       <position name="posOpArapucaDouble1-Frame-1-14" unit="cm" 
+         x="-327.29"
+	 y="-205.5" 
+	 z="1238.35"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-14-2"/>
+       <position name="posArapucaDouble2-Frame-1-14" unit="cm" 
+         x="-328.03"
+	 y="-131.5" 
+	 z="1455.35"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-14-2"/>
+       <position name="posOpArapucaDouble2-Frame-1-14" unit="cm" 
+         x="-327.29"
+	 y="-131.5" 
+	 z="1455.35"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-14-3"/>
+       <position name="posArapucaDouble3-Frame-1-14" unit="cm" 
+         x="-328.03"
+	 y="-40.8" 
+	 z="1309.35"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-14-3"/>
+       <position name="posOpArapucaDouble3-Frame-1-14" unit="cm" 
+         x="-327.29"
+	 y="-40.8" 
+	 z="1309.35"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-15-0"/>
+       <position name="posArapucaDouble0-Frame-1-15" unit="cm" 
+         x="-328.03"
+	 y="-296.2" 
+	 z="1683.65"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-15-0"/>
+       <position name="posOpArapucaDouble0-Frame-1-15" unit="cm" 
+         x="-327.29"
+	 y="-296.2" 
+	 z="1683.65"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-15-1"/>
+       <position name="posArapucaDouble1-Frame-1-15" unit="cm" 
+         x="-328.03"
+	 y="-205.5" 
+	 z="1537.65"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-15-1"/>
+       <position name="posOpArapucaDouble1-Frame-1-15" unit="cm" 
+         x="-327.29"
+	 y="-205.5" 
+	 z="1537.65"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-15-2"/>
+       <position name="posArapucaDouble2-Frame-1-15" unit="cm" 
+         x="-328.03"
+	 y="-131.5" 
+	 z="1754.65"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-15-2"/>
+       <position name="posOpArapucaDouble2-Frame-1-15" unit="cm" 
+         x="-327.29"
+	 y="-131.5" 
+	 z="1754.65"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-15-3"/>
+       <position name="posArapucaDouble3-Frame-1-15" unit="cm" 
+         x="-328.03"
+	 y="-40.8" 
+	 z="1608.65"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-15-3"/>
+       <position name="posOpArapucaDouble3-Frame-1-15" unit="cm" 
+         x="-327.29"
+	 y="-40.8" 
+	 z="1608.65"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-16-0"/>
+       <position name="posArapucaDouble0-Frame-1-16" unit="cm" 
+         x="-328.03"
+	 y="-296.2" 
+	 z="1982.95"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-16-0"/>
+       <position name="posOpArapucaDouble0-Frame-1-16" unit="cm" 
+         x="-327.29"
+	 y="-296.2" 
+	 z="1982.95"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-16-1"/>
+       <position name="posArapucaDouble1-Frame-1-16" unit="cm" 
+         x="-328.03"
+	 y="-205.5" 
+	 z="1836.95"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-16-1"/>
+       <position name="posOpArapucaDouble1-Frame-1-16" unit="cm" 
+         x="-327.29"
+	 y="-205.5" 
+	 z="1836.95"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-16-2"/>
+       <position name="posArapucaDouble2-Frame-1-16" unit="cm" 
+         x="-328.03"
+	 y="-131.5" 
+	 z="2053.95"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-16-2"/>
+       <position name="posOpArapucaDouble2-Frame-1-16" unit="cm" 
+         x="-327.29"
+	 y="-131.5" 
+	 z="2053.95"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-16-3"/>
+       <position name="posArapucaDouble3-Frame-1-16" unit="cm" 
+         x="-328.03"
+	 y="-40.8" 
+	 z="1907.95"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-16-3"/>
+       <position name="posOpArapucaDouble3-Frame-1-16" unit="cm" 
+         x="-327.29"
+	 y="-40.8" 
+	 z="1907.95"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-17-0"/>
+       <position name="posArapucaDouble0-Frame-1-17" unit="cm" 
+         x="-328.03"
+	 y="-296.2" 
+	 z="2282.25"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-17-0"/>
+       <position name="posOpArapucaDouble0-Frame-1-17" unit="cm" 
+         x="-327.29"
+	 y="-296.2" 
+	 z="2282.25"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-17-1"/>
+       <position name="posArapucaDouble1-Frame-1-17" unit="cm" 
+         x="-328.03"
+	 y="-205.5" 
+	 z="2136.25"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-17-1"/>
+       <position name="posOpArapucaDouble1-Frame-1-17" unit="cm" 
+         x="-327.29"
+	 y="-205.5" 
+	 z="2136.25"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-17-2"/>
+       <position name="posArapucaDouble2-Frame-1-17" unit="cm" 
+         x="-328.03"
+	 y="-131.5" 
+	 z="2353.25"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-17-2"/>
+       <position name="posOpArapucaDouble2-Frame-1-17" unit="cm" 
+         x="-327.29"
+	 y="-131.5" 
+	 z="2353.25"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-17-3"/>
+       <position name="posArapucaDouble3-Frame-1-17" unit="cm" 
+         x="-328.03"
+	 y="-40.8" 
+	 z="2207.25"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-17-3"/>
+       <position name="posOpArapucaDouble3-Frame-1-17" unit="cm" 
+         x="-327.29"
+	 y="-40.8" 
+	 z="2207.25"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-18-0"/>
+       <position name="posArapucaDouble0-Frame-1-18" unit="cm" 
+         x="-328.03"
+	 y="-296.2" 
+	 z="2581.55"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-18-0"/>
+       <position name="posOpArapucaDouble0-Frame-1-18" unit="cm" 
+         x="-327.29"
+	 y="-296.2" 
+	 z="2581.55"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-18-1"/>
+       <position name="posArapucaDouble1-Frame-1-18" unit="cm" 
+         x="-328.03"
+	 y="-205.5" 
+	 z="2435.55"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-18-1"/>
+       <position name="posOpArapucaDouble1-Frame-1-18" unit="cm" 
+         x="-327.29"
+	 y="-205.5" 
+	 z="2435.55"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-18-2"/>
+       <position name="posArapucaDouble2-Frame-1-18" unit="cm" 
+         x="-328.03"
+	 y="-131.5" 
+	 z="2652.55"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-18-2"/>
+       <position name="posOpArapucaDouble2-Frame-1-18" unit="cm" 
+         x="-327.29"
+	 y="-131.5" 
+	 z="2652.55"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-18-3"/>
+       <position name="posArapucaDouble3-Frame-1-18" unit="cm" 
+         x="-328.03"
+	 y="-40.8" 
+	 z="2506.55"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-18-3"/>
+       <position name="posOpArapucaDouble3-Frame-1-18" unit="cm" 
+         x="-327.29"
+	 y="-40.8" 
+	 z="2506.55"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-19-0"/>
+       <position name="posArapucaDouble0-Frame-1-19" unit="cm" 
+         x="-328.03"
+	 y="-296.2" 
+	 z="2880.85"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-19-0"/>
+       <position name="posOpArapucaDouble0-Frame-1-19" unit="cm" 
+         x="-327.29"
+	 y="-296.2" 
+	 z="2880.85"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-19-1"/>
+       <position name="posArapucaDouble1-Frame-1-19" unit="cm" 
+         x="-328.03"
+	 y="-205.5" 
+	 z="2734.85"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-19-1"/>
+       <position name="posOpArapucaDouble1-Frame-1-19" unit="cm" 
+         x="-327.29"
+	 y="-205.5" 
+	 z="2734.85"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-19-2"/>
+       <position name="posArapucaDouble2-Frame-1-19" unit="cm" 
+         x="-328.03"
+	 y="-131.5" 
+	 z="2951.85"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-19-2"/>
+       <position name="posOpArapucaDouble2-Frame-1-19" unit="cm" 
+         x="-327.29"
+	 y="-131.5" 
+	 z="2951.85"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_1-19-3"/>
+       <position name="posArapucaDouble3-Frame-1-19" unit="cm" 
+         x="-328.03"
+	 y="-40.8" 
+	 z="2805.85"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-19-3"/>
+       <position name="posOpArapucaDouble3-Frame-1-19" unit="cm" 
+         x="-327.29"
+	 y="-40.8" 
+	 z="2805.85"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-0-0"/>
+       <position name="posArapucaDouble0-Frame-2-0" unit="cm" 
+         x="-328.03"
+	 y="40.8" 
+	 z="-2805.85"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-0"/>
+       <position name="posOpArapucaDouble0-Frame-2-0" unit="cm" 
+         x="-327.29"
+	 y="40.8" 
+	 z="-2805.85"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-0-1"/>
+       <position name="posArapucaDouble1-Frame-2-0" unit="cm" 
+         x="-328.03"
+	 y="131.5" 
+	 z="-2951.85"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-1"/>
+       <position name="posOpArapucaDouble1-Frame-2-0" unit="cm" 
+         x="-327.29"
+	 y="131.5" 
+	 z="-2951.85"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-0-2"/>
+       <position name="posArapucaDouble2-Frame-2-0" unit="cm" 
+         x="-328.03"
+	 y="205.5" 
+	 z="-2734.85"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-2"/>
+       <position name="posOpArapucaDouble2-Frame-2-0" unit="cm" 
+         x="-327.29"
+	 y="205.5" 
+	 z="-2734.85"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-0-3"/>
+       <position name="posArapucaDouble3-Frame-2-0" unit="cm" 
+         x="-328.03"
+	 y="296.2" 
+	 z="-2880.85"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-3"/>
+       <position name="posOpArapucaDouble3-Frame-2-0" unit="cm" 
+         x="-327.29"
+	 y="296.2" 
+	 z="-2880.85"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-1-0"/>
+       <position name="posArapucaDouble0-Frame-2-1" unit="cm" 
+         x="-328.03"
+	 y="40.8" 
+	 z="-2506.55"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-0"/>
+       <position name="posOpArapucaDouble0-Frame-2-1" unit="cm" 
+         x="-327.29"
+	 y="40.8" 
+	 z="-2506.55"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-1-1"/>
+       <position name="posArapucaDouble1-Frame-2-1" unit="cm" 
+         x="-328.03"
+	 y="131.5" 
+	 z="-2652.55"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-1"/>
+       <position name="posOpArapucaDouble1-Frame-2-1" unit="cm" 
+         x="-327.29"
+	 y="131.5" 
+	 z="-2652.55"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-1-2"/>
+       <position name="posArapucaDouble2-Frame-2-1" unit="cm" 
+         x="-328.03"
+	 y="205.5" 
+	 z="-2435.55"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-2"/>
+       <position name="posOpArapucaDouble2-Frame-2-1" unit="cm" 
+         x="-327.29"
+	 y="205.5" 
+	 z="-2435.55"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-1-3"/>
+       <position name="posArapucaDouble3-Frame-2-1" unit="cm" 
+         x="-328.03"
+	 y="296.2" 
+	 z="-2581.55"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-3"/>
+       <position name="posOpArapucaDouble3-Frame-2-1" unit="cm" 
+         x="-327.29"
+	 y="296.2" 
+	 z="-2581.55"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-2-0"/>
+       <position name="posArapucaDouble0-Frame-2-2" unit="cm" 
+         x="-328.03"
+	 y="40.8" 
+	 z="-2207.25"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-0"/>
+       <position name="posOpArapucaDouble0-Frame-2-2" unit="cm" 
+         x="-327.29"
+	 y="40.8" 
+	 z="-2207.25"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-2-1"/>
+       <position name="posArapucaDouble1-Frame-2-2" unit="cm" 
+         x="-328.03"
+	 y="131.5" 
+	 z="-2353.25"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-1"/>
+       <position name="posOpArapucaDouble1-Frame-2-2" unit="cm" 
+         x="-327.29"
+	 y="131.5" 
+	 z="-2353.25"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-2-2"/>
+       <position name="posArapucaDouble2-Frame-2-2" unit="cm" 
+         x="-328.03"
+	 y="205.5" 
+	 z="-2136.25"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-2"/>
+       <position name="posOpArapucaDouble2-Frame-2-2" unit="cm" 
+         x="-327.29"
+	 y="205.5" 
+	 z="-2136.25"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-2-3"/>
+       <position name="posArapucaDouble3-Frame-2-2" unit="cm" 
+         x="-328.03"
+	 y="296.2" 
+	 z="-2282.25"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-3"/>
+       <position name="posOpArapucaDouble3-Frame-2-2" unit="cm" 
+         x="-327.29"
+	 y="296.2" 
+	 z="-2282.25"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-3-0"/>
+       <position name="posArapucaDouble0-Frame-2-3" unit="cm" 
+         x="-328.03"
+	 y="40.8" 
+	 z="-1907.95"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-3-0"/>
+       <position name="posOpArapucaDouble0-Frame-2-3" unit="cm" 
+         x="-327.29"
+	 y="40.8" 
+	 z="-1907.95"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-3-1"/>
+       <position name="posArapucaDouble1-Frame-2-3" unit="cm" 
+         x="-328.03"
+	 y="131.5" 
+	 z="-2053.95"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-3-1"/>
+       <position name="posOpArapucaDouble1-Frame-2-3" unit="cm" 
+         x="-327.29"
+	 y="131.5" 
+	 z="-2053.95"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-3-2"/>
+       <position name="posArapucaDouble2-Frame-2-3" unit="cm" 
+         x="-328.03"
+	 y="205.5" 
+	 z="-1836.95"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-3-2"/>
+       <position name="posOpArapucaDouble2-Frame-2-3" unit="cm" 
+         x="-327.29"
+	 y="205.5" 
+	 z="-1836.95"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-3-3"/>
+       <position name="posArapucaDouble3-Frame-2-3" unit="cm" 
+         x="-328.03"
+	 y="296.2" 
+	 z="-1982.95"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-3-3"/>
+       <position name="posOpArapucaDouble3-Frame-2-3" unit="cm" 
+         x="-327.29"
+	 y="296.2" 
+	 z="-1982.95"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-4-0"/>
+       <position name="posArapucaDouble0-Frame-2-4" unit="cm" 
+         x="-328.03"
+	 y="40.8" 
+	 z="-1608.65"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-4-0"/>
+       <position name="posOpArapucaDouble0-Frame-2-4" unit="cm" 
+         x="-327.29"
+	 y="40.8" 
+	 z="-1608.65"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-4-1"/>
+       <position name="posArapucaDouble1-Frame-2-4" unit="cm" 
+         x="-328.03"
+	 y="131.5" 
+	 z="-1754.65"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-4-1"/>
+       <position name="posOpArapucaDouble1-Frame-2-4" unit="cm" 
+         x="-327.29"
+	 y="131.5" 
+	 z="-1754.65"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-4-2"/>
+       <position name="posArapucaDouble2-Frame-2-4" unit="cm" 
+         x="-328.03"
+	 y="205.5" 
+	 z="-1537.65"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-4-2"/>
+       <position name="posOpArapucaDouble2-Frame-2-4" unit="cm" 
+         x="-327.29"
+	 y="205.5" 
+	 z="-1537.65"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-4-3"/>
+       <position name="posArapucaDouble3-Frame-2-4" unit="cm" 
+         x="-328.03"
+	 y="296.2" 
+	 z="-1683.65"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-4-3"/>
+       <position name="posOpArapucaDouble3-Frame-2-4" unit="cm" 
+         x="-327.29"
+	 y="296.2" 
+	 z="-1683.65"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-5-0"/>
+       <position name="posArapucaDouble0-Frame-2-5" unit="cm" 
+         x="-328.03"
+	 y="40.8" 
+	 z="-1309.35"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-5-0"/>
+       <position name="posOpArapucaDouble0-Frame-2-5" unit="cm" 
+         x="-327.29"
+	 y="40.8" 
+	 z="-1309.35"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-5-1"/>
+       <position name="posArapucaDouble1-Frame-2-5" unit="cm" 
+         x="-328.03"
+	 y="131.5" 
+	 z="-1455.35"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-5-1"/>
+       <position name="posOpArapucaDouble1-Frame-2-5" unit="cm" 
+         x="-327.29"
+	 y="131.5" 
+	 z="-1455.35"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-5-2"/>
+       <position name="posArapucaDouble2-Frame-2-5" unit="cm" 
+         x="-328.03"
+	 y="205.5" 
+	 z="-1238.35"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-5-2"/>
+       <position name="posOpArapucaDouble2-Frame-2-5" unit="cm" 
+         x="-327.29"
+	 y="205.5" 
+	 z="-1238.35"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-5-3"/>
+       <position name="posArapucaDouble3-Frame-2-5" unit="cm" 
+         x="-328.03"
+	 y="296.2" 
+	 z="-1384.35"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-5-3"/>
+       <position name="posOpArapucaDouble3-Frame-2-5" unit="cm" 
+         x="-327.29"
+	 y="296.2" 
+	 z="-1384.35"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-6-0"/>
+       <position name="posArapucaDouble0-Frame-2-6" unit="cm" 
+         x="-328.03"
+	 y="40.8" 
+	 z="-1010.05"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-6-0"/>
+       <position name="posOpArapucaDouble0-Frame-2-6" unit="cm" 
+         x="-327.29"
+	 y="40.8" 
+	 z="-1010.05"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-6-1"/>
+       <position name="posArapucaDouble1-Frame-2-6" unit="cm" 
+         x="-328.03"
+	 y="131.5" 
+	 z="-1156.05"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-6-1"/>
+       <position name="posOpArapucaDouble1-Frame-2-6" unit="cm" 
+         x="-327.29"
+	 y="131.5" 
+	 z="-1156.05"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-6-2"/>
+       <position name="posArapucaDouble2-Frame-2-6" unit="cm" 
+         x="-328.03"
+	 y="205.5" 
+	 z="-939.05"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-6-2"/>
+       <position name="posOpArapucaDouble2-Frame-2-6" unit="cm" 
+         x="-327.29"
+	 y="205.5" 
+	 z="-939.05"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-6-3"/>
+       <position name="posArapucaDouble3-Frame-2-6" unit="cm" 
+         x="-328.03"
+	 y="296.2" 
+	 z="-1085.05"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-6-3"/>
+       <position name="posOpArapucaDouble3-Frame-2-6" unit="cm" 
+         x="-327.29"
+	 y="296.2" 
+	 z="-1085.05"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-7-0"/>
+       <position name="posArapucaDouble0-Frame-2-7" unit="cm" 
+         x="-328.03"
+	 y="40.8" 
+	 z="-710.75"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-7-0"/>
+       <position name="posOpArapucaDouble0-Frame-2-7" unit="cm" 
+         x="-327.29"
+	 y="40.8" 
+	 z="-710.75"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-7-1"/>
+       <position name="posArapucaDouble1-Frame-2-7" unit="cm" 
+         x="-328.03"
+	 y="131.5" 
+	 z="-856.75"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-7-1"/>
+       <position name="posOpArapucaDouble1-Frame-2-7" unit="cm" 
+         x="-327.29"
+	 y="131.5" 
+	 z="-856.75"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-7-2"/>
+       <position name="posArapucaDouble2-Frame-2-7" unit="cm" 
+         x="-328.03"
+	 y="205.5" 
+	 z="-639.75"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-7-2"/>
+       <position name="posOpArapucaDouble2-Frame-2-7" unit="cm" 
+         x="-327.29"
+	 y="205.5" 
+	 z="-639.75"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-7-3"/>
+       <position name="posArapucaDouble3-Frame-2-7" unit="cm" 
+         x="-328.03"
+	 y="296.2" 
+	 z="-785.75"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-7-3"/>
+       <position name="posOpArapucaDouble3-Frame-2-7" unit="cm" 
+         x="-327.29"
+	 y="296.2" 
+	 z="-785.75"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-8-0"/>
+       <position name="posArapucaDouble0-Frame-2-8" unit="cm" 
+         x="-328.03"
+	 y="40.8" 
+	 z="-411.45"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-8-0"/>
+       <position name="posOpArapucaDouble0-Frame-2-8" unit="cm" 
+         x="-327.29"
+	 y="40.8" 
+	 z="-411.45"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-8-1"/>
+       <position name="posArapucaDouble1-Frame-2-8" unit="cm" 
+         x="-328.03"
+	 y="131.5" 
+	 z="-557.45"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-8-1"/>
+       <position name="posOpArapucaDouble1-Frame-2-8" unit="cm" 
+         x="-327.29"
+	 y="131.5" 
+	 z="-557.45"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-8-2"/>
+       <position name="posArapucaDouble2-Frame-2-8" unit="cm" 
+         x="-328.03"
+	 y="205.5" 
+	 z="-340.45"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-8-2"/>
+       <position name="posOpArapucaDouble2-Frame-2-8" unit="cm" 
+         x="-327.29"
+	 y="205.5" 
+	 z="-340.45"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-8-3"/>
+       <position name="posArapucaDouble3-Frame-2-8" unit="cm" 
+         x="-328.03"
+	 y="296.2" 
+	 z="-486.45"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-8-3"/>
+       <position name="posOpArapucaDouble3-Frame-2-8" unit="cm" 
+         x="-327.29"
+	 y="296.2" 
+	 z="-486.45"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-9-0"/>
+       <position name="posArapucaDouble0-Frame-2-9" unit="cm" 
+         x="-328.03"
+	 y="40.8" 
+	 z="-112.15"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-9-0"/>
+       <position name="posOpArapucaDouble0-Frame-2-9" unit="cm" 
+         x="-327.29"
+	 y="40.8" 
+	 z="-112.15"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-9-1"/>
+       <position name="posArapucaDouble1-Frame-2-9" unit="cm" 
+         x="-328.03"
+	 y="131.5" 
+	 z="-258.15"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-9-1"/>
+       <position name="posOpArapucaDouble1-Frame-2-9" unit="cm" 
+         x="-327.29"
+	 y="131.5" 
+	 z="-258.15"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-9-2"/>
+       <position name="posArapucaDouble2-Frame-2-9" unit="cm" 
+         x="-328.03"
+	 y="205.5" 
+	 z="-41.1499999999997"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-9-2"/>
+       <position name="posOpArapucaDouble2-Frame-2-9" unit="cm" 
+         x="-327.29"
+	 y="205.5" 
+	 z="-41.1499999999997"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-9-3"/>
+       <position name="posArapucaDouble3-Frame-2-9" unit="cm" 
+         x="-328.03"
+	 y="296.2" 
+	 z="-187.15"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-9-3"/>
+       <position name="posOpArapucaDouble3-Frame-2-9" unit="cm" 
+         x="-327.29"
+	 y="296.2" 
+	 z="-187.15"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-10-0"/>
+       <position name="posArapucaDouble0-Frame-2-10" unit="cm" 
+         x="-328.03"
+	 y="40.8" 
+	 z="187.15"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-10-0"/>
+       <position name="posOpArapucaDouble0-Frame-2-10" unit="cm" 
+         x="-327.29"
+	 y="40.8" 
+	 z="187.15"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-10-1"/>
+       <position name="posArapucaDouble1-Frame-2-10" unit="cm" 
+         x="-328.03"
+	 y="131.5" 
+	 z="41.1500000000003"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-10-1"/>
+       <position name="posOpArapucaDouble1-Frame-2-10" unit="cm" 
+         x="-327.29"
+	 y="131.5" 
+	 z="41.1500000000003"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-10-2"/>
+       <position name="posArapucaDouble2-Frame-2-10" unit="cm" 
+         x="-328.03"
+	 y="205.5" 
+	 z="258.15"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-10-2"/>
+       <position name="posOpArapucaDouble2-Frame-2-10" unit="cm" 
+         x="-327.29"
+	 y="205.5" 
+	 z="258.15"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-10-3"/>
+       <position name="posArapucaDouble3-Frame-2-10" unit="cm" 
+         x="-328.03"
+	 y="296.2" 
+	 z="112.15"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-10-3"/>
+       <position name="posOpArapucaDouble3-Frame-2-10" unit="cm" 
+         x="-327.29"
+	 y="296.2" 
+	 z="112.15"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-11-0"/>
+       <position name="posArapucaDouble0-Frame-2-11" unit="cm" 
+         x="-328.03"
+	 y="40.8" 
+	 z="486.45"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-11-0"/>
+       <position name="posOpArapucaDouble0-Frame-2-11" unit="cm" 
+         x="-327.29"
+	 y="40.8" 
+	 z="486.45"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-11-1"/>
+       <position name="posArapucaDouble1-Frame-2-11" unit="cm" 
+         x="-328.03"
+	 y="131.5" 
+	 z="340.45"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-11-1"/>
+       <position name="posOpArapucaDouble1-Frame-2-11" unit="cm" 
+         x="-327.29"
+	 y="131.5" 
+	 z="340.45"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-11-2"/>
+       <position name="posArapucaDouble2-Frame-2-11" unit="cm" 
+         x="-328.03"
+	 y="205.5" 
+	 z="557.45"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-11-2"/>
+       <position name="posOpArapucaDouble2-Frame-2-11" unit="cm" 
+         x="-327.29"
+	 y="205.5" 
+	 z="557.45"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-11-3"/>
+       <position name="posArapucaDouble3-Frame-2-11" unit="cm" 
+         x="-328.03"
+	 y="296.2" 
+	 z="411.45"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-11-3"/>
+       <position name="posOpArapucaDouble3-Frame-2-11" unit="cm" 
+         x="-327.29"
+	 y="296.2" 
+	 z="411.45"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-12-0"/>
+       <position name="posArapucaDouble0-Frame-2-12" unit="cm" 
+         x="-328.03"
+	 y="40.8" 
+	 z="785.75"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-12-0"/>
+       <position name="posOpArapucaDouble0-Frame-2-12" unit="cm" 
+         x="-327.29"
+	 y="40.8" 
+	 z="785.75"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-12-1"/>
+       <position name="posArapucaDouble1-Frame-2-12" unit="cm" 
+         x="-328.03"
+	 y="131.5" 
+	 z="639.75"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-12-1"/>
+       <position name="posOpArapucaDouble1-Frame-2-12" unit="cm" 
+         x="-327.29"
+	 y="131.5" 
+	 z="639.75"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-12-2"/>
+       <position name="posArapucaDouble2-Frame-2-12" unit="cm" 
+         x="-328.03"
+	 y="205.5" 
+	 z="856.75"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-12-2"/>
+       <position name="posOpArapucaDouble2-Frame-2-12" unit="cm" 
+         x="-327.29"
+	 y="205.5" 
+	 z="856.75"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-12-3"/>
+       <position name="posArapucaDouble3-Frame-2-12" unit="cm" 
+         x="-328.03"
+	 y="296.2" 
+	 z="710.75"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-12-3"/>
+       <position name="posOpArapucaDouble3-Frame-2-12" unit="cm" 
+         x="-327.29"
+	 y="296.2" 
+	 z="710.75"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-13-0"/>
+       <position name="posArapucaDouble0-Frame-2-13" unit="cm" 
+         x="-328.03"
+	 y="40.8" 
+	 z="1085.05"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-13-0"/>
+       <position name="posOpArapucaDouble0-Frame-2-13" unit="cm" 
+         x="-327.29"
+	 y="40.8" 
+	 z="1085.05"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-13-1"/>
+       <position name="posArapucaDouble1-Frame-2-13" unit="cm" 
+         x="-328.03"
+	 y="131.5" 
+	 z="939.05"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-13-1"/>
+       <position name="posOpArapucaDouble1-Frame-2-13" unit="cm" 
+         x="-327.29"
+	 y="131.5" 
+	 z="939.05"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-13-2"/>
+       <position name="posArapucaDouble2-Frame-2-13" unit="cm" 
+         x="-328.03"
+	 y="205.5" 
+	 z="1156.05"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-13-2"/>
+       <position name="posOpArapucaDouble2-Frame-2-13" unit="cm" 
+         x="-327.29"
+	 y="205.5" 
+	 z="1156.05"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-13-3"/>
+       <position name="posArapucaDouble3-Frame-2-13" unit="cm" 
+         x="-328.03"
+	 y="296.2" 
+	 z="1010.05"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-13-3"/>
+       <position name="posOpArapucaDouble3-Frame-2-13" unit="cm" 
+         x="-327.29"
+	 y="296.2" 
+	 z="1010.05"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-14-0"/>
+       <position name="posArapucaDouble0-Frame-2-14" unit="cm" 
+         x="-328.03"
+	 y="40.8" 
+	 z="1384.35"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-14-0"/>
+       <position name="posOpArapucaDouble0-Frame-2-14" unit="cm" 
+         x="-327.29"
+	 y="40.8" 
+	 z="1384.35"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-14-1"/>
+       <position name="posArapucaDouble1-Frame-2-14" unit="cm" 
+         x="-328.03"
+	 y="131.5" 
+	 z="1238.35"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-14-1"/>
+       <position name="posOpArapucaDouble1-Frame-2-14" unit="cm" 
+         x="-327.29"
+	 y="131.5" 
+	 z="1238.35"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-14-2"/>
+       <position name="posArapucaDouble2-Frame-2-14" unit="cm" 
+         x="-328.03"
+	 y="205.5" 
+	 z="1455.35"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-14-2"/>
+       <position name="posOpArapucaDouble2-Frame-2-14" unit="cm" 
+         x="-327.29"
+	 y="205.5" 
+	 z="1455.35"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-14-3"/>
+       <position name="posArapucaDouble3-Frame-2-14" unit="cm" 
+         x="-328.03"
+	 y="296.2" 
+	 z="1309.35"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-14-3"/>
+       <position name="posOpArapucaDouble3-Frame-2-14" unit="cm" 
+         x="-327.29"
+	 y="296.2" 
+	 z="1309.35"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-15-0"/>
+       <position name="posArapucaDouble0-Frame-2-15" unit="cm" 
+         x="-328.03"
+	 y="40.8" 
+	 z="1683.65"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-15-0"/>
+       <position name="posOpArapucaDouble0-Frame-2-15" unit="cm" 
+         x="-327.29"
+	 y="40.8" 
+	 z="1683.65"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-15-1"/>
+       <position name="posArapucaDouble1-Frame-2-15" unit="cm" 
+         x="-328.03"
+	 y="131.5" 
+	 z="1537.65"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-15-1"/>
+       <position name="posOpArapucaDouble1-Frame-2-15" unit="cm" 
+         x="-327.29"
+	 y="131.5" 
+	 z="1537.65"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-15-2"/>
+       <position name="posArapucaDouble2-Frame-2-15" unit="cm" 
+         x="-328.03"
+	 y="205.5" 
+	 z="1754.65"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-15-2"/>
+       <position name="posOpArapucaDouble2-Frame-2-15" unit="cm" 
+         x="-327.29"
+	 y="205.5" 
+	 z="1754.65"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-15-3"/>
+       <position name="posArapucaDouble3-Frame-2-15" unit="cm" 
+         x="-328.03"
+	 y="296.2" 
+	 z="1608.65"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-15-3"/>
+       <position name="posOpArapucaDouble3-Frame-2-15" unit="cm" 
+         x="-327.29"
+	 y="296.2" 
+	 z="1608.65"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-16-0"/>
+       <position name="posArapucaDouble0-Frame-2-16" unit="cm" 
+         x="-328.03"
+	 y="40.8" 
+	 z="1982.95"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-16-0"/>
+       <position name="posOpArapucaDouble0-Frame-2-16" unit="cm" 
+         x="-327.29"
+	 y="40.8" 
+	 z="1982.95"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-16-1"/>
+       <position name="posArapucaDouble1-Frame-2-16" unit="cm" 
+         x="-328.03"
+	 y="131.5" 
+	 z="1836.95"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-16-1"/>
+       <position name="posOpArapucaDouble1-Frame-2-16" unit="cm" 
+         x="-327.29"
+	 y="131.5" 
+	 z="1836.95"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-16-2"/>
+       <position name="posArapucaDouble2-Frame-2-16" unit="cm" 
+         x="-328.03"
+	 y="205.5" 
+	 z="2053.95"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-16-2"/>
+       <position name="posOpArapucaDouble2-Frame-2-16" unit="cm" 
+         x="-327.29"
+	 y="205.5" 
+	 z="2053.95"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-16-3"/>
+       <position name="posArapucaDouble3-Frame-2-16" unit="cm" 
+         x="-328.03"
+	 y="296.2" 
+	 z="1907.95"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-16-3"/>
+       <position name="posOpArapucaDouble3-Frame-2-16" unit="cm" 
+         x="-327.29"
+	 y="296.2" 
+	 z="1907.95"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-17-0"/>
+       <position name="posArapucaDouble0-Frame-2-17" unit="cm" 
+         x="-328.03"
+	 y="40.8" 
+	 z="2282.25"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-17-0"/>
+       <position name="posOpArapucaDouble0-Frame-2-17" unit="cm" 
+         x="-327.29"
+	 y="40.8" 
+	 z="2282.25"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-17-1"/>
+       <position name="posArapucaDouble1-Frame-2-17" unit="cm" 
+         x="-328.03"
+	 y="131.5" 
+	 z="2136.25"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-17-1"/>
+       <position name="posOpArapucaDouble1-Frame-2-17" unit="cm" 
+         x="-327.29"
+	 y="131.5" 
+	 z="2136.25"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-17-2"/>
+       <position name="posArapucaDouble2-Frame-2-17" unit="cm" 
+         x="-328.03"
+	 y="205.5" 
+	 z="2353.25"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-17-2"/>
+       <position name="posOpArapucaDouble2-Frame-2-17" unit="cm" 
+         x="-327.29"
+	 y="205.5" 
+	 z="2353.25"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-17-3"/>
+       <position name="posArapucaDouble3-Frame-2-17" unit="cm" 
+         x="-328.03"
+	 y="296.2" 
+	 z="2207.25"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-17-3"/>
+       <position name="posOpArapucaDouble3-Frame-2-17" unit="cm" 
+         x="-327.29"
+	 y="296.2" 
+	 z="2207.25"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-18-0"/>
+       <position name="posArapucaDouble0-Frame-2-18" unit="cm" 
+         x="-328.03"
+	 y="40.8" 
+	 z="2581.55"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-18-0"/>
+       <position name="posOpArapucaDouble0-Frame-2-18" unit="cm" 
+         x="-327.29"
+	 y="40.8" 
+	 z="2581.55"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-18-1"/>
+       <position name="posArapucaDouble1-Frame-2-18" unit="cm" 
+         x="-328.03"
+	 y="131.5" 
+	 z="2435.55"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-18-1"/>
+       <position name="posOpArapucaDouble1-Frame-2-18" unit="cm" 
+         x="-327.29"
+	 y="131.5" 
+	 z="2435.55"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-18-2"/>
+       <position name="posArapucaDouble2-Frame-2-18" unit="cm" 
+         x="-328.03"
+	 y="205.5" 
+	 z="2652.55"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-18-2"/>
+       <position name="posOpArapucaDouble2-Frame-2-18" unit="cm" 
+         x="-327.29"
+	 y="205.5" 
+	 z="2652.55"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-18-3"/>
+       <position name="posArapucaDouble3-Frame-2-18" unit="cm" 
+         x="-328.03"
+	 y="296.2" 
+	 z="2506.55"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-18-3"/>
+       <position name="posOpArapucaDouble3-Frame-2-18" unit="cm" 
+         x="-327.29"
+	 y="296.2" 
+	 z="2506.55"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-19-0"/>
+       <position name="posArapucaDouble0-Frame-2-19" unit="cm" 
+         x="-328.03"
+	 y="40.8" 
+	 z="2880.85"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-19-0"/>
+       <position name="posOpArapucaDouble0-Frame-2-19" unit="cm" 
+         x="-327.29"
+	 y="40.8" 
+	 z="2880.85"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-19-1"/>
+       <position name="posArapucaDouble1-Frame-2-19" unit="cm" 
+         x="-328.03"
+	 y="131.5" 
+	 z="2734.85"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-19-1"/>
+       <position name="posOpArapucaDouble1-Frame-2-19" unit="cm" 
+         x="-327.29"
+	 y="131.5" 
+	 z="2734.85"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-19-2"/>
+       <position name="posArapucaDouble2-Frame-2-19" unit="cm" 
+         x="-328.03"
+	 y="205.5" 
+	 z="2951.85"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-19-2"/>
+       <position name="posOpArapucaDouble2-Frame-2-19" unit="cm" 
+         x="-327.29"
+	 y="205.5" 
+	 z="2951.85"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_2-19-3"/>
+       <position name="posArapucaDouble3-Frame-2-19" unit="cm" 
+         x="-328.03"
+	 y="296.2" 
+	 z="2805.85"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-19-3"/>
+       <position name="posOpArapucaDouble3-Frame-2-19" unit="cm" 
+         x="-327.29"
+	 y="296.2" 
+	 z="2805.85"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-0-0"/>
+       <position name="posArapucaDouble0-Frame-3-0" unit="cm" 
+         x="-328.03"
+	 y="377.8" 
+	 z="-2805.85"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-0"/>
+       <position name="posOpArapucaDouble0-Frame-3-0" unit="cm" 
+         x="-327.29"
+	 y="377.8" 
+	 z="-2805.85"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-0-1"/>
+       <position name="posArapucaDouble1-Frame-3-0" unit="cm" 
+         x="-328.03"
+	 y="468.5" 
+	 z="-2951.85"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-1"/>
+       <position name="posOpArapucaDouble1-Frame-3-0" unit="cm" 
+         x="-327.29"
+	 y="468.5" 
+	 z="-2951.85"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-0-2"/>
+       <position name="posArapucaDouble2-Frame-3-0" unit="cm" 
+         x="-328.03"
+	 y="542.5" 
+	 z="-2734.85"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-2"/>
+       <position name="posOpArapucaDouble2-Frame-3-0" unit="cm" 
+         x="-327.29"
+	 y="542.5" 
+	 z="-2734.85"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-0-3"/>
+       <position name="posArapucaDouble3-Frame-3-0" unit="cm" 
+         x="-328.03"
+	 y="633.2" 
+	 z="-2880.85"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-3"/>
+       <position name="posOpArapucaDouble3-Frame-3-0" unit="cm" 
+         x="-327.29"
+	 y="633.2" 
+	 z="-2880.85"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-1-0"/>
+       <position name="posArapucaDouble0-Frame-3-1" unit="cm" 
+         x="-328.03"
+	 y="377.8" 
+	 z="-2506.55"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-0"/>
+       <position name="posOpArapucaDouble0-Frame-3-1" unit="cm" 
+         x="-327.29"
+	 y="377.8" 
+	 z="-2506.55"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-1-1"/>
+       <position name="posArapucaDouble1-Frame-3-1" unit="cm" 
+         x="-328.03"
+	 y="468.5" 
+	 z="-2652.55"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-1"/>
+       <position name="posOpArapucaDouble1-Frame-3-1" unit="cm" 
+         x="-327.29"
+	 y="468.5" 
+	 z="-2652.55"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-1-2"/>
+       <position name="posArapucaDouble2-Frame-3-1" unit="cm" 
+         x="-328.03"
+	 y="542.5" 
+	 z="-2435.55"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-2"/>
+       <position name="posOpArapucaDouble2-Frame-3-1" unit="cm" 
+         x="-327.29"
+	 y="542.5" 
+	 z="-2435.55"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-1-3"/>
+       <position name="posArapucaDouble3-Frame-3-1" unit="cm" 
+         x="-328.03"
+	 y="633.2" 
+	 z="-2581.55"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-3"/>
+       <position name="posOpArapucaDouble3-Frame-3-1" unit="cm" 
+         x="-327.29"
+	 y="633.2" 
+	 z="-2581.55"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-2-0"/>
+       <position name="posArapucaDouble0-Frame-3-2" unit="cm" 
+         x="-328.03"
+	 y="377.8" 
+	 z="-2207.25"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-0"/>
+       <position name="posOpArapucaDouble0-Frame-3-2" unit="cm" 
+         x="-327.29"
+	 y="377.8" 
+	 z="-2207.25"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-2-1"/>
+       <position name="posArapucaDouble1-Frame-3-2" unit="cm" 
+         x="-328.03"
+	 y="468.5" 
+	 z="-2353.25"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-1"/>
+       <position name="posOpArapucaDouble1-Frame-3-2" unit="cm" 
+         x="-327.29"
+	 y="468.5" 
+	 z="-2353.25"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-2-2"/>
+       <position name="posArapucaDouble2-Frame-3-2" unit="cm" 
+         x="-328.03"
+	 y="542.5" 
+	 z="-2136.25"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-2"/>
+       <position name="posOpArapucaDouble2-Frame-3-2" unit="cm" 
+         x="-327.29"
+	 y="542.5" 
+	 z="-2136.25"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-2-3"/>
+       <position name="posArapucaDouble3-Frame-3-2" unit="cm" 
+         x="-328.03"
+	 y="633.2" 
+	 z="-2282.25"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-3"/>
+       <position name="posOpArapucaDouble3-Frame-3-2" unit="cm" 
+         x="-327.29"
+	 y="633.2" 
+	 z="-2282.25"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-3-0"/>
+       <position name="posArapucaDouble0-Frame-3-3" unit="cm" 
+         x="-328.03"
+	 y="377.8" 
+	 z="-1907.95"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-3-0"/>
+       <position name="posOpArapucaDouble0-Frame-3-3" unit="cm" 
+         x="-327.29"
+	 y="377.8" 
+	 z="-1907.95"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-3-1"/>
+       <position name="posArapucaDouble1-Frame-3-3" unit="cm" 
+         x="-328.03"
+	 y="468.5" 
+	 z="-2053.95"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-3-1"/>
+       <position name="posOpArapucaDouble1-Frame-3-3" unit="cm" 
+         x="-327.29"
+	 y="468.5" 
+	 z="-2053.95"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-3-2"/>
+       <position name="posArapucaDouble2-Frame-3-3" unit="cm" 
+         x="-328.03"
+	 y="542.5" 
+	 z="-1836.95"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-3-2"/>
+       <position name="posOpArapucaDouble2-Frame-3-3" unit="cm" 
+         x="-327.29"
+	 y="542.5" 
+	 z="-1836.95"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-3-3"/>
+       <position name="posArapucaDouble3-Frame-3-3" unit="cm" 
+         x="-328.03"
+	 y="633.2" 
+	 z="-1982.95"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-3-3"/>
+       <position name="posOpArapucaDouble3-Frame-3-3" unit="cm" 
+         x="-327.29"
+	 y="633.2" 
+	 z="-1982.95"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-4-0"/>
+       <position name="posArapucaDouble0-Frame-3-4" unit="cm" 
+         x="-328.03"
+	 y="377.8" 
+	 z="-1608.65"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-4-0"/>
+       <position name="posOpArapucaDouble0-Frame-3-4" unit="cm" 
+         x="-327.29"
+	 y="377.8" 
+	 z="-1608.65"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-4-1"/>
+       <position name="posArapucaDouble1-Frame-3-4" unit="cm" 
+         x="-328.03"
+	 y="468.5" 
+	 z="-1754.65"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-4-1"/>
+       <position name="posOpArapucaDouble1-Frame-3-4" unit="cm" 
+         x="-327.29"
+	 y="468.5" 
+	 z="-1754.65"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-4-2"/>
+       <position name="posArapucaDouble2-Frame-3-4" unit="cm" 
+         x="-328.03"
+	 y="542.5" 
+	 z="-1537.65"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-4-2"/>
+       <position name="posOpArapucaDouble2-Frame-3-4" unit="cm" 
+         x="-327.29"
+	 y="542.5" 
+	 z="-1537.65"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-4-3"/>
+       <position name="posArapucaDouble3-Frame-3-4" unit="cm" 
+         x="-328.03"
+	 y="633.2" 
+	 z="-1683.65"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-4-3"/>
+       <position name="posOpArapucaDouble3-Frame-3-4" unit="cm" 
+         x="-327.29"
+	 y="633.2" 
+	 z="-1683.65"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-5-0"/>
+       <position name="posArapucaDouble0-Frame-3-5" unit="cm" 
+         x="-328.03"
+	 y="377.8" 
+	 z="-1309.35"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-5-0"/>
+       <position name="posOpArapucaDouble0-Frame-3-5" unit="cm" 
+         x="-327.29"
+	 y="377.8" 
+	 z="-1309.35"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-5-1"/>
+       <position name="posArapucaDouble1-Frame-3-5" unit="cm" 
+         x="-328.03"
+	 y="468.5" 
+	 z="-1455.35"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-5-1"/>
+       <position name="posOpArapucaDouble1-Frame-3-5" unit="cm" 
+         x="-327.29"
+	 y="468.5" 
+	 z="-1455.35"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-5-2"/>
+       <position name="posArapucaDouble2-Frame-3-5" unit="cm" 
+         x="-328.03"
+	 y="542.5" 
+	 z="-1238.35"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-5-2"/>
+       <position name="posOpArapucaDouble2-Frame-3-5" unit="cm" 
+         x="-327.29"
+	 y="542.5" 
+	 z="-1238.35"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-5-3"/>
+       <position name="posArapucaDouble3-Frame-3-5" unit="cm" 
+         x="-328.03"
+	 y="633.2" 
+	 z="-1384.35"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-5-3"/>
+       <position name="posOpArapucaDouble3-Frame-3-5" unit="cm" 
+         x="-327.29"
+	 y="633.2" 
+	 z="-1384.35"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-6-0"/>
+       <position name="posArapucaDouble0-Frame-3-6" unit="cm" 
+         x="-328.03"
+	 y="377.8" 
+	 z="-1010.05"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-6-0"/>
+       <position name="posOpArapucaDouble0-Frame-3-6" unit="cm" 
+         x="-327.29"
+	 y="377.8" 
+	 z="-1010.05"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-6-1"/>
+       <position name="posArapucaDouble1-Frame-3-6" unit="cm" 
+         x="-328.03"
+	 y="468.5" 
+	 z="-1156.05"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-6-1"/>
+       <position name="posOpArapucaDouble1-Frame-3-6" unit="cm" 
+         x="-327.29"
+	 y="468.5" 
+	 z="-1156.05"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-6-2"/>
+       <position name="posArapucaDouble2-Frame-3-6" unit="cm" 
+         x="-328.03"
+	 y="542.5" 
+	 z="-939.05"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-6-2"/>
+       <position name="posOpArapucaDouble2-Frame-3-6" unit="cm" 
+         x="-327.29"
+	 y="542.5" 
+	 z="-939.05"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-6-3"/>
+       <position name="posArapucaDouble3-Frame-3-6" unit="cm" 
+         x="-328.03"
+	 y="633.2" 
+	 z="-1085.05"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-6-3"/>
+       <position name="posOpArapucaDouble3-Frame-3-6" unit="cm" 
+         x="-327.29"
+	 y="633.2" 
+	 z="-1085.05"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-7-0"/>
+       <position name="posArapucaDouble0-Frame-3-7" unit="cm" 
+         x="-328.03"
+	 y="377.8" 
+	 z="-710.75"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-7-0"/>
+       <position name="posOpArapucaDouble0-Frame-3-7" unit="cm" 
+         x="-327.29"
+	 y="377.8" 
+	 z="-710.75"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-7-1"/>
+       <position name="posArapucaDouble1-Frame-3-7" unit="cm" 
+         x="-328.03"
+	 y="468.5" 
+	 z="-856.75"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-7-1"/>
+       <position name="posOpArapucaDouble1-Frame-3-7" unit="cm" 
+         x="-327.29"
+	 y="468.5" 
+	 z="-856.75"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-7-2"/>
+       <position name="posArapucaDouble2-Frame-3-7" unit="cm" 
+         x="-328.03"
+	 y="542.5" 
+	 z="-639.75"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-7-2"/>
+       <position name="posOpArapucaDouble2-Frame-3-7" unit="cm" 
+         x="-327.29"
+	 y="542.5" 
+	 z="-639.75"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-7-3"/>
+       <position name="posArapucaDouble3-Frame-3-7" unit="cm" 
+         x="-328.03"
+	 y="633.2" 
+	 z="-785.75"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-7-3"/>
+       <position name="posOpArapucaDouble3-Frame-3-7" unit="cm" 
+         x="-327.29"
+	 y="633.2" 
+	 z="-785.75"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-8-0"/>
+       <position name="posArapucaDouble0-Frame-3-8" unit="cm" 
+         x="-328.03"
+	 y="377.8" 
+	 z="-411.45"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-8-0"/>
+       <position name="posOpArapucaDouble0-Frame-3-8" unit="cm" 
+         x="-327.29"
+	 y="377.8" 
+	 z="-411.45"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-8-1"/>
+       <position name="posArapucaDouble1-Frame-3-8" unit="cm" 
+         x="-328.03"
+	 y="468.5" 
+	 z="-557.45"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-8-1"/>
+       <position name="posOpArapucaDouble1-Frame-3-8" unit="cm" 
+         x="-327.29"
+	 y="468.5" 
+	 z="-557.45"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-8-2"/>
+       <position name="posArapucaDouble2-Frame-3-8" unit="cm" 
+         x="-328.03"
+	 y="542.5" 
+	 z="-340.45"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-8-2"/>
+       <position name="posOpArapucaDouble2-Frame-3-8" unit="cm" 
+         x="-327.29"
+	 y="542.5" 
+	 z="-340.45"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-8-3"/>
+       <position name="posArapucaDouble3-Frame-3-8" unit="cm" 
+         x="-328.03"
+	 y="633.2" 
+	 z="-486.45"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-8-3"/>
+       <position name="posOpArapucaDouble3-Frame-3-8" unit="cm" 
+         x="-327.29"
+	 y="633.2" 
+	 z="-486.45"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-9-0"/>
+       <position name="posArapucaDouble0-Frame-3-9" unit="cm" 
+         x="-328.03"
+	 y="377.8" 
+	 z="-112.15"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-9-0"/>
+       <position name="posOpArapucaDouble0-Frame-3-9" unit="cm" 
+         x="-327.29"
+	 y="377.8" 
+	 z="-112.15"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-9-1"/>
+       <position name="posArapucaDouble1-Frame-3-9" unit="cm" 
+         x="-328.03"
+	 y="468.5" 
+	 z="-258.15"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-9-1"/>
+       <position name="posOpArapucaDouble1-Frame-3-9" unit="cm" 
+         x="-327.29"
+	 y="468.5" 
+	 z="-258.15"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-9-2"/>
+       <position name="posArapucaDouble2-Frame-3-9" unit="cm" 
+         x="-328.03"
+	 y="542.5" 
+	 z="-41.1499999999997"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-9-2"/>
+       <position name="posOpArapucaDouble2-Frame-3-9" unit="cm" 
+         x="-327.29"
+	 y="542.5" 
+	 z="-41.1499999999997"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-9-3"/>
+       <position name="posArapucaDouble3-Frame-3-9" unit="cm" 
+         x="-328.03"
+	 y="633.2" 
+	 z="-187.15"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-9-3"/>
+       <position name="posOpArapucaDouble3-Frame-3-9" unit="cm" 
+         x="-327.29"
+	 y="633.2" 
+	 z="-187.15"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-10-0"/>
+       <position name="posArapucaDouble0-Frame-3-10" unit="cm" 
+         x="-328.03"
+	 y="377.8" 
+	 z="187.15"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-10-0"/>
+       <position name="posOpArapucaDouble0-Frame-3-10" unit="cm" 
+         x="-327.29"
+	 y="377.8" 
+	 z="187.15"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-10-1"/>
+       <position name="posArapucaDouble1-Frame-3-10" unit="cm" 
+         x="-328.03"
+	 y="468.5" 
+	 z="41.1500000000003"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-10-1"/>
+       <position name="posOpArapucaDouble1-Frame-3-10" unit="cm" 
+         x="-327.29"
+	 y="468.5" 
+	 z="41.1500000000003"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-10-2"/>
+       <position name="posArapucaDouble2-Frame-3-10" unit="cm" 
+         x="-328.03"
+	 y="542.5" 
+	 z="258.15"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-10-2"/>
+       <position name="posOpArapucaDouble2-Frame-3-10" unit="cm" 
+         x="-327.29"
+	 y="542.5" 
+	 z="258.15"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-10-3"/>
+       <position name="posArapucaDouble3-Frame-3-10" unit="cm" 
+         x="-328.03"
+	 y="633.2" 
+	 z="112.15"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-10-3"/>
+       <position name="posOpArapucaDouble3-Frame-3-10" unit="cm" 
+         x="-327.29"
+	 y="633.2" 
+	 z="112.15"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-11-0"/>
+       <position name="posArapucaDouble0-Frame-3-11" unit="cm" 
+         x="-328.03"
+	 y="377.8" 
+	 z="486.45"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-11-0"/>
+       <position name="posOpArapucaDouble0-Frame-3-11" unit="cm" 
+         x="-327.29"
+	 y="377.8" 
+	 z="486.45"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-11-1"/>
+       <position name="posArapucaDouble1-Frame-3-11" unit="cm" 
+         x="-328.03"
+	 y="468.5" 
+	 z="340.45"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-11-1"/>
+       <position name="posOpArapucaDouble1-Frame-3-11" unit="cm" 
+         x="-327.29"
+	 y="468.5" 
+	 z="340.45"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-11-2"/>
+       <position name="posArapucaDouble2-Frame-3-11" unit="cm" 
+         x="-328.03"
+	 y="542.5" 
+	 z="557.45"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-11-2"/>
+       <position name="posOpArapucaDouble2-Frame-3-11" unit="cm" 
+         x="-327.29"
+	 y="542.5" 
+	 z="557.45"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-11-3"/>
+       <position name="posArapucaDouble3-Frame-3-11" unit="cm" 
+         x="-328.03"
+	 y="633.2" 
+	 z="411.45"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-11-3"/>
+       <position name="posOpArapucaDouble3-Frame-3-11" unit="cm" 
+         x="-327.29"
+	 y="633.2" 
+	 z="411.45"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-12-0"/>
+       <position name="posArapucaDouble0-Frame-3-12" unit="cm" 
+         x="-328.03"
+	 y="377.8" 
+	 z="785.75"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-12-0"/>
+       <position name="posOpArapucaDouble0-Frame-3-12" unit="cm" 
+         x="-327.29"
+	 y="377.8" 
+	 z="785.75"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-12-1"/>
+       <position name="posArapucaDouble1-Frame-3-12" unit="cm" 
+         x="-328.03"
+	 y="468.5" 
+	 z="639.75"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-12-1"/>
+       <position name="posOpArapucaDouble1-Frame-3-12" unit="cm" 
+         x="-327.29"
+	 y="468.5" 
+	 z="639.75"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-12-2"/>
+       <position name="posArapucaDouble2-Frame-3-12" unit="cm" 
+         x="-328.03"
+	 y="542.5" 
+	 z="856.75"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-12-2"/>
+       <position name="posOpArapucaDouble2-Frame-3-12" unit="cm" 
+         x="-327.29"
+	 y="542.5" 
+	 z="856.75"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-12-3"/>
+       <position name="posArapucaDouble3-Frame-3-12" unit="cm" 
+         x="-328.03"
+	 y="633.2" 
+	 z="710.75"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-12-3"/>
+       <position name="posOpArapucaDouble3-Frame-3-12" unit="cm" 
+         x="-327.29"
+	 y="633.2" 
+	 z="710.75"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-13-0"/>
+       <position name="posArapucaDouble0-Frame-3-13" unit="cm" 
+         x="-328.03"
+	 y="377.8" 
+	 z="1085.05"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-13-0"/>
+       <position name="posOpArapucaDouble0-Frame-3-13" unit="cm" 
+         x="-327.29"
+	 y="377.8" 
+	 z="1085.05"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-13-1"/>
+       <position name="posArapucaDouble1-Frame-3-13" unit="cm" 
+         x="-328.03"
+	 y="468.5" 
+	 z="939.05"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-13-1"/>
+       <position name="posOpArapucaDouble1-Frame-3-13" unit="cm" 
+         x="-327.29"
+	 y="468.5" 
+	 z="939.05"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-13-2"/>
+       <position name="posArapucaDouble2-Frame-3-13" unit="cm" 
+         x="-328.03"
+	 y="542.5" 
+	 z="1156.05"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-13-2"/>
+       <position name="posOpArapucaDouble2-Frame-3-13" unit="cm" 
+         x="-327.29"
+	 y="542.5" 
+	 z="1156.05"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-13-3"/>
+       <position name="posArapucaDouble3-Frame-3-13" unit="cm" 
+         x="-328.03"
+	 y="633.2" 
+	 z="1010.05"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-13-3"/>
+       <position name="posOpArapucaDouble3-Frame-3-13" unit="cm" 
+         x="-327.29"
+	 y="633.2" 
+	 z="1010.05"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-14-0"/>
+       <position name="posArapucaDouble0-Frame-3-14" unit="cm" 
+         x="-328.03"
+	 y="377.8" 
+	 z="1384.35"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-14-0"/>
+       <position name="posOpArapucaDouble0-Frame-3-14" unit="cm" 
+         x="-327.29"
+	 y="377.8" 
+	 z="1384.35"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-14-1"/>
+       <position name="posArapucaDouble1-Frame-3-14" unit="cm" 
+         x="-328.03"
+	 y="468.5" 
+	 z="1238.35"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-14-1"/>
+       <position name="posOpArapucaDouble1-Frame-3-14" unit="cm" 
+         x="-327.29"
+	 y="468.5" 
+	 z="1238.35"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-14-2"/>
+       <position name="posArapucaDouble2-Frame-3-14" unit="cm" 
+         x="-328.03"
+	 y="542.5" 
+	 z="1455.35"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-14-2"/>
+       <position name="posOpArapucaDouble2-Frame-3-14" unit="cm" 
+         x="-327.29"
+	 y="542.5" 
+	 z="1455.35"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-14-3"/>
+       <position name="posArapucaDouble3-Frame-3-14" unit="cm" 
+         x="-328.03"
+	 y="633.2" 
+	 z="1309.35"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-14-3"/>
+       <position name="posOpArapucaDouble3-Frame-3-14" unit="cm" 
+         x="-327.29"
+	 y="633.2" 
+	 z="1309.35"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-15-0"/>
+       <position name="posArapucaDouble0-Frame-3-15" unit="cm" 
+         x="-328.03"
+	 y="377.8" 
+	 z="1683.65"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-15-0"/>
+       <position name="posOpArapucaDouble0-Frame-3-15" unit="cm" 
+         x="-327.29"
+	 y="377.8" 
+	 z="1683.65"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-15-1"/>
+       <position name="posArapucaDouble1-Frame-3-15" unit="cm" 
+         x="-328.03"
+	 y="468.5" 
+	 z="1537.65"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-15-1"/>
+       <position name="posOpArapucaDouble1-Frame-3-15" unit="cm" 
+         x="-327.29"
+	 y="468.5" 
+	 z="1537.65"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-15-2"/>
+       <position name="posArapucaDouble2-Frame-3-15" unit="cm" 
+         x="-328.03"
+	 y="542.5" 
+	 z="1754.65"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-15-2"/>
+       <position name="posOpArapucaDouble2-Frame-3-15" unit="cm" 
+         x="-327.29"
+	 y="542.5" 
+	 z="1754.65"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-15-3"/>
+       <position name="posArapucaDouble3-Frame-3-15" unit="cm" 
+         x="-328.03"
+	 y="633.2" 
+	 z="1608.65"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-15-3"/>
+       <position name="posOpArapucaDouble3-Frame-3-15" unit="cm" 
+         x="-327.29"
+	 y="633.2" 
+	 z="1608.65"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-16-0"/>
+       <position name="posArapucaDouble0-Frame-3-16" unit="cm" 
+         x="-328.03"
+	 y="377.8" 
+	 z="1982.95"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-16-0"/>
+       <position name="posOpArapucaDouble0-Frame-3-16" unit="cm" 
+         x="-327.29"
+	 y="377.8" 
+	 z="1982.95"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-16-1"/>
+       <position name="posArapucaDouble1-Frame-3-16" unit="cm" 
+         x="-328.03"
+	 y="468.5" 
+	 z="1836.95"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-16-1"/>
+       <position name="posOpArapucaDouble1-Frame-3-16" unit="cm" 
+         x="-327.29"
+	 y="468.5" 
+	 z="1836.95"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-16-2"/>
+       <position name="posArapucaDouble2-Frame-3-16" unit="cm" 
+         x="-328.03"
+	 y="542.5" 
+	 z="2053.95"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-16-2"/>
+       <position name="posOpArapucaDouble2-Frame-3-16" unit="cm" 
+         x="-327.29"
+	 y="542.5" 
+	 z="2053.95"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-16-3"/>
+       <position name="posArapucaDouble3-Frame-3-16" unit="cm" 
+         x="-328.03"
+	 y="633.2" 
+	 z="1907.95"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-16-3"/>
+       <position name="posOpArapucaDouble3-Frame-3-16" unit="cm" 
+         x="-327.29"
+	 y="633.2" 
+	 z="1907.95"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-17-0"/>
+       <position name="posArapucaDouble0-Frame-3-17" unit="cm" 
+         x="-328.03"
+	 y="377.8" 
+	 z="2282.25"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-17-0"/>
+       <position name="posOpArapucaDouble0-Frame-3-17" unit="cm" 
+         x="-327.29"
+	 y="377.8" 
+	 z="2282.25"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-17-1"/>
+       <position name="posArapucaDouble1-Frame-3-17" unit="cm" 
+         x="-328.03"
+	 y="468.5" 
+	 z="2136.25"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-17-1"/>
+       <position name="posOpArapucaDouble1-Frame-3-17" unit="cm" 
+         x="-327.29"
+	 y="468.5" 
+	 z="2136.25"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-17-2"/>
+       <position name="posArapucaDouble2-Frame-3-17" unit="cm" 
+         x="-328.03"
+	 y="542.5" 
+	 z="2353.25"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-17-2"/>
+       <position name="posOpArapucaDouble2-Frame-3-17" unit="cm" 
+         x="-327.29"
+	 y="542.5" 
+	 z="2353.25"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-17-3"/>
+       <position name="posArapucaDouble3-Frame-3-17" unit="cm" 
+         x="-328.03"
+	 y="633.2" 
+	 z="2207.25"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-17-3"/>
+       <position name="posOpArapucaDouble3-Frame-3-17" unit="cm" 
+         x="-327.29"
+	 y="633.2" 
+	 z="2207.25"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-18-0"/>
+       <position name="posArapucaDouble0-Frame-3-18" unit="cm" 
+         x="-328.03"
+	 y="377.8" 
+	 z="2581.55"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-18-0"/>
+       <position name="posOpArapucaDouble0-Frame-3-18" unit="cm" 
+         x="-327.29"
+	 y="377.8" 
+	 z="2581.55"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-18-1"/>
+       <position name="posArapucaDouble1-Frame-3-18" unit="cm" 
+         x="-328.03"
+	 y="468.5" 
+	 z="2435.55"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-18-1"/>
+       <position name="posOpArapucaDouble1-Frame-3-18" unit="cm" 
+         x="-327.29"
+	 y="468.5" 
+	 z="2435.55"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-18-2"/>
+       <position name="posArapucaDouble2-Frame-3-18" unit="cm" 
+         x="-328.03"
+	 y="542.5" 
+	 z="2652.55"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-18-2"/>
+       <position name="posOpArapucaDouble2-Frame-3-18" unit="cm" 
+         x="-327.29"
+	 y="542.5" 
+	 z="2652.55"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-18-3"/>
+       <position name="posArapucaDouble3-Frame-3-18" unit="cm" 
+         x="-328.03"
+	 y="633.2" 
+	 z="2506.55"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-18-3"/>
+       <position name="posOpArapucaDouble3-Frame-3-18" unit="cm" 
+         x="-327.29"
+	 y="633.2" 
+	 z="2506.55"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-19-0"/>
+       <position name="posArapucaDouble0-Frame-3-19" unit="cm" 
+         x="-328.03"
+	 y="377.8" 
+	 z="2880.85"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-19-0"/>
+       <position name="posOpArapucaDouble0-Frame-3-19" unit="cm" 
+         x="-327.29"
+	 y="377.8" 
+	 z="2880.85"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-19-1"/>
+       <position name="posArapucaDouble1-Frame-3-19" unit="cm" 
+         x="-328.03"
+	 y="468.5" 
+	 z="2734.85"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-19-1"/>
+       <position name="posOpArapucaDouble1-Frame-3-19" unit="cm" 
+         x="-327.29"
+	 y="468.5" 
+	 z="2734.85"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-19-2"/>
+       <position name="posArapucaDouble2-Frame-3-19" unit="cm" 
+         x="-328.03"
+	 y="542.5" 
+	 z="2951.85"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-19-2"/>
+       <position name="posOpArapucaDouble2-Frame-3-19" unit="cm" 
+         x="-327.29"
+	 y="542.5" 
+	 z="2951.85"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaDouble_3-19-3"/>
+       <position name="posArapucaDouble3-Frame-3-19" unit="cm" 
+         x="-328.03"
+	 y="633.2" 
+	 z="2805.85"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-19-3"/>
+       <position name="posOpArapucaDouble3-Frame-3-19" unit="cm" 
+         x="-327.29"
+	 y="633.2" 
+	 z="2805.85"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_0-0"/>
+       <position name="posArapuca0-Lat-0" unit="cm" 
+         x="285.02"
+	 y="-745" 
+	 z="-2843.35"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_0-0"/>
+       <position name="posOpArapuca0-Lat-0" unit="cm" 
+         x="285.02"
+	 y="-744.26" 
+	 z="-2843.35"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_0-1"/>
+       <position name="posArapuca1-Lat-0" unit="cm" 
+         x="210.02"
+	 y="-745" 
+	 z="-2843.35"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_0-1"/>
+       <position name="posOpArapuca1-Lat-0" unit="cm" 
+         x="210.02"
+	 y="-744.26" 
+	 z="-2843.35"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_0-2"/>
+       <position name="posArapuca2-Lat-0" unit="cm" 
+         x="135.02"
+	 y="-745" 
+	 z="-2843.35"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_0-2"/>
+       <position name="posOpArapuca2-Lat-0" unit="cm" 
+         x="135.02"
+	 y="-744.26" 
+	 z="-2843.35"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_0-3"/>
+       <position name="posArapuca3-Lat-0" unit="cm" 
+         x="60.02"
+	 y="-745" 
+	 z="-2843.35"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_0-3"/>
+       <position name="posOpArapuca3-Lat-0" unit="cm" 
+         x="60.02"
+	 y="-744.26" 
+	 z="-2843.35"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_0-4"/>
+       <position name="posArapuca4-Lat-0" unit="cm" 
+         x="285.02"
+	 y="745" 
+	 z="-2843.35"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_0-4"/>
+       <position name="posOpArapuca4-Lat-0" unit="cm" 
+         x="285.02"
+	 y="744.26" 
+	 z="-2843.35"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_0-5"/>
+       <position name="posArapuca5-Lat-0" unit="cm" 
+         x="210.02"
+	 y="745" 
+	 z="-2843.35"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_0-5"/>
+       <position name="posOpArapuca5-Lat-0" unit="cm" 
+         x="210.02"
+	 y="744.26" 
+	 z="-2843.35"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_0-6"/>
+       <position name="posArapuca6-Lat-0" unit="cm" 
+         x="135.02"
+	 y="745" 
+	 z="-2843.35"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_0-6"/>
+       <position name="posOpArapuca6-Lat-0" unit="cm" 
+         x="135.02"
+	 y="744.26" 
+	 z="-2843.35"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_0-7"/>
+       <position name="posArapuca7-Lat-0" unit="cm" 
+         x="60.02"
+	 y="745" 
+	 z="-2843.35"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_0-7"/>
+       <position name="posOpArapuca7-Lat-0" unit="cm" 
+         x="60.02"
+	 y="744.26" 
+	 z="-2843.35"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_1-0"/>
+       <position name="posArapuca0-Lat-1" unit="cm" 
+         x="285.02"
+	 y="-745" 
+	 z="-2544.05"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_1-0"/>
+       <position name="posOpArapuca0-Lat-1" unit="cm" 
+         x="285.02"
+	 y="-744.26" 
+	 z="-2544.05"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_1-1"/>
+       <position name="posArapuca1-Lat-1" unit="cm" 
+         x="210.02"
+	 y="-745" 
+	 z="-2544.05"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_1-1"/>
+       <position name="posOpArapuca1-Lat-1" unit="cm" 
+         x="210.02"
+	 y="-744.26" 
+	 z="-2544.05"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_1-2"/>
+       <position name="posArapuca2-Lat-1" unit="cm" 
+         x="135.02"
+	 y="-745" 
+	 z="-2544.05"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_1-2"/>
+       <position name="posOpArapuca2-Lat-1" unit="cm" 
+         x="135.02"
+	 y="-744.26" 
+	 z="-2544.05"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_1-3"/>
+       <position name="posArapuca3-Lat-1" unit="cm" 
+         x="60.02"
+	 y="-745" 
+	 z="-2544.05"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_1-3"/>
+       <position name="posOpArapuca3-Lat-1" unit="cm" 
+         x="60.02"
+	 y="-744.26" 
+	 z="-2544.05"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_1-4"/>
+       <position name="posArapuca4-Lat-1" unit="cm" 
+         x="285.02"
+	 y="745" 
+	 z="-2544.05"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_1-4"/>
+       <position name="posOpArapuca4-Lat-1" unit="cm" 
+         x="285.02"
+	 y="744.26" 
+	 z="-2544.05"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_1-5"/>
+       <position name="posArapuca5-Lat-1" unit="cm" 
+         x="210.02"
+	 y="745" 
+	 z="-2544.05"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_1-5"/>
+       <position name="posOpArapuca5-Lat-1" unit="cm" 
+         x="210.02"
+	 y="744.26" 
+	 z="-2544.05"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_1-6"/>
+       <position name="posArapuca6-Lat-1" unit="cm" 
+         x="135.02"
+	 y="745" 
+	 z="-2544.05"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_1-6"/>
+       <position name="posOpArapuca6-Lat-1" unit="cm" 
+         x="135.02"
+	 y="744.26" 
+	 z="-2544.05"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_1-7"/>
+       <position name="posArapuca7-Lat-1" unit="cm" 
+         x="60.02"
+	 y="745" 
+	 z="-2544.05"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_1-7"/>
+       <position name="posOpArapuca7-Lat-1" unit="cm" 
+         x="60.02"
+	 y="744.26" 
+	 z="-2544.05"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_2-0"/>
+       <position name="posArapuca0-Lat-2" unit="cm" 
+         x="285.02"
+	 y="-745" 
+	 z="-2244.75"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_2-0"/>
+       <position name="posOpArapuca0-Lat-2" unit="cm" 
+         x="285.02"
+	 y="-744.26" 
+	 z="-2244.75"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_2-1"/>
+       <position name="posArapuca1-Lat-2" unit="cm" 
+         x="210.02"
+	 y="-745" 
+	 z="-2244.75"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_2-1"/>
+       <position name="posOpArapuca1-Lat-2" unit="cm" 
+         x="210.02"
+	 y="-744.26" 
+	 z="-2244.75"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_2-2"/>
+       <position name="posArapuca2-Lat-2" unit="cm" 
+         x="135.02"
+	 y="-745" 
+	 z="-2244.75"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_2-2"/>
+       <position name="posOpArapuca2-Lat-2" unit="cm" 
+         x="135.02"
+	 y="-744.26" 
+	 z="-2244.75"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_2-3"/>
+       <position name="posArapuca3-Lat-2" unit="cm" 
+         x="60.02"
+	 y="-745" 
+	 z="-2244.75"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_2-3"/>
+       <position name="posOpArapuca3-Lat-2" unit="cm" 
+         x="60.02"
+	 y="-744.26" 
+	 z="-2244.75"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_2-4"/>
+       <position name="posArapuca4-Lat-2" unit="cm" 
+         x="285.02"
+	 y="745" 
+	 z="-2244.75"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_2-4"/>
+       <position name="posOpArapuca4-Lat-2" unit="cm" 
+         x="285.02"
+	 y="744.26" 
+	 z="-2244.75"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_2-5"/>
+       <position name="posArapuca5-Lat-2" unit="cm" 
+         x="210.02"
+	 y="745" 
+	 z="-2244.75"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_2-5"/>
+       <position name="posOpArapuca5-Lat-2" unit="cm" 
+         x="210.02"
+	 y="744.26" 
+	 z="-2244.75"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_2-6"/>
+       <position name="posArapuca6-Lat-2" unit="cm" 
+         x="135.02"
+	 y="745" 
+	 z="-2244.75"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_2-6"/>
+       <position name="posOpArapuca6-Lat-2" unit="cm" 
+         x="135.02"
+	 y="744.26" 
+	 z="-2244.75"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_2-7"/>
+       <position name="posArapuca7-Lat-2" unit="cm" 
+         x="60.02"
+	 y="745" 
+	 z="-2244.75"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_2-7"/>
+       <position name="posOpArapuca7-Lat-2" unit="cm" 
+         x="60.02"
+	 y="744.26" 
+	 z="-2244.75"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_3-0"/>
+       <position name="posArapuca0-Lat-3" unit="cm" 
+         x="285.02"
+	 y="-745" 
+	 z="-1945.45"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_3-0"/>
+       <position name="posOpArapuca0-Lat-3" unit="cm" 
+         x="285.02"
+	 y="-744.26" 
+	 z="-1945.45"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_3-1"/>
+       <position name="posArapuca1-Lat-3" unit="cm" 
+         x="210.02"
+	 y="-745" 
+	 z="-1945.45"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_3-1"/>
+       <position name="posOpArapuca1-Lat-3" unit="cm" 
+         x="210.02"
+	 y="-744.26" 
+	 z="-1945.45"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_3-2"/>
+       <position name="posArapuca2-Lat-3" unit="cm" 
+         x="135.02"
+	 y="-745" 
+	 z="-1945.45"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_3-2"/>
+       <position name="posOpArapuca2-Lat-3" unit="cm" 
+         x="135.02"
+	 y="-744.26" 
+	 z="-1945.45"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_3-3"/>
+       <position name="posArapuca3-Lat-3" unit="cm" 
+         x="60.02"
+	 y="-745" 
+	 z="-1945.45"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_3-3"/>
+       <position name="posOpArapuca3-Lat-3" unit="cm" 
+         x="60.02"
+	 y="-744.26" 
+	 z="-1945.45"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_3-4"/>
+       <position name="posArapuca4-Lat-3" unit="cm" 
+         x="285.02"
+	 y="745" 
+	 z="-1945.45"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_3-4"/>
+       <position name="posOpArapuca4-Lat-3" unit="cm" 
+         x="285.02"
+	 y="744.26" 
+	 z="-1945.45"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_3-5"/>
+       <position name="posArapuca5-Lat-3" unit="cm" 
+         x="210.02"
+	 y="745" 
+	 z="-1945.45"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_3-5"/>
+       <position name="posOpArapuca5-Lat-3" unit="cm" 
+         x="210.02"
+	 y="744.26" 
+	 z="-1945.45"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_3-6"/>
+       <position name="posArapuca6-Lat-3" unit="cm" 
+         x="135.02"
+	 y="745" 
+	 z="-1945.45"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_3-6"/>
+       <position name="posOpArapuca6-Lat-3" unit="cm" 
+         x="135.02"
+	 y="744.26" 
+	 z="-1945.45"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_3-7"/>
+       <position name="posArapuca7-Lat-3" unit="cm" 
+         x="60.02"
+	 y="745" 
+	 z="-1945.45"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_3-7"/>
+       <position name="posOpArapuca7-Lat-3" unit="cm" 
+         x="60.02"
+	 y="744.26" 
+	 z="-1945.45"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_4-0"/>
+       <position name="posArapuca0-Lat-4" unit="cm" 
+         x="285.02"
+	 y="-745" 
+	 z="-1646.15"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_4-0"/>
+       <position name="posOpArapuca0-Lat-4" unit="cm" 
+         x="285.02"
+	 y="-744.26" 
+	 z="-1646.15"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_4-1"/>
+       <position name="posArapuca1-Lat-4" unit="cm" 
+         x="210.02"
+	 y="-745" 
+	 z="-1646.15"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_4-1"/>
+       <position name="posOpArapuca1-Lat-4" unit="cm" 
+         x="210.02"
+	 y="-744.26" 
+	 z="-1646.15"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_4-2"/>
+       <position name="posArapuca2-Lat-4" unit="cm" 
+         x="135.02"
+	 y="-745" 
+	 z="-1646.15"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_4-2"/>
+       <position name="posOpArapuca2-Lat-4" unit="cm" 
+         x="135.02"
+	 y="-744.26" 
+	 z="-1646.15"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_4-3"/>
+       <position name="posArapuca3-Lat-4" unit="cm" 
+         x="60.02"
+	 y="-745" 
+	 z="-1646.15"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_4-3"/>
+       <position name="posOpArapuca3-Lat-4" unit="cm" 
+         x="60.02"
+	 y="-744.26" 
+	 z="-1646.15"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_4-4"/>
+       <position name="posArapuca4-Lat-4" unit="cm" 
+         x="285.02"
+	 y="745" 
+	 z="-1646.15"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_4-4"/>
+       <position name="posOpArapuca4-Lat-4" unit="cm" 
+         x="285.02"
+	 y="744.26" 
+	 z="-1646.15"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_4-5"/>
+       <position name="posArapuca5-Lat-4" unit="cm" 
+         x="210.02"
+	 y="745" 
+	 z="-1646.15"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_4-5"/>
+       <position name="posOpArapuca5-Lat-4" unit="cm" 
+         x="210.02"
+	 y="744.26" 
+	 z="-1646.15"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_4-6"/>
+       <position name="posArapuca6-Lat-4" unit="cm" 
+         x="135.02"
+	 y="745" 
+	 z="-1646.15"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_4-6"/>
+       <position name="posOpArapuca6-Lat-4" unit="cm" 
+         x="135.02"
+	 y="744.26" 
+	 z="-1646.15"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_4-7"/>
+       <position name="posArapuca7-Lat-4" unit="cm" 
+         x="60.02"
+	 y="745" 
+	 z="-1646.15"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_4-7"/>
+       <position name="posOpArapuca7-Lat-4" unit="cm" 
+         x="60.02"
+	 y="744.26" 
+	 z="-1646.15"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_5-0"/>
+       <position name="posArapuca0-Lat-5" unit="cm" 
+         x="285.02"
+	 y="-745" 
+	 z="-1346.85"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_5-0"/>
+       <position name="posOpArapuca0-Lat-5" unit="cm" 
+         x="285.02"
+	 y="-744.26" 
+	 z="-1346.85"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_5-1"/>
+       <position name="posArapuca1-Lat-5" unit="cm" 
+         x="210.02"
+	 y="-745" 
+	 z="-1346.85"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_5-1"/>
+       <position name="posOpArapuca1-Lat-5" unit="cm" 
+         x="210.02"
+	 y="-744.26" 
+	 z="-1346.85"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_5-2"/>
+       <position name="posArapuca2-Lat-5" unit="cm" 
+         x="135.02"
+	 y="-745" 
+	 z="-1346.85"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_5-2"/>
+       <position name="posOpArapuca2-Lat-5" unit="cm" 
+         x="135.02"
+	 y="-744.26" 
+	 z="-1346.85"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_5-3"/>
+       <position name="posArapuca3-Lat-5" unit="cm" 
+         x="60.02"
+	 y="-745" 
+	 z="-1346.85"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_5-3"/>
+       <position name="posOpArapuca3-Lat-5" unit="cm" 
+         x="60.02"
+	 y="-744.26" 
+	 z="-1346.85"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_5-4"/>
+       <position name="posArapuca4-Lat-5" unit="cm" 
+         x="285.02"
+	 y="745" 
+	 z="-1346.85"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_5-4"/>
+       <position name="posOpArapuca4-Lat-5" unit="cm" 
+         x="285.02"
+	 y="744.26" 
+	 z="-1346.85"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_5-5"/>
+       <position name="posArapuca5-Lat-5" unit="cm" 
+         x="210.02"
+	 y="745" 
+	 z="-1346.85"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_5-5"/>
+       <position name="posOpArapuca5-Lat-5" unit="cm" 
+         x="210.02"
+	 y="744.26" 
+	 z="-1346.85"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_5-6"/>
+       <position name="posArapuca6-Lat-5" unit="cm" 
+         x="135.02"
+	 y="745" 
+	 z="-1346.85"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_5-6"/>
+       <position name="posOpArapuca6-Lat-5" unit="cm" 
+         x="135.02"
+	 y="744.26" 
+	 z="-1346.85"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_5-7"/>
+       <position name="posArapuca7-Lat-5" unit="cm" 
+         x="60.02"
+	 y="745" 
+	 z="-1346.85"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_5-7"/>
+       <position name="posOpArapuca7-Lat-5" unit="cm" 
+         x="60.02"
+	 y="744.26" 
+	 z="-1346.85"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_6-0"/>
+       <position name="posArapuca0-Lat-6" unit="cm" 
+         x="285.02"
+	 y="-745" 
+	 z="-1047.55"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_6-0"/>
+       <position name="posOpArapuca0-Lat-6" unit="cm" 
+         x="285.02"
+	 y="-744.26" 
+	 z="-1047.55"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_6-1"/>
+       <position name="posArapuca1-Lat-6" unit="cm" 
+         x="210.02"
+	 y="-745" 
+	 z="-1047.55"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_6-1"/>
+       <position name="posOpArapuca1-Lat-6" unit="cm" 
+         x="210.02"
+	 y="-744.26" 
+	 z="-1047.55"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_6-2"/>
+       <position name="posArapuca2-Lat-6" unit="cm" 
+         x="135.02"
+	 y="-745" 
+	 z="-1047.55"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_6-2"/>
+       <position name="posOpArapuca2-Lat-6" unit="cm" 
+         x="135.02"
+	 y="-744.26" 
+	 z="-1047.55"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_6-3"/>
+       <position name="posArapuca3-Lat-6" unit="cm" 
+         x="60.02"
+	 y="-745" 
+	 z="-1047.55"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_6-3"/>
+       <position name="posOpArapuca3-Lat-6" unit="cm" 
+         x="60.02"
+	 y="-744.26" 
+	 z="-1047.55"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_6-4"/>
+       <position name="posArapuca4-Lat-6" unit="cm" 
+         x="285.02"
+	 y="745" 
+	 z="-1047.55"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_6-4"/>
+       <position name="posOpArapuca4-Lat-6" unit="cm" 
+         x="285.02"
+	 y="744.26" 
+	 z="-1047.55"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_6-5"/>
+       <position name="posArapuca5-Lat-6" unit="cm" 
+         x="210.02"
+	 y="745" 
+	 z="-1047.55"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_6-5"/>
+       <position name="posOpArapuca5-Lat-6" unit="cm" 
+         x="210.02"
+	 y="744.26" 
+	 z="-1047.55"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_6-6"/>
+       <position name="posArapuca6-Lat-6" unit="cm" 
+         x="135.02"
+	 y="745" 
+	 z="-1047.55"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_6-6"/>
+       <position name="posOpArapuca6-Lat-6" unit="cm" 
+         x="135.02"
+	 y="744.26" 
+	 z="-1047.55"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_6-7"/>
+       <position name="posArapuca7-Lat-6" unit="cm" 
+         x="60.02"
+	 y="745" 
+	 z="-1047.55"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_6-7"/>
+       <position name="posOpArapuca7-Lat-6" unit="cm" 
+         x="60.02"
+	 y="744.26" 
+	 z="-1047.55"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_7-0"/>
+       <position name="posArapuca0-Lat-7" unit="cm" 
+         x="285.02"
+	 y="-745" 
+	 z="-748.25"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_7-0"/>
+       <position name="posOpArapuca0-Lat-7" unit="cm" 
+         x="285.02"
+	 y="-744.26" 
+	 z="-748.25"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_7-1"/>
+       <position name="posArapuca1-Lat-7" unit="cm" 
+         x="210.02"
+	 y="-745" 
+	 z="-748.25"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_7-1"/>
+       <position name="posOpArapuca1-Lat-7" unit="cm" 
+         x="210.02"
+	 y="-744.26" 
+	 z="-748.25"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_7-2"/>
+       <position name="posArapuca2-Lat-7" unit="cm" 
+         x="135.02"
+	 y="-745" 
+	 z="-748.25"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_7-2"/>
+       <position name="posOpArapuca2-Lat-7" unit="cm" 
+         x="135.02"
+	 y="-744.26" 
+	 z="-748.25"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_7-3"/>
+       <position name="posArapuca3-Lat-7" unit="cm" 
+         x="60.02"
+	 y="-745" 
+	 z="-748.25"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_7-3"/>
+       <position name="posOpArapuca3-Lat-7" unit="cm" 
+         x="60.02"
+	 y="-744.26" 
+	 z="-748.25"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_7-4"/>
+       <position name="posArapuca4-Lat-7" unit="cm" 
+         x="285.02"
+	 y="745" 
+	 z="-748.25"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_7-4"/>
+       <position name="posOpArapuca4-Lat-7" unit="cm" 
+         x="285.02"
+	 y="744.26" 
+	 z="-748.25"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_7-5"/>
+       <position name="posArapuca5-Lat-7" unit="cm" 
+         x="210.02"
+	 y="745" 
+	 z="-748.25"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_7-5"/>
+       <position name="posOpArapuca5-Lat-7" unit="cm" 
+         x="210.02"
+	 y="744.26" 
+	 z="-748.25"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_7-6"/>
+       <position name="posArapuca6-Lat-7" unit="cm" 
+         x="135.02"
+	 y="745" 
+	 z="-748.25"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_7-6"/>
+       <position name="posOpArapuca6-Lat-7" unit="cm" 
+         x="135.02"
+	 y="744.26" 
+	 z="-748.25"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_7-7"/>
+       <position name="posArapuca7-Lat-7" unit="cm" 
+         x="60.02"
+	 y="745" 
+	 z="-748.25"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_7-7"/>
+       <position name="posOpArapuca7-Lat-7" unit="cm" 
+         x="60.02"
+	 y="744.26" 
+	 z="-748.25"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_8-0"/>
+       <position name="posArapuca0-Lat-8" unit="cm" 
+         x="285.02"
+	 y="-745" 
+	 z="-448.95"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_8-0"/>
+       <position name="posOpArapuca0-Lat-8" unit="cm" 
+         x="285.02"
+	 y="-744.26" 
+	 z="-448.95"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_8-1"/>
+       <position name="posArapuca1-Lat-8" unit="cm" 
+         x="210.02"
+	 y="-745" 
+	 z="-448.95"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_8-1"/>
+       <position name="posOpArapuca1-Lat-8" unit="cm" 
+         x="210.02"
+	 y="-744.26" 
+	 z="-448.95"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_8-2"/>
+       <position name="posArapuca2-Lat-8" unit="cm" 
+         x="135.02"
+	 y="-745" 
+	 z="-448.95"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_8-2"/>
+       <position name="posOpArapuca2-Lat-8" unit="cm" 
+         x="135.02"
+	 y="-744.26" 
+	 z="-448.95"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_8-3"/>
+       <position name="posArapuca3-Lat-8" unit="cm" 
+         x="60.02"
+	 y="-745" 
+	 z="-448.95"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_8-3"/>
+       <position name="posOpArapuca3-Lat-8" unit="cm" 
+         x="60.02"
+	 y="-744.26" 
+	 z="-448.95"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_8-4"/>
+       <position name="posArapuca4-Lat-8" unit="cm" 
+         x="285.02"
+	 y="745" 
+	 z="-448.95"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_8-4"/>
+       <position name="posOpArapuca4-Lat-8" unit="cm" 
+         x="285.02"
+	 y="744.26" 
+	 z="-448.95"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_8-5"/>
+       <position name="posArapuca5-Lat-8" unit="cm" 
+         x="210.02"
+	 y="745" 
+	 z="-448.95"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_8-5"/>
+       <position name="posOpArapuca5-Lat-8" unit="cm" 
+         x="210.02"
+	 y="744.26" 
+	 z="-448.95"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_8-6"/>
+       <position name="posArapuca6-Lat-8" unit="cm" 
+         x="135.02"
+	 y="745" 
+	 z="-448.95"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_8-6"/>
+       <position name="posOpArapuca6-Lat-8" unit="cm" 
+         x="135.02"
+	 y="744.26" 
+	 z="-448.95"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_8-7"/>
+       <position name="posArapuca7-Lat-8" unit="cm" 
+         x="60.02"
+	 y="745" 
+	 z="-448.95"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_8-7"/>
+       <position name="posOpArapuca7-Lat-8" unit="cm" 
+         x="60.02"
+	 y="744.26" 
+	 z="-448.95"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_9-0"/>
+       <position name="posArapuca0-Lat-9" unit="cm" 
+         x="285.02"
+	 y="-745" 
+	 z="-149.65"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_9-0"/>
+       <position name="posOpArapuca0-Lat-9" unit="cm" 
+         x="285.02"
+	 y="-744.26" 
+	 z="-149.65"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_9-1"/>
+       <position name="posArapuca1-Lat-9" unit="cm" 
+         x="210.02"
+	 y="-745" 
+	 z="-149.65"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_9-1"/>
+       <position name="posOpArapuca1-Lat-9" unit="cm" 
+         x="210.02"
+	 y="-744.26" 
+	 z="-149.65"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_9-2"/>
+       <position name="posArapuca2-Lat-9" unit="cm" 
+         x="135.02"
+	 y="-745" 
+	 z="-149.65"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_9-2"/>
+       <position name="posOpArapuca2-Lat-9" unit="cm" 
+         x="135.02"
+	 y="-744.26" 
+	 z="-149.65"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_9-3"/>
+       <position name="posArapuca3-Lat-9" unit="cm" 
+         x="60.02"
+	 y="-745" 
+	 z="-149.65"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_9-3"/>
+       <position name="posOpArapuca3-Lat-9" unit="cm" 
+         x="60.02"
+	 y="-744.26" 
+	 z="-149.65"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_9-4"/>
+       <position name="posArapuca4-Lat-9" unit="cm" 
+         x="285.02"
+	 y="745" 
+	 z="-149.65"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_9-4"/>
+       <position name="posOpArapuca4-Lat-9" unit="cm" 
+         x="285.02"
+	 y="744.26" 
+	 z="-149.65"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_9-5"/>
+       <position name="posArapuca5-Lat-9" unit="cm" 
+         x="210.02"
+	 y="745" 
+	 z="-149.65"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_9-5"/>
+       <position name="posOpArapuca5-Lat-9" unit="cm" 
+         x="210.02"
+	 y="744.26" 
+	 z="-149.65"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_9-6"/>
+       <position name="posArapuca6-Lat-9" unit="cm" 
+         x="135.02"
+	 y="745" 
+	 z="-149.65"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_9-6"/>
+       <position name="posOpArapuca6-Lat-9" unit="cm" 
+         x="135.02"
+	 y="744.26" 
+	 z="-149.65"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_9-7"/>
+       <position name="posArapuca7-Lat-9" unit="cm" 
+         x="60.02"
+	 y="745" 
+	 z="-149.65"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_9-7"/>
+       <position name="posOpArapuca7-Lat-9" unit="cm" 
+         x="60.02"
+	 y="744.26" 
+	 z="-149.65"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_10-0"/>
+       <position name="posArapuca0-Lat-10" unit="cm" 
+         x="285.02"
+	 y="-745" 
+	 z="149.65"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_10-0"/>
+       <position name="posOpArapuca0-Lat-10" unit="cm" 
+         x="285.02"
+	 y="-744.26" 
+	 z="149.65"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_10-1"/>
+       <position name="posArapuca1-Lat-10" unit="cm" 
+         x="210.02"
+	 y="-745" 
+	 z="149.65"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_10-1"/>
+       <position name="posOpArapuca1-Lat-10" unit="cm" 
+         x="210.02"
+	 y="-744.26" 
+	 z="149.65"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_10-2"/>
+       <position name="posArapuca2-Lat-10" unit="cm" 
+         x="135.02"
+	 y="-745" 
+	 z="149.65"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_10-2"/>
+       <position name="posOpArapuca2-Lat-10" unit="cm" 
+         x="135.02"
+	 y="-744.26" 
+	 z="149.65"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_10-3"/>
+       <position name="posArapuca3-Lat-10" unit="cm" 
+         x="60.02"
+	 y="-745" 
+	 z="149.65"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_10-3"/>
+       <position name="posOpArapuca3-Lat-10" unit="cm" 
+         x="60.02"
+	 y="-744.26" 
+	 z="149.65"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_10-4"/>
+       <position name="posArapuca4-Lat-10" unit="cm" 
+         x="285.02"
+	 y="745" 
+	 z="149.65"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_10-4"/>
+       <position name="posOpArapuca4-Lat-10" unit="cm" 
+         x="285.02"
+	 y="744.26" 
+	 z="149.65"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_10-5"/>
+       <position name="posArapuca5-Lat-10" unit="cm" 
+         x="210.02"
+	 y="745" 
+	 z="149.65"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_10-5"/>
+       <position name="posOpArapuca5-Lat-10" unit="cm" 
+         x="210.02"
+	 y="744.26" 
+	 z="149.65"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_10-6"/>
+       <position name="posArapuca6-Lat-10" unit="cm" 
+         x="135.02"
+	 y="745" 
+	 z="149.65"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_10-6"/>
+       <position name="posOpArapuca6-Lat-10" unit="cm" 
+         x="135.02"
+	 y="744.26" 
+	 z="149.65"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_10-7"/>
+       <position name="posArapuca7-Lat-10" unit="cm" 
+         x="60.02"
+	 y="745" 
+	 z="149.65"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_10-7"/>
+       <position name="posOpArapuca7-Lat-10" unit="cm" 
+         x="60.02"
+	 y="744.26" 
+	 z="149.65"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_11-0"/>
+       <position name="posArapuca0-Lat-11" unit="cm" 
+         x="285.02"
+	 y="-745" 
+	 z="448.95"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_11-0"/>
+       <position name="posOpArapuca0-Lat-11" unit="cm" 
+         x="285.02"
+	 y="-744.26" 
+	 z="448.95"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_11-1"/>
+       <position name="posArapuca1-Lat-11" unit="cm" 
+         x="210.02"
+	 y="-745" 
+	 z="448.95"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_11-1"/>
+       <position name="posOpArapuca1-Lat-11" unit="cm" 
+         x="210.02"
+	 y="-744.26" 
+	 z="448.95"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_11-2"/>
+       <position name="posArapuca2-Lat-11" unit="cm" 
+         x="135.02"
+	 y="-745" 
+	 z="448.95"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_11-2"/>
+       <position name="posOpArapuca2-Lat-11" unit="cm" 
+         x="135.02"
+	 y="-744.26" 
+	 z="448.95"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_11-3"/>
+       <position name="posArapuca3-Lat-11" unit="cm" 
+         x="60.02"
+	 y="-745" 
+	 z="448.95"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_11-3"/>
+       <position name="posOpArapuca3-Lat-11" unit="cm" 
+         x="60.02"
+	 y="-744.26" 
+	 z="448.95"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_11-4"/>
+       <position name="posArapuca4-Lat-11" unit="cm" 
+         x="285.02"
+	 y="745" 
+	 z="448.95"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_11-4"/>
+       <position name="posOpArapuca4-Lat-11" unit="cm" 
+         x="285.02"
+	 y="744.26" 
+	 z="448.95"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_11-5"/>
+       <position name="posArapuca5-Lat-11" unit="cm" 
+         x="210.02"
+	 y="745" 
+	 z="448.95"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_11-5"/>
+       <position name="posOpArapuca5-Lat-11" unit="cm" 
+         x="210.02"
+	 y="744.26" 
+	 z="448.95"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_11-6"/>
+       <position name="posArapuca6-Lat-11" unit="cm" 
+         x="135.02"
+	 y="745" 
+	 z="448.95"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_11-6"/>
+       <position name="posOpArapuca6-Lat-11" unit="cm" 
+         x="135.02"
+	 y="744.26" 
+	 z="448.95"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_11-7"/>
+       <position name="posArapuca7-Lat-11" unit="cm" 
+         x="60.02"
+	 y="745" 
+	 z="448.95"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_11-7"/>
+       <position name="posOpArapuca7-Lat-11" unit="cm" 
+         x="60.02"
+	 y="744.26" 
+	 z="448.95"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_12-0"/>
+       <position name="posArapuca0-Lat-12" unit="cm" 
+         x="285.02"
+	 y="-745" 
+	 z="748.25"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_12-0"/>
+       <position name="posOpArapuca0-Lat-12" unit="cm" 
+         x="285.02"
+	 y="-744.26" 
+	 z="748.25"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_12-1"/>
+       <position name="posArapuca1-Lat-12" unit="cm" 
+         x="210.02"
+	 y="-745" 
+	 z="748.25"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_12-1"/>
+       <position name="posOpArapuca1-Lat-12" unit="cm" 
+         x="210.02"
+	 y="-744.26" 
+	 z="748.25"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_12-2"/>
+       <position name="posArapuca2-Lat-12" unit="cm" 
+         x="135.02"
+	 y="-745" 
+	 z="748.25"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_12-2"/>
+       <position name="posOpArapuca2-Lat-12" unit="cm" 
+         x="135.02"
+	 y="-744.26" 
+	 z="748.25"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_12-3"/>
+       <position name="posArapuca3-Lat-12" unit="cm" 
+         x="60.02"
+	 y="-745" 
+	 z="748.25"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_12-3"/>
+       <position name="posOpArapuca3-Lat-12" unit="cm" 
+         x="60.02"
+	 y="-744.26" 
+	 z="748.25"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_12-4"/>
+       <position name="posArapuca4-Lat-12" unit="cm" 
+         x="285.02"
+	 y="745" 
+	 z="748.25"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_12-4"/>
+       <position name="posOpArapuca4-Lat-12" unit="cm" 
+         x="285.02"
+	 y="744.26" 
+	 z="748.25"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_12-5"/>
+       <position name="posArapuca5-Lat-12" unit="cm" 
+         x="210.02"
+	 y="745" 
+	 z="748.25"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_12-5"/>
+       <position name="posOpArapuca5-Lat-12" unit="cm" 
+         x="210.02"
+	 y="744.26" 
+	 z="748.25"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_12-6"/>
+       <position name="posArapuca6-Lat-12" unit="cm" 
+         x="135.02"
+	 y="745" 
+	 z="748.25"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_12-6"/>
+       <position name="posOpArapuca6-Lat-12" unit="cm" 
+         x="135.02"
+	 y="744.26" 
+	 z="748.25"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_12-7"/>
+       <position name="posArapuca7-Lat-12" unit="cm" 
+         x="60.02"
+	 y="745" 
+	 z="748.25"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_12-7"/>
+       <position name="posOpArapuca7-Lat-12" unit="cm" 
+         x="60.02"
+	 y="744.26" 
+	 z="748.25"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_13-0"/>
+       <position name="posArapuca0-Lat-13" unit="cm" 
+         x="285.02"
+	 y="-745" 
+	 z="1047.55"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_13-0"/>
+       <position name="posOpArapuca0-Lat-13" unit="cm" 
+         x="285.02"
+	 y="-744.26" 
+	 z="1047.55"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_13-1"/>
+       <position name="posArapuca1-Lat-13" unit="cm" 
+         x="210.02"
+	 y="-745" 
+	 z="1047.55"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_13-1"/>
+       <position name="posOpArapuca1-Lat-13" unit="cm" 
+         x="210.02"
+	 y="-744.26" 
+	 z="1047.55"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_13-2"/>
+       <position name="posArapuca2-Lat-13" unit="cm" 
+         x="135.02"
+	 y="-745" 
+	 z="1047.55"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_13-2"/>
+       <position name="posOpArapuca2-Lat-13" unit="cm" 
+         x="135.02"
+	 y="-744.26" 
+	 z="1047.55"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_13-3"/>
+       <position name="posArapuca3-Lat-13" unit="cm" 
+         x="60.02"
+	 y="-745" 
+	 z="1047.55"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_13-3"/>
+       <position name="posOpArapuca3-Lat-13" unit="cm" 
+         x="60.02"
+	 y="-744.26" 
+	 z="1047.55"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_13-4"/>
+       <position name="posArapuca4-Lat-13" unit="cm" 
+         x="285.02"
+	 y="745" 
+	 z="1047.55"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_13-4"/>
+       <position name="posOpArapuca4-Lat-13" unit="cm" 
+         x="285.02"
+	 y="744.26" 
+	 z="1047.55"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_13-5"/>
+       <position name="posArapuca5-Lat-13" unit="cm" 
+         x="210.02"
+	 y="745" 
+	 z="1047.55"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_13-5"/>
+       <position name="posOpArapuca5-Lat-13" unit="cm" 
+         x="210.02"
+	 y="744.26" 
+	 z="1047.55"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_13-6"/>
+       <position name="posArapuca6-Lat-13" unit="cm" 
+         x="135.02"
+	 y="745" 
+	 z="1047.55"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_13-6"/>
+       <position name="posOpArapuca6-Lat-13" unit="cm" 
+         x="135.02"
+	 y="744.26" 
+	 z="1047.55"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_13-7"/>
+       <position name="posArapuca7-Lat-13" unit="cm" 
+         x="60.02"
+	 y="745" 
+	 z="1047.55"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_13-7"/>
+       <position name="posOpArapuca7-Lat-13" unit="cm" 
+         x="60.02"
+	 y="744.26" 
+	 z="1047.55"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_14-0"/>
+       <position name="posArapuca0-Lat-14" unit="cm" 
+         x="285.02"
+	 y="-745" 
+	 z="1346.85"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_14-0"/>
+       <position name="posOpArapuca0-Lat-14" unit="cm" 
+         x="285.02"
+	 y="-744.26" 
+	 z="1346.85"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_14-1"/>
+       <position name="posArapuca1-Lat-14" unit="cm" 
+         x="210.02"
+	 y="-745" 
+	 z="1346.85"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_14-1"/>
+       <position name="posOpArapuca1-Lat-14" unit="cm" 
+         x="210.02"
+	 y="-744.26" 
+	 z="1346.85"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_14-2"/>
+       <position name="posArapuca2-Lat-14" unit="cm" 
+         x="135.02"
+	 y="-745" 
+	 z="1346.85"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_14-2"/>
+       <position name="posOpArapuca2-Lat-14" unit="cm" 
+         x="135.02"
+	 y="-744.26" 
+	 z="1346.85"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_14-3"/>
+       <position name="posArapuca3-Lat-14" unit="cm" 
+         x="60.02"
+	 y="-745" 
+	 z="1346.85"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_14-3"/>
+       <position name="posOpArapuca3-Lat-14" unit="cm" 
+         x="60.02"
+	 y="-744.26" 
+	 z="1346.85"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_14-4"/>
+       <position name="posArapuca4-Lat-14" unit="cm" 
+         x="285.02"
+	 y="745" 
+	 z="1346.85"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_14-4"/>
+       <position name="posOpArapuca4-Lat-14" unit="cm" 
+         x="285.02"
+	 y="744.26" 
+	 z="1346.85"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_14-5"/>
+       <position name="posArapuca5-Lat-14" unit="cm" 
+         x="210.02"
+	 y="745" 
+	 z="1346.85"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_14-5"/>
+       <position name="posOpArapuca5-Lat-14" unit="cm" 
+         x="210.02"
+	 y="744.26" 
+	 z="1346.85"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_14-6"/>
+       <position name="posArapuca6-Lat-14" unit="cm" 
+         x="135.02"
+	 y="745" 
+	 z="1346.85"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_14-6"/>
+       <position name="posOpArapuca6-Lat-14" unit="cm" 
+         x="135.02"
+	 y="744.26" 
+	 z="1346.85"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_14-7"/>
+       <position name="posArapuca7-Lat-14" unit="cm" 
+         x="60.02"
+	 y="745" 
+	 z="1346.85"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_14-7"/>
+       <position name="posOpArapuca7-Lat-14" unit="cm" 
+         x="60.02"
+	 y="744.26" 
+	 z="1346.85"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_15-0"/>
+       <position name="posArapuca0-Lat-15" unit="cm" 
+         x="285.02"
+	 y="-745" 
+	 z="1646.15"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_15-0"/>
+       <position name="posOpArapuca0-Lat-15" unit="cm" 
+         x="285.02"
+	 y="-744.26" 
+	 z="1646.15"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_15-1"/>
+       <position name="posArapuca1-Lat-15" unit="cm" 
+         x="210.02"
+	 y="-745" 
+	 z="1646.15"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_15-1"/>
+       <position name="posOpArapuca1-Lat-15" unit="cm" 
+         x="210.02"
+	 y="-744.26" 
+	 z="1646.15"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_15-2"/>
+       <position name="posArapuca2-Lat-15" unit="cm" 
+         x="135.02"
+	 y="-745" 
+	 z="1646.15"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_15-2"/>
+       <position name="posOpArapuca2-Lat-15" unit="cm" 
+         x="135.02"
+	 y="-744.26" 
+	 z="1646.15"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_15-3"/>
+       <position name="posArapuca3-Lat-15" unit="cm" 
+         x="60.02"
+	 y="-745" 
+	 z="1646.15"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_15-3"/>
+       <position name="posOpArapuca3-Lat-15" unit="cm" 
+         x="60.02"
+	 y="-744.26" 
+	 z="1646.15"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_15-4"/>
+       <position name="posArapuca4-Lat-15" unit="cm" 
+         x="285.02"
+	 y="745" 
+	 z="1646.15"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_15-4"/>
+       <position name="posOpArapuca4-Lat-15" unit="cm" 
+         x="285.02"
+	 y="744.26" 
+	 z="1646.15"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_15-5"/>
+       <position name="posArapuca5-Lat-15" unit="cm" 
+         x="210.02"
+	 y="745" 
+	 z="1646.15"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_15-5"/>
+       <position name="posOpArapuca5-Lat-15" unit="cm" 
+         x="210.02"
+	 y="744.26" 
+	 z="1646.15"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_15-6"/>
+       <position name="posArapuca6-Lat-15" unit="cm" 
+         x="135.02"
+	 y="745" 
+	 z="1646.15"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_15-6"/>
+       <position name="posOpArapuca6-Lat-15" unit="cm" 
+         x="135.02"
+	 y="744.26" 
+	 z="1646.15"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_15-7"/>
+       <position name="posArapuca7-Lat-15" unit="cm" 
+         x="60.02"
+	 y="745" 
+	 z="1646.15"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_15-7"/>
+       <position name="posOpArapuca7-Lat-15" unit="cm" 
+         x="60.02"
+	 y="744.26" 
+	 z="1646.15"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_16-0"/>
+       <position name="posArapuca0-Lat-16" unit="cm" 
+         x="285.02"
+	 y="-745" 
+	 z="1945.45"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_16-0"/>
+       <position name="posOpArapuca0-Lat-16" unit="cm" 
+         x="285.02"
+	 y="-744.26" 
+	 z="1945.45"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_16-1"/>
+       <position name="posArapuca1-Lat-16" unit="cm" 
+         x="210.02"
+	 y="-745" 
+	 z="1945.45"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_16-1"/>
+       <position name="posOpArapuca1-Lat-16" unit="cm" 
+         x="210.02"
+	 y="-744.26" 
+	 z="1945.45"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_16-2"/>
+       <position name="posArapuca2-Lat-16" unit="cm" 
+         x="135.02"
+	 y="-745" 
+	 z="1945.45"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_16-2"/>
+       <position name="posOpArapuca2-Lat-16" unit="cm" 
+         x="135.02"
+	 y="-744.26" 
+	 z="1945.45"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_16-3"/>
+       <position name="posArapuca3-Lat-16" unit="cm" 
+         x="60.02"
+	 y="-745" 
+	 z="1945.45"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_16-3"/>
+       <position name="posOpArapuca3-Lat-16" unit="cm" 
+         x="60.02"
+	 y="-744.26" 
+	 z="1945.45"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_16-4"/>
+       <position name="posArapuca4-Lat-16" unit="cm" 
+         x="285.02"
+	 y="745" 
+	 z="1945.45"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_16-4"/>
+       <position name="posOpArapuca4-Lat-16" unit="cm" 
+         x="285.02"
+	 y="744.26" 
+	 z="1945.45"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_16-5"/>
+       <position name="posArapuca5-Lat-16" unit="cm" 
+         x="210.02"
+	 y="745" 
+	 z="1945.45"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_16-5"/>
+       <position name="posOpArapuca5-Lat-16" unit="cm" 
+         x="210.02"
+	 y="744.26" 
+	 z="1945.45"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_16-6"/>
+       <position name="posArapuca6-Lat-16" unit="cm" 
+         x="135.02"
+	 y="745" 
+	 z="1945.45"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_16-6"/>
+       <position name="posOpArapuca6-Lat-16" unit="cm" 
+         x="135.02"
+	 y="744.26" 
+	 z="1945.45"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_16-7"/>
+       <position name="posArapuca7-Lat-16" unit="cm" 
+         x="60.02"
+	 y="745" 
+	 z="1945.45"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_16-7"/>
+       <position name="posOpArapuca7-Lat-16" unit="cm" 
+         x="60.02"
+	 y="744.26" 
+	 z="1945.45"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_17-0"/>
+       <position name="posArapuca0-Lat-17" unit="cm" 
+         x="285.02"
+	 y="-745" 
+	 z="2244.75"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_17-0"/>
+       <position name="posOpArapuca0-Lat-17" unit="cm" 
+         x="285.02"
+	 y="-744.26" 
+	 z="2244.75"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_17-1"/>
+       <position name="posArapuca1-Lat-17" unit="cm" 
+         x="210.02"
+	 y="-745" 
+	 z="2244.75"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_17-1"/>
+       <position name="posOpArapuca1-Lat-17" unit="cm" 
+         x="210.02"
+	 y="-744.26" 
+	 z="2244.75"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_17-2"/>
+       <position name="posArapuca2-Lat-17" unit="cm" 
+         x="135.02"
+	 y="-745" 
+	 z="2244.75"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_17-2"/>
+       <position name="posOpArapuca2-Lat-17" unit="cm" 
+         x="135.02"
+	 y="-744.26" 
+	 z="2244.75"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_17-3"/>
+       <position name="posArapuca3-Lat-17" unit="cm" 
+         x="60.02"
+	 y="-745" 
+	 z="2244.75"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_17-3"/>
+       <position name="posOpArapuca3-Lat-17" unit="cm" 
+         x="60.02"
+	 y="-744.26" 
+	 z="2244.75"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_17-4"/>
+       <position name="posArapuca4-Lat-17" unit="cm" 
+         x="285.02"
+	 y="745" 
+	 z="2244.75"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_17-4"/>
+       <position name="posOpArapuca4-Lat-17" unit="cm" 
+         x="285.02"
+	 y="744.26" 
+	 z="2244.75"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_17-5"/>
+       <position name="posArapuca5-Lat-17" unit="cm" 
+         x="210.02"
+	 y="745" 
+	 z="2244.75"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_17-5"/>
+       <position name="posOpArapuca5-Lat-17" unit="cm" 
+         x="210.02"
+	 y="744.26" 
+	 z="2244.75"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_17-6"/>
+       <position name="posArapuca6-Lat-17" unit="cm" 
+         x="135.02"
+	 y="745" 
+	 z="2244.75"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_17-6"/>
+       <position name="posOpArapuca6-Lat-17" unit="cm" 
+         x="135.02"
+	 y="744.26" 
+	 z="2244.75"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_17-7"/>
+       <position name="posArapuca7-Lat-17" unit="cm" 
+         x="60.02"
+	 y="745" 
+	 z="2244.75"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_17-7"/>
+       <position name="posOpArapuca7-Lat-17" unit="cm" 
+         x="60.02"
+	 y="744.26" 
+	 z="2244.75"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_18-0"/>
+       <position name="posArapuca0-Lat-18" unit="cm" 
+         x="285.02"
+	 y="-745" 
+	 z="2544.05"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_18-0"/>
+       <position name="posOpArapuca0-Lat-18" unit="cm" 
+         x="285.02"
+	 y="-744.26" 
+	 z="2544.05"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_18-1"/>
+       <position name="posArapuca1-Lat-18" unit="cm" 
+         x="210.02"
+	 y="-745" 
+	 z="2544.05"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_18-1"/>
+       <position name="posOpArapuca1-Lat-18" unit="cm" 
+         x="210.02"
+	 y="-744.26" 
+	 z="2544.05"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_18-2"/>
+       <position name="posArapuca2-Lat-18" unit="cm" 
+         x="135.02"
+	 y="-745" 
+	 z="2544.05"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_18-2"/>
+       <position name="posOpArapuca2-Lat-18" unit="cm" 
+         x="135.02"
+	 y="-744.26" 
+	 z="2544.05"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_18-3"/>
+       <position name="posArapuca3-Lat-18" unit="cm" 
+         x="60.02"
+	 y="-745" 
+	 z="2544.05"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_18-3"/>
+       <position name="posOpArapuca3-Lat-18" unit="cm" 
+         x="60.02"
+	 y="-744.26" 
+	 z="2544.05"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_18-4"/>
+       <position name="posArapuca4-Lat-18" unit="cm" 
+         x="285.02"
+	 y="745" 
+	 z="2544.05"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_18-4"/>
+       <position name="posOpArapuca4-Lat-18" unit="cm" 
+         x="285.02"
+	 y="744.26" 
+	 z="2544.05"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_18-5"/>
+       <position name="posArapuca5-Lat-18" unit="cm" 
+         x="210.02"
+	 y="745" 
+	 z="2544.05"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_18-5"/>
+       <position name="posOpArapuca5-Lat-18" unit="cm" 
+         x="210.02"
+	 y="744.26" 
+	 z="2544.05"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_18-6"/>
+       <position name="posArapuca6-Lat-18" unit="cm" 
+         x="135.02"
+	 y="745" 
+	 z="2544.05"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_18-6"/>
+       <position name="posOpArapuca6-Lat-18" unit="cm" 
+         x="135.02"
+	 y="744.26" 
+	 z="2544.05"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_18-7"/>
+       <position name="posArapuca7-Lat-18" unit="cm" 
+         x="60.02"
+	 y="745" 
+	 z="2544.05"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_18-7"/>
+       <position name="posOpArapuca7-Lat-18" unit="cm" 
+         x="60.02"
+	 y="744.26" 
+	 z="2544.05"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_19-0"/>
+       <position name="posArapuca0-Lat-19" unit="cm" 
+         x="285.02"
+	 y="-745" 
+	 z="2843.35"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_19-0"/>
+       <position name="posOpArapuca0-Lat-19" unit="cm" 
+         x="285.02"
+	 y="-744.26" 
+	 z="2843.35"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_19-1"/>
+       <position name="posArapuca1-Lat-19" unit="cm" 
+         x="210.02"
+	 y="-745" 
+	 z="2843.35"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_19-1"/>
+       <position name="posOpArapuca1-Lat-19" unit="cm" 
+         x="210.02"
+	 y="-744.26" 
+	 z="2843.35"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_19-2"/>
+       <position name="posArapuca2-Lat-19" unit="cm" 
+         x="135.02"
+	 y="-745" 
+	 z="2843.35"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_19-2"/>
+       <position name="posOpArapuca2-Lat-19" unit="cm" 
+         x="135.02"
+	 y="-744.26" 
+	 z="2843.35"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_19-3"/>
+       <position name="posArapuca3-Lat-19" unit="cm" 
+         x="60.02"
+	 y="-745" 
+	 z="2843.35"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_19-3"/>
+       <position name="posOpArapuca3-Lat-19" unit="cm" 
+         x="60.02"
+	 y="-744.26" 
+	 z="2843.35"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_19-4"/>
+       <position name="posArapuca4-Lat-19" unit="cm" 
+         x="285.02"
+	 y="745" 
+	 z="2843.35"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_19-4"/>
+       <position name="posOpArapuca4-Lat-19" unit="cm" 
+         x="285.02"
+	 y="744.26" 
+	 z="2843.35"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_19-5"/>
+       <position name="posArapuca5-Lat-19" unit="cm" 
+         x="210.02"
+	 y="745" 
+	 z="2843.35"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_19-5"/>
+       <position name="posOpArapuca5-Lat-19" unit="cm" 
+         x="210.02"
+	 y="744.26" 
+	 z="2843.35"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_19-6"/>
+       <position name="posArapuca6-Lat-19" unit="cm" 
+         x="135.02"
+	 y="745" 
+	 z="2843.35"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_19-6"/>
+       <position name="posOpArapuca6-Lat-19" unit="cm" 
+         x="135.02"
+	 y="744.26" 
+	 z="2843.35"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapucaLat_19-7"/>
+       <position name="posArapuca7-Lat-19" unit="cm" 
+         x="60.02"
+	 y="745" 
+	 z="2843.35"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_19-7"/>
+       <position name="posOpArapuca7-Lat-19" unit="cm" 
+         x="60.02"
+	 y="744.26" 
+	 z="2843.35"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca0-ShortLat-19" unit="cm" 
+         x="285.02"
+	 y="-220" 
+	 z="-3090"/>
+       <rotationref ref="rMinus90AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca1-ShortLat-19" unit="cm" 
+         x="210.02"
+	 y="-220" 
+	 z="-3090"/>
+       <rotationref ref="rMinus90AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca2-ShortLat-19" unit="cm" 
+         x="135.02"
+	 y="-220" 
+	 z="-3090"/>
+       <rotationref ref="rMinus90AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca3-ShortLat-19" unit="cm" 
+         x="60.02"
+	 y="-220" 
+	 z="-3090"/>
+       <rotationref ref="rMinus90AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca4-ShortLat-19" unit="cm" 
+         x="285.02"
+	 y="-220" 
+	 z="3090"/>
+       <rotationref ref="rPlus90AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca5-ShortLat-19" unit="cm" 
+         x="210.02"
+	 y="-220" 
+	 z="3090"/>
+       <rotationref ref="rPlus90AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca6-ShortLat-19" unit="cm" 
+         x="135.02"
+	 y="-220" 
+	 z="3090"/>
+       <rotationref ref="rPlus90AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca7-ShortLat-19" unit="cm" 
+         x="60.02"
+	 y="-220" 
+	 z="3090"/>
+       <rotationref ref="rPlus90AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca0-ShortLat-19" unit="cm" 
+         x="285.02"
+	 y="220" 
+	 z="-3090"/>
+       <rotationref ref="rMinus90AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca1-ShortLat-19" unit="cm" 
+         x="210.02"
+	 y="220" 
+	 z="-3090"/>
+       <rotationref ref="rMinus90AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca2-ShortLat-19" unit="cm" 
+         x="135.02"
+	 y="220" 
+	 z="-3090"/>
+       <rotationref ref="rMinus90AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca3-ShortLat-19" unit="cm" 
+         x="60.02"
+	 y="220" 
+	 z="-3090"/>
+       <rotationref ref="rMinus90AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca4-ShortLat-19" unit="cm" 
+         x="285.02"
+	 y="220" 
+	 z="3090"/>
+       <rotationref ref="rPlus90AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca5-ShortLat-19" unit="cm" 
+         x="210.02"
+	 y="220" 
+	 z="3090"/>
+       <rotationref ref="rPlus90AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca6-ShortLat-19" unit="cm" 
+         x="135.02"
+	 y="220" 
+	 z="3090"/>
+       <rotationref ref="rPlus90AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca7-ShortLat-19" unit="cm" 
+         x="60.02"
+	 y="220" 
+	 z="3090"/>
+       <rotationref ref="rPlus90AboutX"/>
+     </physvol>
+    </volume>
+
+    <volume name="volFoamPadding">
+      <materialref ref="fibrous_glass"/>
+      <solidref ref="FoamPadding"/>
+    </volume>
+
+    <volume name="volSteelSupport">
+      <materialref ref="AirSteelMixture"/>
+      <solidref ref="SteelSupport"/>
+    </volume>
+
+    <volume name="volDetEnclosure">
+      <materialref ref="Air"/>
+      <solidref ref="DetEnclosure"/>
+
+       <physvol>
+           <volumeref ref="volFoamPadding"/>
+           <positionref ref="posCryoInDetEnc"/>
+       </physvol>
+       <physvol>
+           <volumeref ref="volSteelSupport"/>
+           <positionref ref="posCryoInDetEnc"/>
+       </physvol>
+       <physvol>
+           <volumeref ref="volCryostat"/>
+           <positionref ref="posCryoInDetEnc"/>
+       </physvol>
+    </volume>
+
+    <volume name="volWorld" >
+      <materialref ref="DUSEL_Rock"/>
+      <solidref ref="World"/>
+
+      <physvol>
+        <volumeref ref="volDetEnclosure"/>
+	<position name="posDetEnclosure" unit="cm" x="50.03" y="-1.13686837721616e-13" z="2993"/>
+      </physvol>
+
+    </volume>
+</structure>
+
+  <setup name="Default" version="1.0">
+    <world ref="volWorld"/>
+  </setup>
+
+</gdml_simple_extension>

--- a/dunecore/Geometry/gdml/dunevd10kt_3view_30deg_v5_refactored_1x8x20ref_nowires.gdml
+++ b/dunecore/Geometry/gdml/dunevd10kt_3view_30deg_v5_refactored_1x8x20ref_nowires.gdml
@@ -397,6 +397,24 @@
      <tube name="FieldShaperLongtube" rmin="0.5" rmax="2.285" z="5986" deltaphi="360" startphi="0" aunit="deg" lunit="cm"/>
      <tube name="FieldShaperLongtubeSlim" rmin="0.5" rmax="0.75" z="5986" deltaphi="360" startphi="0" aunit="deg" lunit="cm"/>
      <tube name="FieldShaperShorttube" rmin="0.5" rmax="2.285" z="1348" deltaphi="360" startphi="0" aunit="deg" lunit="cm"/>
+     <tube name="FieldShaperShorttubeWindowSlim" rmin="0.5" rmax="0.75" z="670" deltaphi="360" startphi="0" aunit="deg" lunit="cm"/>
+     <tube name="FieldShaperShorttubeWindowNotSlim" rmin="0.5" rmax="2.285" z="339" deltaphi="360" startphi="0" aunit="deg" lunit="cm"/>
+
+
+    <union name="FSunionWindow1">
+      <first ref="FieldShaperShorttubeWindowSlim"/>
+      <second ref="FieldShaperShorttubeWindowNotSlim"/>
+      <position name="posFieldShaperShortTube_shift1" unit="cm" x="0" y="0" z="504.5"/>
+    </union>
+
+    <union name="FieldShaperShorttubeSlim">
+      <first ref="FSunionWindow1"/>
+      <second ref="FieldShaperShorttubeWindowNotSlim"/>
+      <position name="posFieldShaperShortTube_shift2" unit="cm" x="0" y="0" z="-504.5"/>
+    </union>
+
+
+
 
     <union name="FSunion1">
       <first ref="FieldShaperLongtube"/>
@@ -455,7 +473,7 @@
 
     <union name="FSunionSlim2">
       <first ref="FSunionSlim1"/>
-      <second ref="FieldShaperShorttube"/>
+      <second ref="FieldShaperShorttubeSlim"/>
    		<position name="esquinapos9" unit="cm" x="-676.3" y="0" z="2995.3"/>
    		<rotationref ref="rPlus90AboutY"/>
     </union>
@@ -482,7 +500,7 @@
 
     <union name="FSunionSlim6">
       <first ref="FSunionSlim5"/>
-      <second ref="FieldShaperShorttube"/>
+      <second ref="FieldShaperShorttubeSlim"/>
    		<position name="esquinapos12" unit="cm" x="-676.3" y="0" z="-2995.3"/>
 		<rotationref ref="rPlus90AboutY"/>
     </union>
@@ -942,10 +960,6 @@
       <colorref ref="green"/>
     </volume>
 
-    <volume name="volArapucaShortLat">
-      <materialref ref="G10"/>
-      <solidref ref="ArapucaWalls"/>
-    </volume>
     <volume name="volOpDetSensitive">
       <materialref ref="LAr"/>
       <solidref ref="ArapucaAcceptanceWindow"/>
@@ -969,3846 +983,6 @@
       </physvol>
     </volume>
 
-    <volume name="volArapucaDouble_0-0-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-0-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-0-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-0-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-0-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-0-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-0-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-0-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-1-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-1-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-1-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-1-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-1-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-1-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-1-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-1-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-2-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-2-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-2-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-2-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-2-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-2-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-2-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-2-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-3-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-3-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-3-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-3-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-3-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-3-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-3-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-3-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-4-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-4-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-4-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-4-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-4-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-4-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-4-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-4-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-5-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-5-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-5-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-5-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-5-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-5-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-5-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-5-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-6-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-6-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-6-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-6-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-6-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-6-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-6-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-6-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-7-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-7-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-7-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-7-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-7-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-7-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-7-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-7-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-8-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-8-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-8-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-8-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-8-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-8-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-8-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-8-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-9-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-9-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-9-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-9-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-9-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-9-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-9-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-9-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-10-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-10-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-10-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-10-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-10-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-10-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-10-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-10-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-11-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-11-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-11-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-11-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-11-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-11-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-11-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-11-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-12-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-12-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-12-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-12-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-12-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-12-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-12-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-12-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-13-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-13-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-13-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-13-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-13-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-13-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-13-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-13-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-14-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-14-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-14-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-14-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-14-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-14-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-14-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-14-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-15-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-15-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-15-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-15-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-15-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-15-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-15-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-15-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-16-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-16-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-16-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-16-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-16-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-16-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-16-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-16-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-17-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-17-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-17-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-17-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-17-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-17-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-17-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-17-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-18-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-18-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-18-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-18-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-18-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-18-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-18-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-18-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-19-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-19-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-19-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-19-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-19-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-19-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-19-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-19-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-0-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-0-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-0-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-0-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-0-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-0-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-0-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-0-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-1-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-1-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-1-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-1-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-1-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-1-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-1-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-1-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-2-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-2-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-2-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-2-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-2-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-2-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-2-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-2-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-3-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-3-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-3-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-3-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-3-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-3-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-3-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-3-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-4-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-4-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-4-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-4-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-4-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-4-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-4-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-4-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-5-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-5-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-5-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-5-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-5-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-5-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-5-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-5-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-6-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-6-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-6-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-6-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-6-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-6-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-6-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-6-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-7-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-7-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-7-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-7-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-7-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-7-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-7-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-7-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-8-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-8-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-8-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-8-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-8-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-8-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-8-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-8-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-9-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-9-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-9-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-9-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-9-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-9-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-9-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-9-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-10-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-10-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-10-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-10-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-10-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-10-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-10-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-10-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-11-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-11-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-11-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-11-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-11-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-11-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-11-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-11-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-12-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-12-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-12-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-12-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-12-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-12-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-12-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-12-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-13-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-13-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-13-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-13-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-13-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-13-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-13-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-13-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-14-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-14-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-14-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-14-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-14-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-14-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-14-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-14-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-15-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-15-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-15-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-15-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-15-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-15-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-15-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-15-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-16-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-16-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-16-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-16-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-16-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-16-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-16-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-16-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-17-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-17-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-17-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-17-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-17-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-17-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-17-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-17-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-18-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-18-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-18-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-18-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-18-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-18-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-18-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-18-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-19-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-19-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-19-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-19-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-19-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-19-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-19-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-19-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-0-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-0-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-0-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-0-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-0-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-0-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-0-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-0-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-1-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-1-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-1-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-1-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-1-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-1-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-1-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-1-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-2-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-2-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-2-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-2-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-2-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-2-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-2-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-2-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-3-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-3-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-3-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-3-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-3-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-3-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-3-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-3-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-4-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-4-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-4-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-4-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-4-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-4-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-4-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-4-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-5-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-5-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-5-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-5-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-5-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-5-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-5-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-5-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-6-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-6-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-6-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-6-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-6-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-6-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-6-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-6-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-7-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-7-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-7-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-7-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-7-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-7-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-7-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-7-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-8-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-8-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-8-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-8-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-8-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-8-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-8-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-8-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-9-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-9-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-9-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-9-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-9-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-9-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-9-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-9-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-10-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-10-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-10-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-10-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-10-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-10-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-10-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-10-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-11-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-11-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-11-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-11-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-11-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-11-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-11-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-11-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-12-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-12-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-12-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-12-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-12-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-12-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-12-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-12-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-13-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-13-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-13-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-13-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-13-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-13-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-13-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-13-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-14-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-14-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-14-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-14-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-14-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-14-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-14-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-14-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-15-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-15-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-15-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-15-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-15-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-15-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-15-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-15-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-16-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-16-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-16-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-16-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-16-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-16-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-16-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-16-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-17-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-17-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-17-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-17-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-17-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-17-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-17-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-17-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-18-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-18-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-18-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-18-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-18-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-18-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-18-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-18-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-19-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-19-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-19-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-19-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-19-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-19-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-19-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-19-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-0-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-0-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-0-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-0-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-0-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-0-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-0-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-0-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-1-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-1-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-1-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-1-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-1-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-1-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-1-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-1-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-2-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-2-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-2-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-2-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-2-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-2-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-2-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-2-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-3-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-3-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-3-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-3-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-3-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-3-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-3-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-3-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-4-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-4-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-4-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-4-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-4-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-4-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-4-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-4-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-5-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-5-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-5-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-5-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-5-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-5-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-5-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-5-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-6-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-6-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-6-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-6-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-6-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-6-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-6-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-6-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-7-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-7-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-7-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-7-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-7-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-7-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-7-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-7-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-8-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-8-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-8-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-8-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-8-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-8-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-8-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-8-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-9-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-9-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-9-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-9-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-9-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-9-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-9-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-9-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-10-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-10-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-10-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-10-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-10-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-10-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-10-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-10-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-11-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-11-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-11-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-11-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-11-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-11-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-11-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-11-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-12-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-12-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-12-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-12-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-12-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-12-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-12-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-12-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-13-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-13-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-13-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-13-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-13-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-13-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-13-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-13-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-14-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-14-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-14-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-14-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-14-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-14-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-14-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-14-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-15-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-15-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-15-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-15-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-15-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-15-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-15-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-15-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-16-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-16-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-16-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-16-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-16-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-16-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-16-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-16-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-17-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-17-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-17-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-17-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-17-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-17-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-17-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-17-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-18-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-18-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-18-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-18-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-18-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-18-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-18-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-18-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-19-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-19-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-19-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-19-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-19-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-19-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-19-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-19-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_0-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_0-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_0-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_0-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_0-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_0-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_0-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_0-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_0-4">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_0-4">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_0-5">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_0-5">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_0-6">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_0-6">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_0-7">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_0-7">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_1-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_1-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_1-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_1-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_1-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_1-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_1-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_1-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_1-4">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_1-4">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_1-5">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_1-5">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_1-6">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_1-6">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_1-7">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_1-7">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_2-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_2-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_2-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_2-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_2-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_2-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_2-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_2-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_2-4">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_2-4">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_2-5">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_2-5">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_2-6">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_2-6">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_2-7">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_2-7">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_3-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_3-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_3-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_3-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_3-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_3-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_3-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_3-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_3-4">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_3-4">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_3-5">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_3-5">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_3-6">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_3-6">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_3-7">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_3-7">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_4-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_4-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_4-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_4-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_4-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_4-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_4-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_4-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_4-4">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_4-4">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_4-5">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_4-5">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_4-6">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_4-6">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_4-7">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_4-7">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_5-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_5-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_5-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_5-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_5-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_5-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_5-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_5-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_5-4">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_5-4">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_5-5">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_5-5">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_5-6">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_5-6">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_5-7">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_5-7">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_6-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_6-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_6-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_6-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_6-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_6-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_6-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_6-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_6-4">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_6-4">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_6-5">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_6-5">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_6-6">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_6-6">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_6-7">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_6-7">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_7-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_7-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_7-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_7-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_7-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_7-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_7-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_7-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_7-4">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_7-4">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_7-5">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_7-5">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_7-6">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_7-6">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_7-7">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_7-7">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_8-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_8-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_8-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_8-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_8-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_8-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_8-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_8-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_8-4">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_8-4">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_8-5">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_8-5">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_8-6">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_8-6">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_8-7">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_8-7">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_9-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_9-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_9-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_9-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_9-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_9-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_9-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_9-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_9-4">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_9-4">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_9-5">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_9-5">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_9-6">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_9-6">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_9-7">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_9-7">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_10-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_10-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_10-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_10-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_10-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_10-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_10-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_10-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_10-4">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_10-4">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_10-5">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_10-5">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_10-6">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_10-6">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_10-7">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_10-7">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_11-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_11-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_11-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_11-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_11-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_11-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_11-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_11-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_11-4">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_11-4">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_11-5">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_11-5">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_11-6">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_11-6">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_11-7">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_11-7">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_12-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_12-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_12-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_12-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_12-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_12-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_12-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_12-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_12-4">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_12-4">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_12-5">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_12-5">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_12-6">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_12-6">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_12-7">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_12-7">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_13-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_13-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_13-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_13-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_13-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_13-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_13-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_13-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_13-4">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_13-4">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_13-5">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_13-5">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_13-6">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_13-6">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_13-7">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_13-7">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_14-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_14-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_14-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_14-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_14-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_14-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_14-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_14-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_14-4">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_14-4">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_14-5">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_14-5">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_14-6">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_14-6">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_14-7">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_14-7">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_15-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_15-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_15-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_15-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_15-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_15-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_15-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_15-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_15-4">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_15-4">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_15-5">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_15-5">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_15-6">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_15-6">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_15-7">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_15-7">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_16-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_16-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_16-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_16-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_16-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_16-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_16-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_16-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_16-4">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_16-4">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_16-5">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_16-5">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_16-6">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_16-6">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_16-7">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_16-7">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_17-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_17-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_17-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_17-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_17-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_17-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_17-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_17-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_17-4">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_17-4">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_17-5">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_17-5">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_17-6">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_17-6">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_17-7">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_17-7">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_18-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_18-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_18-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_18-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_18-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_18-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_18-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_18-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_18-4">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_18-4">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_18-5">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_18-5">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_18-6">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_18-6">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_18-7">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_18-7">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_19-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_19-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_19-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_19-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_19-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_19-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_19-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_19-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_19-4">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_19-4">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_19-5">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_19-5">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_19-6">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_19-6">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_19-7">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_19-7">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
 
     <volume name="volCryostat">
       <materialref ref="LAr" />
@@ -7686,7 +3860,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>    
      <physvol>
-       <volumeref ref="volArapucaDouble_0-0-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-0-0" unit="cm" 
          x="-328.03"
 	 y="-633.2" 
@@ -7694,14 +3868,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-0"/>
-       <position name="posOpArapucaDouble0-Frame-0-0" unit="cm" 
-         x="-327.29"
-	 y="-633.2" 
-	 z="-2805.85"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-0-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-0-0" unit="cm" 
          x="-328.03"
 	 y="-542.5" 
@@ -7709,14 +3876,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-1"/>
-       <position name="posOpArapucaDouble1-Frame-0-0" unit="cm" 
-         x="-327.29"
-	 y="-542.5" 
-	 z="-2951.85"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-0-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-0-0" unit="cm" 
          x="-328.03"
 	 y="-468.5" 
@@ -7724,14 +3884,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-2"/>
-       <position name="posOpArapucaDouble2-Frame-0-0" unit="cm" 
-         x="-327.29"
-	 y="-468.5" 
-	 z="-2734.85"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-0-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-0-0" unit="cm" 
          x="-328.03"
 	 y="-377.8" 
@@ -7739,14 +3892,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-3"/>
-       <position name="posOpArapucaDouble3-Frame-0-0" unit="cm" 
-         x="-327.29"
-	 y="-377.8" 
-	 z="-2880.85"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-1-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-0-1" unit="cm" 
          x="-328.03"
 	 y="-633.2" 
@@ -7754,14 +3900,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-0"/>
-       <position name="posOpArapucaDouble0-Frame-0-1" unit="cm" 
-         x="-327.29"
-	 y="-633.2" 
-	 z="-2506.55"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-1-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-0-1" unit="cm" 
          x="-328.03"
 	 y="-542.5" 
@@ -7769,14 +3908,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-1"/>
-       <position name="posOpArapucaDouble1-Frame-0-1" unit="cm" 
-         x="-327.29"
-	 y="-542.5" 
-	 z="-2652.55"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-1-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-0-1" unit="cm" 
          x="-328.03"
 	 y="-468.5" 
@@ -7784,14 +3916,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-2"/>
-       <position name="posOpArapucaDouble2-Frame-0-1" unit="cm" 
-         x="-327.29"
-	 y="-468.5" 
-	 z="-2435.55"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-1-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-0-1" unit="cm" 
          x="-328.03"
 	 y="-377.8" 
@@ -7799,14 +3924,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-3"/>
-       <position name="posOpArapucaDouble3-Frame-0-1" unit="cm" 
-         x="-327.29"
-	 y="-377.8" 
-	 z="-2581.55"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-2-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-0-2" unit="cm" 
          x="-328.03"
 	 y="-633.2" 
@@ -7814,14 +3932,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-0"/>
-       <position name="posOpArapucaDouble0-Frame-0-2" unit="cm" 
-         x="-327.29"
-	 y="-633.2" 
-	 z="-2207.25"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-2-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-0-2" unit="cm" 
          x="-328.03"
 	 y="-542.5" 
@@ -7829,14 +3940,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-1"/>
-       <position name="posOpArapucaDouble1-Frame-0-2" unit="cm" 
-         x="-327.29"
-	 y="-542.5" 
-	 z="-2353.25"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-2-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-0-2" unit="cm" 
          x="-328.03"
 	 y="-468.5" 
@@ -7844,14 +3948,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-2"/>
-       <position name="posOpArapucaDouble2-Frame-0-2" unit="cm" 
-         x="-327.29"
-	 y="-468.5" 
-	 z="-2136.25"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-2-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-0-2" unit="cm" 
          x="-328.03"
 	 y="-377.8" 
@@ -7859,14 +3956,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-3"/>
-       <position name="posOpArapucaDouble3-Frame-0-2" unit="cm" 
-         x="-327.29"
-	 y="-377.8" 
-	 z="-2282.25"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-3-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-0-3" unit="cm" 
          x="-328.03"
 	 y="-633.2" 
@@ -7874,14 +3964,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-3-0"/>
-       <position name="posOpArapucaDouble0-Frame-0-3" unit="cm" 
-         x="-327.29"
-	 y="-633.2" 
-	 z="-1907.95"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-3-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-0-3" unit="cm" 
          x="-328.03"
 	 y="-542.5" 
@@ -7889,14 +3972,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-3-1"/>
-       <position name="posOpArapucaDouble1-Frame-0-3" unit="cm" 
-         x="-327.29"
-	 y="-542.5" 
-	 z="-2053.95"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-3-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-0-3" unit="cm" 
          x="-328.03"
 	 y="-468.5" 
@@ -7904,14 +3980,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-3-2"/>
-       <position name="posOpArapucaDouble2-Frame-0-3" unit="cm" 
-         x="-327.29"
-	 y="-468.5" 
-	 z="-1836.95"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-3-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-0-3" unit="cm" 
          x="-328.03"
 	 y="-377.8" 
@@ -7919,14 +3988,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-3-3"/>
-       <position name="posOpArapucaDouble3-Frame-0-3" unit="cm" 
-         x="-327.29"
-	 y="-377.8" 
-	 z="-1982.95"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-4-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-0-4" unit="cm" 
          x="-328.03"
 	 y="-633.2" 
@@ -7934,14 +3996,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-4-0"/>
-       <position name="posOpArapucaDouble0-Frame-0-4" unit="cm" 
-         x="-327.29"
-	 y="-633.2" 
-	 z="-1608.65"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-4-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-0-4" unit="cm" 
          x="-328.03"
 	 y="-542.5" 
@@ -7949,14 +4004,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-4-1"/>
-       <position name="posOpArapucaDouble1-Frame-0-4" unit="cm" 
-         x="-327.29"
-	 y="-542.5" 
-	 z="-1754.65"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-4-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-0-4" unit="cm" 
          x="-328.03"
 	 y="-468.5" 
@@ -7964,14 +4012,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-4-2"/>
-       <position name="posOpArapucaDouble2-Frame-0-4" unit="cm" 
-         x="-327.29"
-	 y="-468.5" 
-	 z="-1537.65"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-4-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-0-4" unit="cm" 
          x="-328.03"
 	 y="-377.8" 
@@ -7979,14 +4020,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-4-3"/>
-       <position name="posOpArapucaDouble3-Frame-0-4" unit="cm" 
-         x="-327.29"
-	 y="-377.8" 
-	 z="-1683.65"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-5-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-0-5" unit="cm" 
          x="-328.03"
 	 y="-633.2" 
@@ -7994,14 +4028,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-5-0"/>
-       <position name="posOpArapucaDouble0-Frame-0-5" unit="cm" 
-         x="-327.29"
-	 y="-633.2" 
-	 z="-1309.35"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-5-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-0-5" unit="cm" 
          x="-328.03"
 	 y="-542.5" 
@@ -8009,14 +4036,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-5-1"/>
-       <position name="posOpArapucaDouble1-Frame-0-5" unit="cm" 
-         x="-327.29"
-	 y="-542.5" 
-	 z="-1455.35"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-5-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-0-5" unit="cm" 
          x="-328.03"
 	 y="-468.5" 
@@ -8024,14 +4044,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-5-2"/>
-       <position name="posOpArapucaDouble2-Frame-0-5" unit="cm" 
-         x="-327.29"
-	 y="-468.5" 
-	 z="-1238.35"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-5-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-0-5" unit="cm" 
          x="-328.03"
 	 y="-377.8" 
@@ -8039,14 +4052,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-5-3"/>
-       <position name="posOpArapucaDouble3-Frame-0-5" unit="cm" 
-         x="-327.29"
-	 y="-377.8" 
-	 z="-1384.35"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-6-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-0-6" unit="cm" 
          x="-328.03"
 	 y="-633.2" 
@@ -8054,14 +4060,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-6-0"/>
-       <position name="posOpArapucaDouble0-Frame-0-6" unit="cm" 
-         x="-327.29"
-	 y="-633.2" 
-	 z="-1010.05"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-6-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-0-6" unit="cm" 
          x="-328.03"
 	 y="-542.5" 
@@ -8069,14 +4068,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-6-1"/>
-       <position name="posOpArapucaDouble1-Frame-0-6" unit="cm" 
-         x="-327.29"
-	 y="-542.5" 
-	 z="-1156.05"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-6-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-0-6" unit="cm" 
          x="-328.03"
 	 y="-468.5" 
@@ -8084,14 +4076,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-6-2"/>
-       <position name="posOpArapucaDouble2-Frame-0-6" unit="cm" 
-         x="-327.29"
-	 y="-468.5" 
-	 z="-939.05"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-6-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-0-6" unit="cm" 
          x="-328.03"
 	 y="-377.8" 
@@ -8099,14 +4084,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-6-3"/>
-       <position name="posOpArapucaDouble3-Frame-0-6" unit="cm" 
-         x="-327.29"
-	 y="-377.8" 
-	 z="-1085.05"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-7-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-0-7" unit="cm" 
          x="-328.03"
 	 y="-633.2" 
@@ -8114,14 +4092,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-7-0"/>
-       <position name="posOpArapucaDouble0-Frame-0-7" unit="cm" 
-         x="-327.29"
-	 y="-633.2" 
-	 z="-710.75"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-7-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-0-7" unit="cm" 
          x="-328.03"
 	 y="-542.5" 
@@ -8129,14 +4100,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-7-1"/>
-       <position name="posOpArapucaDouble1-Frame-0-7" unit="cm" 
-         x="-327.29"
-	 y="-542.5" 
-	 z="-856.75"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-7-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-0-7" unit="cm" 
          x="-328.03"
 	 y="-468.5" 
@@ -8144,14 +4108,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-7-2"/>
-       <position name="posOpArapucaDouble2-Frame-0-7" unit="cm" 
-         x="-327.29"
-	 y="-468.5" 
-	 z="-639.75"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-7-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-0-7" unit="cm" 
          x="-328.03"
 	 y="-377.8" 
@@ -8159,14 +4116,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-7-3"/>
-       <position name="posOpArapucaDouble3-Frame-0-7" unit="cm" 
-         x="-327.29"
-	 y="-377.8" 
-	 z="-785.75"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-8-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-0-8" unit="cm" 
          x="-328.03"
 	 y="-633.2" 
@@ -8174,14 +4124,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-8-0"/>
-       <position name="posOpArapucaDouble0-Frame-0-8" unit="cm" 
-         x="-327.29"
-	 y="-633.2" 
-	 z="-411.45"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-8-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-0-8" unit="cm" 
          x="-328.03"
 	 y="-542.5" 
@@ -8189,14 +4132,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-8-1"/>
-       <position name="posOpArapucaDouble1-Frame-0-8" unit="cm" 
-         x="-327.29"
-	 y="-542.5" 
-	 z="-557.45"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-8-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-0-8" unit="cm" 
          x="-328.03"
 	 y="-468.5" 
@@ -8204,14 +4140,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-8-2"/>
-       <position name="posOpArapucaDouble2-Frame-0-8" unit="cm" 
-         x="-327.29"
-	 y="-468.5" 
-	 z="-340.45"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-8-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-0-8" unit="cm" 
          x="-328.03"
 	 y="-377.8" 
@@ -8219,14 +4148,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-8-3"/>
-       <position name="posOpArapucaDouble3-Frame-0-8" unit="cm" 
-         x="-327.29"
-	 y="-377.8" 
-	 z="-486.45"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-9-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-0-9" unit="cm" 
          x="-328.03"
 	 y="-633.2" 
@@ -8234,14 +4156,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-9-0"/>
-       <position name="posOpArapucaDouble0-Frame-0-9" unit="cm" 
-         x="-327.29"
-	 y="-633.2" 
-	 z="-112.15"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-9-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-0-9" unit="cm" 
          x="-328.03"
 	 y="-542.5" 
@@ -8249,14 +4164,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-9-1"/>
-       <position name="posOpArapucaDouble1-Frame-0-9" unit="cm" 
-         x="-327.29"
-	 y="-542.5" 
-	 z="-258.15"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-9-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-0-9" unit="cm" 
          x="-328.03"
 	 y="-468.5" 
@@ -8264,14 +4172,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-9-2"/>
-       <position name="posOpArapucaDouble2-Frame-0-9" unit="cm" 
-         x="-327.29"
-	 y="-468.5" 
-	 z="-41.1499999999997"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-9-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-0-9" unit="cm" 
          x="-328.03"
 	 y="-377.8" 
@@ -8279,14 +4180,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-9-3"/>
-       <position name="posOpArapucaDouble3-Frame-0-9" unit="cm" 
-         x="-327.29"
-	 y="-377.8" 
-	 z="-187.15"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-10-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-0-10" unit="cm" 
          x="-328.03"
 	 y="-633.2" 
@@ -8294,14 +4188,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-10-0"/>
-       <position name="posOpArapucaDouble0-Frame-0-10" unit="cm" 
-         x="-327.29"
-	 y="-633.2" 
-	 z="187.15"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-10-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-0-10" unit="cm" 
          x="-328.03"
 	 y="-542.5" 
@@ -8309,14 +4196,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-10-1"/>
-       <position name="posOpArapucaDouble1-Frame-0-10" unit="cm" 
-         x="-327.29"
-	 y="-542.5" 
-	 z="41.1500000000003"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-10-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-0-10" unit="cm" 
          x="-328.03"
 	 y="-468.5" 
@@ -8324,14 +4204,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-10-2"/>
-       <position name="posOpArapucaDouble2-Frame-0-10" unit="cm" 
-         x="-327.29"
-	 y="-468.5" 
-	 z="258.15"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-10-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-0-10" unit="cm" 
          x="-328.03"
 	 y="-377.8" 
@@ -8339,14 +4212,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-10-3"/>
-       <position name="posOpArapucaDouble3-Frame-0-10" unit="cm" 
-         x="-327.29"
-	 y="-377.8" 
-	 z="112.15"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-11-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-0-11" unit="cm" 
          x="-328.03"
 	 y="-633.2" 
@@ -8354,14 +4220,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-11-0"/>
-       <position name="posOpArapucaDouble0-Frame-0-11" unit="cm" 
-         x="-327.29"
-	 y="-633.2" 
-	 z="486.45"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-11-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-0-11" unit="cm" 
          x="-328.03"
 	 y="-542.5" 
@@ -8369,14 +4228,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-11-1"/>
-       <position name="posOpArapucaDouble1-Frame-0-11" unit="cm" 
-         x="-327.29"
-	 y="-542.5" 
-	 z="340.45"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-11-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-0-11" unit="cm" 
          x="-328.03"
 	 y="-468.5" 
@@ -8384,14 +4236,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-11-2"/>
-       <position name="posOpArapucaDouble2-Frame-0-11" unit="cm" 
-         x="-327.29"
-	 y="-468.5" 
-	 z="557.45"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-11-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-0-11" unit="cm" 
          x="-328.03"
 	 y="-377.8" 
@@ -8399,14 +4244,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-11-3"/>
-       <position name="posOpArapucaDouble3-Frame-0-11" unit="cm" 
-         x="-327.29"
-	 y="-377.8" 
-	 z="411.45"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-12-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-0-12" unit="cm" 
          x="-328.03"
 	 y="-633.2" 
@@ -8414,14 +4252,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-12-0"/>
-       <position name="posOpArapucaDouble0-Frame-0-12" unit="cm" 
-         x="-327.29"
-	 y="-633.2" 
-	 z="785.75"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-12-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-0-12" unit="cm" 
          x="-328.03"
 	 y="-542.5" 
@@ -8429,14 +4260,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-12-1"/>
-       <position name="posOpArapucaDouble1-Frame-0-12" unit="cm" 
-         x="-327.29"
-	 y="-542.5" 
-	 z="639.75"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-12-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-0-12" unit="cm" 
          x="-328.03"
 	 y="-468.5" 
@@ -8444,14 +4268,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-12-2"/>
-       <position name="posOpArapucaDouble2-Frame-0-12" unit="cm" 
-         x="-327.29"
-	 y="-468.5" 
-	 z="856.75"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-12-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-0-12" unit="cm" 
          x="-328.03"
 	 y="-377.8" 
@@ -8459,14 +4276,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-12-3"/>
-       <position name="posOpArapucaDouble3-Frame-0-12" unit="cm" 
-         x="-327.29"
-	 y="-377.8" 
-	 z="710.75"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-13-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-0-13" unit="cm" 
          x="-328.03"
 	 y="-633.2" 
@@ -8474,14 +4284,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-13-0"/>
-       <position name="posOpArapucaDouble0-Frame-0-13" unit="cm" 
-         x="-327.29"
-	 y="-633.2" 
-	 z="1085.05"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-13-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-0-13" unit="cm" 
          x="-328.03"
 	 y="-542.5" 
@@ -8489,14 +4292,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-13-1"/>
-       <position name="posOpArapucaDouble1-Frame-0-13" unit="cm" 
-         x="-327.29"
-	 y="-542.5" 
-	 z="939.05"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-13-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-0-13" unit="cm" 
          x="-328.03"
 	 y="-468.5" 
@@ -8504,14 +4300,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-13-2"/>
-       <position name="posOpArapucaDouble2-Frame-0-13" unit="cm" 
-         x="-327.29"
-	 y="-468.5" 
-	 z="1156.05"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-13-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-0-13" unit="cm" 
          x="-328.03"
 	 y="-377.8" 
@@ -8519,14 +4308,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-13-3"/>
-       <position name="posOpArapucaDouble3-Frame-0-13" unit="cm" 
-         x="-327.29"
-	 y="-377.8" 
-	 z="1010.05"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-14-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-0-14" unit="cm" 
          x="-328.03"
 	 y="-633.2" 
@@ -8534,14 +4316,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-14-0"/>
-       <position name="posOpArapucaDouble0-Frame-0-14" unit="cm" 
-         x="-327.29"
-	 y="-633.2" 
-	 z="1384.35"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-14-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-0-14" unit="cm" 
          x="-328.03"
 	 y="-542.5" 
@@ -8549,14 +4324,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-14-1"/>
-       <position name="posOpArapucaDouble1-Frame-0-14" unit="cm" 
-         x="-327.29"
-	 y="-542.5" 
-	 z="1238.35"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-14-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-0-14" unit="cm" 
          x="-328.03"
 	 y="-468.5" 
@@ -8564,14 +4332,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-14-2"/>
-       <position name="posOpArapucaDouble2-Frame-0-14" unit="cm" 
-         x="-327.29"
-	 y="-468.5" 
-	 z="1455.35"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-14-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-0-14" unit="cm" 
          x="-328.03"
 	 y="-377.8" 
@@ -8579,14 +4340,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-14-3"/>
-       <position name="posOpArapucaDouble3-Frame-0-14" unit="cm" 
-         x="-327.29"
-	 y="-377.8" 
-	 z="1309.35"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-15-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-0-15" unit="cm" 
          x="-328.03"
 	 y="-633.2" 
@@ -8594,14 +4348,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-15-0"/>
-       <position name="posOpArapucaDouble0-Frame-0-15" unit="cm" 
-         x="-327.29"
-	 y="-633.2" 
-	 z="1683.65"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-15-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-0-15" unit="cm" 
          x="-328.03"
 	 y="-542.5" 
@@ -8609,14 +4356,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-15-1"/>
-       <position name="posOpArapucaDouble1-Frame-0-15" unit="cm" 
-         x="-327.29"
-	 y="-542.5" 
-	 z="1537.65"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-15-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-0-15" unit="cm" 
          x="-328.03"
 	 y="-468.5" 
@@ -8624,14 +4364,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-15-2"/>
-       <position name="posOpArapucaDouble2-Frame-0-15" unit="cm" 
-         x="-327.29"
-	 y="-468.5" 
-	 z="1754.65"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-15-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-0-15" unit="cm" 
          x="-328.03"
 	 y="-377.8" 
@@ -8639,14 +4372,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-15-3"/>
-       <position name="posOpArapucaDouble3-Frame-0-15" unit="cm" 
-         x="-327.29"
-	 y="-377.8" 
-	 z="1608.65"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-16-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-0-16" unit="cm" 
          x="-328.03"
 	 y="-633.2" 
@@ -8654,14 +4380,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-16-0"/>
-       <position name="posOpArapucaDouble0-Frame-0-16" unit="cm" 
-         x="-327.29"
-	 y="-633.2" 
-	 z="1982.95"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-16-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-0-16" unit="cm" 
          x="-328.03"
 	 y="-542.5" 
@@ -8669,14 +4388,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-16-1"/>
-       <position name="posOpArapucaDouble1-Frame-0-16" unit="cm" 
-         x="-327.29"
-	 y="-542.5" 
-	 z="1836.95"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-16-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-0-16" unit="cm" 
          x="-328.03"
 	 y="-468.5" 
@@ -8684,14 +4396,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-16-2"/>
-       <position name="posOpArapucaDouble2-Frame-0-16" unit="cm" 
-         x="-327.29"
-	 y="-468.5" 
-	 z="2053.95"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-16-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-0-16" unit="cm" 
          x="-328.03"
 	 y="-377.8" 
@@ -8699,14 +4404,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-16-3"/>
-       <position name="posOpArapucaDouble3-Frame-0-16" unit="cm" 
-         x="-327.29"
-	 y="-377.8" 
-	 z="1907.95"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-17-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-0-17" unit="cm" 
          x="-328.03"
 	 y="-633.2" 
@@ -8714,14 +4412,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-17-0"/>
-       <position name="posOpArapucaDouble0-Frame-0-17" unit="cm" 
-         x="-327.29"
-	 y="-633.2" 
-	 z="2282.25"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-17-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-0-17" unit="cm" 
          x="-328.03"
 	 y="-542.5" 
@@ -8729,14 +4420,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-17-1"/>
-       <position name="posOpArapucaDouble1-Frame-0-17" unit="cm" 
-         x="-327.29"
-	 y="-542.5" 
-	 z="2136.25"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-17-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-0-17" unit="cm" 
          x="-328.03"
 	 y="-468.5" 
@@ -8744,14 +4428,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-17-2"/>
-       <position name="posOpArapucaDouble2-Frame-0-17" unit="cm" 
-         x="-327.29"
-	 y="-468.5" 
-	 z="2353.25"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-17-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-0-17" unit="cm" 
          x="-328.03"
 	 y="-377.8" 
@@ -8759,14 +4436,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-17-3"/>
-       <position name="posOpArapucaDouble3-Frame-0-17" unit="cm" 
-         x="-327.29"
-	 y="-377.8" 
-	 z="2207.25"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-18-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-0-18" unit="cm" 
          x="-328.03"
 	 y="-633.2" 
@@ -8774,14 +4444,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-18-0"/>
-       <position name="posOpArapucaDouble0-Frame-0-18" unit="cm" 
-         x="-327.29"
-	 y="-633.2" 
-	 z="2581.55"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-18-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-0-18" unit="cm" 
          x="-328.03"
 	 y="-542.5" 
@@ -8789,14 +4452,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-18-1"/>
-       <position name="posOpArapucaDouble1-Frame-0-18" unit="cm" 
-         x="-327.29"
-	 y="-542.5" 
-	 z="2435.55"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-18-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-0-18" unit="cm" 
          x="-328.03"
 	 y="-468.5" 
@@ -8804,14 +4460,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-18-2"/>
-       <position name="posOpArapucaDouble2-Frame-0-18" unit="cm" 
-         x="-327.29"
-	 y="-468.5" 
-	 z="2652.55"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-18-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-0-18" unit="cm" 
          x="-328.03"
 	 y="-377.8" 
@@ -8819,14 +4468,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-18-3"/>
-       <position name="posOpArapucaDouble3-Frame-0-18" unit="cm" 
-         x="-327.29"
-	 y="-377.8" 
-	 z="2506.55"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-19-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-0-19" unit="cm" 
          x="-328.03"
 	 y="-633.2" 
@@ -8834,14 +4476,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-19-0"/>
-       <position name="posOpArapucaDouble0-Frame-0-19" unit="cm" 
-         x="-327.29"
-	 y="-633.2" 
-	 z="2880.85"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-19-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-0-19" unit="cm" 
          x="-328.03"
 	 y="-542.5" 
@@ -8849,14 +4484,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-19-1"/>
-       <position name="posOpArapucaDouble1-Frame-0-19" unit="cm" 
-         x="-327.29"
-	 y="-542.5" 
-	 z="2734.85"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-19-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-0-19" unit="cm" 
          x="-328.03"
 	 y="-468.5" 
@@ -8864,14 +4492,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-19-2"/>
-       <position name="posOpArapucaDouble2-Frame-0-19" unit="cm" 
-         x="-327.29"
-	 y="-468.5" 
-	 z="2951.85"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-19-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-0-19" unit="cm" 
          x="-328.03"
 	 y="-377.8" 
@@ -8879,14 +4500,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-19-3"/>
-       <position name="posOpArapucaDouble3-Frame-0-19" unit="cm" 
-         x="-327.29"
-	 y="-377.8" 
-	 z="2805.85"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-0-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-1-0" unit="cm" 
          x="-328.03"
 	 y="-296.2" 
@@ -8894,14 +4508,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-0"/>
-       <position name="posOpArapucaDouble0-Frame-1-0" unit="cm" 
-         x="-327.29"
-	 y="-296.2" 
-	 z="-2805.85"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-0-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-1-0" unit="cm" 
          x="-328.03"
 	 y="-205.5" 
@@ -8909,14 +4516,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-1"/>
-       <position name="posOpArapucaDouble1-Frame-1-0" unit="cm" 
-         x="-327.29"
-	 y="-205.5" 
-	 z="-2951.85"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-0-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-1-0" unit="cm" 
          x="-328.03"
 	 y="-131.5" 
@@ -8924,14 +4524,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-2"/>
-       <position name="posOpArapucaDouble2-Frame-1-0" unit="cm" 
-         x="-327.29"
-	 y="-131.5" 
-	 z="-2734.85"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-0-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-1-0" unit="cm" 
          x="-328.03"
 	 y="-40.8" 
@@ -8939,14 +4532,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-3"/>
-       <position name="posOpArapucaDouble3-Frame-1-0" unit="cm" 
-         x="-327.29"
-	 y="-40.8" 
-	 z="-2880.85"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-1-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-1-1" unit="cm" 
          x="-328.03"
 	 y="-296.2" 
@@ -8954,14 +4540,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-0"/>
-       <position name="posOpArapucaDouble0-Frame-1-1" unit="cm" 
-         x="-327.29"
-	 y="-296.2" 
-	 z="-2506.55"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-1-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-1-1" unit="cm" 
          x="-328.03"
 	 y="-205.5" 
@@ -8969,14 +4548,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-1"/>
-       <position name="posOpArapucaDouble1-Frame-1-1" unit="cm" 
-         x="-327.29"
-	 y="-205.5" 
-	 z="-2652.55"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-1-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-1-1" unit="cm" 
          x="-328.03"
 	 y="-131.5" 
@@ -8984,14 +4556,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-2"/>
-       <position name="posOpArapucaDouble2-Frame-1-1" unit="cm" 
-         x="-327.29"
-	 y="-131.5" 
-	 z="-2435.55"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-1-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-1-1" unit="cm" 
          x="-328.03"
 	 y="-40.8" 
@@ -8999,14 +4564,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-3"/>
-       <position name="posOpArapucaDouble3-Frame-1-1" unit="cm" 
-         x="-327.29"
-	 y="-40.8" 
-	 z="-2581.55"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-2-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-1-2" unit="cm" 
          x="-328.03"
 	 y="-296.2" 
@@ -9014,14 +4572,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-0"/>
-       <position name="posOpArapucaDouble0-Frame-1-2" unit="cm" 
-         x="-327.29"
-	 y="-296.2" 
-	 z="-2207.25"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-2-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-1-2" unit="cm" 
          x="-328.03"
 	 y="-205.5" 
@@ -9029,14 +4580,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-1"/>
-       <position name="posOpArapucaDouble1-Frame-1-2" unit="cm" 
-         x="-327.29"
-	 y="-205.5" 
-	 z="-2353.25"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-2-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-1-2" unit="cm" 
          x="-328.03"
 	 y="-131.5" 
@@ -9044,14 +4588,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-2"/>
-       <position name="posOpArapucaDouble2-Frame-1-2" unit="cm" 
-         x="-327.29"
-	 y="-131.5" 
-	 z="-2136.25"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-2-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-1-2" unit="cm" 
          x="-328.03"
 	 y="-40.8" 
@@ -9059,14 +4596,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-3"/>
-       <position name="posOpArapucaDouble3-Frame-1-2" unit="cm" 
-         x="-327.29"
-	 y="-40.8" 
-	 z="-2282.25"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-3-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-1-3" unit="cm" 
          x="-328.03"
 	 y="-296.2" 
@@ -9074,14 +4604,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-3-0"/>
-       <position name="posOpArapucaDouble0-Frame-1-3" unit="cm" 
-         x="-327.29"
-	 y="-296.2" 
-	 z="-1907.95"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-3-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-1-3" unit="cm" 
          x="-328.03"
 	 y="-205.5" 
@@ -9089,14 +4612,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-3-1"/>
-       <position name="posOpArapucaDouble1-Frame-1-3" unit="cm" 
-         x="-327.29"
-	 y="-205.5" 
-	 z="-2053.95"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-3-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-1-3" unit="cm" 
          x="-328.03"
 	 y="-131.5" 
@@ -9104,14 +4620,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-3-2"/>
-       <position name="posOpArapucaDouble2-Frame-1-3" unit="cm" 
-         x="-327.29"
-	 y="-131.5" 
-	 z="-1836.95"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-3-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-1-3" unit="cm" 
          x="-328.03"
 	 y="-40.8" 
@@ -9119,14 +4628,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-3-3"/>
-       <position name="posOpArapucaDouble3-Frame-1-3" unit="cm" 
-         x="-327.29"
-	 y="-40.8" 
-	 z="-1982.95"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-4-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-1-4" unit="cm" 
          x="-328.03"
 	 y="-296.2" 
@@ -9134,14 +4636,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-4-0"/>
-       <position name="posOpArapucaDouble0-Frame-1-4" unit="cm" 
-         x="-327.29"
-	 y="-296.2" 
-	 z="-1608.65"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-4-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-1-4" unit="cm" 
          x="-328.03"
 	 y="-205.5" 
@@ -9149,14 +4644,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-4-1"/>
-       <position name="posOpArapucaDouble1-Frame-1-4" unit="cm" 
-         x="-327.29"
-	 y="-205.5" 
-	 z="-1754.65"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-4-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-1-4" unit="cm" 
          x="-328.03"
 	 y="-131.5" 
@@ -9164,14 +4652,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-4-2"/>
-       <position name="posOpArapucaDouble2-Frame-1-4" unit="cm" 
-         x="-327.29"
-	 y="-131.5" 
-	 z="-1537.65"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-4-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-1-4" unit="cm" 
          x="-328.03"
 	 y="-40.8" 
@@ -9179,14 +4660,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-4-3"/>
-       <position name="posOpArapucaDouble3-Frame-1-4" unit="cm" 
-         x="-327.29"
-	 y="-40.8" 
-	 z="-1683.65"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-5-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-1-5" unit="cm" 
          x="-328.03"
 	 y="-296.2" 
@@ -9194,14 +4668,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-5-0"/>
-       <position name="posOpArapucaDouble0-Frame-1-5" unit="cm" 
-         x="-327.29"
-	 y="-296.2" 
-	 z="-1309.35"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-5-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-1-5" unit="cm" 
          x="-328.03"
 	 y="-205.5" 
@@ -9209,14 +4676,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-5-1"/>
-       <position name="posOpArapucaDouble1-Frame-1-5" unit="cm" 
-         x="-327.29"
-	 y="-205.5" 
-	 z="-1455.35"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-5-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-1-5" unit="cm" 
          x="-328.03"
 	 y="-131.5" 
@@ -9224,14 +4684,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-5-2"/>
-       <position name="posOpArapucaDouble2-Frame-1-5" unit="cm" 
-         x="-327.29"
-	 y="-131.5" 
-	 z="-1238.35"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-5-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-1-5" unit="cm" 
          x="-328.03"
 	 y="-40.8" 
@@ -9239,14 +4692,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-5-3"/>
-       <position name="posOpArapucaDouble3-Frame-1-5" unit="cm" 
-         x="-327.29"
-	 y="-40.8" 
-	 z="-1384.35"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-6-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-1-6" unit="cm" 
          x="-328.03"
 	 y="-296.2" 
@@ -9254,14 +4700,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-6-0"/>
-       <position name="posOpArapucaDouble0-Frame-1-6" unit="cm" 
-         x="-327.29"
-	 y="-296.2" 
-	 z="-1010.05"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-6-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-1-6" unit="cm" 
          x="-328.03"
 	 y="-205.5" 
@@ -9269,14 +4708,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-6-1"/>
-       <position name="posOpArapucaDouble1-Frame-1-6" unit="cm" 
-         x="-327.29"
-	 y="-205.5" 
-	 z="-1156.05"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-6-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-1-6" unit="cm" 
          x="-328.03"
 	 y="-131.5" 
@@ -9284,14 +4716,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-6-2"/>
-       <position name="posOpArapucaDouble2-Frame-1-6" unit="cm" 
-         x="-327.29"
-	 y="-131.5" 
-	 z="-939.05"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-6-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-1-6" unit="cm" 
          x="-328.03"
 	 y="-40.8" 
@@ -9299,14 +4724,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-6-3"/>
-       <position name="posOpArapucaDouble3-Frame-1-6" unit="cm" 
-         x="-327.29"
-	 y="-40.8" 
-	 z="-1085.05"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-7-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-1-7" unit="cm" 
          x="-328.03"
 	 y="-296.2" 
@@ -9314,14 +4732,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-7-0"/>
-       <position name="posOpArapucaDouble0-Frame-1-7" unit="cm" 
-         x="-327.29"
-	 y="-296.2" 
-	 z="-710.75"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-7-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-1-7" unit="cm" 
          x="-328.03"
 	 y="-205.5" 
@@ -9329,14 +4740,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-7-1"/>
-       <position name="posOpArapucaDouble1-Frame-1-7" unit="cm" 
-         x="-327.29"
-	 y="-205.5" 
-	 z="-856.75"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-7-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-1-7" unit="cm" 
          x="-328.03"
 	 y="-131.5" 
@@ -9344,14 +4748,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-7-2"/>
-       <position name="posOpArapucaDouble2-Frame-1-7" unit="cm" 
-         x="-327.29"
-	 y="-131.5" 
-	 z="-639.75"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-7-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-1-7" unit="cm" 
          x="-328.03"
 	 y="-40.8" 
@@ -9359,14 +4756,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-7-3"/>
-       <position name="posOpArapucaDouble3-Frame-1-7" unit="cm" 
-         x="-327.29"
-	 y="-40.8" 
-	 z="-785.75"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-8-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-1-8" unit="cm" 
          x="-328.03"
 	 y="-296.2" 
@@ -9374,14 +4764,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-8-0"/>
-       <position name="posOpArapucaDouble0-Frame-1-8" unit="cm" 
-         x="-327.29"
-	 y="-296.2" 
-	 z="-411.45"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-8-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-1-8" unit="cm" 
          x="-328.03"
 	 y="-205.5" 
@@ -9389,14 +4772,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-8-1"/>
-       <position name="posOpArapucaDouble1-Frame-1-8" unit="cm" 
-         x="-327.29"
-	 y="-205.5" 
-	 z="-557.45"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-8-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-1-8" unit="cm" 
          x="-328.03"
 	 y="-131.5" 
@@ -9404,14 +4780,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-8-2"/>
-       <position name="posOpArapucaDouble2-Frame-1-8" unit="cm" 
-         x="-327.29"
-	 y="-131.5" 
-	 z="-340.45"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-8-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-1-8" unit="cm" 
          x="-328.03"
 	 y="-40.8" 
@@ -9419,14 +4788,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-8-3"/>
-       <position name="posOpArapucaDouble3-Frame-1-8" unit="cm" 
-         x="-327.29"
-	 y="-40.8" 
-	 z="-486.45"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-9-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-1-9" unit="cm" 
          x="-328.03"
 	 y="-296.2" 
@@ -9434,14 +4796,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-9-0"/>
-       <position name="posOpArapucaDouble0-Frame-1-9" unit="cm" 
-         x="-327.29"
-	 y="-296.2" 
-	 z="-112.15"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-9-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-1-9" unit="cm" 
          x="-328.03"
 	 y="-205.5" 
@@ -9449,14 +4804,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-9-1"/>
-       <position name="posOpArapucaDouble1-Frame-1-9" unit="cm" 
-         x="-327.29"
-	 y="-205.5" 
-	 z="-258.15"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-9-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-1-9" unit="cm" 
          x="-328.03"
 	 y="-131.5" 
@@ -9464,14 +4812,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-9-2"/>
-       <position name="posOpArapucaDouble2-Frame-1-9" unit="cm" 
-         x="-327.29"
-	 y="-131.5" 
-	 z="-41.1499999999997"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-9-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-1-9" unit="cm" 
          x="-328.03"
 	 y="-40.8" 
@@ -9479,14 +4820,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-9-3"/>
-       <position name="posOpArapucaDouble3-Frame-1-9" unit="cm" 
-         x="-327.29"
-	 y="-40.8" 
-	 z="-187.15"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-10-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-1-10" unit="cm" 
          x="-328.03"
 	 y="-296.2" 
@@ -9494,14 +4828,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-10-0"/>
-       <position name="posOpArapucaDouble0-Frame-1-10" unit="cm" 
-         x="-327.29"
-	 y="-296.2" 
-	 z="187.15"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-10-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-1-10" unit="cm" 
          x="-328.03"
 	 y="-205.5" 
@@ -9509,14 +4836,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-10-1"/>
-       <position name="posOpArapucaDouble1-Frame-1-10" unit="cm" 
-         x="-327.29"
-	 y="-205.5" 
-	 z="41.1500000000003"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-10-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-1-10" unit="cm" 
          x="-328.03"
 	 y="-131.5" 
@@ -9524,14 +4844,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-10-2"/>
-       <position name="posOpArapucaDouble2-Frame-1-10" unit="cm" 
-         x="-327.29"
-	 y="-131.5" 
-	 z="258.15"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-10-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-1-10" unit="cm" 
          x="-328.03"
 	 y="-40.8" 
@@ -9539,14 +4852,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-10-3"/>
-       <position name="posOpArapucaDouble3-Frame-1-10" unit="cm" 
-         x="-327.29"
-	 y="-40.8" 
-	 z="112.15"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-11-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-1-11" unit="cm" 
          x="-328.03"
 	 y="-296.2" 
@@ -9554,14 +4860,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-11-0"/>
-       <position name="posOpArapucaDouble0-Frame-1-11" unit="cm" 
-         x="-327.29"
-	 y="-296.2" 
-	 z="486.45"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-11-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-1-11" unit="cm" 
          x="-328.03"
 	 y="-205.5" 
@@ -9569,14 +4868,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-11-1"/>
-       <position name="posOpArapucaDouble1-Frame-1-11" unit="cm" 
-         x="-327.29"
-	 y="-205.5" 
-	 z="340.45"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-11-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-1-11" unit="cm" 
          x="-328.03"
 	 y="-131.5" 
@@ -9584,14 +4876,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-11-2"/>
-       <position name="posOpArapucaDouble2-Frame-1-11" unit="cm" 
-         x="-327.29"
-	 y="-131.5" 
-	 z="557.45"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-11-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-1-11" unit="cm" 
          x="-328.03"
 	 y="-40.8" 
@@ -9599,14 +4884,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-11-3"/>
-       <position name="posOpArapucaDouble3-Frame-1-11" unit="cm" 
-         x="-327.29"
-	 y="-40.8" 
-	 z="411.45"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-12-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-1-12" unit="cm" 
          x="-328.03"
 	 y="-296.2" 
@@ -9614,14 +4892,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-12-0"/>
-       <position name="posOpArapucaDouble0-Frame-1-12" unit="cm" 
-         x="-327.29"
-	 y="-296.2" 
-	 z="785.75"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-12-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-1-12" unit="cm" 
          x="-328.03"
 	 y="-205.5" 
@@ -9629,14 +4900,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-12-1"/>
-       <position name="posOpArapucaDouble1-Frame-1-12" unit="cm" 
-         x="-327.29"
-	 y="-205.5" 
-	 z="639.75"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-12-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-1-12" unit="cm" 
          x="-328.03"
 	 y="-131.5" 
@@ -9644,14 +4908,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-12-2"/>
-       <position name="posOpArapucaDouble2-Frame-1-12" unit="cm" 
-         x="-327.29"
-	 y="-131.5" 
-	 z="856.75"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-12-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-1-12" unit="cm" 
          x="-328.03"
 	 y="-40.8" 
@@ -9659,14 +4916,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-12-3"/>
-       <position name="posOpArapucaDouble3-Frame-1-12" unit="cm" 
-         x="-327.29"
-	 y="-40.8" 
-	 z="710.75"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-13-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-1-13" unit="cm" 
          x="-328.03"
 	 y="-296.2" 
@@ -9674,14 +4924,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-13-0"/>
-       <position name="posOpArapucaDouble0-Frame-1-13" unit="cm" 
-         x="-327.29"
-	 y="-296.2" 
-	 z="1085.05"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-13-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-1-13" unit="cm" 
          x="-328.03"
 	 y="-205.5" 
@@ -9689,14 +4932,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-13-1"/>
-       <position name="posOpArapucaDouble1-Frame-1-13" unit="cm" 
-         x="-327.29"
-	 y="-205.5" 
-	 z="939.05"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-13-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-1-13" unit="cm" 
          x="-328.03"
 	 y="-131.5" 
@@ -9704,14 +4940,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-13-2"/>
-       <position name="posOpArapucaDouble2-Frame-1-13" unit="cm" 
-         x="-327.29"
-	 y="-131.5" 
-	 z="1156.05"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-13-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-1-13" unit="cm" 
          x="-328.03"
 	 y="-40.8" 
@@ -9719,14 +4948,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-13-3"/>
-       <position name="posOpArapucaDouble3-Frame-1-13" unit="cm" 
-         x="-327.29"
-	 y="-40.8" 
-	 z="1010.05"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-14-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-1-14" unit="cm" 
          x="-328.03"
 	 y="-296.2" 
@@ -9734,14 +4956,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-14-0"/>
-       <position name="posOpArapucaDouble0-Frame-1-14" unit="cm" 
-         x="-327.29"
-	 y="-296.2" 
-	 z="1384.35"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-14-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-1-14" unit="cm" 
          x="-328.03"
 	 y="-205.5" 
@@ -9749,14 +4964,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-14-1"/>
-       <position name="posOpArapucaDouble1-Frame-1-14" unit="cm" 
-         x="-327.29"
-	 y="-205.5" 
-	 z="1238.35"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-14-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-1-14" unit="cm" 
          x="-328.03"
 	 y="-131.5" 
@@ -9764,14 +4972,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-14-2"/>
-       <position name="posOpArapucaDouble2-Frame-1-14" unit="cm" 
-         x="-327.29"
-	 y="-131.5" 
-	 z="1455.35"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-14-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-1-14" unit="cm" 
          x="-328.03"
 	 y="-40.8" 
@@ -9779,14 +4980,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-14-3"/>
-       <position name="posOpArapucaDouble3-Frame-1-14" unit="cm" 
-         x="-327.29"
-	 y="-40.8" 
-	 z="1309.35"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-15-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-1-15" unit="cm" 
          x="-328.03"
 	 y="-296.2" 
@@ -9794,14 +4988,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-15-0"/>
-       <position name="posOpArapucaDouble0-Frame-1-15" unit="cm" 
-         x="-327.29"
-	 y="-296.2" 
-	 z="1683.65"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-15-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-1-15" unit="cm" 
          x="-328.03"
 	 y="-205.5" 
@@ -9809,14 +4996,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-15-1"/>
-       <position name="posOpArapucaDouble1-Frame-1-15" unit="cm" 
-         x="-327.29"
-	 y="-205.5" 
-	 z="1537.65"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-15-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-1-15" unit="cm" 
          x="-328.03"
 	 y="-131.5" 
@@ -9824,14 +5004,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-15-2"/>
-       <position name="posOpArapucaDouble2-Frame-1-15" unit="cm" 
-         x="-327.29"
-	 y="-131.5" 
-	 z="1754.65"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-15-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-1-15" unit="cm" 
          x="-328.03"
 	 y="-40.8" 
@@ -9839,14 +5012,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-15-3"/>
-       <position name="posOpArapucaDouble3-Frame-1-15" unit="cm" 
-         x="-327.29"
-	 y="-40.8" 
-	 z="1608.65"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-16-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-1-16" unit="cm" 
          x="-328.03"
 	 y="-296.2" 
@@ -9854,14 +5020,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-16-0"/>
-       <position name="posOpArapucaDouble0-Frame-1-16" unit="cm" 
-         x="-327.29"
-	 y="-296.2" 
-	 z="1982.95"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-16-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-1-16" unit="cm" 
          x="-328.03"
 	 y="-205.5" 
@@ -9869,14 +5028,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-16-1"/>
-       <position name="posOpArapucaDouble1-Frame-1-16" unit="cm" 
-         x="-327.29"
-	 y="-205.5" 
-	 z="1836.95"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-16-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-1-16" unit="cm" 
          x="-328.03"
 	 y="-131.5" 
@@ -9884,14 +5036,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-16-2"/>
-       <position name="posOpArapucaDouble2-Frame-1-16" unit="cm" 
-         x="-327.29"
-	 y="-131.5" 
-	 z="2053.95"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-16-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-1-16" unit="cm" 
          x="-328.03"
 	 y="-40.8" 
@@ -9899,14 +5044,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-16-3"/>
-       <position name="posOpArapucaDouble3-Frame-1-16" unit="cm" 
-         x="-327.29"
-	 y="-40.8" 
-	 z="1907.95"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-17-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-1-17" unit="cm" 
          x="-328.03"
 	 y="-296.2" 
@@ -9914,14 +5052,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-17-0"/>
-       <position name="posOpArapucaDouble0-Frame-1-17" unit="cm" 
-         x="-327.29"
-	 y="-296.2" 
-	 z="2282.25"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-17-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-1-17" unit="cm" 
          x="-328.03"
 	 y="-205.5" 
@@ -9929,14 +5060,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-17-1"/>
-       <position name="posOpArapucaDouble1-Frame-1-17" unit="cm" 
-         x="-327.29"
-	 y="-205.5" 
-	 z="2136.25"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-17-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-1-17" unit="cm" 
          x="-328.03"
 	 y="-131.5" 
@@ -9944,14 +5068,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-17-2"/>
-       <position name="posOpArapucaDouble2-Frame-1-17" unit="cm" 
-         x="-327.29"
-	 y="-131.5" 
-	 z="2353.25"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-17-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-1-17" unit="cm" 
          x="-328.03"
 	 y="-40.8" 
@@ -9959,14 +5076,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-17-3"/>
-       <position name="posOpArapucaDouble3-Frame-1-17" unit="cm" 
-         x="-327.29"
-	 y="-40.8" 
-	 z="2207.25"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-18-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-1-18" unit="cm" 
          x="-328.03"
 	 y="-296.2" 
@@ -9974,14 +5084,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-18-0"/>
-       <position name="posOpArapucaDouble0-Frame-1-18" unit="cm" 
-         x="-327.29"
-	 y="-296.2" 
-	 z="2581.55"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-18-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-1-18" unit="cm" 
          x="-328.03"
 	 y="-205.5" 
@@ -9989,14 +5092,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-18-1"/>
-       <position name="posOpArapucaDouble1-Frame-1-18" unit="cm" 
-         x="-327.29"
-	 y="-205.5" 
-	 z="2435.55"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-18-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-1-18" unit="cm" 
          x="-328.03"
 	 y="-131.5" 
@@ -10004,14 +5100,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-18-2"/>
-       <position name="posOpArapucaDouble2-Frame-1-18" unit="cm" 
-         x="-327.29"
-	 y="-131.5" 
-	 z="2652.55"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-18-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-1-18" unit="cm" 
          x="-328.03"
 	 y="-40.8" 
@@ -10019,14 +5108,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-18-3"/>
-       <position name="posOpArapucaDouble3-Frame-1-18" unit="cm" 
-         x="-327.29"
-	 y="-40.8" 
-	 z="2506.55"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-19-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-1-19" unit="cm" 
          x="-328.03"
 	 y="-296.2" 
@@ -10034,14 +5116,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-19-0"/>
-       <position name="posOpArapucaDouble0-Frame-1-19" unit="cm" 
-         x="-327.29"
-	 y="-296.2" 
-	 z="2880.85"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-19-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-1-19" unit="cm" 
          x="-328.03"
 	 y="-205.5" 
@@ -10049,14 +5124,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-19-1"/>
-       <position name="posOpArapucaDouble1-Frame-1-19" unit="cm" 
-         x="-327.29"
-	 y="-205.5" 
-	 z="2734.85"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-19-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-1-19" unit="cm" 
          x="-328.03"
 	 y="-131.5" 
@@ -10064,14 +5132,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-19-2"/>
-       <position name="posOpArapucaDouble2-Frame-1-19" unit="cm" 
-         x="-327.29"
-	 y="-131.5" 
-	 z="2951.85"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-19-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-1-19" unit="cm" 
          x="-328.03"
 	 y="-40.8" 
@@ -10079,14 +5140,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-19-3"/>
-       <position name="posOpArapucaDouble3-Frame-1-19" unit="cm" 
-         x="-327.29"
-	 y="-40.8" 
-	 z="2805.85"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-0-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-2-0" unit="cm" 
          x="-328.03"
 	 y="40.8" 
@@ -10094,14 +5148,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-0"/>
-       <position name="posOpArapucaDouble0-Frame-2-0" unit="cm" 
-         x="-327.29"
-	 y="40.8" 
-	 z="-2805.85"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-0-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-2-0" unit="cm" 
          x="-328.03"
 	 y="131.5" 
@@ -10109,14 +5156,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-1"/>
-       <position name="posOpArapucaDouble1-Frame-2-0" unit="cm" 
-         x="-327.29"
-	 y="131.5" 
-	 z="-2951.85"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-0-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-2-0" unit="cm" 
          x="-328.03"
 	 y="205.5" 
@@ -10124,14 +5164,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-2"/>
-       <position name="posOpArapucaDouble2-Frame-2-0" unit="cm" 
-         x="-327.29"
-	 y="205.5" 
-	 z="-2734.85"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-0-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-2-0" unit="cm" 
          x="-328.03"
 	 y="296.2" 
@@ -10139,14 +5172,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-3"/>
-       <position name="posOpArapucaDouble3-Frame-2-0" unit="cm" 
-         x="-327.29"
-	 y="296.2" 
-	 z="-2880.85"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-1-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-2-1" unit="cm" 
          x="-328.03"
 	 y="40.8" 
@@ -10154,14 +5180,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-0"/>
-       <position name="posOpArapucaDouble0-Frame-2-1" unit="cm" 
-         x="-327.29"
-	 y="40.8" 
-	 z="-2506.55"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-1-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-2-1" unit="cm" 
          x="-328.03"
 	 y="131.5" 
@@ -10169,14 +5188,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-1"/>
-       <position name="posOpArapucaDouble1-Frame-2-1" unit="cm" 
-         x="-327.29"
-	 y="131.5" 
-	 z="-2652.55"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-1-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-2-1" unit="cm" 
          x="-328.03"
 	 y="205.5" 
@@ -10184,14 +5196,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-2"/>
-       <position name="posOpArapucaDouble2-Frame-2-1" unit="cm" 
-         x="-327.29"
-	 y="205.5" 
-	 z="-2435.55"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-1-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-2-1" unit="cm" 
          x="-328.03"
 	 y="296.2" 
@@ -10199,14 +5204,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-3"/>
-       <position name="posOpArapucaDouble3-Frame-2-1" unit="cm" 
-         x="-327.29"
-	 y="296.2" 
-	 z="-2581.55"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-2-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-2-2" unit="cm" 
          x="-328.03"
 	 y="40.8" 
@@ -10214,14 +5212,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-0"/>
-       <position name="posOpArapucaDouble0-Frame-2-2" unit="cm" 
-         x="-327.29"
-	 y="40.8" 
-	 z="-2207.25"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-2-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-2-2" unit="cm" 
          x="-328.03"
 	 y="131.5" 
@@ -10229,14 +5220,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-1"/>
-       <position name="posOpArapucaDouble1-Frame-2-2" unit="cm" 
-         x="-327.29"
-	 y="131.5" 
-	 z="-2353.25"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-2-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-2-2" unit="cm" 
          x="-328.03"
 	 y="205.5" 
@@ -10244,14 +5228,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-2"/>
-       <position name="posOpArapucaDouble2-Frame-2-2" unit="cm" 
-         x="-327.29"
-	 y="205.5" 
-	 z="-2136.25"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-2-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-2-2" unit="cm" 
          x="-328.03"
 	 y="296.2" 
@@ -10259,14 +5236,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-3"/>
-       <position name="posOpArapucaDouble3-Frame-2-2" unit="cm" 
-         x="-327.29"
-	 y="296.2" 
-	 z="-2282.25"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-3-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-2-3" unit="cm" 
          x="-328.03"
 	 y="40.8" 
@@ -10274,14 +5244,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-3-0"/>
-       <position name="posOpArapucaDouble0-Frame-2-3" unit="cm" 
-         x="-327.29"
-	 y="40.8" 
-	 z="-1907.95"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-3-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-2-3" unit="cm" 
          x="-328.03"
 	 y="131.5" 
@@ -10289,14 +5252,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-3-1"/>
-       <position name="posOpArapucaDouble1-Frame-2-3" unit="cm" 
-         x="-327.29"
-	 y="131.5" 
-	 z="-2053.95"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-3-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-2-3" unit="cm" 
          x="-328.03"
 	 y="205.5" 
@@ -10304,14 +5260,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-3-2"/>
-       <position name="posOpArapucaDouble2-Frame-2-3" unit="cm" 
-         x="-327.29"
-	 y="205.5" 
-	 z="-1836.95"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-3-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-2-3" unit="cm" 
          x="-328.03"
 	 y="296.2" 
@@ -10319,14 +5268,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-3-3"/>
-       <position name="posOpArapucaDouble3-Frame-2-3" unit="cm" 
-         x="-327.29"
-	 y="296.2" 
-	 z="-1982.95"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-4-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-2-4" unit="cm" 
          x="-328.03"
 	 y="40.8" 
@@ -10334,14 +5276,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-4-0"/>
-       <position name="posOpArapucaDouble0-Frame-2-4" unit="cm" 
-         x="-327.29"
-	 y="40.8" 
-	 z="-1608.65"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-4-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-2-4" unit="cm" 
          x="-328.03"
 	 y="131.5" 
@@ -10349,14 +5284,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-4-1"/>
-       <position name="posOpArapucaDouble1-Frame-2-4" unit="cm" 
-         x="-327.29"
-	 y="131.5" 
-	 z="-1754.65"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-4-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-2-4" unit="cm" 
          x="-328.03"
 	 y="205.5" 
@@ -10364,14 +5292,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-4-2"/>
-       <position name="posOpArapucaDouble2-Frame-2-4" unit="cm" 
-         x="-327.29"
-	 y="205.5" 
-	 z="-1537.65"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-4-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-2-4" unit="cm" 
          x="-328.03"
 	 y="296.2" 
@@ -10379,14 +5300,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-4-3"/>
-       <position name="posOpArapucaDouble3-Frame-2-4" unit="cm" 
-         x="-327.29"
-	 y="296.2" 
-	 z="-1683.65"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-5-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-2-5" unit="cm" 
          x="-328.03"
 	 y="40.8" 
@@ -10394,14 +5308,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-5-0"/>
-       <position name="posOpArapucaDouble0-Frame-2-5" unit="cm" 
-         x="-327.29"
-	 y="40.8" 
-	 z="-1309.35"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-5-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-2-5" unit="cm" 
          x="-328.03"
 	 y="131.5" 
@@ -10409,14 +5316,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-5-1"/>
-       <position name="posOpArapucaDouble1-Frame-2-5" unit="cm" 
-         x="-327.29"
-	 y="131.5" 
-	 z="-1455.35"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-5-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-2-5" unit="cm" 
          x="-328.03"
 	 y="205.5" 
@@ -10424,14 +5324,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-5-2"/>
-       <position name="posOpArapucaDouble2-Frame-2-5" unit="cm" 
-         x="-327.29"
-	 y="205.5" 
-	 z="-1238.35"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-5-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-2-5" unit="cm" 
          x="-328.03"
 	 y="296.2" 
@@ -10439,14 +5332,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-5-3"/>
-       <position name="posOpArapucaDouble3-Frame-2-5" unit="cm" 
-         x="-327.29"
-	 y="296.2" 
-	 z="-1384.35"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-6-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-2-6" unit="cm" 
          x="-328.03"
 	 y="40.8" 
@@ -10454,14 +5340,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-6-0"/>
-       <position name="posOpArapucaDouble0-Frame-2-6" unit="cm" 
-         x="-327.29"
-	 y="40.8" 
-	 z="-1010.05"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-6-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-2-6" unit="cm" 
          x="-328.03"
 	 y="131.5" 
@@ -10469,14 +5348,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-6-1"/>
-       <position name="posOpArapucaDouble1-Frame-2-6" unit="cm" 
-         x="-327.29"
-	 y="131.5" 
-	 z="-1156.05"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-6-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-2-6" unit="cm" 
          x="-328.03"
 	 y="205.5" 
@@ -10484,14 +5356,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-6-2"/>
-       <position name="posOpArapucaDouble2-Frame-2-6" unit="cm" 
-         x="-327.29"
-	 y="205.5" 
-	 z="-939.05"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-6-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-2-6" unit="cm" 
          x="-328.03"
 	 y="296.2" 
@@ -10499,14 +5364,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-6-3"/>
-       <position name="posOpArapucaDouble3-Frame-2-6" unit="cm" 
-         x="-327.29"
-	 y="296.2" 
-	 z="-1085.05"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-7-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-2-7" unit="cm" 
          x="-328.03"
 	 y="40.8" 
@@ -10514,14 +5372,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-7-0"/>
-       <position name="posOpArapucaDouble0-Frame-2-7" unit="cm" 
-         x="-327.29"
-	 y="40.8" 
-	 z="-710.75"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-7-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-2-7" unit="cm" 
          x="-328.03"
 	 y="131.5" 
@@ -10529,14 +5380,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-7-1"/>
-       <position name="posOpArapucaDouble1-Frame-2-7" unit="cm" 
-         x="-327.29"
-	 y="131.5" 
-	 z="-856.75"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-7-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-2-7" unit="cm" 
          x="-328.03"
 	 y="205.5" 
@@ -10544,14 +5388,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-7-2"/>
-       <position name="posOpArapucaDouble2-Frame-2-7" unit="cm" 
-         x="-327.29"
-	 y="205.5" 
-	 z="-639.75"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-7-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-2-7" unit="cm" 
          x="-328.03"
 	 y="296.2" 
@@ -10559,14 +5396,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-7-3"/>
-       <position name="posOpArapucaDouble3-Frame-2-7" unit="cm" 
-         x="-327.29"
-	 y="296.2" 
-	 z="-785.75"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-8-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-2-8" unit="cm" 
          x="-328.03"
 	 y="40.8" 
@@ -10574,14 +5404,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-8-0"/>
-       <position name="posOpArapucaDouble0-Frame-2-8" unit="cm" 
-         x="-327.29"
-	 y="40.8" 
-	 z="-411.45"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-8-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-2-8" unit="cm" 
          x="-328.03"
 	 y="131.5" 
@@ -10589,14 +5412,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-8-1"/>
-       <position name="posOpArapucaDouble1-Frame-2-8" unit="cm" 
-         x="-327.29"
-	 y="131.5" 
-	 z="-557.45"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-8-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-2-8" unit="cm" 
          x="-328.03"
 	 y="205.5" 
@@ -10604,14 +5420,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-8-2"/>
-       <position name="posOpArapucaDouble2-Frame-2-8" unit="cm" 
-         x="-327.29"
-	 y="205.5" 
-	 z="-340.45"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-8-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-2-8" unit="cm" 
          x="-328.03"
 	 y="296.2" 
@@ -10619,14 +5428,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-8-3"/>
-       <position name="posOpArapucaDouble3-Frame-2-8" unit="cm" 
-         x="-327.29"
-	 y="296.2" 
-	 z="-486.45"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-9-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-2-9" unit="cm" 
          x="-328.03"
 	 y="40.8" 
@@ -10634,14 +5436,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-9-0"/>
-       <position name="posOpArapucaDouble0-Frame-2-9" unit="cm" 
-         x="-327.29"
-	 y="40.8" 
-	 z="-112.15"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-9-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-2-9" unit="cm" 
          x="-328.03"
 	 y="131.5" 
@@ -10649,14 +5444,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-9-1"/>
-       <position name="posOpArapucaDouble1-Frame-2-9" unit="cm" 
-         x="-327.29"
-	 y="131.5" 
-	 z="-258.15"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-9-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-2-9" unit="cm" 
          x="-328.03"
 	 y="205.5" 
@@ -10664,14 +5452,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-9-2"/>
-       <position name="posOpArapucaDouble2-Frame-2-9" unit="cm" 
-         x="-327.29"
-	 y="205.5" 
-	 z="-41.1499999999997"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-9-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-2-9" unit="cm" 
          x="-328.03"
 	 y="296.2" 
@@ -10679,14 +5460,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-9-3"/>
-       <position name="posOpArapucaDouble3-Frame-2-9" unit="cm" 
-         x="-327.29"
-	 y="296.2" 
-	 z="-187.15"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-10-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-2-10" unit="cm" 
          x="-328.03"
 	 y="40.8" 
@@ -10694,14 +5468,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-10-0"/>
-       <position name="posOpArapucaDouble0-Frame-2-10" unit="cm" 
-         x="-327.29"
-	 y="40.8" 
-	 z="187.15"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-10-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-2-10" unit="cm" 
          x="-328.03"
 	 y="131.5" 
@@ -10709,14 +5476,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-10-1"/>
-       <position name="posOpArapucaDouble1-Frame-2-10" unit="cm" 
-         x="-327.29"
-	 y="131.5" 
-	 z="41.1500000000003"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-10-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-2-10" unit="cm" 
          x="-328.03"
 	 y="205.5" 
@@ -10724,14 +5484,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-10-2"/>
-       <position name="posOpArapucaDouble2-Frame-2-10" unit="cm" 
-         x="-327.29"
-	 y="205.5" 
-	 z="258.15"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-10-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-2-10" unit="cm" 
          x="-328.03"
 	 y="296.2" 
@@ -10739,14 +5492,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-10-3"/>
-       <position name="posOpArapucaDouble3-Frame-2-10" unit="cm" 
-         x="-327.29"
-	 y="296.2" 
-	 z="112.15"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-11-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-2-11" unit="cm" 
          x="-328.03"
 	 y="40.8" 
@@ -10754,14 +5500,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-11-0"/>
-       <position name="posOpArapucaDouble0-Frame-2-11" unit="cm" 
-         x="-327.29"
-	 y="40.8" 
-	 z="486.45"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-11-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-2-11" unit="cm" 
          x="-328.03"
 	 y="131.5" 
@@ -10769,14 +5508,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-11-1"/>
-       <position name="posOpArapucaDouble1-Frame-2-11" unit="cm" 
-         x="-327.29"
-	 y="131.5" 
-	 z="340.45"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-11-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-2-11" unit="cm" 
          x="-328.03"
 	 y="205.5" 
@@ -10784,14 +5516,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-11-2"/>
-       <position name="posOpArapucaDouble2-Frame-2-11" unit="cm" 
-         x="-327.29"
-	 y="205.5" 
-	 z="557.45"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-11-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-2-11" unit="cm" 
          x="-328.03"
 	 y="296.2" 
@@ -10799,14 +5524,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-11-3"/>
-       <position name="posOpArapucaDouble3-Frame-2-11" unit="cm" 
-         x="-327.29"
-	 y="296.2" 
-	 z="411.45"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-12-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-2-12" unit="cm" 
          x="-328.03"
 	 y="40.8" 
@@ -10814,14 +5532,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-12-0"/>
-       <position name="posOpArapucaDouble0-Frame-2-12" unit="cm" 
-         x="-327.29"
-	 y="40.8" 
-	 z="785.75"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-12-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-2-12" unit="cm" 
          x="-328.03"
 	 y="131.5" 
@@ -10829,14 +5540,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-12-1"/>
-       <position name="posOpArapucaDouble1-Frame-2-12" unit="cm" 
-         x="-327.29"
-	 y="131.5" 
-	 z="639.75"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-12-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-2-12" unit="cm" 
          x="-328.03"
 	 y="205.5" 
@@ -10844,14 +5548,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-12-2"/>
-       <position name="posOpArapucaDouble2-Frame-2-12" unit="cm" 
-         x="-327.29"
-	 y="205.5" 
-	 z="856.75"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-12-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-2-12" unit="cm" 
          x="-328.03"
 	 y="296.2" 
@@ -10859,14 +5556,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-12-3"/>
-       <position name="posOpArapucaDouble3-Frame-2-12" unit="cm" 
-         x="-327.29"
-	 y="296.2" 
-	 z="710.75"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-13-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-2-13" unit="cm" 
          x="-328.03"
 	 y="40.8" 
@@ -10874,14 +5564,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-13-0"/>
-       <position name="posOpArapucaDouble0-Frame-2-13" unit="cm" 
-         x="-327.29"
-	 y="40.8" 
-	 z="1085.05"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-13-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-2-13" unit="cm" 
          x="-328.03"
 	 y="131.5" 
@@ -10889,14 +5572,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-13-1"/>
-       <position name="posOpArapucaDouble1-Frame-2-13" unit="cm" 
-         x="-327.29"
-	 y="131.5" 
-	 z="939.05"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-13-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-2-13" unit="cm" 
          x="-328.03"
 	 y="205.5" 
@@ -10904,14 +5580,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-13-2"/>
-       <position name="posOpArapucaDouble2-Frame-2-13" unit="cm" 
-         x="-327.29"
-	 y="205.5" 
-	 z="1156.05"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-13-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-2-13" unit="cm" 
          x="-328.03"
 	 y="296.2" 
@@ -10919,14 +5588,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-13-3"/>
-       <position name="posOpArapucaDouble3-Frame-2-13" unit="cm" 
-         x="-327.29"
-	 y="296.2" 
-	 z="1010.05"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-14-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-2-14" unit="cm" 
          x="-328.03"
 	 y="40.8" 
@@ -10934,14 +5596,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-14-0"/>
-       <position name="posOpArapucaDouble0-Frame-2-14" unit="cm" 
-         x="-327.29"
-	 y="40.8" 
-	 z="1384.35"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-14-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-2-14" unit="cm" 
          x="-328.03"
 	 y="131.5" 
@@ -10949,14 +5604,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-14-1"/>
-       <position name="posOpArapucaDouble1-Frame-2-14" unit="cm" 
-         x="-327.29"
-	 y="131.5" 
-	 z="1238.35"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-14-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-2-14" unit="cm" 
          x="-328.03"
 	 y="205.5" 
@@ -10964,14 +5612,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-14-2"/>
-       <position name="posOpArapucaDouble2-Frame-2-14" unit="cm" 
-         x="-327.29"
-	 y="205.5" 
-	 z="1455.35"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-14-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-2-14" unit="cm" 
          x="-328.03"
 	 y="296.2" 
@@ -10979,14 +5620,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-14-3"/>
-       <position name="posOpArapucaDouble3-Frame-2-14" unit="cm" 
-         x="-327.29"
-	 y="296.2" 
-	 z="1309.35"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-15-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-2-15" unit="cm" 
          x="-328.03"
 	 y="40.8" 
@@ -10994,14 +5628,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-15-0"/>
-       <position name="posOpArapucaDouble0-Frame-2-15" unit="cm" 
-         x="-327.29"
-	 y="40.8" 
-	 z="1683.65"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-15-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-2-15" unit="cm" 
          x="-328.03"
 	 y="131.5" 
@@ -11009,14 +5636,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-15-1"/>
-       <position name="posOpArapucaDouble1-Frame-2-15" unit="cm" 
-         x="-327.29"
-	 y="131.5" 
-	 z="1537.65"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-15-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-2-15" unit="cm" 
          x="-328.03"
 	 y="205.5" 
@@ -11024,14 +5644,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-15-2"/>
-       <position name="posOpArapucaDouble2-Frame-2-15" unit="cm" 
-         x="-327.29"
-	 y="205.5" 
-	 z="1754.65"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-15-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-2-15" unit="cm" 
          x="-328.03"
 	 y="296.2" 
@@ -11039,14 +5652,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-15-3"/>
-       <position name="posOpArapucaDouble3-Frame-2-15" unit="cm" 
-         x="-327.29"
-	 y="296.2" 
-	 z="1608.65"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-16-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-2-16" unit="cm" 
          x="-328.03"
 	 y="40.8" 
@@ -11054,14 +5660,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-16-0"/>
-       <position name="posOpArapucaDouble0-Frame-2-16" unit="cm" 
-         x="-327.29"
-	 y="40.8" 
-	 z="1982.95"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-16-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-2-16" unit="cm" 
          x="-328.03"
 	 y="131.5" 
@@ -11069,14 +5668,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-16-1"/>
-       <position name="posOpArapucaDouble1-Frame-2-16" unit="cm" 
-         x="-327.29"
-	 y="131.5" 
-	 z="1836.95"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-16-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-2-16" unit="cm" 
          x="-328.03"
 	 y="205.5" 
@@ -11084,14 +5676,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-16-2"/>
-       <position name="posOpArapucaDouble2-Frame-2-16" unit="cm" 
-         x="-327.29"
-	 y="205.5" 
-	 z="2053.95"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-16-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-2-16" unit="cm" 
          x="-328.03"
 	 y="296.2" 
@@ -11099,14 +5684,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-16-3"/>
-       <position name="posOpArapucaDouble3-Frame-2-16" unit="cm" 
-         x="-327.29"
-	 y="296.2" 
-	 z="1907.95"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-17-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-2-17" unit="cm" 
          x="-328.03"
 	 y="40.8" 
@@ -11114,14 +5692,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-17-0"/>
-       <position name="posOpArapucaDouble0-Frame-2-17" unit="cm" 
-         x="-327.29"
-	 y="40.8" 
-	 z="2282.25"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-17-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-2-17" unit="cm" 
          x="-328.03"
 	 y="131.5" 
@@ -11129,14 +5700,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-17-1"/>
-       <position name="posOpArapucaDouble1-Frame-2-17" unit="cm" 
-         x="-327.29"
-	 y="131.5" 
-	 z="2136.25"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-17-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-2-17" unit="cm" 
          x="-328.03"
 	 y="205.5" 
@@ -11144,14 +5708,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-17-2"/>
-       <position name="posOpArapucaDouble2-Frame-2-17" unit="cm" 
-         x="-327.29"
-	 y="205.5" 
-	 z="2353.25"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-17-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-2-17" unit="cm" 
          x="-328.03"
 	 y="296.2" 
@@ -11159,14 +5716,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-17-3"/>
-       <position name="posOpArapucaDouble3-Frame-2-17" unit="cm" 
-         x="-327.29"
-	 y="296.2" 
-	 z="2207.25"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-18-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-2-18" unit="cm" 
          x="-328.03"
 	 y="40.8" 
@@ -11174,14 +5724,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-18-0"/>
-       <position name="posOpArapucaDouble0-Frame-2-18" unit="cm" 
-         x="-327.29"
-	 y="40.8" 
-	 z="2581.55"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-18-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-2-18" unit="cm" 
          x="-328.03"
 	 y="131.5" 
@@ -11189,14 +5732,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-18-1"/>
-       <position name="posOpArapucaDouble1-Frame-2-18" unit="cm" 
-         x="-327.29"
-	 y="131.5" 
-	 z="2435.55"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-18-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-2-18" unit="cm" 
          x="-328.03"
 	 y="205.5" 
@@ -11204,14 +5740,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-18-2"/>
-       <position name="posOpArapucaDouble2-Frame-2-18" unit="cm" 
-         x="-327.29"
-	 y="205.5" 
-	 z="2652.55"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-18-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-2-18" unit="cm" 
          x="-328.03"
 	 y="296.2" 
@@ -11219,14 +5748,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-18-3"/>
-       <position name="posOpArapucaDouble3-Frame-2-18" unit="cm" 
-         x="-327.29"
-	 y="296.2" 
-	 z="2506.55"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-19-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-2-19" unit="cm" 
          x="-328.03"
 	 y="40.8" 
@@ -11234,14 +5756,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-19-0"/>
-       <position name="posOpArapucaDouble0-Frame-2-19" unit="cm" 
-         x="-327.29"
-	 y="40.8" 
-	 z="2880.85"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-19-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-2-19" unit="cm" 
          x="-328.03"
 	 y="131.5" 
@@ -11249,14 +5764,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-19-1"/>
-       <position name="posOpArapucaDouble1-Frame-2-19" unit="cm" 
-         x="-327.29"
-	 y="131.5" 
-	 z="2734.85"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-19-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-2-19" unit="cm" 
          x="-328.03"
 	 y="205.5" 
@@ -11264,14 +5772,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-19-2"/>
-       <position name="posOpArapucaDouble2-Frame-2-19" unit="cm" 
-         x="-327.29"
-	 y="205.5" 
-	 z="2951.85"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-19-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-2-19" unit="cm" 
          x="-328.03"
 	 y="296.2" 
@@ -11279,14 +5780,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-19-3"/>
-       <position name="posOpArapucaDouble3-Frame-2-19" unit="cm" 
-         x="-327.29"
-	 y="296.2" 
-	 z="2805.85"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-0-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-3-0" unit="cm" 
          x="-328.03"
 	 y="377.8" 
@@ -11294,14 +5788,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-0"/>
-       <position name="posOpArapucaDouble0-Frame-3-0" unit="cm" 
-         x="-327.29"
-	 y="377.8" 
-	 z="-2805.85"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-0-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-3-0" unit="cm" 
          x="-328.03"
 	 y="468.5" 
@@ -11309,14 +5796,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-1"/>
-       <position name="posOpArapucaDouble1-Frame-3-0" unit="cm" 
-         x="-327.29"
-	 y="468.5" 
-	 z="-2951.85"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-0-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-3-0" unit="cm" 
          x="-328.03"
 	 y="542.5" 
@@ -11324,14 +5804,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-2"/>
-       <position name="posOpArapucaDouble2-Frame-3-0" unit="cm" 
-         x="-327.29"
-	 y="542.5" 
-	 z="-2734.85"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-0-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-3-0" unit="cm" 
          x="-328.03"
 	 y="633.2" 
@@ -11339,14 +5812,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-3"/>
-       <position name="posOpArapucaDouble3-Frame-3-0" unit="cm" 
-         x="-327.29"
-	 y="633.2" 
-	 z="-2880.85"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-1-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-3-1" unit="cm" 
          x="-328.03"
 	 y="377.8" 
@@ -11354,14 +5820,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-0"/>
-       <position name="posOpArapucaDouble0-Frame-3-1" unit="cm" 
-         x="-327.29"
-	 y="377.8" 
-	 z="-2506.55"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-1-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-3-1" unit="cm" 
          x="-328.03"
 	 y="468.5" 
@@ -11369,14 +5828,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-1"/>
-       <position name="posOpArapucaDouble1-Frame-3-1" unit="cm" 
-         x="-327.29"
-	 y="468.5" 
-	 z="-2652.55"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-1-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-3-1" unit="cm" 
          x="-328.03"
 	 y="542.5" 
@@ -11384,14 +5836,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-2"/>
-       <position name="posOpArapucaDouble2-Frame-3-1" unit="cm" 
-         x="-327.29"
-	 y="542.5" 
-	 z="-2435.55"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-1-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-3-1" unit="cm" 
          x="-328.03"
 	 y="633.2" 
@@ -11399,14 +5844,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-3"/>
-       <position name="posOpArapucaDouble3-Frame-3-1" unit="cm" 
-         x="-327.29"
-	 y="633.2" 
-	 z="-2581.55"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-2-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-3-2" unit="cm" 
          x="-328.03"
 	 y="377.8" 
@@ -11414,14 +5852,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-0"/>
-       <position name="posOpArapucaDouble0-Frame-3-2" unit="cm" 
-         x="-327.29"
-	 y="377.8" 
-	 z="-2207.25"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-2-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-3-2" unit="cm" 
          x="-328.03"
 	 y="468.5" 
@@ -11429,14 +5860,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-1"/>
-       <position name="posOpArapucaDouble1-Frame-3-2" unit="cm" 
-         x="-327.29"
-	 y="468.5" 
-	 z="-2353.25"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-2-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-3-2" unit="cm" 
          x="-328.03"
 	 y="542.5" 
@@ -11444,14 +5868,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-2"/>
-       <position name="posOpArapucaDouble2-Frame-3-2" unit="cm" 
-         x="-327.29"
-	 y="542.5" 
-	 z="-2136.25"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-2-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-3-2" unit="cm" 
          x="-328.03"
 	 y="633.2" 
@@ -11459,14 +5876,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-3"/>
-       <position name="posOpArapucaDouble3-Frame-3-2" unit="cm" 
-         x="-327.29"
-	 y="633.2" 
-	 z="-2282.25"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-3-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-3-3" unit="cm" 
          x="-328.03"
 	 y="377.8" 
@@ -11474,14 +5884,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-3-0"/>
-       <position name="posOpArapucaDouble0-Frame-3-3" unit="cm" 
-         x="-327.29"
-	 y="377.8" 
-	 z="-1907.95"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-3-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-3-3" unit="cm" 
          x="-328.03"
 	 y="468.5" 
@@ -11489,14 +5892,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-3-1"/>
-       <position name="posOpArapucaDouble1-Frame-3-3" unit="cm" 
-         x="-327.29"
-	 y="468.5" 
-	 z="-2053.95"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-3-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-3-3" unit="cm" 
          x="-328.03"
 	 y="542.5" 
@@ -11504,14 +5900,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-3-2"/>
-       <position name="posOpArapucaDouble2-Frame-3-3" unit="cm" 
-         x="-327.29"
-	 y="542.5" 
-	 z="-1836.95"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-3-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-3-3" unit="cm" 
          x="-328.03"
 	 y="633.2" 
@@ -11519,14 +5908,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-3-3"/>
-       <position name="posOpArapucaDouble3-Frame-3-3" unit="cm" 
-         x="-327.29"
-	 y="633.2" 
-	 z="-1982.95"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-4-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-3-4" unit="cm" 
          x="-328.03"
 	 y="377.8" 
@@ -11534,14 +5916,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-4-0"/>
-       <position name="posOpArapucaDouble0-Frame-3-4" unit="cm" 
-         x="-327.29"
-	 y="377.8" 
-	 z="-1608.65"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-4-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-3-4" unit="cm" 
          x="-328.03"
 	 y="468.5" 
@@ -11549,14 +5924,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-4-1"/>
-       <position name="posOpArapucaDouble1-Frame-3-4" unit="cm" 
-         x="-327.29"
-	 y="468.5" 
-	 z="-1754.65"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-4-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-3-4" unit="cm" 
          x="-328.03"
 	 y="542.5" 
@@ -11564,14 +5932,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-4-2"/>
-       <position name="posOpArapucaDouble2-Frame-3-4" unit="cm" 
-         x="-327.29"
-	 y="542.5" 
-	 z="-1537.65"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-4-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-3-4" unit="cm" 
          x="-328.03"
 	 y="633.2" 
@@ -11579,14 +5940,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-4-3"/>
-       <position name="posOpArapucaDouble3-Frame-3-4" unit="cm" 
-         x="-327.29"
-	 y="633.2" 
-	 z="-1683.65"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-5-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-3-5" unit="cm" 
          x="-328.03"
 	 y="377.8" 
@@ -11594,14 +5948,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-5-0"/>
-       <position name="posOpArapucaDouble0-Frame-3-5" unit="cm" 
-         x="-327.29"
-	 y="377.8" 
-	 z="-1309.35"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-5-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-3-5" unit="cm" 
          x="-328.03"
 	 y="468.5" 
@@ -11609,14 +5956,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-5-1"/>
-       <position name="posOpArapucaDouble1-Frame-3-5" unit="cm" 
-         x="-327.29"
-	 y="468.5" 
-	 z="-1455.35"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-5-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-3-5" unit="cm" 
          x="-328.03"
 	 y="542.5" 
@@ -11624,14 +5964,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-5-2"/>
-       <position name="posOpArapucaDouble2-Frame-3-5" unit="cm" 
-         x="-327.29"
-	 y="542.5" 
-	 z="-1238.35"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-5-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-3-5" unit="cm" 
          x="-328.03"
 	 y="633.2" 
@@ -11639,14 +5972,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-5-3"/>
-       <position name="posOpArapucaDouble3-Frame-3-5" unit="cm" 
-         x="-327.29"
-	 y="633.2" 
-	 z="-1384.35"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-6-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-3-6" unit="cm" 
          x="-328.03"
 	 y="377.8" 
@@ -11654,14 +5980,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-6-0"/>
-       <position name="posOpArapucaDouble0-Frame-3-6" unit="cm" 
-         x="-327.29"
-	 y="377.8" 
-	 z="-1010.05"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-6-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-3-6" unit="cm" 
          x="-328.03"
 	 y="468.5" 
@@ -11669,14 +5988,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-6-1"/>
-       <position name="posOpArapucaDouble1-Frame-3-6" unit="cm" 
-         x="-327.29"
-	 y="468.5" 
-	 z="-1156.05"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-6-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-3-6" unit="cm" 
          x="-328.03"
 	 y="542.5" 
@@ -11684,14 +5996,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-6-2"/>
-       <position name="posOpArapucaDouble2-Frame-3-6" unit="cm" 
-         x="-327.29"
-	 y="542.5" 
-	 z="-939.05"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-6-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-3-6" unit="cm" 
          x="-328.03"
 	 y="633.2" 
@@ -11699,14 +6004,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-6-3"/>
-       <position name="posOpArapucaDouble3-Frame-3-6" unit="cm" 
-         x="-327.29"
-	 y="633.2" 
-	 z="-1085.05"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-7-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-3-7" unit="cm" 
          x="-328.03"
 	 y="377.8" 
@@ -11714,14 +6012,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-7-0"/>
-       <position name="posOpArapucaDouble0-Frame-3-7" unit="cm" 
-         x="-327.29"
-	 y="377.8" 
-	 z="-710.75"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-7-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-3-7" unit="cm" 
          x="-328.03"
 	 y="468.5" 
@@ -11729,14 +6020,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-7-1"/>
-       <position name="posOpArapucaDouble1-Frame-3-7" unit="cm" 
-         x="-327.29"
-	 y="468.5" 
-	 z="-856.75"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-7-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-3-7" unit="cm" 
          x="-328.03"
 	 y="542.5" 
@@ -11744,14 +6028,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-7-2"/>
-       <position name="posOpArapucaDouble2-Frame-3-7" unit="cm" 
-         x="-327.29"
-	 y="542.5" 
-	 z="-639.75"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-7-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-3-7" unit="cm" 
          x="-328.03"
 	 y="633.2" 
@@ -11759,14 +6036,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-7-3"/>
-       <position name="posOpArapucaDouble3-Frame-3-7" unit="cm" 
-         x="-327.29"
-	 y="633.2" 
-	 z="-785.75"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-8-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-3-8" unit="cm" 
          x="-328.03"
 	 y="377.8" 
@@ -11774,14 +6044,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-8-0"/>
-       <position name="posOpArapucaDouble0-Frame-3-8" unit="cm" 
-         x="-327.29"
-	 y="377.8" 
-	 z="-411.45"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-8-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-3-8" unit="cm" 
          x="-328.03"
 	 y="468.5" 
@@ -11789,14 +6052,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-8-1"/>
-       <position name="posOpArapucaDouble1-Frame-3-8" unit="cm" 
-         x="-327.29"
-	 y="468.5" 
-	 z="-557.45"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-8-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-3-8" unit="cm" 
          x="-328.03"
 	 y="542.5" 
@@ -11804,14 +6060,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-8-2"/>
-       <position name="posOpArapucaDouble2-Frame-3-8" unit="cm" 
-         x="-327.29"
-	 y="542.5" 
-	 z="-340.45"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-8-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-3-8" unit="cm" 
          x="-328.03"
 	 y="633.2" 
@@ -11819,14 +6068,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-8-3"/>
-       <position name="posOpArapucaDouble3-Frame-3-8" unit="cm" 
-         x="-327.29"
-	 y="633.2" 
-	 z="-486.45"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-9-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-3-9" unit="cm" 
          x="-328.03"
 	 y="377.8" 
@@ -11834,14 +6076,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-9-0"/>
-       <position name="posOpArapucaDouble0-Frame-3-9" unit="cm" 
-         x="-327.29"
-	 y="377.8" 
-	 z="-112.15"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-9-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-3-9" unit="cm" 
          x="-328.03"
 	 y="468.5" 
@@ -11849,14 +6084,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-9-1"/>
-       <position name="posOpArapucaDouble1-Frame-3-9" unit="cm" 
-         x="-327.29"
-	 y="468.5" 
-	 z="-258.15"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-9-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-3-9" unit="cm" 
          x="-328.03"
 	 y="542.5" 
@@ -11864,14 +6092,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-9-2"/>
-       <position name="posOpArapucaDouble2-Frame-3-9" unit="cm" 
-         x="-327.29"
-	 y="542.5" 
-	 z="-41.1499999999997"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-9-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-3-9" unit="cm" 
          x="-328.03"
 	 y="633.2" 
@@ -11879,14 +6100,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-9-3"/>
-       <position name="posOpArapucaDouble3-Frame-3-9" unit="cm" 
-         x="-327.29"
-	 y="633.2" 
-	 z="-187.15"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-10-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-3-10" unit="cm" 
          x="-328.03"
 	 y="377.8" 
@@ -11894,14 +6108,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-10-0"/>
-       <position name="posOpArapucaDouble0-Frame-3-10" unit="cm" 
-         x="-327.29"
-	 y="377.8" 
-	 z="187.15"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-10-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-3-10" unit="cm" 
          x="-328.03"
 	 y="468.5" 
@@ -11909,14 +6116,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-10-1"/>
-       <position name="posOpArapucaDouble1-Frame-3-10" unit="cm" 
-         x="-327.29"
-	 y="468.5" 
-	 z="41.1500000000003"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-10-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-3-10" unit="cm" 
          x="-328.03"
 	 y="542.5" 
@@ -11924,14 +6124,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-10-2"/>
-       <position name="posOpArapucaDouble2-Frame-3-10" unit="cm" 
-         x="-327.29"
-	 y="542.5" 
-	 z="258.15"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-10-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-3-10" unit="cm" 
          x="-328.03"
 	 y="633.2" 
@@ -11939,14 +6132,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-10-3"/>
-       <position name="posOpArapucaDouble3-Frame-3-10" unit="cm" 
-         x="-327.29"
-	 y="633.2" 
-	 z="112.15"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-11-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-3-11" unit="cm" 
          x="-328.03"
 	 y="377.8" 
@@ -11954,14 +6140,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-11-0"/>
-       <position name="posOpArapucaDouble0-Frame-3-11" unit="cm" 
-         x="-327.29"
-	 y="377.8" 
-	 z="486.45"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-11-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-3-11" unit="cm" 
          x="-328.03"
 	 y="468.5" 
@@ -11969,14 +6148,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-11-1"/>
-       <position name="posOpArapucaDouble1-Frame-3-11" unit="cm" 
-         x="-327.29"
-	 y="468.5" 
-	 z="340.45"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-11-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-3-11" unit="cm" 
          x="-328.03"
 	 y="542.5" 
@@ -11984,14 +6156,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-11-2"/>
-       <position name="posOpArapucaDouble2-Frame-3-11" unit="cm" 
-         x="-327.29"
-	 y="542.5" 
-	 z="557.45"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-11-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-3-11" unit="cm" 
          x="-328.03"
 	 y="633.2" 
@@ -11999,14 +6164,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-11-3"/>
-       <position name="posOpArapucaDouble3-Frame-3-11" unit="cm" 
-         x="-327.29"
-	 y="633.2" 
-	 z="411.45"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-12-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-3-12" unit="cm" 
          x="-328.03"
 	 y="377.8" 
@@ -12014,14 +6172,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-12-0"/>
-       <position name="posOpArapucaDouble0-Frame-3-12" unit="cm" 
-         x="-327.29"
-	 y="377.8" 
-	 z="785.75"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-12-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-3-12" unit="cm" 
          x="-328.03"
 	 y="468.5" 
@@ -12029,14 +6180,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-12-1"/>
-       <position name="posOpArapucaDouble1-Frame-3-12" unit="cm" 
-         x="-327.29"
-	 y="468.5" 
-	 z="639.75"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-12-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-3-12" unit="cm" 
          x="-328.03"
 	 y="542.5" 
@@ -12044,14 +6188,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-12-2"/>
-       <position name="posOpArapucaDouble2-Frame-3-12" unit="cm" 
-         x="-327.29"
-	 y="542.5" 
-	 z="856.75"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-12-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-3-12" unit="cm" 
          x="-328.03"
 	 y="633.2" 
@@ -12059,14 +6196,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-12-3"/>
-       <position name="posOpArapucaDouble3-Frame-3-12" unit="cm" 
-         x="-327.29"
-	 y="633.2" 
-	 z="710.75"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-13-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-3-13" unit="cm" 
          x="-328.03"
 	 y="377.8" 
@@ -12074,14 +6204,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-13-0"/>
-       <position name="posOpArapucaDouble0-Frame-3-13" unit="cm" 
-         x="-327.29"
-	 y="377.8" 
-	 z="1085.05"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-13-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-3-13" unit="cm" 
          x="-328.03"
 	 y="468.5" 
@@ -12089,14 +6212,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-13-1"/>
-       <position name="posOpArapucaDouble1-Frame-3-13" unit="cm" 
-         x="-327.29"
-	 y="468.5" 
-	 z="939.05"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-13-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-3-13" unit="cm" 
          x="-328.03"
 	 y="542.5" 
@@ -12104,14 +6220,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-13-2"/>
-       <position name="posOpArapucaDouble2-Frame-3-13" unit="cm" 
-         x="-327.29"
-	 y="542.5" 
-	 z="1156.05"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-13-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-3-13" unit="cm" 
          x="-328.03"
 	 y="633.2" 
@@ -12119,14 +6228,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-13-3"/>
-       <position name="posOpArapucaDouble3-Frame-3-13" unit="cm" 
-         x="-327.29"
-	 y="633.2" 
-	 z="1010.05"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-14-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-3-14" unit="cm" 
          x="-328.03"
 	 y="377.8" 
@@ -12134,14 +6236,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-14-0"/>
-       <position name="posOpArapucaDouble0-Frame-3-14" unit="cm" 
-         x="-327.29"
-	 y="377.8" 
-	 z="1384.35"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-14-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-3-14" unit="cm" 
          x="-328.03"
 	 y="468.5" 
@@ -12149,14 +6244,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-14-1"/>
-       <position name="posOpArapucaDouble1-Frame-3-14" unit="cm" 
-         x="-327.29"
-	 y="468.5" 
-	 z="1238.35"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-14-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-3-14" unit="cm" 
          x="-328.03"
 	 y="542.5" 
@@ -12164,14 +6252,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-14-2"/>
-       <position name="posOpArapucaDouble2-Frame-3-14" unit="cm" 
-         x="-327.29"
-	 y="542.5" 
-	 z="1455.35"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-14-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-3-14" unit="cm" 
          x="-328.03"
 	 y="633.2" 
@@ -12179,14 +6260,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-14-3"/>
-       <position name="posOpArapucaDouble3-Frame-3-14" unit="cm" 
-         x="-327.29"
-	 y="633.2" 
-	 z="1309.35"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-15-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-3-15" unit="cm" 
          x="-328.03"
 	 y="377.8" 
@@ -12194,14 +6268,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-15-0"/>
-       <position name="posOpArapucaDouble0-Frame-3-15" unit="cm" 
-         x="-327.29"
-	 y="377.8" 
-	 z="1683.65"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-15-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-3-15" unit="cm" 
          x="-328.03"
 	 y="468.5" 
@@ -12209,14 +6276,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-15-1"/>
-       <position name="posOpArapucaDouble1-Frame-3-15" unit="cm" 
-         x="-327.29"
-	 y="468.5" 
-	 z="1537.65"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-15-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-3-15" unit="cm" 
          x="-328.03"
 	 y="542.5" 
@@ -12224,14 +6284,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-15-2"/>
-       <position name="posOpArapucaDouble2-Frame-3-15" unit="cm" 
-         x="-327.29"
-	 y="542.5" 
-	 z="1754.65"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-15-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-3-15" unit="cm" 
          x="-328.03"
 	 y="633.2" 
@@ -12239,14 +6292,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-15-3"/>
-       <position name="posOpArapucaDouble3-Frame-3-15" unit="cm" 
-         x="-327.29"
-	 y="633.2" 
-	 z="1608.65"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-16-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-3-16" unit="cm" 
          x="-328.03"
 	 y="377.8" 
@@ -12254,14 +6300,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-16-0"/>
-       <position name="posOpArapucaDouble0-Frame-3-16" unit="cm" 
-         x="-327.29"
-	 y="377.8" 
-	 z="1982.95"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-16-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-3-16" unit="cm" 
          x="-328.03"
 	 y="468.5" 
@@ -12269,14 +6308,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-16-1"/>
-       <position name="posOpArapucaDouble1-Frame-3-16" unit="cm" 
-         x="-327.29"
-	 y="468.5" 
-	 z="1836.95"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-16-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-3-16" unit="cm" 
          x="-328.03"
 	 y="542.5" 
@@ -12284,14 +6316,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-16-2"/>
-       <position name="posOpArapucaDouble2-Frame-3-16" unit="cm" 
-         x="-327.29"
-	 y="542.5" 
-	 z="2053.95"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-16-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-3-16" unit="cm" 
          x="-328.03"
 	 y="633.2" 
@@ -12299,14 +6324,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-16-3"/>
-       <position name="posOpArapucaDouble3-Frame-3-16" unit="cm" 
-         x="-327.29"
-	 y="633.2" 
-	 z="1907.95"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-17-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-3-17" unit="cm" 
          x="-328.03"
 	 y="377.8" 
@@ -12314,14 +6332,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-17-0"/>
-       <position name="posOpArapucaDouble0-Frame-3-17" unit="cm" 
-         x="-327.29"
-	 y="377.8" 
-	 z="2282.25"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-17-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-3-17" unit="cm" 
          x="-328.03"
 	 y="468.5" 
@@ -12329,14 +6340,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-17-1"/>
-       <position name="posOpArapucaDouble1-Frame-3-17" unit="cm" 
-         x="-327.29"
-	 y="468.5" 
-	 z="2136.25"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-17-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-3-17" unit="cm" 
          x="-328.03"
 	 y="542.5" 
@@ -12344,14 +6348,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-17-2"/>
-       <position name="posOpArapucaDouble2-Frame-3-17" unit="cm" 
-         x="-327.29"
-	 y="542.5" 
-	 z="2353.25"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-17-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-3-17" unit="cm" 
          x="-328.03"
 	 y="633.2" 
@@ -12359,14 +6356,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-17-3"/>
-       <position name="posOpArapucaDouble3-Frame-3-17" unit="cm" 
-         x="-327.29"
-	 y="633.2" 
-	 z="2207.25"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-18-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-3-18" unit="cm" 
          x="-328.03"
 	 y="377.8" 
@@ -12374,14 +6364,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-18-0"/>
-       <position name="posOpArapucaDouble0-Frame-3-18" unit="cm" 
-         x="-327.29"
-	 y="377.8" 
-	 z="2581.55"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-18-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-3-18" unit="cm" 
          x="-328.03"
 	 y="468.5" 
@@ -12389,14 +6372,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-18-1"/>
-       <position name="posOpArapucaDouble1-Frame-3-18" unit="cm" 
-         x="-327.29"
-	 y="468.5" 
-	 z="2435.55"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-18-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-3-18" unit="cm" 
          x="-328.03"
 	 y="542.5" 
@@ -12404,14 +6380,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-18-2"/>
-       <position name="posOpArapucaDouble2-Frame-3-18" unit="cm" 
-         x="-327.29"
-	 y="542.5" 
-	 z="2652.55"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-18-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-3-18" unit="cm" 
          x="-328.03"
 	 y="633.2" 
@@ -12419,14 +6388,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-18-3"/>
-       <position name="posOpArapucaDouble3-Frame-3-18" unit="cm" 
-         x="-327.29"
-	 y="633.2" 
-	 z="2506.55"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-19-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-3-19" unit="cm" 
          x="-328.03"
 	 y="377.8" 
@@ -12434,14 +6396,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-19-0"/>
-       <position name="posOpArapucaDouble0-Frame-3-19" unit="cm" 
-         x="-327.29"
-	 y="377.8" 
-	 z="2880.85"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-19-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-3-19" unit="cm" 
          x="-328.03"
 	 y="468.5" 
@@ -12449,14 +6404,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-19-1"/>
-       <position name="posOpArapucaDouble1-Frame-3-19" unit="cm" 
-         x="-327.29"
-	 y="468.5" 
-	 z="2734.85"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-19-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-3-19" unit="cm" 
          x="-328.03"
 	 y="542.5" 
@@ -12464,14 +6412,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-19-2"/>
-       <position name="posOpArapucaDouble2-Frame-3-19" unit="cm" 
-         x="-327.29"
-	 y="542.5" 
-	 z="2951.85"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-19-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-3-19" unit="cm" 
          x="-328.03"
 	 y="633.2" 
@@ -12479,14 +6420,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-19-3"/>
-       <position name="posOpArapucaDouble3-Frame-3-19" unit="cm" 
-         x="-327.29"
-	 y="633.2" 
-	 z="2805.85"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_0-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca0-Lat-0" unit="cm" 
          x="285.02"
 	 y="-745" 
@@ -12494,14 +6428,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_0-0"/>
-       <position name="posOpArapuca0-Lat-0" unit="cm" 
-         x="285.02"
-	 y="-744.26" 
-	 z="-2843.35"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_0-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca1-Lat-0" unit="cm" 
          x="210.02"
 	 y="-745" 
@@ -12509,14 +6436,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_0-1"/>
-       <position name="posOpArapuca1-Lat-0" unit="cm" 
-         x="210.02"
-	 y="-744.26" 
-	 z="-2843.35"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_0-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca2-Lat-0" unit="cm" 
          x="135.02"
 	 y="-745" 
@@ -12524,14 +6444,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_0-2"/>
-       <position name="posOpArapuca2-Lat-0" unit="cm" 
-         x="135.02"
-	 y="-744.26" 
-	 z="-2843.35"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_0-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca3-Lat-0" unit="cm" 
          x="60.02"
 	 y="-745" 
@@ -12539,14 +6452,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_0-3"/>
-       <position name="posOpArapuca3-Lat-0" unit="cm" 
-         x="60.02"
-	 y="-744.26" 
-	 z="-2843.35"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_0-4"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca4-Lat-0" unit="cm" 
          x="285.02"
 	 y="745" 
@@ -12554,14 +6460,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_0-4"/>
-       <position name="posOpArapuca4-Lat-0" unit="cm" 
-         x="285.02"
-	 y="744.26" 
-	 z="-2843.35"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_0-5"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca5-Lat-0" unit="cm" 
          x="210.02"
 	 y="745" 
@@ -12569,14 +6468,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_0-5"/>
-       <position name="posOpArapuca5-Lat-0" unit="cm" 
-         x="210.02"
-	 y="744.26" 
-	 z="-2843.35"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_0-6"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca6-Lat-0" unit="cm" 
          x="135.02"
 	 y="745" 
@@ -12584,14 +6476,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_0-6"/>
-       <position name="posOpArapuca6-Lat-0" unit="cm" 
-         x="135.02"
-	 y="744.26" 
-	 z="-2843.35"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_0-7"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca7-Lat-0" unit="cm" 
          x="60.02"
 	 y="745" 
@@ -12599,14 +6484,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_0-7"/>
-       <position name="posOpArapuca7-Lat-0" unit="cm" 
-         x="60.02"
-	 y="744.26" 
-	 z="-2843.35"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_1-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca0-Lat-1" unit="cm" 
          x="285.02"
 	 y="-745" 
@@ -12614,14 +6492,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_1-0"/>
-       <position name="posOpArapuca0-Lat-1" unit="cm" 
-         x="285.02"
-	 y="-744.26" 
-	 z="-2544.05"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_1-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca1-Lat-1" unit="cm" 
          x="210.02"
 	 y="-745" 
@@ -12629,14 +6500,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_1-1"/>
-       <position name="posOpArapuca1-Lat-1" unit="cm" 
-         x="210.02"
-	 y="-744.26" 
-	 z="-2544.05"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_1-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca2-Lat-1" unit="cm" 
          x="135.02"
 	 y="-745" 
@@ -12644,14 +6508,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_1-2"/>
-       <position name="posOpArapuca2-Lat-1" unit="cm" 
-         x="135.02"
-	 y="-744.26" 
-	 z="-2544.05"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_1-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca3-Lat-1" unit="cm" 
          x="60.02"
 	 y="-745" 
@@ -12659,14 +6516,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_1-3"/>
-       <position name="posOpArapuca3-Lat-1" unit="cm" 
-         x="60.02"
-	 y="-744.26" 
-	 z="-2544.05"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_1-4"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca4-Lat-1" unit="cm" 
          x="285.02"
 	 y="745" 
@@ -12674,14 +6524,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_1-4"/>
-       <position name="posOpArapuca4-Lat-1" unit="cm" 
-         x="285.02"
-	 y="744.26" 
-	 z="-2544.05"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_1-5"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca5-Lat-1" unit="cm" 
          x="210.02"
 	 y="745" 
@@ -12689,14 +6532,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_1-5"/>
-       <position name="posOpArapuca5-Lat-1" unit="cm" 
-         x="210.02"
-	 y="744.26" 
-	 z="-2544.05"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_1-6"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca6-Lat-1" unit="cm" 
          x="135.02"
 	 y="745" 
@@ -12704,14 +6540,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_1-6"/>
-       <position name="posOpArapuca6-Lat-1" unit="cm" 
-         x="135.02"
-	 y="744.26" 
-	 z="-2544.05"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_1-7"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca7-Lat-1" unit="cm" 
          x="60.02"
 	 y="745" 
@@ -12719,14 +6548,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_1-7"/>
-       <position name="posOpArapuca7-Lat-1" unit="cm" 
-         x="60.02"
-	 y="744.26" 
-	 z="-2544.05"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_2-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca0-Lat-2" unit="cm" 
          x="285.02"
 	 y="-745" 
@@ -12734,14 +6556,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_2-0"/>
-       <position name="posOpArapuca0-Lat-2" unit="cm" 
-         x="285.02"
-	 y="-744.26" 
-	 z="-2244.75"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_2-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca1-Lat-2" unit="cm" 
          x="210.02"
 	 y="-745" 
@@ -12749,14 +6564,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_2-1"/>
-       <position name="posOpArapuca1-Lat-2" unit="cm" 
-         x="210.02"
-	 y="-744.26" 
-	 z="-2244.75"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_2-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca2-Lat-2" unit="cm" 
          x="135.02"
 	 y="-745" 
@@ -12764,14 +6572,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_2-2"/>
-       <position name="posOpArapuca2-Lat-2" unit="cm" 
-         x="135.02"
-	 y="-744.26" 
-	 z="-2244.75"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_2-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca3-Lat-2" unit="cm" 
          x="60.02"
 	 y="-745" 
@@ -12779,14 +6580,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_2-3"/>
-       <position name="posOpArapuca3-Lat-2" unit="cm" 
-         x="60.02"
-	 y="-744.26" 
-	 z="-2244.75"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_2-4"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca4-Lat-2" unit="cm" 
          x="285.02"
 	 y="745" 
@@ -12794,14 +6588,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_2-4"/>
-       <position name="posOpArapuca4-Lat-2" unit="cm" 
-         x="285.02"
-	 y="744.26" 
-	 z="-2244.75"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_2-5"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca5-Lat-2" unit="cm" 
          x="210.02"
 	 y="745" 
@@ -12809,14 +6596,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_2-5"/>
-       <position name="posOpArapuca5-Lat-2" unit="cm" 
-         x="210.02"
-	 y="744.26" 
-	 z="-2244.75"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_2-6"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca6-Lat-2" unit="cm" 
          x="135.02"
 	 y="745" 
@@ -12824,14 +6604,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_2-6"/>
-       <position name="posOpArapuca6-Lat-2" unit="cm" 
-         x="135.02"
-	 y="744.26" 
-	 z="-2244.75"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_2-7"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca7-Lat-2" unit="cm" 
          x="60.02"
 	 y="745" 
@@ -12839,14 +6612,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_2-7"/>
-       <position name="posOpArapuca7-Lat-2" unit="cm" 
-         x="60.02"
-	 y="744.26" 
-	 z="-2244.75"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_3-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca0-Lat-3" unit="cm" 
          x="285.02"
 	 y="-745" 
@@ -12854,14 +6620,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_3-0"/>
-       <position name="posOpArapuca0-Lat-3" unit="cm" 
-         x="285.02"
-	 y="-744.26" 
-	 z="-1945.45"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_3-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca1-Lat-3" unit="cm" 
          x="210.02"
 	 y="-745" 
@@ -12869,14 +6628,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_3-1"/>
-       <position name="posOpArapuca1-Lat-3" unit="cm" 
-         x="210.02"
-	 y="-744.26" 
-	 z="-1945.45"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_3-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca2-Lat-3" unit="cm" 
          x="135.02"
 	 y="-745" 
@@ -12884,14 +6636,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_3-2"/>
-       <position name="posOpArapuca2-Lat-3" unit="cm" 
-         x="135.02"
-	 y="-744.26" 
-	 z="-1945.45"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_3-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca3-Lat-3" unit="cm" 
          x="60.02"
 	 y="-745" 
@@ -12899,14 +6644,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_3-3"/>
-       <position name="posOpArapuca3-Lat-3" unit="cm" 
-         x="60.02"
-	 y="-744.26" 
-	 z="-1945.45"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_3-4"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca4-Lat-3" unit="cm" 
          x="285.02"
 	 y="745" 
@@ -12914,14 +6652,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_3-4"/>
-       <position name="posOpArapuca4-Lat-3" unit="cm" 
-         x="285.02"
-	 y="744.26" 
-	 z="-1945.45"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_3-5"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca5-Lat-3" unit="cm" 
          x="210.02"
 	 y="745" 
@@ -12929,14 +6660,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_3-5"/>
-       <position name="posOpArapuca5-Lat-3" unit="cm" 
-         x="210.02"
-	 y="744.26" 
-	 z="-1945.45"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_3-6"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca6-Lat-3" unit="cm" 
          x="135.02"
 	 y="745" 
@@ -12944,14 +6668,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_3-6"/>
-       <position name="posOpArapuca6-Lat-3" unit="cm" 
-         x="135.02"
-	 y="744.26" 
-	 z="-1945.45"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_3-7"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca7-Lat-3" unit="cm" 
          x="60.02"
 	 y="745" 
@@ -12959,14 +6676,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_3-7"/>
-       <position name="posOpArapuca7-Lat-3" unit="cm" 
-         x="60.02"
-	 y="744.26" 
-	 z="-1945.45"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_4-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca0-Lat-4" unit="cm" 
          x="285.02"
 	 y="-745" 
@@ -12974,14 +6684,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_4-0"/>
-       <position name="posOpArapuca0-Lat-4" unit="cm" 
-         x="285.02"
-	 y="-744.26" 
-	 z="-1646.15"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_4-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca1-Lat-4" unit="cm" 
          x="210.02"
 	 y="-745" 
@@ -12989,14 +6692,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_4-1"/>
-       <position name="posOpArapuca1-Lat-4" unit="cm" 
-         x="210.02"
-	 y="-744.26" 
-	 z="-1646.15"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_4-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca2-Lat-4" unit="cm" 
          x="135.02"
 	 y="-745" 
@@ -13004,14 +6700,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_4-2"/>
-       <position name="posOpArapuca2-Lat-4" unit="cm" 
-         x="135.02"
-	 y="-744.26" 
-	 z="-1646.15"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_4-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca3-Lat-4" unit="cm" 
          x="60.02"
 	 y="-745" 
@@ -13019,14 +6708,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_4-3"/>
-       <position name="posOpArapuca3-Lat-4" unit="cm" 
-         x="60.02"
-	 y="-744.26" 
-	 z="-1646.15"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_4-4"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca4-Lat-4" unit="cm" 
          x="285.02"
 	 y="745" 
@@ -13034,14 +6716,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_4-4"/>
-       <position name="posOpArapuca4-Lat-4" unit="cm" 
-         x="285.02"
-	 y="744.26" 
-	 z="-1646.15"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_4-5"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca5-Lat-4" unit="cm" 
          x="210.02"
 	 y="745" 
@@ -13049,14 +6724,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_4-5"/>
-       <position name="posOpArapuca5-Lat-4" unit="cm" 
-         x="210.02"
-	 y="744.26" 
-	 z="-1646.15"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_4-6"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca6-Lat-4" unit="cm" 
          x="135.02"
 	 y="745" 
@@ -13064,14 +6732,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_4-6"/>
-       <position name="posOpArapuca6-Lat-4" unit="cm" 
-         x="135.02"
-	 y="744.26" 
-	 z="-1646.15"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_4-7"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca7-Lat-4" unit="cm" 
          x="60.02"
 	 y="745" 
@@ -13079,14 +6740,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_4-7"/>
-       <position name="posOpArapuca7-Lat-4" unit="cm" 
-         x="60.02"
-	 y="744.26" 
-	 z="-1646.15"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_5-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca0-Lat-5" unit="cm" 
          x="285.02"
 	 y="-745" 
@@ -13094,14 +6748,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_5-0"/>
-       <position name="posOpArapuca0-Lat-5" unit="cm" 
-         x="285.02"
-	 y="-744.26" 
-	 z="-1346.85"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_5-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca1-Lat-5" unit="cm" 
          x="210.02"
 	 y="-745" 
@@ -13109,14 +6756,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_5-1"/>
-       <position name="posOpArapuca1-Lat-5" unit="cm" 
-         x="210.02"
-	 y="-744.26" 
-	 z="-1346.85"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_5-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca2-Lat-5" unit="cm" 
          x="135.02"
 	 y="-745" 
@@ -13124,14 +6764,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_5-2"/>
-       <position name="posOpArapuca2-Lat-5" unit="cm" 
-         x="135.02"
-	 y="-744.26" 
-	 z="-1346.85"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_5-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca3-Lat-5" unit="cm" 
          x="60.02"
 	 y="-745" 
@@ -13139,14 +6772,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_5-3"/>
-       <position name="posOpArapuca3-Lat-5" unit="cm" 
-         x="60.02"
-	 y="-744.26" 
-	 z="-1346.85"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_5-4"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca4-Lat-5" unit="cm" 
          x="285.02"
 	 y="745" 
@@ -13154,14 +6780,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_5-4"/>
-       <position name="posOpArapuca4-Lat-5" unit="cm" 
-         x="285.02"
-	 y="744.26" 
-	 z="-1346.85"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_5-5"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca5-Lat-5" unit="cm" 
          x="210.02"
 	 y="745" 
@@ -13169,14 +6788,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_5-5"/>
-       <position name="posOpArapuca5-Lat-5" unit="cm" 
-         x="210.02"
-	 y="744.26" 
-	 z="-1346.85"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_5-6"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca6-Lat-5" unit="cm" 
          x="135.02"
 	 y="745" 
@@ -13184,14 +6796,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_5-6"/>
-       <position name="posOpArapuca6-Lat-5" unit="cm" 
-         x="135.02"
-	 y="744.26" 
-	 z="-1346.85"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_5-7"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca7-Lat-5" unit="cm" 
          x="60.02"
 	 y="745" 
@@ -13199,14 +6804,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_5-7"/>
-       <position name="posOpArapuca7-Lat-5" unit="cm" 
-         x="60.02"
-	 y="744.26" 
-	 z="-1346.85"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_6-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca0-Lat-6" unit="cm" 
          x="285.02"
 	 y="-745" 
@@ -13214,14 +6812,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_6-0"/>
-       <position name="posOpArapuca0-Lat-6" unit="cm" 
-         x="285.02"
-	 y="-744.26" 
-	 z="-1047.55"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_6-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca1-Lat-6" unit="cm" 
          x="210.02"
 	 y="-745" 
@@ -13229,14 +6820,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_6-1"/>
-       <position name="posOpArapuca1-Lat-6" unit="cm" 
-         x="210.02"
-	 y="-744.26" 
-	 z="-1047.55"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_6-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca2-Lat-6" unit="cm" 
          x="135.02"
 	 y="-745" 
@@ -13244,14 +6828,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_6-2"/>
-       <position name="posOpArapuca2-Lat-6" unit="cm" 
-         x="135.02"
-	 y="-744.26" 
-	 z="-1047.55"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_6-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca3-Lat-6" unit="cm" 
          x="60.02"
 	 y="-745" 
@@ -13259,14 +6836,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_6-3"/>
-       <position name="posOpArapuca3-Lat-6" unit="cm" 
-         x="60.02"
-	 y="-744.26" 
-	 z="-1047.55"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_6-4"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca4-Lat-6" unit="cm" 
          x="285.02"
 	 y="745" 
@@ -13274,14 +6844,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_6-4"/>
-       <position name="posOpArapuca4-Lat-6" unit="cm" 
-         x="285.02"
-	 y="744.26" 
-	 z="-1047.55"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_6-5"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca5-Lat-6" unit="cm" 
          x="210.02"
 	 y="745" 
@@ -13289,14 +6852,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_6-5"/>
-       <position name="posOpArapuca5-Lat-6" unit="cm" 
-         x="210.02"
-	 y="744.26" 
-	 z="-1047.55"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_6-6"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca6-Lat-6" unit="cm" 
          x="135.02"
 	 y="745" 
@@ -13304,14 +6860,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_6-6"/>
-       <position name="posOpArapuca6-Lat-6" unit="cm" 
-         x="135.02"
-	 y="744.26" 
-	 z="-1047.55"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_6-7"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca7-Lat-6" unit="cm" 
          x="60.02"
 	 y="745" 
@@ -13319,14 +6868,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_6-7"/>
-       <position name="posOpArapuca7-Lat-6" unit="cm" 
-         x="60.02"
-	 y="744.26" 
-	 z="-1047.55"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_7-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca0-Lat-7" unit="cm" 
          x="285.02"
 	 y="-745" 
@@ -13334,14 +6876,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_7-0"/>
-       <position name="posOpArapuca0-Lat-7" unit="cm" 
-         x="285.02"
-	 y="-744.26" 
-	 z="-748.25"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_7-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca1-Lat-7" unit="cm" 
          x="210.02"
 	 y="-745" 
@@ -13349,14 +6884,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_7-1"/>
-       <position name="posOpArapuca1-Lat-7" unit="cm" 
-         x="210.02"
-	 y="-744.26" 
-	 z="-748.25"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_7-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca2-Lat-7" unit="cm" 
          x="135.02"
 	 y="-745" 
@@ -13364,14 +6892,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_7-2"/>
-       <position name="posOpArapuca2-Lat-7" unit="cm" 
-         x="135.02"
-	 y="-744.26" 
-	 z="-748.25"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_7-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca3-Lat-7" unit="cm" 
          x="60.02"
 	 y="-745" 
@@ -13379,14 +6900,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_7-3"/>
-       <position name="posOpArapuca3-Lat-7" unit="cm" 
-         x="60.02"
-	 y="-744.26" 
-	 z="-748.25"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_7-4"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca4-Lat-7" unit="cm" 
          x="285.02"
 	 y="745" 
@@ -13394,14 +6908,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_7-4"/>
-       <position name="posOpArapuca4-Lat-7" unit="cm" 
-         x="285.02"
-	 y="744.26" 
-	 z="-748.25"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_7-5"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca5-Lat-7" unit="cm" 
          x="210.02"
 	 y="745" 
@@ -13409,14 +6916,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_7-5"/>
-       <position name="posOpArapuca5-Lat-7" unit="cm" 
-         x="210.02"
-	 y="744.26" 
-	 z="-748.25"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_7-6"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca6-Lat-7" unit="cm" 
          x="135.02"
 	 y="745" 
@@ -13424,14 +6924,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_7-6"/>
-       <position name="posOpArapuca6-Lat-7" unit="cm" 
-         x="135.02"
-	 y="744.26" 
-	 z="-748.25"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_7-7"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca7-Lat-7" unit="cm" 
          x="60.02"
 	 y="745" 
@@ -13439,14 +6932,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_7-7"/>
-       <position name="posOpArapuca7-Lat-7" unit="cm" 
-         x="60.02"
-	 y="744.26" 
-	 z="-748.25"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_8-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca0-Lat-8" unit="cm" 
          x="285.02"
 	 y="-745" 
@@ -13454,14 +6940,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_8-0"/>
-       <position name="posOpArapuca0-Lat-8" unit="cm" 
-         x="285.02"
-	 y="-744.26" 
-	 z="-448.95"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_8-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca1-Lat-8" unit="cm" 
          x="210.02"
 	 y="-745" 
@@ -13469,14 +6948,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_8-1"/>
-       <position name="posOpArapuca1-Lat-8" unit="cm" 
-         x="210.02"
-	 y="-744.26" 
-	 z="-448.95"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_8-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca2-Lat-8" unit="cm" 
          x="135.02"
 	 y="-745" 
@@ -13484,14 +6956,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_8-2"/>
-       <position name="posOpArapuca2-Lat-8" unit="cm" 
-         x="135.02"
-	 y="-744.26" 
-	 z="-448.95"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_8-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca3-Lat-8" unit="cm" 
          x="60.02"
 	 y="-745" 
@@ -13499,14 +6964,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_8-3"/>
-       <position name="posOpArapuca3-Lat-8" unit="cm" 
-         x="60.02"
-	 y="-744.26" 
-	 z="-448.95"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_8-4"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca4-Lat-8" unit="cm" 
          x="285.02"
 	 y="745" 
@@ -13514,14 +6972,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_8-4"/>
-       <position name="posOpArapuca4-Lat-8" unit="cm" 
-         x="285.02"
-	 y="744.26" 
-	 z="-448.95"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_8-5"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca5-Lat-8" unit="cm" 
          x="210.02"
 	 y="745" 
@@ -13529,14 +6980,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_8-5"/>
-       <position name="posOpArapuca5-Lat-8" unit="cm" 
-         x="210.02"
-	 y="744.26" 
-	 z="-448.95"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_8-6"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca6-Lat-8" unit="cm" 
          x="135.02"
 	 y="745" 
@@ -13544,14 +6988,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_8-6"/>
-       <position name="posOpArapuca6-Lat-8" unit="cm" 
-         x="135.02"
-	 y="744.26" 
-	 z="-448.95"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_8-7"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca7-Lat-8" unit="cm" 
          x="60.02"
 	 y="745" 
@@ -13559,14 +6996,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_8-7"/>
-       <position name="posOpArapuca7-Lat-8" unit="cm" 
-         x="60.02"
-	 y="744.26" 
-	 z="-448.95"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_9-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca0-Lat-9" unit="cm" 
          x="285.02"
 	 y="-745" 
@@ -13574,14 +7004,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_9-0"/>
-       <position name="posOpArapuca0-Lat-9" unit="cm" 
-         x="285.02"
-	 y="-744.26" 
-	 z="-149.65"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_9-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca1-Lat-9" unit="cm" 
          x="210.02"
 	 y="-745" 
@@ -13589,14 +7012,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_9-1"/>
-       <position name="posOpArapuca1-Lat-9" unit="cm" 
-         x="210.02"
-	 y="-744.26" 
-	 z="-149.65"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_9-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca2-Lat-9" unit="cm" 
          x="135.02"
 	 y="-745" 
@@ -13604,14 +7020,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_9-2"/>
-       <position name="posOpArapuca2-Lat-9" unit="cm" 
-         x="135.02"
-	 y="-744.26" 
-	 z="-149.65"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_9-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca3-Lat-9" unit="cm" 
          x="60.02"
 	 y="-745" 
@@ -13619,14 +7028,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_9-3"/>
-       <position name="posOpArapuca3-Lat-9" unit="cm" 
-         x="60.02"
-	 y="-744.26" 
-	 z="-149.65"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_9-4"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca4-Lat-9" unit="cm" 
          x="285.02"
 	 y="745" 
@@ -13634,14 +7036,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_9-4"/>
-       <position name="posOpArapuca4-Lat-9" unit="cm" 
-         x="285.02"
-	 y="744.26" 
-	 z="-149.65"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_9-5"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca5-Lat-9" unit="cm" 
          x="210.02"
 	 y="745" 
@@ -13649,14 +7044,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_9-5"/>
-       <position name="posOpArapuca5-Lat-9" unit="cm" 
-         x="210.02"
-	 y="744.26" 
-	 z="-149.65"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_9-6"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca6-Lat-9" unit="cm" 
          x="135.02"
 	 y="745" 
@@ -13664,14 +7052,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_9-6"/>
-       <position name="posOpArapuca6-Lat-9" unit="cm" 
-         x="135.02"
-	 y="744.26" 
-	 z="-149.65"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_9-7"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca7-Lat-9" unit="cm" 
          x="60.02"
 	 y="745" 
@@ -13679,14 +7060,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_9-7"/>
-       <position name="posOpArapuca7-Lat-9" unit="cm" 
-         x="60.02"
-	 y="744.26" 
-	 z="-149.65"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_10-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca0-Lat-10" unit="cm" 
          x="285.02"
 	 y="-745" 
@@ -13694,14 +7068,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_10-0"/>
-       <position name="posOpArapuca0-Lat-10" unit="cm" 
-         x="285.02"
-	 y="-744.26" 
-	 z="149.65"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_10-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca1-Lat-10" unit="cm" 
          x="210.02"
 	 y="-745" 
@@ -13709,14 +7076,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_10-1"/>
-       <position name="posOpArapuca1-Lat-10" unit="cm" 
-         x="210.02"
-	 y="-744.26" 
-	 z="149.65"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_10-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca2-Lat-10" unit="cm" 
          x="135.02"
 	 y="-745" 
@@ -13724,14 +7084,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_10-2"/>
-       <position name="posOpArapuca2-Lat-10" unit="cm" 
-         x="135.02"
-	 y="-744.26" 
-	 z="149.65"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_10-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca3-Lat-10" unit="cm" 
          x="60.02"
 	 y="-745" 
@@ -13739,14 +7092,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_10-3"/>
-       <position name="posOpArapuca3-Lat-10" unit="cm" 
-         x="60.02"
-	 y="-744.26" 
-	 z="149.65"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_10-4"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca4-Lat-10" unit="cm" 
          x="285.02"
 	 y="745" 
@@ -13754,14 +7100,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_10-4"/>
-       <position name="posOpArapuca4-Lat-10" unit="cm" 
-         x="285.02"
-	 y="744.26" 
-	 z="149.65"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_10-5"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca5-Lat-10" unit="cm" 
          x="210.02"
 	 y="745" 
@@ -13769,14 +7108,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_10-5"/>
-       <position name="posOpArapuca5-Lat-10" unit="cm" 
-         x="210.02"
-	 y="744.26" 
-	 z="149.65"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_10-6"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca6-Lat-10" unit="cm" 
          x="135.02"
 	 y="745" 
@@ -13784,14 +7116,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_10-6"/>
-       <position name="posOpArapuca6-Lat-10" unit="cm" 
-         x="135.02"
-	 y="744.26" 
-	 z="149.65"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_10-7"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca7-Lat-10" unit="cm" 
          x="60.02"
 	 y="745" 
@@ -13799,14 +7124,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_10-7"/>
-       <position name="posOpArapuca7-Lat-10" unit="cm" 
-         x="60.02"
-	 y="744.26" 
-	 z="149.65"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_11-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca0-Lat-11" unit="cm" 
          x="285.02"
 	 y="-745" 
@@ -13814,14 +7132,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_11-0"/>
-       <position name="posOpArapuca0-Lat-11" unit="cm" 
-         x="285.02"
-	 y="-744.26" 
-	 z="448.95"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_11-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca1-Lat-11" unit="cm" 
          x="210.02"
 	 y="-745" 
@@ -13829,14 +7140,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_11-1"/>
-       <position name="posOpArapuca1-Lat-11" unit="cm" 
-         x="210.02"
-	 y="-744.26" 
-	 z="448.95"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_11-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca2-Lat-11" unit="cm" 
          x="135.02"
 	 y="-745" 
@@ -13844,14 +7148,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_11-2"/>
-       <position name="posOpArapuca2-Lat-11" unit="cm" 
-         x="135.02"
-	 y="-744.26" 
-	 z="448.95"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_11-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca3-Lat-11" unit="cm" 
          x="60.02"
 	 y="-745" 
@@ -13859,14 +7156,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_11-3"/>
-       <position name="posOpArapuca3-Lat-11" unit="cm" 
-         x="60.02"
-	 y="-744.26" 
-	 z="448.95"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_11-4"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca4-Lat-11" unit="cm" 
          x="285.02"
 	 y="745" 
@@ -13874,14 +7164,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_11-4"/>
-       <position name="posOpArapuca4-Lat-11" unit="cm" 
-         x="285.02"
-	 y="744.26" 
-	 z="448.95"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_11-5"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca5-Lat-11" unit="cm" 
          x="210.02"
 	 y="745" 
@@ -13889,14 +7172,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_11-5"/>
-       <position name="posOpArapuca5-Lat-11" unit="cm" 
-         x="210.02"
-	 y="744.26" 
-	 z="448.95"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_11-6"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca6-Lat-11" unit="cm" 
          x="135.02"
 	 y="745" 
@@ -13904,14 +7180,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_11-6"/>
-       <position name="posOpArapuca6-Lat-11" unit="cm" 
-         x="135.02"
-	 y="744.26" 
-	 z="448.95"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_11-7"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca7-Lat-11" unit="cm" 
          x="60.02"
 	 y="745" 
@@ -13919,14 +7188,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_11-7"/>
-       <position name="posOpArapuca7-Lat-11" unit="cm" 
-         x="60.02"
-	 y="744.26" 
-	 z="448.95"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_12-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca0-Lat-12" unit="cm" 
          x="285.02"
 	 y="-745" 
@@ -13934,14 +7196,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_12-0"/>
-       <position name="posOpArapuca0-Lat-12" unit="cm" 
-         x="285.02"
-	 y="-744.26" 
-	 z="748.25"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_12-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca1-Lat-12" unit="cm" 
          x="210.02"
 	 y="-745" 
@@ -13949,14 +7204,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_12-1"/>
-       <position name="posOpArapuca1-Lat-12" unit="cm" 
-         x="210.02"
-	 y="-744.26" 
-	 z="748.25"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_12-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca2-Lat-12" unit="cm" 
          x="135.02"
 	 y="-745" 
@@ -13964,14 +7212,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_12-2"/>
-       <position name="posOpArapuca2-Lat-12" unit="cm" 
-         x="135.02"
-	 y="-744.26" 
-	 z="748.25"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_12-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca3-Lat-12" unit="cm" 
          x="60.02"
 	 y="-745" 
@@ -13979,14 +7220,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_12-3"/>
-       <position name="posOpArapuca3-Lat-12" unit="cm" 
-         x="60.02"
-	 y="-744.26" 
-	 z="748.25"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_12-4"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca4-Lat-12" unit="cm" 
          x="285.02"
 	 y="745" 
@@ -13994,14 +7228,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_12-4"/>
-       <position name="posOpArapuca4-Lat-12" unit="cm" 
-         x="285.02"
-	 y="744.26" 
-	 z="748.25"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_12-5"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca5-Lat-12" unit="cm" 
          x="210.02"
 	 y="745" 
@@ -14009,14 +7236,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_12-5"/>
-       <position name="posOpArapuca5-Lat-12" unit="cm" 
-         x="210.02"
-	 y="744.26" 
-	 z="748.25"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_12-6"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca6-Lat-12" unit="cm" 
          x="135.02"
 	 y="745" 
@@ -14024,14 +7244,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_12-6"/>
-       <position name="posOpArapuca6-Lat-12" unit="cm" 
-         x="135.02"
-	 y="744.26" 
-	 z="748.25"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_12-7"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca7-Lat-12" unit="cm" 
          x="60.02"
 	 y="745" 
@@ -14039,14 +7252,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_12-7"/>
-       <position name="posOpArapuca7-Lat-12" unit="cm" 
-         x="60.02"
-	 y="744.26" 
-	 z="748.25"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_13-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca0-Lat-13" unit="cm" 
          x="285.02"
 	 y="-745" 
@@ -14054,14 +7260,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_13-0"/>
-       <position name="posOpArapuca0-Lat-13" unit="cm" 
-         x="285.02"
-	 y="-744.26" 
-	 z="1047.55"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_13-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca1-Lat-13" unit="cm" 
          x="210.02"
 	 y="-745" 
@@ -14069,14 +7268,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_13-1"/>
-       <position name="posOpArapuca1-Lat-13" unit="cm" 
-         x="210.02"
-	 y="-744.26" 
-	 z="1047.55"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_13-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca2-Lat-13" unit="cm" 
          x="135.02"
 	 y="-745" 
@@ -14084,14 +7276,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_13-2"/>
-       <position name="posOpArapuca2-Lat-13" unit="cm" 
-         x="135.02"
-	 y="-744.26" 
-	 z="1047.55"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_13-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca3-Lat-13" unit="cm" 
          x="60.02"
 	 y="-745" 
@@ -14099,14 +7284,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_13-3"/>
-       <position name="posOpArapuca3-Lat-13" unit="cm" 
-         x="60.02"
-	 y="-744.26" 
-	 z="1047.55"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_13-4"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca4-Lat-13" unit="cm" 
          x="285.02"
 	 y="745" 
@@ -14114,14 +7292,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_13-4"/>
-       <position name="posOpArapuca4-Lat-13" unit="cm" 
-         x="285.02"
-	 y="744.26" 
-	 z="1047.55"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_13-5"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca5-Lat-13" unit="cm" 
          x="210.02"
 	 y="745" 
@@ -14129,14 +7300,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_13-5"/>
-       <position name="posOpArapuca5-Lat-13" unit="cm" 
-         x="210.02"
-	 y="744.26" 
-	 z="1047.55"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_13-6"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca6-Lat-13" unit="cm" 
          x="135.02"
 	 y="745" 
@@ -14144,14 +7308,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_13-6"/>
-       <position name="posOpArapuca6-Lat-13" unit="cm" 
-         x="135.02"
-	 y="744.26" 
-	 z="1047.55"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_13-7"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca7-Lat-13" unit="cm" 
          x="60.02"
 	 y="745" 
@@ -14159,14 +7316,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_13-7"/>
-       <position name="posOpArapuca7-Lat-13" unit="cm" 
-         x="60.02"
-	 y="744.26" 
-	 z="1047.55"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_14-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca0-Lat-14" unit="cm" 
          x="285.02"
 	 y="-745" 
@@ -14174,14 +7324,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_14-0"/>
-       <position name="posOpArapuca0-Lat-14" unit="cm" 
-         x="285.02"
-	 y="-744.26" 
-	 z="1346.85"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_14-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca1-Lat-14" unit="cm" 
          x="210.02"
 	 y="-745" 
@@ -14189,14 +7332,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_14-1"/>
-       <position name="posOpArapuca1-Lat-14" unit="cm" 
-         x="210.02"
-	 y="-744.26" 
-	 z="1346.85"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_14-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca2-Lat-14" unit="cm" 
          x="135.02"
 	 y="-745" 
@@ -14204,14 +7340,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_14-2"/>
-       <position name="posOpArapuca2-Lat-14" unit="cm" 
-         x="135.02"
-	 y="-744.26" 
-	 z="1346.85"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_14-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca3-Lat-14" unit="cm" 
          x="60.02"
 	 y="-745" 
@@ -14219,14 +7348,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_14-3"/>
-       <position name="posOpArapuca3-Lat-14" unit="cm" 
-         x="60.02"
-	 y="-744.26" 
-	 z="1346.85"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_14-4"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca4-Lat-14" unit="cm" 
          x="285.02"
 	 y="745" 
@@ -14234,14 +7356,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_14-4"/>
-       <position name="posOpArapuca4-Lat-14" unit="cm" 
-         x="285.02"
-	 y="744.26" 
-	 z="1346.85"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_14-5"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca5-Lat-14" unit="cm" 
          x="210.02"
 	 y="745" 
@@ -14249,14 +7364,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_14-5"/>
-       <position name="posOpArapuca5-Lat-14" unit="cm" 
-         x="210.02"
-	 y="744.26" 
-	 z="1346.85"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_14-6"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca6-Lat-14" unit="cm" 
          x="135.02"
 	 y="745" 
@@ -14264,14 +7372,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_14-6"/>
-       <position name="posOpArapuca6-Lat-14" unit="cm" 
-         x="135.02"
-	 y="744.26" 
-	 z="1346.85"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_14-7"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca7-Lat-14" unit="cm" 
          x="60.02"
 	 y="745" 
@@ -14279,14 +7380,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_14-7"/>
-       <position name="posOpArapuca7-Lat-14" unit="cm" 
-         x="60.02"
-	 y="744.26" 
-	 z="1346.85"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_15-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca0-Lat-15" unit="cm" 
          x="285.02"
 	 y="-745" 
@@ -14294,14 +7388,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_15-0"/>
-       <position name="posOpArapuca0-Lat-15" unit="cm" 
-         x="285.02"
-	 y="-744.26" 
-	 z="1646.15"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_15-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca1-Lat-15" unit="cm" 
          x="210.02"
 	 y="-745" 
@@ -14309,14 +7396,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_15-1"/>
-       <position name="posOpArapuca1-Lat-15" unit="cm" 
-         x="210.02"
-	 y="-744.26" 
-	 z="1646.15"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_15-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca2-Lat-15" unit="cm" 
          x="135.02"
 	 y="-745" 
@@ -14324,14 +7404,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_15-2"/>
-       <position name="posOpArapuca2-Lat-15" unit="cm" 
-         x="135.02"
-	 y="-744.26" 
-	 z="1646.15"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_15-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca3-Lat-15" unit="cm" 
          x="60.02"
 	 y="-745" 
@@ -14339,14 +7412,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_15-3"/>
-       <position name="posOpArapuca3-Lat-15" unit="cm" 
-         x="60.02"
-	 y="-744.26" 
-	 z="1646.15"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_15-4"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca4-Lat-15" unit="cm" 
          x="285.02"
 	 y="745" 
@@ -14354,14 +7420,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_15-4"/>
-       <position name="posOpArapuca4-Lat-15" unit="cm" 
-         x="285.02"
-	 y="744.26" 
-	 z="1646.15"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_15-5"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca5-Lat-15" unit="cm" 
          x="210.02"
 	 y="745" 
@@ -14369,14 +7428,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_15-5"/>
-       <position name="posOpArapuca5-Lat-15" unit="cm" 
-         x="210.02"
-	 y="744.26" 
-	 z="1646.15"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_15-6"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca6-Lat-15" unit="cm" 
          x="135.02"
 	 y="745" 
@@ -14384,14 +7436,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_15-6"/>
-       <position name="posOpArapuca6-Lat-15" unit="cm" 
-         x="135.02"
-	 y="744.26" 
-	 z="1646.15"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_15-7"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca7-Lat-15" unit="cm" 
          x="60.02"
 	 y="745" 
@@ -14399,14 +7444,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_15-7"/>
-       <position name="posOpArapuca7-Lat-15" unit="cm" 
-         x="60.02"
-	 y="744.26" 
-	 z="1646.15"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_16-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca0-Lat-16" unit="cm" 
          x="285.02"
 	 y="-745" 
@@ -14414,14 +7452,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_16-0"/>
-       <position name="posOpArapuca0-Lat-16" unit="cm" 
-         x="285.02"
-	 y="-744.26" 
-	 z="1945.45"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_16-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca1-Lat-16" unit="cm" 
          x="210.02"
 	 y="-745" 
@@ -14429,14 +7460,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_16-1"/>
-       <position name="posOpArapuca1-Lat-16" unit="cm" 
-         x="210.02"
-	 y="-744.26" 
-	 z="1945.45"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_16-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca2-Lat-16" unit="cm" 
          x="135.02"
 	 y="-745" 
@@ -14444,14 +7468,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_16-2"/>
-       <position name="posOpArapuca2-Lat-16" unit="cm" 
-         x="135.02"
-	 y="-744.26" 
-	 z="1945.45"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_16-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca3-Lat-16" unit="cm" 
          x="60.02"
 	 y="-745" 
@@ -14459,14 +7476,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_16-3"/>
-       <position name="posOpArapuca3-Lat-16" unit="cm" 
-         x="60.02"
-	 y="-744.26" 
-	 z="1945.45"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_16-4"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca4-Lat-16" unit="cm" 
          x="285.02"
 	 y="745" 
@@ -14474,14 +7484,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_16-4"/>
-       <position name="posOpArapuca4-Lat-16" unit="cm" 
-         x="285.02"
-	 y="744.26" 
-	 z="1945.45"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_16-5"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca5-Lat-16" unit="cm" 
          x="210.02"
 	 y="745" 
@@ -14489,14 +7492,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_16-5"/>
-       <position name="posOpArapuca5-Lat-16" unit="cm" 
-         x="210.02"
-	 y="744.26" 
-	 z="1945.45"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_16-6"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca6-Lat-16" unit="cm" 
          x="135.02"
 	 y="745" 
@@ -14504,14 +7500,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_16-6"/>
-       <position name="posOpArapuca6-Lat-16" unit="cm" 
-         x="135.02"
-	 y="744.26" 
-	 z="1945.45"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_16-7"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca7-Lat-16" unit="cm" 
          x="60.02"
 	 y="745" 
@@ -14519,14 +7508,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_16-7"/>
-       <position name="posOpArapuca7-Lat-16" unit="cm" 
-         x="60.02"
-	 y="744.26" 
-	 z="1945.45"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_17-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca0-Lat-17" unit="cm" 
          x="285.02"
 	 y="-745" 
@@ -14534,14 +7516,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_17-0"/>
-       <position name="posOpArapuca0-Lat-17" unit="cm" 
-         x="285.02"
-	 y="-744.26" 
-	 z="2244.75"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_17-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca1-Lat-17" unit="cm" 
          x="210.02"
 	 y="-745" 
@@ -14549,14 +7524,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_17-1"/>
-       <position name="posOpArapuca1-Lat-17" unit="cm" 
-         x="210.02"
-	 y="-744.26" 
-	 z="2244.75"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_17-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca2-Lat-17" unit="cm" 
          x="135.02"
 	 y="-745" 
@@ -14564,14 +7532,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_17-2"/>
-       <position name="posOpArapuca2-Lat-17" unit="cm" 
-         x="135.02"
-	 y="-744.26" 
-	 z="2244.75"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_17-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca3-Lat-17" unit="cm" 
          x="60.02"
 	 y="-745" 
@@ -14579,14 +7540,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_17-3"/>
-       <position name="posOpArapuca3-Lat-17" unit="cm" 
-         x="60.02"
-	 y="-744.26" 
-	 z="2244.75"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_17-4"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca4-Lat-17" unit="cm" 
          x="285.02"
 	 y="745" 
@@ -14594,14 +7548,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_17-4"/>
-       <position name="posOpArapuca4-Lat-17" unit="cm" 
-         x="285.02"
-	 y="744.26" 
-	 z="2244.75"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_17-5"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca5-Lat-17" unit="cm" 
          x="210.02"
 	 y="745" 
@@ -14609,14 +7556,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_17-5"/>
-       <position name="posOpArapuca5-Lat-17" unit="cm" 
-         x="210.02"
-	 y="744.26" 
-	 z="2244.75"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_17-6"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca6-Lat-17" unit="cm" 
          x="135.02"
 	 y="745" 
@@ -14624,14 +7564,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_17-6"/>
-       <position name="posOpArapuca6-Lat-17" unit="cm" 
-         x="135.02"
-	 y="744.26" 
-	 z="2244.75"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_17-7"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca7-Lat-17" unit="cm" 
          x="60.02"
 	 y="745" 
@@ -14639,14 +7572,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_17-7"/>
-       <position name="posOpArapuca7-Lat-17" unit="cm" 
-         x="60.02"
-	 y="744.26" 
-	 z="2244.75"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_18-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca0-Lat-18" unit="cm" 
          x="285.02"
 	 y="-745" 
@@ -14654,14 +7580,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_18-0"/>
-       <position name="posOpArapuca0-Lat-18" unit="cm" 
-         x="285.02"
-	 y="-744.26" 
-	 z="2544.05"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_18-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca1-Lat-18" unit="cm" 
          x="210.02"
 	 y="-745" 
@@ -14669,14 +7588,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_18-1"/>
-       <position name="posOpArapuca1-Lat-18" unit="cm" 
-         x="210.02"
-	 y="-744.26" 
-	 z="2544.05"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_18-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca2-Lat-18" unit="cm" 
          x="135.02"
 	 y="-745" 
@@ -14684,14 +7596,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_18-2"/>
-       <position name="posOpArapuca2-Lat-18" unit="cm" 
-         x="135.02"
-	 y="-744.26" 
-	 z="2544.05"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_18-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca3-Lat-18" unit="cm" 
          x="60.02"
 	 y="-745" 
@@ -14699,14 +7604,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_18-3"/>
-       <position name="posOpArapuca3-Lat-18" unit="cm" 
-         x="60.02"
-	 y="-744.26" 
-	 z="2544.05"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_18-4"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca4-Lat-18" unit="cm" 
          x="285.02"
 	 y="745" 
@@ -14714,14 +7612,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_18-4"/>
-       <position name="posOpArapuca4-Lat-18" unit="cm" 
-         x="285.02"
-	 y="744.26" 
-	 z="2544.05"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_18-5"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca5-Lat-18" unit="cm" 
          x="210.02"
 	 y="745" 
@@ -14729,14 +7620,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_18-5"/>
-       <position name="posOpArapuca5-Lat-18" unit="cm" 
-         x="210.02"
-	 y="744.26" 
-	 z="2544.05"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_18-6"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca6-Lat-18" unit="cm" 
          x="135.02"
 	 y="745" 
@@ -14744,14 +7628,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_18-6"/>
-       <position name="posOpArapuca6-Lat-18" unit="cm" 
-         x="135.02"
-	 y="744.26" 
-	 z="2544.05"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_18-7"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca7-Lat-18" unit="cm" 
          x="60.02"
 	 y="745" 
@@ -14759,14 +7636,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_18-7"/>
-       <position name="posOpArapuca7-Lat-18" unit="cm" 
-         x="60.02"
-	 y="744.26" 
-	 z="2544.05"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_19-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca0-Lat-19" unit="cm" 
          x="285.02"
 	 y="-745" 
@@ -14774,14 +7644,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_19-0"/>
-       <position name="posOpArapuca0-Lat-19" unit="cm" 
-         x="285.02"
-	 y="-744.26" 
-	 z="2843.35"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_19-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca1-Lat-19" unit="cm" 
          x="210.02"
 	 y="-745" 
@@ -14789,14 +7652,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_19-1"/>
-       <position name="posOpArapuca1-Lat-19" unit="cm" 
-         x="210.02"
-	 y="-744.26" 
-	 z="2843.35"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_19-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca2-Lat-19" unit="cm" 
          x="135.02"
 	 y="-745" 
@@ -14804,14 +7660,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_19-2"/>
-       <position name="posOpArapuca2-Lat-19" unit="cm" 
-         x="135.02"
-	 y="-744.26" 
-	 z="2843.35"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_19-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca3-Lat-19" unit="cm" 
          x="60.02"
 	 y="-745" 
@@ -14819,14 +7668,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_19-3"/>
-       <position name="posOpArapuca3-Lat-19" unit="cm" 
-         x="60.02"
-	 y="-744.26" 
-	 z="2843.35"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_19-4"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca4-Lat-19" unit="cm" 
          x="285.02"
 	 y="745" 
@@ -14834,14 +7676,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_19-4"/>
-       <position name="posOpArapuca4-Lat-19" unit="cm" 
-         x="285.02"
-	 y="744.26" 
-	 z="2843.35"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_19-5"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca5-Lat-19" unit="cm" 
          x="210.02"
 	 y="745" 
@@ -14849,14 +7684,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_19-5"/>
-       <position name="posOpArapuca5-Lat-19" unit="cm" 
-         x="210.02"
-	 y="744.26" 
-	 z="2843.35"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_19-6"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca6-Lat-19" unit="cm" 
          x="135.02"
 	 y="745" 
@@ -14864,14 +7692,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_19-6"/>
-       <position name="posOpArapuca6-Lat-19" unit="cm" 
-         x="135.02"
-	 y="744.26" 
-	 z="2843.35"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_19-7"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca7-Lat-19" unit="cm" 
          x="60.02"
 	 y="745" 
@@ -14879,15 +7700,8 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_19-7"/>
-       <position name="posOpArapuca7-Lat-19" unit="cm" 
-         x="60.02"
-	 y="744.26" 
-	 z="2843.35"/>
-     </physvol>
-     <physvol>
        <volumeref ref="volArapuca"/>
-       <position name="posArapuca0-ShortLat-19" unit="cm" 
+       <position name="posArapuca0-ShortLat-220" unit="cm" 
          x="285.02"
 	 y="-220" 
 	 z="-3090"/>
@@ -14895,7 +7709,7 @@
      </physvol>
      <physvol>
        <volumeref ref="volArapuca"/>
-       <position name="posArapuca1-ShortLat-19" unit="cm" 
+       <position name="posArapuca1-ShortLat-220" unit="cm" 
          x="210.02"
 	 y="-220" 
 	 z="-3090"/>
@@ -14903,7 +7717,7 @@
      </physvol>
      <physvol>
        <volumeref ref="volArapuca"/>
-       <position name="posArapuca2-ShortLat-19" unit="cm" 
+       <position name="posArapuca2-ShortLat-220" unit="cm" 
          x="135.02"
 	 y="-220" 
 	 z="-3090"/>
@@ -14911,7 +7725,7 @@
      </physvol>
      <physvol>
        <volumeref ref="volArapuca"/>
-       <position name="posArapuca3-ShortLat-19" unit="cm" 
+       <position name="posArapuca3-ShortLat-220" unit="cm" 
          x="60.02"
 	 y="-220" 
 	 z="-3090"/>
@@ -14919,7 +7733,7 @@
      </physvol>
      <physvol>
        <volumeref ref="volArapuca"/>
-       <position name="posArapuca4-ShortLat-19" unit="cm" 
+       <position name="posArapuca4-ShortLat-220" unit="cm" 
          x="285.02"
 	 y="-220" 
 	 z="3090"/>
@@ -14927,7 +7741,7 @@
      </physvol>
      <physvol>
        <volumeref ref="volArapuca"/>
-       <position name="posArapuca5-ShortLat-19" unit="cm" 
+       <position name="posArapuca5-ShortLat-220" unit="cm" 
          x="210.02"
 	 y="-220" 
 	 z="3090"/>
@@ -14935,7 +7749,7 @@
      </physvol>
      <physvol>
        <volumeref ref="volArapuca"/>
-       <position name="posArapuca6-ShortLat-19" unit="cm" 
+       <position name="posArapuca6-ShortLat-220" unit="cm" 
          x="135.02"
 	 y="-220" 
 	 z="3090"/>
@@ -14943,7 +7757,7 @@
      </physvol>
      <physvol>
        <volumeref ref="volArapuca"/>
-       <position name="posArapuca7-ShortLat-19" unit="cm" 
+       <position name="posArapuca7-ShortLat-220" unit="cm" 
          x="60.02"
 	 y="-220" 
 	 z="3090"/>
@@ -14951,7 +7765,7 @@
      </physvol>
      <physvol>
        <volumeref ref="volArapuca"/>
-       <position name="posArapuca0-ShortLat-19" unit="cm" 
+       <position name="posArapuca0-ShortLat220" unit="cm" 
          x="285.02"
 	 y="220" 
 	 z="-3090"/>
@@ -14959,7 +7773,7 @@
      </physvol>
      <physvol>
        <volumeref ref="volArapuca"/>
-       <position name="posArapuca1-ShortLat-19" unit="cm" 
+       <position name="posArapuca1-ShortLat220" unit="cm" 
          x="210.02"
 	 y="220" 
 	 z="-3090"/>
@@ -14967,7 +7781,7 @@
      </physvol>
      <physvol>
        <volumeref ref="volArapuca"/>
-       <position name="posArapuca2-ShortLat-19" unit="cm" 
+       <position name="posArapuca2-ShortLat220" unit="cm" 
          x="135.02"
 	 y="220" 
 	 z="-3090"/>
@@ -14975,7 +7789,7 @@
      </physvol>
      <physvol>
        <volumeref ref="volArapuca"/>
-       <position name="posArapuca3-ShortLat-19" unit="cm" 
+       <position name="posArapuca3-ShortLat220" unit="cm" 
          x="60.02"
 	 y="220" 
 	 z="-3090"/>
@@ -14983,7 +7797,7 @@
      </physvol>
      <physvol>
        <volumeref ref="volArapuca"/>
-       <position name="posArapuca4-ShortLat-19" unit="cm" 
+       <position name="posArapuca4-ShortLat220" unit="cm" 
          x="285.02"
 	 y="220" 
 	 z="3090"/>
@@ -14991,7 +7805,7 @@
      </physvol>
      <physvol>
        <volumeref ref="volArapuca"/>
-       <position name="posArapuca5-ShortLat-19" unit="cm" 
+       <position name="posArapuca5-ShortLat220" unit="cm" 
          x="210.02"
 	 y="220" 
 	 z="3090"/>
@@ -14999,7 +7813,7 @@
      </physvol>
      <physvol>
        <volumeref ref="volArapuca"/>
-       <position name="posArapuca6-ShortLat-19" unit="cm" 
+       <position name="posArapuca6-ShortLat220" unit="cm" 
          x="135.02"
 	 y="220" 
 	 z="3090"/>
@@ -15007,7 +7821,7 @@
      </physvol>
      <physvol>
        <volumeref ref="volArapuca"/>
-       <position name="posArapuca7-ShortLat-19" unit="cm" 
+       <position name="posArapuca7-ShortLat220" unit="cm" 
          x="60.02"
 	 y="220" 
 	 z="3090"/>

--- a/dunecore/Geometry/gdml/dunevd10kt_3view_30deg_v5_refactored_1x8x6ref.gdml
+++ b/dunecore/Geometry/gdml/dunevd10kt_3view_30deg_v5_refactored_1x8x6ref.gdml
@@ -397,6 +397,24 @@
      <tube name="FieldShaperLongtube" rmin="0.5" rmax="2.285" z="897.9" deltaphi="360" startphi="0" aunit="deg" lunit="cm"/>
      <tube name="FieldShaperLongtubeSlim" rmin="0.5" rmax="0.75" z="897.9" deltaphi="360" startphi="0" aunit="deg" lunit="cm"/>
      <tube name="FieldShaperShorttube" rmin="0.5" rmax="2.285" z="1348" deltaphi="360" startphi="0" aunit="deg" lunit="cm"/>
+     <tube name="FieldShaperShorttubeWindowSlim" rmin="0.5" rmax="0.75" z="670" deltaphi="360" startphi="0" aunit="deg" lunit="cm"/>
+     <tube name="FieldShaperShorttubeWindowNotSlim" rmin="0.5" rmax="2.285" z="339" deltaphi="360" startphi="0" aunit="deg" lunit="cm"/>
+
+
+    <union name="FSunionWindow1">
+      <first ref="FieldShaperShorttubeWindowSlim"/>
+      <second ref="FieldShaperShorttubeWindowNotSlim"/>
+      <position name="posFieldShaperShortTube_shift1" unit="cm" x="0" y="0" z="504.5"/>
+    </union>
+
+    <union name="FieldShaperShorttubeSlim">
+      <first ref="FSunionWindow1"/>
+      <second ref="FieldShaperShorttubeWindowNotSlim"/>
+      <position name="posFieldShaperShortTube_shift2" unit="cm" x="0" y="0" z="-504.5"/>
+    </union>
+
+
+
 
     <union name="FSunion1">
       <first ref="FieldShaperLongtube"/>
@@ -455,7 +473,7 @@
 
     <union name="FSunionSlim2">
       <first ref="FSunionSlim1"/>
-      <second ref="FieldShaperShorttube"/>
+      <second ref="FieldShaperShorttubeSlim"/>
    		<position name="esquinapos9" unit="cm" x="-676.3" y="0" z="451.25"/>
    		<rotationref ref="rPlus90AboutY"/>
     </union>
@@ -482,7 +500,7 @@
 
     <union name="FSunionSlim6">
       <first ref="FSunionSlim5"/>
-      <second ref="FieldShaperShorttube"/>
+      <second ref="FieldShaperShorttubeSlim"/>
    		<position name="esquinapos12" unit="cm" x="-676.3" y="0" z="-451.25"/>
 		<rotationref ref="rPlus90AboutY"/>
     </union>
@@ -38906,10 +38924,6 @@
       <colorref ref="green"/>
     </volume>
 
-    <volume name="volArapucaShortLat">
-      <materialref ref="G10"/>
-      <solidref ref="ArapucaWalls"/>
-    </volume>
     <volume name="volOpDetSensitive">
       <materialref ref="LAr"/>
       <solidref ref="ArapucaAcceptanceWindow"/>
@@ -38933,582 +38947,6 @@
       </physvol>
     </volume>
 
-    <volume name="volArapucaDouble_0-0-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-0-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-0-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-0-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-0-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-0-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-0-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-0-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-1-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-1-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-1-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-1-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-1-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-1-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-1-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-1-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-2-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-2-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-2-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-2-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-2-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-2-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-2-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-2-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-0-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-0-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-0-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-0-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-0-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-0-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-0-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-0-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-1-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-1-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-1-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-1-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-1-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-1-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-1-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-1-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-2-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-2-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-2-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-2-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-2-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-2-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-2-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-2-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-0-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-0-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-0-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-0-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-0-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-0-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-0-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-0-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-1-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-1-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-1-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-1-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-1-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-1-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-1-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-1-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-2-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-2-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-2-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-2-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-2-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-2-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-2-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-2-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-0-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-0-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-0-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-0-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-0-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-0-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-0-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-0-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-1-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-1-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-1-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-1-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-1-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-1-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-1-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-1-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-2-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-2-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-2-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-2-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-2-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-2-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-2-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-2-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_0-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_0-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_0-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_0-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_0-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_0-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_0-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_0-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_0-4">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_0-4">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_0-5">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_0-5">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_0-6">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_0-6">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_0-7">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_0-7">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_1-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_1-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_1-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_1-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_1-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_1-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_1-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_1-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_1-4">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_1-4">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_1-5">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_1-5">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_1-6">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_1-6">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_1-7">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_1-7">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_2-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_2-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_2-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_2-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_2-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_2-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_2-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_2-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_2-4">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_2-4">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_2-5">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_2-5">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_2-6">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_2-6">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_2-7">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_2-7">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
 
     <volume name="volCryostat">
       <materialref ref="LAr" />
@@ -40414,7 +39852,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>    
      <physvol>
-       <volumeref ref="volArapucaDouble_0-0-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-0-0" unit="cm" 
          x="-328.03"
 	 y="-633.2" 
@@ -40422,14 +39860,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-0"/>
-       <position name="posOpArapucaDouble0-Frame-0-0" unit="cm" 
-         x="-327.29"
-	 y="-633.2" 
-	 z="-261.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-0-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-0-0" unit="cm" 
          x="-328.03"
 	 y="-542.5" 
@@ -40437,14 +39868,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-1"/>
-       <position name="posOpArapucaDouble1-Frame-0-0" unit="cm" 
-         x="-327.29"
-	 y="-542.5" 
-	 z="-407.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-0-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-0-0" unit="cm" 
          x="-328.03"
 	 y="-468.5" 
@@ -40452,14 +39876,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-2"/>
-       <position name="posOpArapucaDouble2-Frame-0-0" unit="cm" 
-         x="-327.29"
-	 y="-468.5" 
-	 z="-190.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-0-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-0-0" unit="cm" 
          x="-328.03"
 	 y="-377.8" 
@@ -40467,14 +39884,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-3"/>
-       <position name="posOpArapucaDouble3-Frame-0-0" unit="cm" 
-         x="-327.29"
-	 y="-377.8" 
-	 z="-336.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-1-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-0-1" unit="cm" 
          x="-328.03"
 	 y="-633.2" 
@@ -40482,14 +39892,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-0"/>
-       <position name="posOpArapucaDouble0-Frame-0-1" unit="cm" 
-         x="-327.29"
-	 y="-633.2" 
-	 z="37.4999999999999"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-1-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-0-1" unit="cm" 
          x="-328.03"
 	 y="-542.5" 
@@ -40497,14 +39900,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-1"/>
-       <position name="posOpArapucaDouble1-Frame-0-1" unit="cm" 
-         x="-327.29"
-	 y="-542.5" 
-	 z="-108.5"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-1-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-0-1" unit="cm" 
          x="-328.03"
 	 y="-468.5" 
@@ -40512,14 +39908,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-2"/>
-       <position name="posOpArapucaDouble2-Frame-0-1" unit="cm" 
-         x="-327.29"
-	 y="-468.5" 
-	 z="108.5"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-1-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-0-1" unit="cm" 
          x="-328.03"
 	 y="-377.8" 
@@ -40527,14 +39916,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-3"/>
-       <position name="posOpArapucaDouble3-Frame-0-1" unit="cm" 
-         x="-327.29"
-	 y="-377.8" 
-	 z="-37.5000000000001"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-2-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-0-2" unit="cm" 
          x="-328.03"
 	 y="-633.2" 
@@ -40542,14 +39924,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-0"/>
-       <position name="posOpArapucaDouble0-Frame-0-2" unit="cm" 
-         x="-327.29"
-	 y="-633.2" 
-	 z="336.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-2-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-0-2" unit="cm" 
          x="-328.03"
 	 y="-542.5" 
@@ -40557,14 +39932,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-1"/>
-       <position name="posOpArapucaDouble1-Frame-0-2" unit="cm" 
-         x="-327.29"
-	 y="-542.5" 
-	 z="190.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-2-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-0-2" unit="cm" 
          x="-328.03"
 	 y="-468.5" 
@@ -40572,14 +39940,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-2"/>
-       <position name="posOpArapucaDouble2-Frame-0-2" unit="cm" 
-         x="-327.29"
-	 y="-468.5" 
-	 z="407.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-2-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-0-2" unit="cm" 
          x="-328.03"
 	 y="-377.8" 
@@ -40587,14 +39948,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-3"/>
-       <position name="posOpArapucaDouble3-Frame-0-2" unit="cm" 
-         x="-327.29"
-	 y="-377.8" 
-	 z="261.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-0-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-1-0" unit="cm" 
          x="-328.03"
 	 y="-296.2" 
@@ -40602,14 +39956,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-0"/>
-       <position name="posOpArapucaDouble0-Frame-1-0" unit="cm" 
-         x="-327.29"
-	 y="-296.2" 
-	 z="-261.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-0-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-1-0" unit="cm" 
          x="-328.03"
 	 y="-205.5" 
@@ -40617,14 +39964,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-1"/>
-       <position name="posOpArapucaDouble1-Frame-1-0" unit="cm" 
-         x="-327.29"
-	 y="-205.5" 
-	 z="-407.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-0-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-1-0" unit="cm" 
          x="-328.03"
 	 y="-131.5" 
@@ -40632,14 +39972,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-2"/>
-       <position name="posOpArapucaDouble2-Frame-1-0" unit="cm" 
-         x="-327.29"
-	 y="-131.5" 
-	 z="-190.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-0-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-1-0" unit="cm" 
          x="-328.03"
 	 y="-40.8" 
@@ -40647,14 +39980,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-3"/>
-       <position name="posOpArapucaDouble3-Frame-1-0" unit="cm" 
-         x="-327.29"
-	 y="-40.8" 
-	 z="-336.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-1-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-1-1" unit="cm" 
          x="-328.03"
 	 y="-296.2" 
@@ -40662,14 +39988,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-0"/>
-       <position name="posOpArapucaDouble0-Frame-1-1" unit="cm" 
-         x="-327.29"
-	 y="-296.2" 
-	 z="37.4999999999999"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-1-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-1-1" unit="cm" 
          x="-328.03"
 	 y="-205.5" 
@@ -40677,14 +39996,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-1"/>
-       <position name="posOpArapucaDouble1-Frame-1-1" unit="cm" 
-         x="-327.29"
-	 y="-205.5" 
-	 z="-108.5"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-1-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-1-1" unit="cm" 
          x="-328.03"
 	 y="-131.5" 
@@ -40692,14 +40004,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-2"/>
-       <position name="posOpArapucaDouble2-Frame-1-1" unit="cm" 
-         x="-327.29"
-	 y="-131.5" 
-	 z="108.5"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-1-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-1-1" unit="cm" 
          x="-328.03"
 	 y="-40.8" 
@@ -40707,14 +40012,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-3"/>
-       <position name="posOpArapucaDouble3-Frame-1-1" unit="cm" 
-         x="-327.29"
-	 y="-40.8" 
-	 z="-37.5000000000001"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-2-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-1-2" unit="cm" 
          x="-328.03"
 	 y="-296.2" 
@@ -40722,14 +40020,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-0"/>
-       <position name="posOpArapucaDouble0-Frame-1-2" unit="cm" 
-         x="-327.29"
-	 y="-296.2" 
-	 z="336.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-2-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-1-2" unit="cm" 
          x="-328.03"
 	 y="-205.5" 
@@ -40737,14 +40028,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-1"/>
-       <position name="posOpArapucaDouble1-Frame-1-2" unit="cm" 
-         x="-327.29"
-	 y="-205.5" 
-	 z="190.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-2-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-1-2" unit="cm" 
          x="-328.03"
 	 y="-131.5" 
@@ -40752,14 +40036,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-2"/>
-       <position name="posOpArapucaDouble2-Frame-1-2" unit="cm" 
-         x="-327.29"
-	 y="-131.5" 
-	 z="407.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-2-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-1-2" unit="cm" 
          x="-328.03"
 	 y="-40.8" 
@@ -40767,14 +40044,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-3"/>
-       <position name="posOpArapucaDouble3-Frame-1-2" unit="cm" 
-         x="-327.29"
-	 y="-40.8" 
-	 z="261.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-0-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-2-0" unit="cm" 
          x="-328.03"
 	 y="40.8" 
@@ -40782,14 +40052,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-0"/>
-       <position name="posOpArapucaDouble0-Frame-2-0" unit="cm" 
-         x="-327.29"
-	 y="40.8" 
-	 z="-261.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-0-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-2-0" unit="cm" 
          x="-328.03"
 	 y="131.5" 
@@ -40797,14 +40060,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-1"/>
-       <position name="posOpArapucaDouble1-Frame-2-0" unit="cm" 
-         x="-327.29"
-	 y="131.5" 
-	 z="-407.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-0-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-2-0" unit="cm" 
          x="-328.03"
 	 y="205.5" 
@@ -40812,14 +40068,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-2"/>
-       <position name="posOpArapucaDouble2-Frame-2-0" unit="cm" 
-         x="-327.29"
-	 y="205.5" 
-	 z="-190.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-0-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-2-0" unit="cm" 
          x="-328.03"
 	 y="296.2" 
@@ -40827,14 +40076,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-3"/>
-       <position name="posOpArapucaDouble3-Frame-2-0" unit="cm" 
-         x="-327.29"
-	 y="296.2" 
-	 z="-336.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-1-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-2-1" unit="cm" 
          x="-328.03"
 	 y="40.8" 
@@ -40842,14 +40084,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-0"/>
-       <position name="posOpArapucaDouble0-Frame-2-1" unit="cm" 
-         x="-327.29"
-	 y="40.8" 
-	 z="37.4999999999999"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-1-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-2-1" unit="cm" 
          x="-328.03"
 	 y="131.5" 
@@ -40857,14 +40092,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-1"/>
-       <position name="posOpArapucaDouble1-Frame-2-1" unit="cm" 
-         x="-327.29"
-	 y="131.5" 
-	 z="-108.5"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-1-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-2-1" unit="cm" 
          x="-328.03"
 	 y="205.5" 
@@ -40872,14 +40100,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-2"/>
-       <position name="posOpArapucaDouble2-Frame-2-1" unit="cm" 
-         x="-327.29"
-	 y="205.5" 
-	 z="108.5"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-1-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-2-1" unit="cm" 
          x="-328.03"
 	 y="296.2" 
@@ -40887,14 +40108,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-3"/>
-       <position name="posOpArapucaDouble3-Frame-2-1" unit="cm" 
-         x="-327.29"
-	 y="296.2" 
-	 z="-37.5000000000001"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-2-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-2-2" unit="cm" 
          x="-328.03"
 	 y="40.8" 
@@ -40902,14 +40116,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-0"/>
-       <position name="posOpArapucaDouble0-Frame-2-2" unit="cm" 
-         x="-327.29"
-	 y="40.8" 
-	 z="336.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-2-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-2-2" unit="cm" 
          x="-328.03"
 	 y="131.5" 
@@ -40917,14 +40124,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-1"/>
-       <position name="posOpArapucaDouble1-Frame-2-2" unit="cm" 
-         x="-327.29"
-	 y="131.5" 
-	 z="190.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-2-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-2-2" unit="cm" 
          x="-328.03"
 	 y="205.5" 
@@ -40932,14 +40132,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-2"/>
-       <position name="posOpArapucaDouble2-Frame-2-2" unit="cm" 
-         x="-327.29"
-	 y="205.5" 
-	 z="407.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-2-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-2-2" unit="cm" 
          x="-328.03"
 	 y="296.2" 
@@ -40947,14 +40140,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-3"/>
-       <position name="posOpArapucaDouble3-Frame-2-2" unit="cm" 
-         x="-327.29"
-	 y="296.2" 
-	 z="261.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-0-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-3-0" unit="cm" 
          x="-328.03"
 	 y="377.8" 
@@ -40962,14 +40148,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-0"/>
-       <position name="posOpArapucaDouble0-Frame-3-0" unit="cm" 
-         x="-327.29"
-	 y="377.8" 
-	 z="-261.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-0-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-3-0" unit="cm" 
          x="-328.03"
 	 y="468.5" 
@@ -40977,14 +40156,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-1"/>
-       <position name="posOpArapucaDouble1-Frame-3-0" unit="cm" 
-         x="-327.29"
-	 y="468.5" 
-	 z="-407.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-0-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-3-0" unit="cm" 
          x="-328.03"
 	 y="542.5" 
@@ -40992,14 +40164,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-2"/>
-       <position name="posOpArapucaDouble2-Frame-3-0" unit="cm" 
-         x="-327.29"
-	 y="542.5" 
-	 z="-190.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-0-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-3-0" unit="cm" 
          x="-328.03"
 	 y="633.2" 
@@ -41007,14 +40172,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-3"/>
-       <position name="posOpArapucaDouble3-Frame-3-0" unit="cm" 
-         x="-327.29"
-	 y="633.2" 
-	 z="-336.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-1-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-3-1" unit="cm" 
          x="-328.03"
 	 y="377.8" 
@@ -41022,14 +40180,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-0"/>
-       <position name="posOpArapucaDouble0-Frame-3-1" unit="cm" 
-         x="-327.29"
-	 y="377.8" 
-	 z="37.4999999999999"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-1-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-3-1" unit="cm" 
          x="-328.03"
 	 y="468.5" 
@@ -41037,14 +40188,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-1"/>
-       <position name="posOpArapucaDouble1-Frame-3-1" unit="cm" 
-         x="-327.29"
-	 y="468.5" 
-	 z="-108.5"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-1-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-3-1" unit="cm" 
          x="-328.03"
 	 y="542.5" 
@@ -41052,14 +40196,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-2"/>
-       <position name="posOpArapucaDouble2-Frame-3-1" unit="cm" 
-         x="-327.29"
-	 y="542.5" 
-	 z="108.5"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-1-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-3-1" unit="cm" 
          x="-328.03"
 	 y="633.2" 
@@ -41067,14 +40204,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-3"/>
-       <position name="posOpArapucaDouble3-Frame-3-1" unit="cm" 
-         x="-327.29"
-	 y="633.2" 
-	 z="-37.5000000000001"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-2-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-3-2" unit="cm" 
          x="-328.03"
 	 y="377.8" 
@@ -41082,14 +40212,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-0"/>
-       <position name="posOpArapucaDouble0-Frame-3-2" unit="cm" 
-         x="-327.29"
-	 y="377.8" 
-	 z="336.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-2-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-3-2" unit="cm" 
          x="-328.03"
 	 y="468.5" 
@@ -41097,14 +40220,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-1"/>
-       <position name="posOpArapucaDouble1-Frame-3-2" unit="cm" 
-         x="-327.29"
-	 y="468.5" 
-	 z="190.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-2-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-3-2" unit="cm" 
          x="-328.03"
 	 y="542.5" 
@@ -41112,14 +40228,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-2"/>
-       <position name="posOpArapucaDouble2-Frame-3-2" unit="cm" 
-         x="-327.29"
-	 y="542.5" 
-	 z="407.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-2-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-3-2" unit="cm" 
          x="-328.03"
 	 y="633.2" 
@@ -41127,14 +40236,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-3"/>
-       <position name="posOpArapucaDouble3-Frame-3-2" unit="cm" 
-         x="-327.29"
-	 y="633.2" 
-	 z="261.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_0-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca0-Lat-0" unit="cm" 
          x="285.02"
 	 y="-745" 
@@ -41142,14 +40244,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_0-0"/>
-       <position name="posOpArapuca0-Lat-0" unit="cm" 
-         x="285.02"
-	 y="-744.26" 
-	 z="-299.3"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_0-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca1-Lat-0" unit="cm" 
          x="210.02"
 	 y="-745" 
@@ -41157,14 +40252,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_0-1"/>
-       <position name="posOpArapuca1-Lat-0" unit="cm" 
-         x="210.02"
-	 y="-744.26" 
-	 z="-299.3"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_0-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca2-Lat-0" unit="cm" 
          x="135.02"
 	 y="-745" 
@@ -41172,14 +40260,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_0-2"/>
-       <position name="posOpArapuca2-Lat-0" unit="cm" 
-         x="135.02"
-	 y="-744.26" 
-	 z="-299.3"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_0-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca3-Lat-0" unit="cm" 
          x="60.02"
 	 y="-745" 
@@ -41187,14 +40268,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_0-3"/>
-       <position name="posOpArapuca3-Lat-0" unit="cm" 
-         x="60.02"
-	 y="-744.26" 
-	 z="-299.3"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_0-4"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca4-Lat-0" unit="cm" 
          x="285.02"
 	 y="745" 
@@ -41202,14 +40276,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_0-4"/>
-       <position name="posOpArapuca4-Lat-0" unit="cm" 
-         x="285.02"
-	 y="744.26" 
-	 z="-299.3"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_0-5"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca5-Lat-0" unit="cm" 
          x="210.02"
 	 y="745" 
@@ -41217,14 +40284,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_0-5"/>
-       <position name="posOpArapuca5-Lat-0" unit="cm" 
-         x="210.02"
-	 y="744.26" 
-	 z="-299.3"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_0-6"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca6-Lat-0" unit="cm" 
          x="135.02"
 	 y="745" 
@@ -41232,14 +40292,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_0-6"/>
-       <position name="posOpArapuca6-Lat-0" unit="cm" 
-         x="135.02"
-	 y="744.26" 
-	 z="-299.3"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_0-7"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca7-Lat-0" unit="cm" 
          x="60.02"
 	 y="745" 
@@ -41247,14 +40300,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_0-7"/>
-       <position name="posOpArapuca7-Lat-0" unit="cm" 
-         x="60.02"
-	 y="744.26" 
-	 z="-299.3"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_1-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca0-Lat-1" unit="cm" 
          x="285.02"
 	 y="-745" 
@@ -41262,14 +40308,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_1-0"/>
-       <position name="posOpArapuca0-Lat-1" unit="cm" 
-         x="285.02"
-	 y="-744.26" 
-	 z="2.8421709430404e-13"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_1-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca1-Lat-1" unit="cm" 
          x="210.02"
 	 y="-745" 
@@ -41277,14 +40316,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_1-1"/>
-       <position name="posOpArapuca1-Lat-1" unit="cm" 
-         x="210.02"
-	 y="-744.26" 
-	 z="2.8421709430404e-13"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_1-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca2-Lat-1" unit="cm" 
          x="135.02"
 	 y="-745" 
@@ -41292,14 +40324,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_1-2"/>
-       <position name="posOpArapuca2-Lat-1" unit="cm" 
-         x="135.02"
-	 y="-744.26" 
-	 z="2.8421709430404e-13"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_1-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca3-Lat-1" unit="cm" 
          x="60.02"
 	 y="-745" 
@@ -41307,14 +40332,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_1-3"/>
-       <position name="posOpArapuca3-Lat-1" unit="cm" 
-         x="60.02"
-	 y="-744.26" 
-	 z="2.8421709430404e-13"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_1-4"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca4-Lat-1" unit="cm" 
          x="285.02"
 	 y="745" 
@@ -41322,14 +40340,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_1-4"/>
-       <position name="posOpArapuca4-Lat-1" unit="cm" 
-         x="285.02"
-	 y="744.26" 
-	 z="2.8421709430404e-13"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_1-5"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca5-Lat-1" unit="cm" 
          x="210.02"
 	 y="745" 
@@ -41337,14 +40348,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_1-5"/>
-       <position name="posOpArapuca5-Lat-1" unit="cm" 
-         x="210.02"
-	 y="744.26" 
-	 z="2.8421709430404e-13"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_1-6"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca6-Lat-1" unit="cm" 
          x="135.02"
 	 y="745" 
@@ -41352,14 +40356,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_1-6"/>
-       <position name="posOpArapuca6-Lat-1" unit="cm" 
-         x="135.02"
-	 y="744.26" 
-	 z="2.8421709430404e-13"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_1-7"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca7-Lat-1" unit="cm" 
          x="60.02"
 	 y="745" 
@@ -41367,14 +40364,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_1-7"/>
-       <position name="posOpArapuca7-Lat-1" unit="cm" 
-         x="60.02"
-	 y="744.26" 
-	 z="2.8421709430404e-13"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_2-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca0-Lat-2" unit="cm" 
          x="285.02"
 	 y="-745" 
@@ -41382,14 +40372,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_2-0"/>
-       <position name="posOpArapuca0-Lat-2" unit="cm" 
-         x="285.02"
-	 y="-744.26" 
-	 z="299.3"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_2-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca1-Lat-2" unit="cm" 
          x="210.02"
 	 y="-745" 
@@ -41397,14 +40380,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_2-1"/>
-       <position name="posOpArapuca1-Lat-2" unit="cm" 
-         x="210.02"
-	 y="-744.26" 
-	 z="299.3"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_2-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca2-Lat-2" unit="cm" 
          x="135.02"
 	 y="-745" 
@@ -41412,14 +40388,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_2-2"/>
-       <position name="posOpArapuca2-Lat-2" unit="cm" 
-         x="135.02"
-	 y="-744.26" 
-	 z="299.3"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_2-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca3-Lat-2" unit="cm" 
          x="60.02"
 	 y="-745" 
@@ -41427,14 +40396,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_2-3"/>
-       <position name="posOpArapuca3-Lat-2" unit="cm" 
-         x="60.02"
-	 y="-744.26" 
-	 z="299.3"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_2-4"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca4-Lat-2" unit="cm" 
          x="285.02"
 	 y="745" 
@@ -41442,14 +40404,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_2-4"/>
-       <position name="posOpArapuca4-Lat-2" unit="cm" 
-         x="285.02"
-	 y="744.26" 
-	 z="299.3"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_2-5"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca5-Lat-2" unit="cm" 
          x="210.02"
 	 y="745" 
@@ -41457,14 +40412,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_2-5"/>
-       <position name="posOpArapuca5-Lat-2" unit="cm" 
-         x="210.02"
-	 y="744.26" 
-	 z="299.3"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_2-6"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca6-Lat-2" unit="cm" 
          x="135.02"
 	 y="745" 
@@ -41472,14 +40420,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_2-6"/>
-       <position name="posOpArapuca6-Lat-2" unit="cm" 
-         x="135.02"
-	 y="744.26" 
-	 z="299.3"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_2-7"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca7-Lat-2" unit="cm" 
          x="60.02"
 	 y="745" 
@@ -41487,15 +40428,8 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_2-7"/>
-       <position name="posOpArapuca7-Lat-2" unit="cm" 
-         x="60.02"
-	 y="744.26" 
-	 z="299.3"/>
-     </physvol>
-     <physvol>
        <volumeref ref="volArapuca"/>
-       <position name="posArapuca0-ShortLat-2" unit="cm" 
+       <position name="posArapuca0-ShortLat-220" unit="cm" 
          x="285.02"
 	 y="-220" 
 	 z="-545.95"/>
@@ -41503,7 +40437,7 @@
      </physvol>
      <physvol>
        <volumeref ref="volArapuca"/>
-       <position name="posArapuca1-ShortLat-2" unit="cm" 
+       <position name="posArapuca1-ShortLat-220" unit="cm" 
          x="210.02"
 	 y="-220" 
 	 z="-545.95"/>
@@ -41511,7 +40445,7 @@
      </physvol>
      <physvol>
        <volumeref ref="volArapuca"/>
-       <position name="posArapuca2-ShortLat-2" unit="cm" 
+       <position name="posArapuca2-ShortLat-220" unit="cm" 
          x="135.02"
 	 y="-220" 
 	 z="-545.95"/>
@@ -41519,7 +40453,7 @@
      </physvol>
      <physvol>
        <volumeref ref="volArapuca"/>
-       <position name="posArapuca3-ShortLat-2" unit="cm" 
+       <position name="posArapuca3-ShortLat-220" unit="cm" 
          x="60.02"
 	 y="-220" 
 	 z="-545.95"/>
@@ -41527,7 +40461,7 @@
      </physvol>
      <physvol>
        <volumeref ref="volArapuca"/>
-       <position name="posArapuca4-ShortLat-2" unit="cm" 
+       <position name="posArapuca4-ShortLat-220" unit="cm" 
          x="285.02"
 	 y="-220" 
 	 z="545.95"/>
@@ -41535,7 +40469,7 @@
      </physvol>
      <physvol>
        <volumeref ref="volArapuca"/>
-       <position name="posArapuca5-ShortLat-2" unit="cm" 
+       <position name="posArapuca5-ShortLat-220" unit="cm" 
          x="210.02"
 	 y="-220" 
 	 z="545.95"/>
@@ -41543,7 +40477,7 @@
      </physvol>
      <physvol>
        <volumeref ref="volArapuca"/>
-       <position name="posArapuca6-ShortLat-2" unit="cm" 
+       <position name="posArapuca6-ShortLat-220" unit="cm" 
          x="135.02"
 	 y="-220" 
 	 z="545.95"/>
@@ -41551,7 +40485,7 @@
      </physvol>
      <physvol>
        <volumeref ref="volArapuca"/>
-       <position name="posArapuca7-ShortLat-2" unit="cm" 
+       <position name="posArapuca7-ShortLat-220" unit="cm" 
          x="60.02"
 	 y="-220" 
 	 z="545.95"/>
@@ -41559,7 +40493,7 @@
      </physvol>
      <physvol>
        <volumeref ref="volArapuca"/>
-       <position name="posArapuca0-ShortLat-2" unit="cm" 
+       <position name="posArapuca0-ShortLat220" unit="cm" 
          x="285.02"
 	 y="220" 
 	 z="-545.95"/>
@@ -41567,7 +40501,7 @@
      </physvol>
      <physvol>
        <volumeref ref="volArapuca"/>
-       <position name="posArapuca1-ShortLat-2" unit="cm" 
+       <position name="posArapuca1-ShortLat220" unit="cm" 
          x="210.02"
 	 y="220" 
 	 z="-545.95"/>
@@ -41575,7 +40509,7 @@
      </physvol>
      <physvol>
        <volumeref ref="volArapuca"/>
-       <position name="posArapuca2-ShortLat-2" unit="cm" 
+       <position name="posArapuca2-ShortLat220" unit="cm" 
          x="135.02"
 	 y="220" 
 	 z="-545.95"/>
@@ -41583,7 +40517,7 @@
      </physvol>
      <physvol>
        <volumeref ref="volArapuca"/>
-       <position name="posArapuca3-ShortLat-2" unit="cm" 
+       <position name="posArapuca3-ShortLat220" unit="cm" 
          x="60.02"
 	 y="220" 
 	 z="-545.95"/>
@@ -41591,7 +40525,7 @@
      </physvol>
      <physvol>
        <volumeref ref="volArapuca"/>
-       <position name="posArapuca4-ShortLat-2" unit="cm" 
+       <position name="posArapuca4-ShortLat220" unit="cm" 
          x="285.02"
 	 y="220" 
 	 z="545.95"/>
@@ -41599,7 +40533,7 @@
      </physvol>
      <physvol>
        <volumeref ref="volArapuca"/>
-       <position name="posArapuca5-ShortLat-2" unit="cm" 
+       <position name="posArapuca5-ShortLat220" unit="cm" 
          x="210.02"
 	 y="220" 
 	 z="545.95"/>
@@ -41607,7 +40541,7 @@
      </physvol>
      <physvol>
        <volumeref ref="volArapuca"/>
-       <position name="posArapuca6-ShortLat-2" unit="cm" 
+       <position name="posArapuca6-ShortLat220" unit="cm" 
          x="135.02"
 	 y="220" 
 	 z="545.95"/>
@@ -41615,7 +40549,7 @@
      </physvol>
      <physvol>
        <volumeref ref="volArapuca"/>
-       <position name="posArapuca7-ShortLat-2" unit="cm" 
+       <position name="posArapuca7-ShortLat220" unit="cm" 
          x="60.02"
 	 y="220" 
 	 z="545.95"/>

--- a/dunecore/Geometry/gdml/dunevd10kt_3view_30deg_v5_refactored_1x8x6ref_nowires.gdml
+++ b/dunecore/Geometry/gdml/dunevd10kt_3view_30deg_v5_refactored_1x8x6ref_nowires.gdml
@@ -397,6 +397,24 @@
      <tube name="FieldShaperLongtube" rmin="0.5" rmax="2.285" z="897.9" deltaphi="360" startphi="0" aunit="deg" lunit="cm"/>
      <tube name="FieldShaperLongtubeSlim" rmin="0.5" rmax="0.75" z="897.9" deltaphi="360" startphi="0" aunit="deg" lunit="cm"/>
      <tube name="FieldShaperShorttube" rmin="0.5" rmax="2.285" z="1348" deltaphi="360" startphi="0" aunit="deg" lunit="cm"/>
+     <tube name="FieldShaperShorttubeWindowSlim" rmin="0.5" rmax="0.75" z="670" deltaphi="360" startphi="0" aunit="deg" lunit="cm"/>
+     <tube name="FieldShaperShorttubeWindowNotSlim" rmin="0.5" rmax="2.285" z="339" deltaphi="360" startphi="0" aunit="deg" lunit="cm"/>
+
+
+    <union name="FSunionWindow1">
+      <first ref="FieldShaperShorttubeWindowSlim"/>
+      <second ref="FieldShaperShorttubeWindowNotSlim"/>
+      <position name="posFieldShaperShortTube_shift1" unit="cm" x="0" y="0" z="504.5"/>
+    </union>
+
+    <union name="FieldShaperShorttubeSlim">
+      <first ref="FSunionWindow1"/>
+      <second ref="FieldShaperShorttubeWindowNotSlim"/>
+      <position name="posFieldShaperShortTube_shift2" unit="cm" x="0" y="0" z="-504.5"/>
+    </union>
+
+
+
 
     <union name="FSunion1">
       <first ref="FieldShaperLongtube"/>
@@ -455,7 +473,7 @@
 
     <union name="FSunionSlim2">
       <first ref="FSunionSlim1"/>
-      <second ref="FieldShaperShorttube"/>
+      <second ref="FieldShaperShorttubeSlim"/>
    		<position name="esquinapos9" unit="cm" x="-676.3" y="0" z="451.25"/>
    		<rotationref ref="rPlus90AboutY"/>
     </union>
@@ -482,7 +500,7 @@
 
     <union name="FSunionSlim6">
       <first ref="FSunionSlim5"/>
-      <second ref="FieldShaperShorttube"/>
+      <second ref="FieldShaperShorttubeSlim"/>
    		<position name="esquinapos12" unit="cm" x="-676.3" y="0" z="-451.25"/>
 		<rotationref ref="rPlus90AboutY"/>
     </union>
@@ -942,10 +960,6 @@
       <colorref ref="green"/>
     </volume>
 
-    <volume name="volArapucaShortLat">
-      <materialref ref="G10"/>
-      <solidref ref="ArapucaWalls"/>
-    </volume>
     <volume name="volOpDetSensitive">
       <materialref ref="LAr"/>
       <solidref ref="ArapucaAcceptanceWindow"/>
@@ -969,582 +983,6 @@
       </physvol>
     </volume>
 
-    <volume name="volArapucaDouble_0-0-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-0-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-0-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-0-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-0-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-0-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-0-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-0-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-1-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-1-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-1-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-1-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-1-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-1-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-1-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-1-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-2-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-2-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-2-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-2-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-2-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-2-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_0-2-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_0-2-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-0-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-0-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-0-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-0-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-0-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-0-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-0-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-0-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-1-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-1-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-1-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-1-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-1-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-1-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-1-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-1-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-2-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-2-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-2-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-2-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-2-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-2-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_1-2-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_1-2-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-0-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-0-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-0-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-0-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-0-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-0-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-0-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-0-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-1-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-1-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-1-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-1-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-1-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-1-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-1-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-1-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-2-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-2-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-2-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-2-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-2-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-2-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_2-2-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_2-2-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-0-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-0-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-0-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-0-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-0-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-0-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-0-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-0-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-1-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-1-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-1-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-1-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-1-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-1-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-1-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-1-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-2-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-2-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-2-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-2-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-2-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-2-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaDouble_3-2-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaDouble_3-2-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_0-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_0-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_0-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_0-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_0-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_0-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_0-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_0-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_0-4">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_0-4">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_0-5">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_0-5">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_0-6">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_0-6">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_0-7">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_0-7">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_1-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_1-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_1-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_1-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_1-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_1-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_1-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_1-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_1-4">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_1-4">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_1-5">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_1-5">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_1-6">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_1-6">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_1-7">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_1-7">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_2-0">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_2-0">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_2-1">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_2-1">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_2-2">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_2-2">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_2-3">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_2-3">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_2-4">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_2-4">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_2-5">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_2-5">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_2-6">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_2-6">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
-    <volume name="volArapucaLat_2-7">
-      <materialref ref="G10" />
-      <solidref ref="ArapucaWalls" />
-    </volume>
-    <volume name="volOpDetSensitive_ArapucaLat_2-7">
-      <materialref ref="LAr"/>
-      <solidref ref="ArapucaAcceptanceWindow"/>
-    </volume>
 
     <volume name="volCryostat">
       <materialref ref="LAr" />
@@ -2450,7 +1888,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>    
      <physvol>
-       <volumeref ref="volArapucaDouble_0-0-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-0-0" unit="cm" 
          x="-328.03"
 	 y="-633.2" 
@@ -2458,14 +1896,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-0"/>
-       <position name="posOpArapucaDouble0-Frame-0-0" unit="cm" 
-         x="-327.29"
-	 y="-633.2" 
-	 z="-261.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-0-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-0-0" unit="cm" 
          x="-328.03"
 	 y="-542.5" 
@@ -2473,14 +1904,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-1"/>
-       <position name="posOpArapucaDouble1-Frame-0-0" unit="cm" 
-         x="-327.29"
-	 y="-542.5" 
-	 z="-407.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-0-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-0-0" unit="cm" 
          x="-328.03"
 	 y="-468.5" 
@@ -2488,14 +1912,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-2"/>
-       <position name="posOpArapucaDouble2-Frame-0-0" unit="cm" 
-         x="-327.29"
-	 y="-468.5" 
-	 z="-190.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-0-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-0-0" unit="cm" 
          x="-328.03"
 	 y="-377.8" 
@@ -2503,14 +1920,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-3"/>
-       <position name="posOpArapucaDouble3-Frame-0-0" unit="cm" 
-         x="-327.29"
-	 y="-377.8" 
-	 z="-336.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-1-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-0-1" unit="cm" 
          x="-328.03"
 	 y="-633.2" 
@@ -2518,14 +1928,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-0"/>
-       <position name="posOpArapucaDouble0-Frame-0-1" unit="cm" 
-         x="-327.29"
-	 y="-633.2" 
-	 z="37.4999999999999"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-1-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-0-1" unit="cm" 
          x="-328.03"
 	 y="-542.5" 
@@ -2533,14 +1936,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-1"/>
-       <position name="posOpArapucaDouble1-Frame-0-1" unit="cm" 
-         x="-327.29"
-	 y="-542.5" 
-	 z="-108.5"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-1-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-0-1" unit="cm" 
          x="-328.03"
 	 y="-468.5" 
@@ -2548,14 +1944,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-2"/>
-       <position name="posOpArapucaDouble2-Frame-0-1" unit="cm" 
-         x="-327.29"
-	 y="-468.5" 
-	 z="108.5"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-1-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-0-1" unit="cm" 
          x="-328.03"
 	 y="-377.8" 
@@ -2563,14 +1952,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-3"/>
-       <position name="posOpArapucaDouble3-Frame-0-1" unit="cm" 
-         x="-327.29"
-	 y="-377.8" 
-	 z="-37.5000000000001"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-2-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-0-2" unit="cm" 
          x="-328.03"
 	 y="-633.2" 
@@ -2578,14 +1960,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-0"/>
-       <position name="posOpArapucaDouble0-Frame-0-2" unit="cm" 
-         x="-327.29"
-	 y="-633.2" 
-	 z="336.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-2-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-0-2" unit="cm" 
          x="-328.03"
 	 y="-542.5" 
@@ -2593,14 +1968,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-1"/>
-       <position name="posOpArapucaDouble1-Frame-0-2" unit="cm" 
-         x="-327.29"
-	 y="-542.5" 
-	 z="190.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-2-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-0-2" unit="cm" 
          x="-328.03"
 	 y="-468.5" 
@@ -2608,14 +1976,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-2"/>
-       <position name="posOpArapucaDouble2-Frame-0-2" unit="cm" 
-         x="-327.29"
-	 y="-468.5" 
-	 z="407.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_0-2-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-0-2" unit="cm" 
          x="-328.03"
 	 y="-377.8" 
@@ -2623,14 +1984,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-3"/>
-       <position name="posOpArapucaDouble3-Frame-0-2" unit="cm" 
-         x="-327.29"
-	 y="-377.8" 
-	 z="261.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-0-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-1-0" unit="cm" 
          x="-328.03"
 	 y="-296.2" 
@@ -2638,14 +1992,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-0"/>
-       <position name="posOpArapucaDouble0-Frame-1-0" unit="cm" 
-         x="-327.29"
-	 y="-296.2" 
-	 z="-261.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-0-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-1-0" unit="cm" 
          x="-328.03"
 	 y="-205.5" 
@@ -2653,14 +2000,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-1"/>
-       <position name="posOpArapucaDouble1-Frame-1-0" unit="cm" 
-         x="-327.29"
-	 y="-205.5" 
-	 z="-407.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-0-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-1-0" unit="cm" 
          x="-328.03"
 	 y="-131.5" 
@@ -2668,14 +2008,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-2"/>
-       <position name="posOpArapucaDouble2-Frame-1-0" unit="cm" 
-         x="-327.29"
-	 y="-131.5" 
-	 z="-190.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-0-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-1-0" unit="cm" 
          x="-328.03"
 	 y="-40.8" 
@@ -2683,14 +2016,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-3"/>
-       <position name="posOpArapucaDouble3-Frame-1-0" unit="cm" 
-         x="-327.29"
-	 y="-40.8" 
-	 z="-336.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-1-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-1-1" unit="cm" 
          x="-328.03"
 	 y="-296.2" 
@@ -2698,14 +2024,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-0"/>
-       <position name="posOpArapucaDouble0-Frame-1-1" unit="cm" 
-         x="-327.29"
-	 y="-296.2" 
-	 z="37.4999999999999"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-1-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-1-1" unit="cm" 
          x="-328.03"
 	 y="-205.5" 
@@ -2713,14 +2032,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-1"/>
-       <position name="posOpArapucaDouble1-Frame-1-1" unit="cm" 
-         x="-327.29"
-	 y="-205.5" 
-	 z="-108.5"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-1-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-1-1" unit="cm" 
          x="-328.03"
 	 y="-131.5" 
@@ -2728,14 +2040,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-2"/>
-       <position name="posOpArapucaDouble2-Frame-1-1" unit="cm" 
-         x="-327.29"
-	 y="-131.5" 
-	 z="108.5"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-1-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-1-1" unit="cm" 
          x="-328.03"
 	 y="-40.8" 
@@ -2743,14 +2048,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-3"/>
-       <position name="posOpArapucaDouble3-Frame-1-1" unit="cm" 
-         x="-327.29"
-	 y="-40.8" 
-	 z="-37.5000000000001"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-2-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-1-2" unit="cm" 
          x="-328.03"
 	 y="-296.2" 
@@ -2758,14 +2056,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-0"/>
-       <position name="posOpArapucaDouble0-Frame-1-2" unit="cm" 
-         x="-327.29"
-	 y="-296.2" 
-	 z="336.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-2-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-1-2" unit="cm" 
          x="-328.03"
 	 y="-205.5" 
@@ -2773,14 +2064,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-1"/>
-       <position name="posOpArapucaDouble1-Frame-1-2" unit="cm" 
-         x="-327.29"
-	 y="-205.5" 
-	 z="190.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-2-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-1-2" unit="cm" 
          x="-328.03"
 	 y="-131.5" 
@@ -2788,14 +2072,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-2"/>
-       <position name="posOpArapucaDouble2-Frame-1-2" unit="cm" 
-         x="-327.29"
-	 y="-131.5" 
-	 z="407.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_1-2-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-1-2" unit="cm" 
          x="-328.03"
 	 y="-40.8" 
@@ -2803,14 +2080,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-3"/>
-       <position name="posOpArapucaDouble3-Frame-1-2" unit="cm" 
-         x="-327.29"
-	 y="-40.8" 
-	 z="261.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-0-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-2-0" unit="cm" 
          x="-328.03"
 	 y="40.8" 
@@ -2818,14 +2088,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-0"/>
-       <position name="posOpArapucaDouble0-Frame-2-0" unit="cm" 
-         x="-327.29"
-	 y="40.8" 
-	 z="-261.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-0-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-2-0" unit="cm" 
          x="-328.03"
 	 y="131.5" 
@@ -2833,14 +2096,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-1"/>
-       <position name="posOpArapucaDouble1-Frame-2-0" unit="cm" 
-         x="-327.29"
-	 y="131.5" 
-	 z="-407.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-0-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-2-0" unit="cm" 
          x="-328.03"
 	 y="205.5" 
@@ -2848,14 +2104,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-2"/>
-       <position name="posOpArapucaDouble2-Frame-2-0" unit="cm" 
-         x="-327.29"
-	 y="205.5" 
-	 z="-190.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-0-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-2-0" unit="cm" 
          x="-328.03"
 	 y="296.2" 
@@ -2863,14 +2112,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-3"/>
-       <position name="posOpArapucaDouble3-Frame-2-0" unit="cm" 
-         x="-327.29"
-	 y="296.2" 
-	 z="-336.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-1-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-2-1" unit="cm" 
          x="-328.03"
 	 y="40.8" 
@@ -2878,14 +2120,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-0"/>
-       <position name="posOpArapucaDouble0-Frame-2-1" unit="cm" 
-         x="-327.29"
-	 y="40.8" 
-	 z="37.4999999999999"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-1-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-2-1" unit="cm" 
          x="-328.03"
 	 y="131.5" 
@@ -2893,14 +2128,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-1"/>
-       <position name="posOpArapucaDouble1-Frame-2-1" unit="cm" 
-         x="-327.29"
-	 y="131.5" 
-	 z="-108.5"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-1-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-2-1" unit="cm" 
          x="-328.03"
 	 y="205.5" 
@@ -2908,14 +2136,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-2"/>
-       <position name="posOpArapucaDouble2-Frame-2-1" unit="cm" 
-         x="-327.29"
-	 y="205.5" 
-	 z="108.5"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-1-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-2-1" unit="cm" 
          x="-328.03"
 	 y="296.2" 
@@ -2923,14 +2144,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-3"/>
-       <position name="posOpArapucaDouble3-Frame-2-1" unit="cm" 
-         x="-327.29"
-	 y="296.2" 
-	 z="-37.5000000000001"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-2-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-2-2" unit="cm" 
          x="-328.03"
 	 y="40.8" 
@@ -2938,14 +2152,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-0"/>
-       <position name="posOpArapucaDouble0-Frame-2-2" unit="cm" 
-         x="-327.29"
-	 y="40.8" 
-	 z="336.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-2-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-2-2" unit="cm" 
          x="-328.03"
 	 y="131.5" 
@@ -2953,14 +2160,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-1"/>
-       <position name="posOpArapucaDouble1-Frame-2-2" unit="cm" 
-         x="-327.29"
-	 y="131.5" 
-	 z="190.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-2-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-2-2" unit="cm" 
          x="-328.03"
 	 y="205.5" 
@@ -2968,14 +2168,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-2"/>
-       <position name="posOpArapucaDouble2-Frame-2-2" unit="cm" 
-         x="-327.29"
-	 y="205.5" 
-	 z="407.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_2-2-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-2-2" unit="cm" 
          x="-328.03"
 	 y="296.2" 
@@ -2983,14 +2176,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-3"/>
-       <position name="posOpArapucaDouble3-Frame-2-2" unit="cm" 
-         x="-327.29"
-	 y="296.2" 
-	 z="261.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-0-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-3-0" unit="cm" 
          x="-328.03"
 	 y="377.8" 
@@ -2998,14 +2184,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-0"/>
-       <position name="posOpArapucaDouble0-Frame-3-0" unit="cm" 
-         x="-327.29"
-	 y="377.8" 
-	 z="-261.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-0-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-3-0" unit="cm" 
          x="-328.03"
 	 y="468.5" 
@@ -3013,14 +2192,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-1"/>
-       <position name="posOpArapucaDouble1-Frame-3-0" unit="cm" 
-         x="-327.29"
-	 y="468.5" 
-	 z="-407.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-0-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-3-0" unit="cm" 
          x="-328.03"
 	 y="542.5" 
@@ -3028,14 +2200,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-2"/>
-       <position name="posOpArapucaDouble2-Frame-3-0" unit="cm" 
-         x="-327.29"
-	 y="542.5" 
-	 z="-190.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-0-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-3-0" unit="cm" 
          x="-328.03"
 	 y="633.2" 
@@ -3043,14 +2208,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-3"/>
-       <position name="posOpArapucaDouble3-Frame-3-0" unit="cm" 
-         x="-327.29"
-	 y="633.2" 
-	 z="-336.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-1-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-3-1" unit="cm" 
          x="-328.03"
 	 y="377.8" 
@@ -3058,14 +2216,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-0"/>
-       <position name="posOpArapucaDouble0-Frame-3-1" unit="cm" 
-         x="-327.29"
-	 y="377.8" 
-	 z="37.4999999999999"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-1-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-3-1" unit="cm" 
          x="-328.03"
 	 y="468.5" 
@@ -3073,14 +2224,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-1"/>
-       <position name="posOpArapucaDouble1-Frame-3-1" unit="cm" 
-         x="-327.29"
-	 y="468.5" 
-	 z="-108.5"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-1-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-3-1" unit="cm" 
          x="-328.03"
 	 y="542.5" 
@@ -3088,14 +2232,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-2"/>
-       <position name="posOpArapucaDouble2-Frame-3-1" unit="cm" 
-         x="-327.29"
-	 y="542.5" 
-	 z="108.5"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-1-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-3-1" unit="cm" 
          x="-328.03"
 	 y="633.2" 
@@ -3103,14 +2240,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-3"/>
-       <position name="posOpArapucaDouble3-Frame-3-1" unit="cm" 
-         x="-327.29"
-	 y="633.2" 
-	 z="-37.5000000000001"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-2-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble0-Frame-3-2" unit="cm" 
          x="-328.03"
 	 y="377.8" 
@@ -3118,14 +2248,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-0"/>
-       <position name="posOpArapucaDouble0-Frame-3-2" unit="cm" 
-         x="-327.29"
-	 y="377.8" 
-	 z="336.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-2-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-3-2" unit="cm" 
          x="-328.03"
 	 y="468.5" 
@@ -3133,14 +2256,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-1"/>
-       <position name="posOpArapucaDouble1-Frame-3-2" unit="cm" 
-         x="-327.29"
-	 y="468.5" 
-	 z="190.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-2-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-3-2" unit="cm" 
          x="-328.03"
 	 y="542.5" 
@@ -3148,14 +2264,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-2"/>
-       <position name="posOpArapucaDouble2-Frame-3-2" unit="cm" 
-         x="-327.29"
-	 y="542.5" 
-	 z="407.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaDouble_3-2-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapucaDouble3-Frame-3-2" unit="cm" 
          x="-328.03"
 	 y="633.2" 
@@ -3163,14 +2272,7 @@
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-3"/>
-       <position name="posOpArapucaDouble3-Frame-3-2" unit="cm" 
-         x="-327.29"
-	 y="633.2" 
-	 z="261.8"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_0-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca0-Lat-0" unit="cm" 
          x="285.02"
 	 y="-745" 
@@ -3178,14 +2280,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_0-0"/>
-       <position name="posOpArapuca0-Lat-0" unit="cm" 
-         x="285.02"
-	 y="-744.26" 
-	 z="-299.3"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_0-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca1-Lat-0" unit="cm" 
          x="210.02"
 	 y="-745" 
@@ -3193,14 +2288,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_0-1"/>
-       <position name="posOpArapuca1-Lat-0" unit="cm" 
-         x="210.02"
-	 y="-744.26" 
-	 z="-299.3"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_0-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca2-Lat-0" unit="cm" 
          x="135.02"
 	 y="-745" 
@@ -3208,14 +2296,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_0-2"/>
-       <position name="posOpArapuca2-Lat-0" unit="cm" 
-         x="135.02"
-	 y="-744.26" 
-	 z="-299.3"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_0-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca3-Lat-0" unit="cm" 
          x="60.02"
 	 y="-745" 
@@ -3223,14 +2304,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_0-3"/>
-       <position name="posOpArapuca3-Lat-0" unit="cm" 
-         x="60.02"
-	 y="-744.26" 
-	 z="-299.3"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_0-4"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca4-Lat-0" unit="cm" 
          x="285.02"
 	 y="745" 
@@ -3238,14 +2312,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_0-4"/>
-       <position name="posOpArapuca4-Lat-0" unit="cm" 
-         x="285.02"
-	 y="744.26" 
-	 z="-299.3"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_0-5"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca5-Lat-0" unit="cm" 
          x="210.02"
 	 y="745" 
@@ -3253,14 +2320,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_0-5"/>
-       <position name="posOpArapuca5-Lat-0" unit="cm" 
-         x="210.02"
-	 y="744.26" 
-	 z="-299.3"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_0-6"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca6-Lat-0" unit="cm" 
          x="135.02"
 	 y="745" 
@@ -3268,14 +2328,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_0-6"/>
-       <position name="posOpArapuca6-Lat-0" unit="cm" 
-         x="135.02"
-	 y="744.26" 
-	 z="-299.3"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_0-7"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca7-Lat-0" unit="cm" 
          x="60.02"
 	 y="745" 
@@ -3283,14 +2336,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_0-7"/>
-       <position name="posOpArapuca7-Lat-0" unit="cm" 
-         x="60.02"
-	 y="744.26" 
-	 z="-299.3"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_1-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca0-Lat-1" unit="cm" 
          x="285.02"
 	 y="-745" 
@@ -3298,14 +2344,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_1-0"/>
-       <position name="posOpArapuca0-Lat-1" unit="cm" 
-         x="285.02"
-	 y="-744.26" 
-	 z="2.8421709430404e-13"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_1-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca1-Lat-1" unit="cm" 
          x="210.02"
 	 y="-745" 
@@ -3313,14 +2352,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_1-1"/>
-       <position name="posOpArapuca1-Lat-1" unit="cm" 
-         x="210.02"
-	 y="-744.26" 
-	 z="2.8421709430404e-13"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_1-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca2-Lat-1" unit="cm" 
          x="135.02"
 	 y="-745" 
@@ -3328,14 +2360,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_1-2"/>
-       <position name="posOpArapuca2-Lat-1" unit="cm" 
-         x="135.02"
-	 y="-744.26" 
-	 z="2.8421709430404e-13"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_1-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca3-Lat-1" unit="cm" 
          x="60.02"
 	 y="-745" 
@@ -3343,14 +2368,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_1-3"/>
-       <position name="posOpArapuca3-Lat-1" unit="cm" 
-         x="60.02"
-	 y="-744.26" 
-	 z="2.8421709430404e-13"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_1-4"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca4-Lat-1" unit="cm" 
          x="285.02"
 	 y="745" 
@@ -3358,14 +2376,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_1-4"/>
-       <position name="posOpArapuca4-Lat-1" unit="cm" 
-         x="285.02"
-	 y="744.26" 
-	 z="2.8421709430404e-13"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_1-5"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca5-Lat-1" unit="cm" 
          x="210.02"
 	 y="745" 
@@ -3373,14 +2384,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_1-5"/>
-       <position name="posOpArapuca5-Lat-1" unit="cm" 
-         x="210.02"
-	 y="744.26" 
-	 z="2.8421709430404e-13"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_1-6"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca6-Lat-1" unit="cm" 
          x="135.02"
 	 y="745" 
@@ -3388,14 +2392,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_1-6"/>
-       <position name="posOpArapuca6-Lat-1" unit="cm" 
-         x="135.02"
-	 y="744.26" 
-	 z="2.8421709430404e-13"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_1-7"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca7-Lat-1" unit="cm" 
          x="60.02"
 	 y="745" 
@@ -3403,14 +2400,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_1-7"/>
-       <position name="posOpArapuca7-Lat-1" unit="cm" 
-         x="60.02"
-	 y="744.26" 
-	 z="2.8421709430404e-13"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_2-0"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca0-Lat-2" unit="cm" 
          x="285.02"
 	 y="-745" 
@@ -3418,14 +2408,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_2-0"/>
-       <position name="posOpArapuca0-Lat-2" unit="cm" 
-         x="285.02"
-	 y="-744.26" 
-	 z="299.3"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_2-1"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca1-Lat-2" unit="cm" 
          x="210.02"
 	 y="-745" 
@@ -3433,14 +2416,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_2-1"/>
-       <position name="posOpArapuca1-Lat-2" unit="cm" 
-         x="210.02"
-	 y="-744.26" 
-	 z="299.3"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_2-2"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca2-Lat-2" unit="cm" 
          x="135.02"
 	 y="-745" 
@@ -3448,14 +2424,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_2-2"/>
-       <position name="posOpArapuca2-Lat-2" unit="cm" 
-         x="135.02"
-	 y="-744.26" 
-	 z="299.3"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_2-3"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca3-Lat-2" unit="cm" 
          x="60.02"
 	 y="-745" 
@@ -3463,14 +2432,7 @@
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_2-3"/>
-       <position name="posOpArapuca3-Lat-2" unit="cm" 
-         x="60.02"
-	 y="-744.26" 
-	 z="299.3"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_2-4"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca4-Lat-2" unit="cm" 
          x="285.02"
 	 y="745" 
@@ -3478,14 +2440,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_2-4"/>
-       <position name="posOpArapuca4-Lat-2" unit="cm" 
-         x="285.02"
-	 y="744.26" 
-	 z="299.3"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_2-5"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca5-Lat-2" unit="cm" 
          x="210.02"
 	 y="745" 
@@ -3493,14 +2448,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_2-5"/>
-       <position name="posOpArapuca5-Lat-2" unit="cm" 
-         x="210.02"
-	 y="744.26" 
-	 z="299.3"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_2-6"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca6-Lat-2" unit="cm" 
          x="135.02"
 	 y="745" 
@@ -3508,14 +2456,7 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_2-6"/>
-       <position name="posOpArapuca6-Lat-2" unit="cm" 
-         x="135.02"
-	 y="744.26" 
-	 z="299.3"/>
-     </physvol>
-     <physvol>
-       <volumeref ref="volArapucaLat_2-7"/>
+       <volumeref ref="volArapuca"/>
        <position name="posArapuca7-Lat-2" unit="cm" 
          x="60.02"
 	 y="745" 
@@ -3523,15 +2464,8 @@
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
-       <volumeref ref="volOpDetSensitive_ArapucaLat_2-7"/>
-       <position name="posOpArapuca7-Lat-2" unit="cm" 
-         x="60.02"
-	 y="744.26" 
-	 z="299.3"/>
-     </physvol>
-     <physvol>
        <volumeref ref="volArapuca"/>
-       <position name="posArapuca0-ShortLat-2" unit="cm" 
+       <position name="posArapuca0-ShortLat-220" unit="cm" 
          x="285.02"
 	 y="-220" 
 	 z="-545.95"/>
@@ -3539,7 +2473,7 @@
      </physvol>
      <physvol>
        <volumeref ref="volArapuca"/>
-       <position name="posArapuca1-ShortLat-2" unit="cm" 
+       <position name="posArapuca1-ShortLat-220" unit="cm" 
          x="210.02"
 	 y="-220" 
 	 z="-545.95"/>
@@ -3547,7 +2481,7 @@
      </physvol>
      <physvol>
        <volumeref ref="volArapuca"/>
-       <position name="posArapuca2-ShortLat-2" unit="cm" 
+       <position name="posArapuca2-ShortLat-220" unit="cm" 
          x="135.02"
 	 y="-220" 
 	 z="-545.95"/>
@@ -3555,7 +2489,7 @@
      </physvol>
      <physvol>
        <volumeref ref="volArapuca"/>
-       <position name="posArapuca3-ShortLat-2" unit="cm" 
+       <position name="posArapuca3-ShortLat-220" unit="cm" 
          x="60.02"
 	 y="-220" 
 	 z="-545.95"/>
@@ -3563,7 +2497,7 @@
      </physvol>
      <physvol>
        <volumeref ref="volArapuca"/>
-       <position name="posArapuca4-ShortLat-2" unit="cm" 
+       <position name="posArapuca4-ShortLat-220" unit="cm" 
          x="285.02"
 	 y="-220" 
 	 z="545.95"/>
@@ -3571,7 +2505,7 @@
      </physvol>
      <physvol>
        <volumeref ref="volArapuca"/>
-       <position name="posArapuca5-ShortLat-2" unit="cm" 
+       <position name="posArapuca5-ShortLat-220" unit="cm" 
          x="210.02"
 	 y="-220" 
 	 z="545.95"/>
@@ -3579,7 +2513,7 @@
      </physvol>
      <physvol>
        <volumeref ref="volArapuca"/>
-       <position name="posArapuca6-ShortLat-2" unit="cm" 
+       <position name="posArapuca6-ShortLat-220" unit="cm" 
          x="135.02"
 	 y="-220" 
 	 z="545.95"/>
@@ -3587,7 +2521,7 @@
      </physvol>
      <physvol>
        <volumeref ref="volArapuca"/>
-       <position name="posArapuca7-ShortLat-2" unit="cm" 
+       <position name="posArapuca7-ShortLat-220" unit="cm" 
          x="60.02"
 	 y="-220" 
 	 z="545.95"/>
@@ -3595,7 +2529,7 @@
      </physvol>
      <physvol>
        <volumeref ref="volArapuca"/>
-       <position name="posArapuca0-ShortLat-2" unit="cm" 
+       <position name="posArapuca0-ShortLat220" unit="cm" 
          x="285.02"
 	 y="220" 
 	 z="-545.95"/>
@@ -3603,7 +2537,7 @@
      </physvol>
      <physvol>
        <volumeref ref="volArapuca"/>
-       <position name="posArapuca1-ShortLat-2" unit="cm" 
+       <position name="posArapuca1-ShortLat220" unit="cm" 
          x="210.02"
 	 y="220" 
 	 z="-545.95"/>
@@ -3611,7 +2545,7 @@
      </physvol>
      <physvol>
        <volumeref ref="volArapuca"/>
-       <position name="posArapuca2-ShortLat-2" unit="cm" 
+       <position name="posArapuca2-ShortLat220" unit="cm" 
          x="135.02"
 	 y="220" 
 	 z="-545.95"/>
@@ -3619,7 +2553,7 @@
      </physvol>
      <physvol>
        <volumeref ref="volArapuca"/>
-       <position name="posArapuca3-ShortLat-2" unit="cm" 
+       <position name="posArapuca3-ShortLat220" unit="cm" 
          x="60.02"
 	 y="220" 
 	 z="-545.95"/>
@@ -3627,7 +2561,7 @@
      </physvol>
      <physvol>
        <volumeref ref="volArapuca"/>
-       <position name="posArapuca4-ShortLat-2" unit="cm" 
+       <position name="posArapuca4-ShortLat220" unit="cm" 
          x="285.02"
 	 y="220" 
 	 z="545.95"/>
@@ -3635,7 +2569,7 @@
      </physvol>
      <physvol>
        <volumeref ref="volArapuca"/>
-       <position name="posArapuca5-ShortLat-2" unit="cm" 
+       <position name="posArapuca5-ShortLat220" unit="cm" 
          x="210.02"
 	 y="220" 
 	 z="545.95"/>
@@ -3643,7 +2577,7 @@
      </physvol>
      <physvol>
        <volumeref ref="volArapuca"/>
-       <position name="posArapuca6-ShortLat-2" unit="cm" 
+       <position name="posArapuca6-ShortLat220" unit="cm" 
          x="135.02"
 	 y="220" 
 	 z="545.95"/>
@@ -3651,7 +2585,7 @@
      </physvol>
      <physvol>
        <volumeref ref="volArapuca"/>
-       <position name="posArapuca7-ShortLat-2" unit="cm" 
+       <position name="posArapuca7-ShortLat220" unit="cm" 
          x="60.02"
 	 y="220" 
 	 z="545.95"/>

--- a/dunecore/Geometry/gdml/dunevd10kt_3view_30deg_v5_refactored_1x8x6ref_nowires.gdml
+++ b/dunecore/Geometry/gdml/dunevd10kt_3view_30deg_v5_refactored_1x8x6ref_nowires.gdml
@@ -2,6 +2,8 @@
 <gdml_simple_extension xmlns:gdml_simple_extension="http://www.example.org"
                        xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"          
                        xs:noNamespaceSchemaLocation="RefactoredGDMLSchema/SimpleExtension.xsd"> 
+
+
 <extension>
    <color name="magenta"     R="0.0"  G="1.0"  B="0.0"  A="1.0" />
    <color name="green"       R="0.0"  G="1.0"  B="0.0"  A="1.0" />
@@ -31,6 +33,10 @@
    <rotation name="rPlus180AboutY"	unit="deg" x="0" y="180"   z="0"/>
    <rotation name="rPlus180AboutXPlus180AboutY"	unit="deg" x="180" y="180"   z="0"/>
    <rotation name="rIdentity"		unit="deg" x="0" y="0"   z="0"/>
+   <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+   <rotation name="rPlus90AboutXPlus180AboutY" unit="deg" x="90" y="180" z="0" />
+   <rotation name="rPlus90AboutXMinux90AboutY" unit="deg" x="90" y="270" z="0" />
+   <rotation name="rPlus90AboutZ" unit="deg" x="0" y="0" z="90" />
 </define>
 <materials>
   <element name="videRef" formula="VACUUM" Z="1">  <atom value="1"/> </element>
@@ -396,21 +402,21 @@
       <first ref="FieldShaperLongtube"/>
       <second ref="FieldShaperCorner"/>
    		<position name="esquinapos1" unit="cm" x="-2.3" y="0" z="448.95"/>
-		<rotation name="rot1" unit="deg" x="90" y="0" z="0" />
+		<rotationref ref="rPlus90AboutX"/>
     </union>
 
     <union name="FSunion2">
       <first ref="FSunion1"/>
       <second ref="FieldShaperShorttube"/>
    		<position name="esquinapos2" unit="cm" x="-676.3" y="0" z="451.25"/>
-   		<rotation name="rot2" unit="deg" x="0" y="90" z="0" />
+   		<rotationref ref="rPlus90AboutY"/>
     </union>
 
     <union name="FSunion3">
       <first ref="FSunion2"/>
       <second ref="FieldShaperCorner"/>
    		<position name="esquinapos3" unit="cm" x="-1350.3" y="0" z="448.95"/>
-		<rotation name="rot3" unit="deg" x="90" y="270" z="0" />
+		<rotationref ref="rPlus90AboutXMinux90AboutY"/>
     </union>
 
     <union name="FSunion4">
@@ -423,42 +429,42 @@
       <first ref="FSunion4"/>
       <second ref="FieldShaperCorner"/>
    		<position name="esquinapos5" unit="cm" x="-1350.3" y="0" z="-448.95"/>
-		<rotation name="rot5" unit="deg" x="90" y="180" z="0" />
+		<rotationref ref="rPlus90AboutXPlus180AboutY"/>
     </union>
 
     <union name="FSunion6">
       <first ref="FSunion5"/>
       <second ref="FieldShaperShorttube"/>
    		<position name="esquinapos6" unit="cm" x="-676.3" y="0" z="-451.25"/>
-		<rotation name="rot6" unit="deg" x="0" y="90" z="0" />
+		<rotationref ref="rPlus90AboutY"/>
     </union>
 
     <union name="FieldShaperSolid">
       <first ref="FSunion6"/>
       <second ref="FieldShaperCorner"/>
    		<position name="esquinapos7" unit="cm" x="-2.3" y="0" z="-448.95"/>
-		<rotation name="rot7" unit="deg" x="90" y="90" z="0" />
+		<rotationref ref="rPlus90AboutXPlus90AboutY"/>
     </union>
     
     <union name="FSunionSlim1">
       <first ref="FieldShaperLongtubeSlim"/>
       <second ref="FieldShaperCorner"/>
-   		<position name="esquinapos1" unit="cm" x="-2.3" y="0" z="448.95"/>
-		<rotation name="rot1" unit="deg" x="90" y="0" z="0" />
+   		<position name="esquinapos8" unit="cm" x="-2.3" y="0" z="448.95"/>
+		<rotationref ref="rPlus90AboutX"/>
     </union>
 
     <union name="FSunionSlim2">
       <first ref="FSunionSlim1"/>
       <second ref="FieldShaperShorttube"/>
-   		<position name="esquinapos2" unit="cm" x="-676.3" y="0" z="451.25"/>
-   		<rotation name="rot2" unit="deg" x="0" y="90" z="0" />
+   		<position name="esquinapos9" unit="cm" x="-676.3" y="0" z="451.25"/>
+   		<rotationref ref="rPlus90AboutY"/>
     </union>
 
     <union name="FSunionSlim3">
       <first ref="FSunionSlim2"/>
       <second ref="FieldShaperCorner"/>
-   		<position name="esquinapos3" unit="cm" x="-1350.3" y="0" z="448.95"/>
-		<rotation name="rot3" unit="deg" x="90" y="270" z="0" />
+   		<position name="esquinapos10" unit="cm" x="-1350.3" y="0" z="448.95"/>
+		<rotationref ref="rPlus90AboutXMinux90AboutY"/>
     </union>
 
     <union name="FSunionSlim4">
@@ -470,22 +476,22 @@
     <union name="FSunionSlim5">
       <first ref="FSunionSlim4"/>
       <second ref="FieldShaperCorner"/>
-   		<position name="esquinapos5" unit="cm" x="-1350.3" y="0" z="-448.95"/>
-		<rotation name="rot5" unit="deg" x="90" y="180" z="0" />
+   		<position name="esquinapos11" unit="cm" x="-1350.3" y="0" z="-448.95"/>
+		<rotationref ref="rPlus90AboutXPlus180AboutY"/>
     </union>
 
     <union name="FSunionSlim6">
       <first ref="FSunionSlim5"/>
       <second ref="FieldShaperShorttube"/>
-   		<position name="esquinapos6" unit="cm" x="-676.3" y="0" z="-451.25"/>
-		<rotation name="rot6" unit="deg" x="0" y="90" z="0" />
+   		<position name="esquinapos12" unit="cm" x="-676.3" y="0" z="-451.25"/>
+		<rotationref ref="rPlus90AboutY"/>
     </union>
 
     <union name="FieldShaperSolidSlim">
       <first ref="FSunionSlim6"/>
       <second ref="FieldShaperCorner"/>
-   		<position name="esquinapos7" unit="cm" x="-2.3" y="0" z="-448.95"/>
-		<rotation name="rot7" unit="deg" x="90" y="90" z="0" />
+   		<position name="esquinapos13" unit="cm" x="-2.3" y="0" z="-448.95"/>
+		<rotationref ref="rPlus90AboutXPlus90AboutY"/>
     </union>
     
 
@@ -563,28 +569,28 @@
 
     <box name="Cryostat" lunit="cm" 
       x="850.3" 
-      y="1548.24" 
-      z="1098.14"/>
+      y="1510.24" 
+      z="1112.14"/>
 
     <box name="ArgonInterior" lunit="cm" 
       x="850.06"
-      y="1548"
-      z="1097.9"/>
+      y="1510"
+      z="1111.9"/>
 
     <box name="GaseousArgon" lunit="cm" 
       x="100 - 0.01"
-      y="1548"
-      z="1097.9"/>
+      y="1510"
+      z="1111.9"/>
 
     <box name="ExternalAuxOut" lunit="cm" 
       x="850.06 - 99.9999999999999"
-      y="1548 - 2*2.5 - 2*40"
-      z="1097.9"/>
+      y="1510 - 2*2.5 - 2*10"
+      z="1111.9"/>
 
     <box name="ExternalAuxIn" lunit="cm" 
       x="850.06"
       y="1359.17"
-      z="1097.9 + 1"/>
+      z="1111.9 + 1"/>
 
    <subtraction name="ExternalActive">
       <first ref="ExternalAuxOut"/>
@@ -697,8 +703,8 @@
 
     <box name="FoamPadBlock" lunit="cm"
       x="1010.3"
-      y="1708.24"
-      z="1258.14" />
+      y="1670.24"
+      z="1272.14" />
 
     <subtraction name="FoamPadding">
       <first ref="FoamPadBlock"/>
@@ -708,8 +714,8 @@
 
     <box name="SteelSupportBlock" lunit="cm"
       x="1210.3"
-      y="1908.24"
-      z="1458.14" />
+      y="1870.24"
+      z="1472.14" />
 
     <subtraction name="SteelSupport">
       <first ref="SteelSupportBlock"/>
@@ -719,22 +725,22 @@
 
     <box name="DetEnclosure" lunit="cm" 
       x="1310.3"
-      y="2108.24"
-      z="1658.14"/>
+      y="2070.24"
+      z="1672.14"/>
 
 
     <box name="World" lunit="cm" 
       x="9310.3" 
-      y="10108.24" 
-      z="9658.14"/>
+      y="10070.24" 
+      z="9672.14"/>
 </solids>
 <structure>
 <volume name="volFieldShaper">
-  <materialref ref="Al2O3"/>
+  <materialref ref="ALUMINUM_Al"/>
   <solidref ref="FieldShaperSolid"/>
 </volume>
 <volume name="volFieldShaperSlim">
-  <materialref ref="Al2O3"/>
+  <materialref ref="ALUMINUM_Al"/>
   <solidref ref="FieldShaperSolidSlim"/>
 </volume>
 
@@ -915,8 +921,8 @@
       <materialref ref="STEEL_STAINLESS_Fe7Cr2Ni" />
       <solidref ref="SteelShell" />
     </volume>
-    <volume name="volGroundGrid">
-      <materialref ref="STEEL_STAINLESS_Fe7Cr2Ni" />
+    <volume name="volCathodeGrid">
+      <materialref ref="G10" />
       <solidref ref="CathodeGrid" />
     </volume>
     <volume name="volAnodePlate">
@@ -935,6 +941,34 @@
       <auxiliary auxtype="Efield" auxunit="V/cm" auxvalue="0*V/cm"/>
       <colorref ref="green"/>
     </volume>
+
+    <volume name="volArapucaShortLat">
+      <materialref ref="G10"/>
+      <solidref ref="ArapucaWalls"/>
+    </volume>
+    <volume name="volOpDetSensitive">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+
+    <volume name="Arapuca">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+
+    <volume name="volArapuca">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaOut"/>
+      <physvol>
+        <volumeref ref="Arapuca"/>
+        <positionref ref="posCenter"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volOpDetSensitive"/>
+        <position name="opdetshift" unit="cm" x="0" y="0.5" z="0"/>
+      </physvol>
+    </volume>
+
     <volume name="volArapucaDouble_0-0-0">
       <materialref ref="G10" />
       <solidref ref="ArapucaWalls" />
@@ -1770,546 +1804,546 @@
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper0" unit="cm"  x="-322.03" y="-676.3" z="0" />
-     <rotation name="rotFS0" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper1" unit="cm"  x="-316.03" y="-676.3" z="0" />
-     <rotation name="rotFS1" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper2" unit="cm"  x="-310.03" y="-676.3" z="0" />
-     <rotation name="rotFS2" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper3" unit="cm"  x="-304.03" y="-676.3" z="0" />
-     <rotation name="rotFS3" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper4" unit="cm"  x="-298.03" y="-676.3" z="0" />
-     <rotation name="rotFS4" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper5" unit="cm"  x="-292.03" y="-676.3" z="0" />
-     <rotation name="rotFS5" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper6" unit="cm"  x="-286.03" y="-676.3" z="0" />
-     <rotation name="rotFS6" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper7" unit="cm"  x="-280.03" y="-676.3" z="0" />
-     <rotation name="rotFS7" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper8" unit="cm"  x="-274.03" y="-676.3" z="0" />
-     <rotation name="rotFS8" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper9" unit="cm"  x="-268.03" y="-676.3" z="0" />
-     <rotation name="rotFS9" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper10" unit="cm"  x="-262.03" y="-676.3" z="0" />
-     <rotation name="rotFS10" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper11" unit="cm"  x="-256.03" y="-676.3" z="0" />
-     <rotation name="rotFS11" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper12" unit="cm"  x="-250.03" y="-676.3" z="0" />
-     <rotation name="rotFS12" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper13" unit="cm"  x="-244.03" y="-676.3" z="0" />
-     <rotation name="rotFS13" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper14" unit="cm"  x="-238.03" y="-676.3" z="0" />
-     <rotation name="rotFS14" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper15" unit="cm"  x="-232.03" y="-676.3" z="0" />
-     <rotation name="rotFS15" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper16" unit="cm"  x="-226.03" y="-676.3" z="0" />
-     <rotation name="rotFS16" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper17" unit="cm"  x="-220.03" y="-676.3" z="0" />
-     <rotation name="rotFS17" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper18" unit="cm"  x="-214.03" y="-676.3" z="0" />
-     <rotation name="rotFS18" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper19" unit="cm"  x="-208.03" y="-676.3" z="0" />
-     <rotation name="rotFS19" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper20" unit="cm"  x="-202.03" y="-676.3" z="0" />
-     <rotation name="rotFS20" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper21" unit="cm"  x="-196.03" y="-676.3" z="0" />
-     <rotation name="rotFS21" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper22" unit="cm"  x="-190.03" y="-676.3" z="0" />
-     <rotation name="rotFS22" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper23" unit="cm"  x="-184.03" y="-676.3" z="0" />
-     <rotation name="rotFS23" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper24" unit="cm"  x="-178.03" y="-676.3" z="0" />
-     <rotation name="rotFS24" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper25" unit="cm"  x="-172.03" y="-676.3" z="0" />
-     <rotation name="rotFS25" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper26" unit="cm"  x="-166.03" y="-676.3" z="0" />
-     <rotation name="rotFS26" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper27" unit="cm"  x="-160.03" y="-676.3" z="0" />
-     <rotation name="rotFS27" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper28" unit="cm"  x="-154.03" y="-676.3" z="0" />
-     <rotation name="rotFS28" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper29" unit="cm"  x="-148.03" y="-676.3" z="0" />
-     <rotation name="rotFS29" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper30" unit="cm"  x="-142.03" y="-676.3" z="0" />
-     <rotation name="rotFS30" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper31" unit="cm"  x="-136.03" y="-676.3" z="0" />
-     <rotation name="rotFS31" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper32" unit="cm"  x="-130.03" y="-676.3" z="0" />
-     <rotation name="rotFS32" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper33" unit="cm"  x="-124.03" y="-676.3" z="0" />
-     <rotation name="rotFS33" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper34" unit="cm"  x="-118.03" y="-676.3" z="0" />
-     <rotation name="rotFS34" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper35" unit="cm"  x="-112.03" y="-676.3" z="0" />
-     <rotation name="rotFS35" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper36" unit="cm"  x="-106.03" y="-676.3" z="0" />
-     <rotation name="rotFS36" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper37" unit="cm"  x="-100.03" y="-676.3" z="0" />
-     <rotation name="rotFS37" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper38" unit="cm"  x="-94.03" y="-676.3" z="0" />
-     <rotation name="rotFS38" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper39" unit="cm"  x="-88.03" y="-676.3" z="0" />
-     <rotation name="rotFS39" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper40" unit="cm"  x="-82.03" y="-676.3" z="0" />
-     <rotation name="rotFS40" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaper"/>
      <position name="posFieldShaper41" unit="cm"  x="-76.03" y="-676.3" z="0" />
-     <rotation name="rotFS41" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper42" unit="cm"  x="-70.03" y="-676.3" z="0" />
-     <rotation name="rotFS42" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper43" unit="cm"  x="-64.03" y="-676.3" z="0" />
-     <rotation name="rotFS43" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper44" unit="cm"  x="-58.03" y="-676.3" z="0" />
-     <rotation name="rotFS44" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper45" unit="cm"  x="-52.03" y="-676.3" z="0" />
-     <rotation name="rotFS45" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper46" unit="cm"  x="-46.03" y="-676.3" z="0" />
-     <rotation name="rotFS46" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper47" unit="cm"  x="-40.03" y="-676.3" z="0" />
-     <rotation name="rotFS47" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper48" unit="cm"  x="-34.03" y="-676.3" z="0" />
-     <rotation name="rotFS48" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper49" unit="cm"  x="-28.03" y="-676.3" z="0" />
-     <rotation name="rotFS49" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper50" unit="cm"  x="-22.03" y="-676.3" z="0" />
-     <rotation name="rotFS50" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper51" unit="cm"  x="-16.03" y="-676.3" z="0" />
-     <rotation name="rotFS51" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper52" unit="cm"  x="-10.03" y="-676.3" z="0" />
-     <rotation name="rotFS52" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper53" unit="cm"  x="-4.03000000000002" y="-676.3" z="0" />
-     <rotation name="rotFS53" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper54" unit="cm"  x="1.96999999999998" y="-676.3" z="0" />
-     <rotation name="rotFS54" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper55" unit="cm"  x="7.96999999999998" y="-676.3" z="0" />
-     <rotation name="rotFS55" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper56" unit="cm"  x="13.97" y="-676.3" z="0" />
-     <rotation name="rotFS56" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper57" unit="cm"  x="19.97" y="-676.3" z="0" />
-     <rotation name="rotFS57" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper58" unit="cm"  x="25.97" y="-676.3" z="0" />
-     <rotation name="rotFS58" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper59" unit="cm"  x="31.97" y="-676.3" z="0" />
-     <rotation name="rotFS59" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper60" unit="cm"  x="37.97" y="-676.3" z="0" />
-     <rotation name="rotFS60" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper61" unit="cm"  x="43.97" y="-676.3" z="0" />
-     <rotation name="rotFS61" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper62" unit="cm"  x="49.97" y="-676.3" z="0" />
-     <rotation name="rotFS62" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper63" unit="cm"  x="55.97" y="-676.3" z="0" />
-     <rotation name="rotFS63" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper64" unit="cm"  x="61.97" y="-676.3" z="0" />
-     <rotation name="rotFS64" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper65" unit="cm"  x="67.97" y="-676.3" z="0" />
-     <rotation name="rotFS65" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper66" unit="cm"  x="73.97" y="-676.3" z="0" />
-     <rotation name="rotFS66" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper67" unit="cm"  x="79.97" y="-676.3" z="0" />
-     <rotation name="rotFS67" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper68" unit="cm"  x="85.97" y="-676.3" z="0" />
-     <rotation name="rotFS68" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper69" unit="cm"  x="91.97" y="-676.3" z="0" />
-     <rotation name="rotFS69" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper70" unit="cm"  x="97.97" y="-676.3" z="0" />
-     <rotation name="rotFS70" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper71" unit="cm"  x="103.97" y="-676.3" z="0" />
-     <rotation name="rotFS71" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper72" unit="cm"  x="109.97" y="-676.3" z="0" />
-     <rotation name="rotFS72" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper73" unit="cm"  x="115.97" y="-676.3" z="0" />
-     <rotation name="rotFS73" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper74" unit="cm"  x="121.97" y="-676.3" z="0" />
-     <rotation name="rotFS74" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper75" unit="cm"  x="127.97" y="-676.3" z="0" />
-     <rotation name="rotFS75" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper76" unit="cm"  x="133.97" y="-676.3" z="0" />
-     <rotation name="rotFS76" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper77" unit="cm"  x="139.97" y="-676.3" z="0" />
-     <rotation name="rotFS77" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper78" unit="cm"  x="145.97" y="-676.3" z="0" />
-     <rotation name="rotFS78" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper79" unit="cm"  x="151.97" y="-676.3" z="0" />
-     <rotation name="rotFS79" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper80" unit="cm"  x="157.97" y="-676.3" z="0" />
-     <rotation name="rotFS80" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper81" unit="cm"  x="163.97" y="-676.3" z="0" />
-     <rotation name="rotFS81" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper82" unit="cm"  x="169.97" y="-676.3" z="0" />
-     <rotation name="rotFS82" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper83" unit="cm"  x="175.97" y="-676.3" z="0" />
-     <rotation name="rotFS83" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper84" unit="cm"  x="181.97" y="-676.3" z="0" />
-     <rotation name="rotFS84" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper85" unit="cm"  x="187.97" y="-676.3" z="0" />
-     <rotation name="rotFS85" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper86" unit="cm"  x="193.97" y="-676.3" z="0" />
-     <rotation name="rotFS86" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper87" unit="cm"  x="199.97" y="-676.3" z="0" />
-     <rotation name="rotFS87" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper88" unit="cm"  x="205.97" y="-676.3" z="0" />
-     <rotation name="rotFS88" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper89" unit="cm"  x="211.97" y="-676.3" z="0" />
-     <rotation name="rotFS89" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper90" unit="cm"  x="217.97" y="-676.3" z="0" />
-     <rotation name="rotFS90" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper91" unit="cm"  x="223.97" y="-676.3" z="0" />
-     <rotation name="rotFS91" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper92" unit="cm"  x="229.97" y="-676.3" z="0" />
-     <rotation name="rotFS92" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper93" unit="cm"  x="235.97" y="-676.3" z="0" />
-     <rotation name="rotFS93" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper94" unit="cm"  x="241.97" y="-676.3" z="0" />
-     <rotation name="rotFS94" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper95" unit="cm"  x="247.97" y="-676.3" z="0" />
-     <rotation name="rotFS95" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper96" unit="cm"  x="253.97" y="-676.3" z="0" />
-     <rotation name="rotFS96" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper97" unit="cm"  x="259.97" y="-676.3" z="0" />
-     <rotation name="rotFS97" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper98" unit="cm"  x="265.97" y="-676.3" z="0" />
-     <rotation name="rotFS98" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper99" unit="cm"  x="271.97" y="-676.3" z="0" />
-     <rotation name="rotFS99" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper100" unit="cm"  x="277.97" y="-676.3" z="0" />
-     <rotation name="rotFS100" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper101" unit="cm"  x="283.97" y="-676.3" z="0" />
-     <rotation name="rotFS101" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper102" unit="cm"  x="289.97" y="-676.3" z="0" />
-     <rotation name="rotFS102" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper103" unit="cm"  x="295.97" y="-676.3" z="0" />
-     <rotation name="rotFS103" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper104" unit="cm"  x="301.97" y="-676.3" z="0" />
-     <rotation name="rotFS104" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper105" unit="cm"  x="307.97" y="-676.3" z="0" />
-     <rotation name="rotFS105" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper106" unit="cm"  x="313.97" y="-676.3" z="0" />
-     <rotation name="rotFS106" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
   <physvol>
      <volumeref ref="volFieldShaperSlim"/>
      <position name="posFieldShaper107" unit="cm"  x="319.97" y="-676.3" z="0" />
-     <rotation name="rotFS107" unit="deg" x="0" y="0" z="90" />
+     <rotationref ref="rPlus90AboutZ"/>
   </physvol>
       <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-0" unit="cm" x="-328.03" y="-505.5" z="-299.3"/>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-0" unit="cm" x="-328.03" y="-505.5" z="-299.3"/>
       </physvol>
       <physvol>
        <volumeref ref="volAnodePlate"/>
@@ -2317,8 +2351,8 @@
        <rotationref ref="rIdentity"/>
      </physvol>    
       <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-1" unit="cm" x="-328.03" y="-168.5" z="-299.3"/>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-1" unit="cm" x="-328.03" y="-168.5" z="-299.3"/>
       </physvol>
       <physvol>
        <volumeref ref="volAnodePlate"/>
@@ -2326,8 +2360,8 @@
        <rotationref ref="rIdentity"/>
      </physvol>    
       <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-2" unit="cm" x="-328.03" y="168.5" z="-299.3"/>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-2" unit="cm" x="-328.03" y="168.5" z="-299.3"/>
       </physvol>
       <physvol>
        <volumeref ref="volAnodePlate"/>
@@ -2335,8 +2369,8 @@
        <rotationref ref="rIdentity"/>
      </physvol>    
       <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-3" unit="cm" x="-328.03" y="505.5" z="-299.3"/>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-3" unit="cm" x="-328.03" y="505.5" z="-299.3"/>
       </physvol>
       <physvol>
        <volumeref ref="volAnodePlate"/>
@@ -2344,8 +2378,8 @@
        <rotationref ref="rIdentity"/>
      </physvol>    
       <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-4" unit="cm" x="-328.03" y="-505.5" z="-5.6843418860808e-14"/>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-4" unit="cm" x="-328.03" y="-505.5" z="-5.6843418860808e-14"/>
       </physvol>
       <physvol>
        <volumeref ref="volAnodePlate"/>
@@ -2353,8 +2387,8 @@
        <rotationref ref="rIdentity"/>
      </physvol>    
       <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-5" unit="cm" x="-328.03" y="-168.5" z="-5.6843418860808e-14"/>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-5" unit="cm" x="-328.03" y="-168.5" z="-5.6843418860808e-14"/>
       </physvol>
       <physvol>
        <volumeref ref="volAnodePlate"/>
@@ -2362,8 +2396,8 @@
        <rotationref ref="rIdentity"/>
      </physvol>    
       <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-6" unit="cm" x="-328.03" y="168.5" z="-5.6843418860808e-14"/>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-6" unit="cm" x="-328.03" y="168.5" z="-5.6843418860808e-14"/>
       </physvol>
       <physvol>
        <volumeref ref="volAnodePlate"/>
@@ -2371,8 +2405,8 @@
        <rotationref ref="rIdentity"/>
      </physvol>    
       <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-7" unit="cm" x="-328.03" y="505.5" z="-5.6843418860808e-14"/>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-7" unit="cm" x="-328.03" y="505.5" z="-5.6843418860808e-14"/>
       </physvol>
       <physvol>
        <volumeref ref="volAnodePlate"/>
@@ -2380,8 +2414,8 @@
        <rotationref ref="rIdentity"/>
      </physvol>    
       <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-8" unit="cm" x="-328.03" y="-505.5" z="299.3"/>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-8" unit="cm" x="-328.03" y="-505.5" z="299.3"/>
       </physvol>
       <physvol>
        <volumeref ref="volAnodePlate"/>
@@ -2389,8 +2423,8 @@
        <rotationref ref="rIdentity"/>
      </physvol>    
       <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-9" unit="cm" x="-328.03" y="-168.5" z="299.3"/>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-9" unit="cm" x="-328.03" y="-168.5" z="299.3"/>
       </physvol>
       <physvol>
        <volumeref ref="volAnodePlate"/>
@@ -2398,8 +2432,8 @@
        <rotationref ref="rIdentity"/>
      </physvol>    
       <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-10" unit="cm" x="-328.03" y="168.5" z="299.3"/>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-10" unit="cm" x="-328.03" y="168.5" z="299.3"/>
       </physvol>
       <physvol>
        <volumeref ref="volAnodePlate"/>
@@ -2407,8 +2441,8 @@
        <rotationref ref="rIdentity"/>
      </physvol>    
       <physvol>
-   <volumeref ref="volGroundGrid"/>
-   <position name="posGroundGrid-11" unit="cm" x="-328.03" y="505.5" z="299.3"/>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-11" unit="cm" x="-328.03" y="505.5" z="299.3"/>
       </physvol>
       <physvol>
        <volumeref ref="volAnodePlate"/>
@@ -2421,7 +2455,7 @@
          x="-328.03"
 	 y="-633.2" 
 	 z="-261.8"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-0"/>
@@ -2436,7 +2470,7 @@
          x="-328.03"
 	 y="-542.5" 
 	 z="-407.8"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-1"/>
@@ -2451,7 +2485,7 @@
          x="-328.03"
 	 y="-468.5" 
 	 z="-190.8"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-2"/>
@@ -2466,7 +2500,7 @@
          x="-328.03"
 	 y="-377.8" 
 	 z="-336.8"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-0-3"/>
@@ -2481,7 +2515,7 @@
          x="-328.03"
 	 y="-633.2" 
 	 z="37.4999999999999"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-0"/>
@@ -2496,7 +2530,7 @@
          x="-328.03"
 	 y="-542.5" 
 	 z="-108.5"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-1"/>
@@ -2511,7 +2545,7 @@
          x="-328.03"
 	 y="-468.5" 
 	 z="108.5"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-2"/>
@@ -2526,7 +2560,7 @@
          x="-328.03"
 	 y="-377.8" 
 	 z="-37.5000000000001"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-1-3"/>
@@ -2541,7 +2575,7 @@
          x="-328.03"
 	 y="-633.2" 
 	 z="336.8"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-0"/>
@@ -2556,7 +2590,7 @@
          x="-328.03"
 	 y="-542.5" 
 	 z="190.8"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-1"/>
@@ -2571,7 +2605,7 @@
          x="-328.03"
 	 y="-468.5" 
 	 z="407.8"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-2"/>
@@ -2586,7 +2620,7 @@
          x="-328.03"
 	 y="-377.8" 
 	 z="261.8"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_0-2-3"/>
@@ -2601,7 +2635,7 @@
          x="-328.03"
 	 y="-296.2" 
 	 z="-261.8"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-0"/>
@@ -2616,7 +2650,7 @@
          x="-328.03"
 	 y="-205.5" 
 	 z="-407.8"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-1"/>
@@ -2631,7 +2665,7 @@
          x="-328.03"
 	 y="-131.5" 
 	 z="-190.8"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-2"/>
@@ -2646,7 +2680,7 @@
          x="-328.03"
 	 y="-40.8" 
 	 z="-336.8"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-0-3"/>
@@ -2661,7 +2695,7 @@
          x="-328.03"
 	 y="-296.2" 
 	 z="37.4999999999999"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-0"/>
@@ -2676,7 +2710,7 @@
          x="-328.03"
 	 y="-205.5" 
 	 z="-108.5"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-1"/>
@@ -2691,7 +2725,7 @@
          x="-328.03"
 	 y="-131.5" 
 	 z="108.5"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-2"/>
@@ -2706,7 +2740,7 @@
          x="-328.03"
 	 y="-40.8" 
 	 z="-37.5000000000001"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-1-3"/>
@@ -2721,7 +2755,7 @@
          x="-328.03"
 	 y="-296.2" 
 	 z="336.8"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-0"/>
@@ -2736,7 +2770,7 @@
          x="-328.03"
 	 y="-205.5" 
 	 z="190.8"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-1"/>
@@ -2751,7 +2785,7 @@
          x="-328.03"
 	 y="-131.5" 
 	 z="407.8"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-2"/>
@@ -2766,7 +2800,7 @@
          x="-328.03"
 	 y="-40.8" 
 	 z="261.8"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_1-2-3"/>
@@ -2781,7 +2815,7 @@
          x="-328.03"
 	 y="40.8" 
 	 z="-261.8"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-0"/>
@@ -2796,7 +2830,7 @@
          x="-328.03"
 	 y="131.5" 
 	 z="-407.8"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-1"/>
@@ -2811,7 +2845,7 @@
          x="-328.03"
 	 y="205.5" 
 	 z="-190.8"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-2"/>
@@ -2826,7 +2860,7 @@
          x="-328.03"
 	 y="296.2" 
 	 z="-336.8"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-0-3"/>
@@ -2841,7 +2875,7 @@
          x="-328.03"
 	 y="40.8" 
 	 z="37.4999999999999"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-0"/>
@@ -2856,7 +2890,7 @@
          x="-328.03"
 	 y="131.5" 
 	 z="-108.5"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-1"/>
@@ -2871,7 +2905,7 @@
          x="-328.03"
 	 y="205.5" 
 	 z="108.5"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-2"/>
@@ -2886,7 +2920,7 @@
          x="-328.03"
 	 y="296.2" 
 	 z="-37.5000000000001"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-1-3"/>
@@ -2901,7 +2935,7 @@
          x="-328.03"
 	 y="40.8" 
 	 z="336.8"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-0"/>
@@ -2916,7 +2950,7 @@
          x="-328.03"
 	 y="131.5" 
 	 z="190.8"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-1"/>
@@ -2931,7 +2965,7 @@
          x="-328.03"
 	 y="205.5" 
 	 z="407.8"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-2"/>
@@ -2946,7 +2980,7 @@
          x="-328.03"
 	 y="296.2" 
 	 z="261.8"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_2-2-3"/>
@@ -2961,7 +2995,7 @@
          x="-328.03"
 	 y="377.8" 
 	 z="-261.8"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-0"/>
@@ -2976,7 +3010,7 @@
          x="-328.03"
 	 y="468.5" 
 	 z="-407.8"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-1"/>
@@ -2991,7 +3025,7 @@
          x="-328.03"
 	 y="542.5" 
 	 z="-190.8"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-2"/>
@@ -3006,7 +3040,7 @@
          x="-328.03"
 	 y="633.2" 
 	 z="-336.8"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-0-3"/>
@@ -3021,7 +3055,7 @@
          x="-328.03"
 	 y="377.8" 
 	 z="37.4999999999999"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-0"/>
@@ -3036,7 +3070,7 @@
          x="-328.03"
 	 y="468.5" 
 	 z="-108.5"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-1"/>
@@ -3051,7 +3085,7 @@
          x="-328.03"
 	 y="542.5" 
 	 z="108.5"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-2"/>
@@ -3066,7 +3100,7 @@
          x="-328.03"
 	 y="633.2" 
 	 z="-37.5000000000001"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-1-3"/>
@@ -3081,7 +3115,7 @@
          x="-328.03"
 	 y="377.8" 
 	 z="336.8"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-0"/>
@@ -3096,7 +3130,7 @@
          x="-328.03"
 	 y="468.5" 
 	 z="190.8"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-1"/>
@@ -3111,7 +3145,7 @@
          x="-328.03"
 	 y="542.5" 
 	 z="407.8"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-2"/>
@@ -3126,7 +3160,7 @@
          x="-328.03"
 	 y="633.2" 
 	 z="261.8"/>
-       <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaDouble_3-2-3"/>
@@ -3138,362 +3172,490 @@
      <physvol>
        <volumeref ref="volArapucaLat_0-0"/>
        <position name="posArapuca0-Lat-0" unit="cm" 
-         x="-40"
-	 y="-734" 
+         x="285.02"
+	 y="-745" 
 	 z="-299.3"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-0"/>
        <position name="posOpArapuca0-Lat-0" unit="cm" 
-         x="-40"
-	 y="-733.26" 
+         x="285.02"
+	 y="-744.26" 
 	 z="-299.3"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-1"/>
        <position name="posArapuca1-Lat-0" unit="cm" 
-         x="-115"
-	 y="-734" 
+         x="210.02"
+	 y="-745" 
 	 z="-299.3"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-1"/>
        <position name="posOpArapuca1-Lat-0" unit="cm" 
-         x="-115"
-	 y="-733.26" 
+         x="210.02"
+	 y="-744.26" 
 	 z="-299.3"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-2"/>
        <position name="posArapuca2-Lat-0" unit="cm" 
-         x="-190"
-	 y="-734" 
+         x="135.02"
+	 y="-745" 
 	 z="-299.3"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-2"/>
        <position name="posOpArapuca2-Lat-0" unit="cm" 
-         x="-190"
-	 y="-733.26" 
+         x="135.02"
+	 y="-744.26" 
 	 z="-299.3"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-3"/>
        <position name="posArapuca3-Lat-0" unit="cm" 
-         x="-265"
-	 y="-734" 
+         x="60.02"
+	 y="-745" 
 	 z="-299.3"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-3"/>
        <position name="posOpArapuca3-Lat-0" unit="cm" 
-         x="-265"
-	 y="-733.26" 
+         x="60.02"
+	 y="-744.26" 
 	 z="-299.3"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-4"/>
        <position name="posArapuca4-Lat-0" unit="cm" 
-         x="-40"
-	 y="734" 
+         x="285.02"
+	 y="745" 
 	 z="-299.3"/>
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-4"/>
        <position name="posOpArapuca4-Lat-0" unit="cm" 
-         x="-40"
-	 y="733.26" 
+         x="285.02"
+	 y="744.26" 
 	 z="-299.3"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-5"/>
        <position name="posArapuca5-Lat-0" unit="cm" 
-         x="-115"
-	 y="734" 
+         x="210.02"
+	 y="745" 
 	 z="-299.3"/>
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-5"/>
        <position name="posOpArapuca5-Lat-0" unit="cm" 
-         x="-115"
-	 y="733.26" 
+         x="210.02"
+	 y="744.26" 
 	 z="-299.3"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-6"/>
        <position name="posArapuca6-Lat-0" unit="cm" 
-         x="-190"
-	 y="734" 
+         x="135.02"
+	 y="745" 
 	 z="-299.3"/>
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-6"/>
        <position name="posOpArapuca6-Lat-0" unit="cm" 
-         x="-190"
-	 y="733.26" 
+         x="135.02"
+	 y="744.26" 
 	 z="-299.3"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_0-7"/>
        <position name="posArapuca7-Lat-0" unit="cm" 
-         x="-265"
-	 y="734" 
+         x="60.02"
+	 y="745" 
 	 z="-299.3"/>
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_0-7"/>
        <position name="posOpArapuca7-Lat-0" unit="cm" 
-         x="-265"
-	 y="733.26" 
+         x="60.02"
+	 y="744.26" 
 	 z="-299.3"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-0"/>
        <position name="posArapuca0-Lat-1" unit="cm" 
-         x="-40"
-	 y="-734" 
+         x="285.02"
+	 y="-745" 
 	 z="2.8421709430404e-13"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-0"/>
        <position name="posOpArapuca0-Lat-1" unit="cm" 
-         x="-40"
-	 y="-733.26" 
+         x="285.02"
+	 y="-744.26" 
 	 z="2.8421709430404e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-1"/>
        <position name="posArapuca1-Lat-1" unit="cm" 
-         x="-115"
-	 y="-734" 
+         x="210.02"
+	 y="-745" 
 	 z="2.8421709430404e-13"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-1"/>
        <position name="posOpArapuca1-Lat-1" unit="cm" 
-         x="-115"
-	 y="-733.26" 
+         x="210.02"
+	 y="-744.26" 
 	 z="2.8421709430404e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-2"/>
        <position name="posArapuca2-Lat-1" unit="cm" 
-         x="-190"
-	 y="-734" 
+         x="135.02"
+	 y="-745" 
 	 z="2.8421709430404e-13"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-2"/>
        <position name="posOpArapuca2-Lat-1" unit="cm" 
-         x="-190"
-	 y="-733.26" 
+         x="135.02"
+	 y="-744.26" 
 	 z="2.8421709430404e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-3"/>
        <position name="posArapuca3-Lat-1" unit="cm" 
-         x="-265"
-	 y="-734" 
+         x="60.02"
+	 y="-745" 
 	 z="2.8421709430404e-13"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-3"/>
        <position name="posOpArapuca3-Lat-1" unit="cm" 
-         x="-265"
-	 y="-733.26" 
+         x="60.02"
+	 y="-744.26" 
 	 z="2.8421709430404e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-4"/>
        <position name="posArapuca4-Lat-1" unit="cm" 
-         x="-40"
-	 y="734" 
+         x="285.02"
+	 y="745" 
 	 z="2.8421709430404e-13"/>
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-4"/>
        <position name="posOpArapuca4-Lat-1" unit="cm" 
-         x="-40"
-	 y="733.26" 
+         x="285.02"
+	 y="744.26" 
 	 z="2.8421709430404e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-5"/>
        <position name="posArapuca5-Lat-1" unit="cm" 
-         x="-115"
-	 y="734" 
+         x="210.02"
+	 y="745" 
 	 z="2.8421709430404e-13"/>
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-5"/>
        <position name="posOpArapuca5-Lat-1" unit="cm" 
-         x="-115"
-	 y="733.26" 
+         x="210.02"
+	 y="744.26" 
 	 z="2.8421709430404e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-6"/>
        <position name="posArapuca6-Lat-1" unit="cm" 
-         x="-190"
-	 y="734" 
+         x="135.02"
+	 y="745" 
 	 z="2.8421709430404e-13"/>
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-6"/>
        <position name="posOpArapuca6-Lat-1" unit="cm" 
-         x="-190"
-	 y="733.26" 
+         x="135.02"
+	 y="744.26" 
 	 z="2.8421709430404e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_1-7"/>
        <position name="posArapuca7-Lat-1" unit="cm" 
-         x="-265"
-	 y="734" 
+         x="60.02"
+	 y="745" 
 	 z="2.8421709430404e-13"/>
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_1-7"/>
        <position name="posOpArapuca7-Lat-1" unit="cm" 
-         x="-265"
-	 y="733.26" 
+         x="60.02"
+	 y="744.26" 
 	 z="2.8421709430404e-13"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-0"/>
        <position name="posArapuca0-Lat-2" unit="cm" 
-         x="-40"
-	 y="-734" 
+         x="285.02"
+	 y="-745" 
 	 z="299.3"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-0"/>
        <position name="posOpArapuca0-Lat-2" unit="cm" 
-         x="-40"
-	 y="-733.26" 
+         x="285.02"
+	 y="-744.26" 
 	 z="299.3"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-1"/>
        <position name="posArapuca1-Lat-2" unit="cm" 
-         x="-115"
-	 y="-734" 
+         x="210.02"
+	 y="-745" 
 	 z="299.3"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-1"/>
        <position name="posOpArapuca1-Lat-2" unit="cm" 
-         x="-115"
-	 y="-733.26" 
+         x="210.02"
+	 y="-744.26" 
 	 z="299.3"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-2"/>
        <position name="posArapuca2-Lat-2" unit="cm" 
-         x="-190"
-	 y="-734" 
+         x="135.02"
+	 y="-745" 
 	 z="299.3"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-2"/>
        <position name="posOpArapuca2-Lat-2" unit="cm" 
-         x="-190"
-	 y="-733.26" 
+         x="135.02"
+	 y="-744.26" 
 	 z="299.3"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-3"/>
        <position name="posArapuca3-Lat-2" unit="cm" 
-         x="-265"
-	 y="-734" 
+         x="60.02"
+	 y="-745" 
 	 z="299.3"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-3"/>
        <position name="posOpArapuca3-Lat-2" unit="cm" 
-         x="-265"
-	 y="-733.26" 
+         x="60.02"
+	 y="-744.26" 
 	 z="299.3"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-4"/>
        <position name="posArapuca4-Lat-2" unit="cm" 
-         x="-40"
-	 y="734" 
+         x="285.02"
+	 y="745" 
 	 z="299.3"/>
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-4"/>
        <position name="posOpArapuca4-Lat-2" unit="cm" 
-         x="-40"
-	 y="733.26" 
+         x="285.02"
+	 y="744.26" 
 	 z="299.3"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-5"/>
        <position name="posArapuca5-Lat-2" unit="cm" 
-         x="-115"
-	 y="734" 
+         x="210.02"
+	 y="745" 
 	 z="299.3"/>
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-5"/>
        <position name="posOpArapuca5-Lat-2" unit="cm" 
-         x="-115"
-	 y="733.26" 
+         x="210.02"
+	 y="744.26" 
 	 z="299.3"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-6"/>
        <position name="posArapuca6-Lat-2" unit="cm" 
-         x="-190"
-	 y="734" 
+         x="135.02"
+	 y="745" 
 	 z="299.3"/>
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-6"/>
        <position name="posOpArapuca6-Lat-2" unit="cm" 
-         x="-190"
-	 y="733.26" 
+         x="135.02"
+	 y="744.26" 
 	 z="299.3"/>
      </physvol>
      <physvol>
        <volumeref ref="volArapucaLat_2-7"/>
        <position name="posArapuca7-Lat-2" unit="cm" 
-         x="-265"
-	 y="734" 
+         x="60.02"
+	 y="745" 
 	 z="299.3"/>
        <rotationref ref="rPlus180AboutX"/>
      </physvol>
      <physvol>
        <volumeref ref="volOpDetSensitive_ArapucaLat_2-7"/>
        <position name="posOpArapuca7-Lat-2" unit="cm" 
-         x="-265"
-	 y="733.26" 
+         x="60.02"
+	 y="744.26" 
 	 z="299.3"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca0-ShortLat-2" unit="cm" 
+         x="285.02"
+	 y="-220" 
+	 z="-545.95"/>
+       <rotationref ref="rMinus90AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca1-ShortLat-2" unit="cm" 
+         x="210.02"
+	 y="-220" 
+	 z="-545.95"/>
+       <rotationref ref="rMinus90AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca2-ShortLat-2" unit="cm" 
+         x="135.02"
+	 y="-220" 
+	 z="-545.95"/>
+       <rotationref ref="rMinus90AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca3-ShortLat-2" unit="cm" 
+         x="60.02"
+	 y="-220" 
+	 z="-545.95"/>
+       <rotationref ref="rMinus90AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca4-ShortLat-2" unit="cm" 
+         x="285.02"
+	 y="-220" 
+	 z="545.95"/>
+       <rotationref ref="rPlus90AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca5-ShortLat-2" unit="cm" 
+         x="210.02"
+	 y="-220" 
+	 z="545.95"/>
+       <rotationref ref="rPlus90AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca6-ShortLat-2" unit="cm" 
+         x="135.02"
+	 y="-220" 
+	 z="545.95"/>
+       <rotationref ref="rPlus90AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca7-ShortLat-2" unit="cm" 
+         x="60.02"
+	 y="-220" 
+	 z="545.95"/>
+       <rotationref ref="rPlus90AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca0-ShortLat-2" unit="cm" 
+         x="285.02"
+	 y="220" 
+	 z="-545.95"/>
+       <rotationref ref="rMinus90AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca1-ShortLat-2" unit="cm" 
+         x="210.02"
+	 y="220" 
+	 z="-545.95"/>
+       <rotationref ref="rMinus90AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca2-ShortLat-2" unit="cm" 
+         x="135.02"
+	 y="220" 
+	 z="-545.95"/>
+       <rotationref ref="rMinus90AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca3-ShortLat-2" unit="cm" 
+         x="60.02"
+	 y="220" 
+	 z="-545.95"/>
+       <rotationref ref="rMinus90AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca4-ShortLat-2" unit="cm" 
+         x="285.02"
+	 y="220" 
+	 z="545.95"/>
+       <rotationref ref="rPlus90AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca5-ShortLat-2" unit="cm" 
+         x="210.02"
+	 y="220" 
+	 z="545.95"/>
+       <rotationref ref="rPlus90AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca6-ShortLat-2" unit="cm" 
+         x="135.02"
+	 y="220" 
+	 z="545.95"/>
+       <rotationref ref="rPlus90AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca7-ShortLat-2" unit="cm" 
+         x="60.02"
+	 y="220" 
+	 z="545.95"/>
+       <rotationref ref="rPlus90AboutX"/>
      </physvol>
     </volume>
 
@@ -3536,7 +3698,9 @@
 
     </volume>
 </structure>
+
   <setup name="Default" version="1.0">
     <world ref="volWorld"/>
   </setup>
+
 </gdml_simple_extension>

--- a/dunecore/Geometry/gdml/generate_dunevd10kt_3view_30deg_v5_refactored.pl
+++ b/dunecore/Geometry/gdml/generate_dunevd10kt_3view_30deg_v5_refactored.pl
@@ -1,0 +1,2377 @@
+#!/usr/bin/perl
+
+#
+#
+#  First attempt to make a GDML fragment generator for the DUNE vertical drift 
+#  10kt detector geometry with 3 views: +/- Xdeg for induction and 90 deg collection
+#  The lower chamber is not added yet. 
+#  !!!NOTE!!!: the readout is on a positive Y plane (drift along horizontal X)
+#              due to current reco limitations)
+#  No photon detectors declared
+#  Simplified treatment of inter-module dead spaces
+#
+#  Created: Thu Oct  1 16:45:27 CEST 2020
+#           Vyacheslav Galymov <vgalymov@ipnl.in2p3.fr>
+#
+#  Modified:
+#           VG: Added defs to enable use in the refactored sim framework
+#           VG: 23.02.21 Adjust plane dimensions to fit a given number of ch per side
+#           VG: 23.02.21 Group CRUs in CRPs
+#           VG: 02.03.21 The length for the ROP is force to be the lenght
+#                        given by nch_collection x pitch_collection
+#    V2:    Laura Paulucci (lpaulucc@fnal.gov): Sept 2021 PDS added. 
+#             Use option -pds=1 for backup design (membrane only coverage).
+#             Default (pds=0) is the reference design (~4-pi).
+#             This is linked with a larger geometry to account for photon propagation, generate it with -k=4.
+#             Field Cage is turned on with reference and backup designs to match PDS option.
+#	      For not including the pds, please use option -pds=-1
+#    V3:      Mar 2022: Cathode included
+#             Apr 2022: Pitch and number of channels changed. 
+#                       Collection pitch = 5.1 mm (4.89 mm in v2)
+#                       Induction pitch = 7.65 mm (7.335 mm in v2) 
+#                       Reference for changes: https://indico.fnal.gov/event/53111/timetable/
+#    V4:    May 2022: Inclusion of anode plate on top of the 3 wire planes as requested by the background TF.
+#           This is included together with the cathode switch on. In order to avoid overlaps, the gaseous argon
+#           was decreased and displaced by $anodePlateWidth = 0.01 cm. Currently the material of this plate is 
+#           set to vm2000 so that no additional geometry (ReflAnode) is needed to obtain optical fast simulation.
+#    V5:    Reorganize the "wire" generator algorithm to allow 
+#           easily generating full length strips on the CRU plane
+#           These are then split through mid-CRU section to make
+#           wire objets for geo planes and geo vol TPCs, as done
+#           by V. Galymov for the ColdBox2
+#           LAr buffer around the active volume in Y and Z has been adapted in the workspace geometries to fit
+#           the numbers of the full geometry.
+#           PDS:
+#                Arapucas in the short laterals included in all 8-CRMs-width workspace geometries.
+#                Distance Membrane to Arapuca is set to 10cm.
+#                Field Cage is set to Aluminum_Al, cathode is set to G10.
+#           TO DO: include perforated PCB in the gdml (see LEMs in dual phase gdml)
+#
+#################################################################################
+
+# Each subroutine generates a fragment GDML file, and the last subroutine
+# creates an XML file that make_gdml.pl will use to appropriately arrange
+# the fragment GDML files to create the final desired DUNE GDML file, 
+# to be named by make_gdml output command
+
+##################################################################################
+
+
+#use warnings;
+use gdmlMaterials;
+use Math::Trig;
+use Getopt::Long;
+use Math::BigFloat;
+Math::BigFloat->precision(-16);
+
+###
+GetOptions( "help|h" => \$help,
+	    "suffix|s:s" => \$suffix,
+	    "output|o:s" => \$output,
+	    "wires|w:s" => \$wires,  
+            "workspace|k:s" => \$wkspc,
+            "pdsconfig|pds:s" => \$pdsconfig);
+
+my $FieldCage_switch="on";
+my $Cathode_switch="on";
+$GroundGrid_switch="off";
+$ExtractionGrid_switch="off";
+
+if ( defined $help )
+{
+    # If the user requested help, print the usage notes and exit.
+    usage();
+    exit;
+}
+
+if ( ! defined $suffix )
+{
+    # The user didn't supply a suffix, so append nothing to the file
+    # names.
+    $suffix = "";
+}
+else
+{
+    # Otherwise, stick a "-" before the suffix, so that a suffix of
+    # "test" applied to filename.gdml becomes "filename-test.gdml".
+    $suffix = "-" . $suffix;
+}
+
+
+$workspace = 0;
+if(defined $wkspc ) 
+{
+    $workspace = $wkspc;
+}
+elsif ( $workspace != 0 )
+{
+    print "\t\tCreating smaller workspace geometry.\n";
+}
+
+if ( ! defined $pdsconfig )
+{
+    $pdsconfig = 0;
+    print "\t\tCreating reference design: 4-pi PDS converage.\n";
+}
+elsif ( $pdsconfig == 1 )
+{
+    print "\t\tCreating backup design: membrane-only PDS coverage.\n";
+}
+
+# set wires on to be the default, unless given an input by the user
+$wires_on = 1; # 1=on, 0=off
+if (defined $wires)
+{
+    $wires_on = $wires;
+}
+
+$tpc_on = 1;
+$basename="dunevd10kt";
+
+
+##################################################################
+############## Parameters for One Readout Panel ##################
+
+$widthCRM_active  = $widthPCBActive;  
+$lengthCRM_active = $lengthPCBActive; 
+
+$widthCRM  = $widthPCBActive  + 2 * $borderCRM;
+$lengthCRM = $lengthPCBActive + 2 * $borderCRM;
+
+$borderCRP = 0.5; # cm
+
+
+# views and channel counts per CRU (=1/2 of CRP)
+%nChans = ('Ind1', 476, 'Ind2', 476, 'Col', 2*292);
+$nViews = keys %nChans;
+
+# first induction view
+$wirePitchU      = 0.765;  # cm
+$wireAngleU      = 150.0;   # deg
+
+# second induction view
+$wirePitchV      = 0.765;  # cm
+$wireAngleV      = 30.0;    # deg
+
+# last collection view
+$wirePitchZ      = 0.51;   # cm
+
+# offset of 1st u/v strip centre I measured 
+# (not as precisely probably) directly from gerber
+@offsetUVwire = (1.50, 0.87); # cm
+
+# Active CRU area
+$lengthPCBActive = 149.0;    #cm
+$widthPCBActive  = 335.8;    #cm
+$gapCRU          = 0.1;      #cm
+$borderCRP       = 0.6;      #cm
+
+# total area covered by CRP
+$widthCRP  =     $widthPCBActive  + 2 * $borderCRP;
+$lengthCRP = 2 * $lengthPCBActive + 2 * $borderCRP + $gapCRU;
+
+# number of CRMs in y and z
+$nCRM_x   = 4 * 2;
+$nCRM_z   = 20 * 2;
+
+# create a smaller geometry
+if( $workspace == 1 )
+{
+    $nCRM_x = 1 * 2;
+    $nCRM_z = 1 * 2;
+}
+
+# create a smaller geometry
+if( $workspace == 2 )
+{
+    $nCRM_x = 2 * 2;
+    $nCRM_z = 2 * 2;
+}
+
+# create a smaller geometry (1x8x6)
+if( $workspace == 3 )
+{
+    $nCRM_x = 4 * 2;
+    $nCRM_z = 3 * 2;
+}
+
+# create pds geometry (1x8x14)
+if( $workspace == 4 )
+{
+    $nCRM_x = 4 * 2;
+    $nCRM_z = 7 * 2;
+}
+# create full geometry with only one drift volume
+if( $workspace == 5 )
+{
+    $nCRM_x = 4 * 2;
+    $nCRM_z = 20 * 2;
+}
+
+
+# calculate tpc area based on number of CRMs and their dimensions
+# each CRP should have a 2x2 CRMs
+$widthTPCActive  = $nCRM_x/2 * $widthCRP;
+$lengthTPCActive = $nCRM_z/2 * $lengthCRP;
+
+# active volume dimensions 
+$driftTPCActive  = 650.0;
+
+# model anode strips as wires of some diameter
+$padWidth          = 0.02;
+$ReadoutPlane      = $nViews * $padWidth; # 3 readout planes (no space b/w)!
+
+# anode plate definition
+$anodePlateWidth   = $padWidth/2.;
+
+##################################################################
+############## Parameters for TPC and inner volume ###############
+
+# inner volume dimensions of the cryostat
+$Argon_x = 1510;
+$Argon_y = 1510;
+$Argon_z = 6200;
+
+# width of gas argon layer on top
+$HeightGaseousAr = 100;
+
+if( $workspace != 0 )
+{
+    #active tpc + 1.0 m buffer on each side
+    $Argon_x = $driftTPCActive + $HeightGaseousAr + $ReadoutPlane + 100;
+    $Argon_y = $widthTPCActive + 162;
+    $Argon_z = $lengthTPCActive + 214.0;
+}
+
+
+# size of liquid argon buffer
+$xLArBuffer = $Argon_x - $driftTPCActive - $HeightGaseousAr - $ReadoutPlane;
+$yLArBuffer = 0.5 * ($Argon_y - $widthTPCActive);
+$zLArBuffer = 0.5 * ($Argon_z - $lengthTPCActive);
+
+# cryostat 
+$SteelThickness = 0.12; # membrane
+
+$Cryostat_x = $Argon_x + 2*$SteelThickness;
+$Cryostat_y = $Argon_y + 2*$SteelThickness;
+$Cryostat_z = $Argon_z + 2*$SteelThickness;
+
+##################################################################
+############## DetEnc and World relevant parameters  #############
+
+$SteelSupport_x  =  100;
+$SteelSupport_y  =  100;
+$SteelSupport_z  =  100; 
+$FoamPadding     =  80;  
+$FracMassOfSteel =  0.5; #The steel support is not a solid block, but a mixture of air and steel
+$FracMassOfAir   =  1 - $FracMassOfSteel;
+
+
+$SpaceSteelSupportToWall    = 100;
+$SpaceSteelSupportToCeiling = 100;
+
+$DetEncX  =    $Cryostat_x
+                  + 2*($SteelSupport_x + $FoamPadding) + $SpaceSteelSupportToCeiling;
+
+$DetEncY  =    $Cryostat_y
+                  + 2*($SteelSupport_y + $FoamPadding) + 2*$SpaceSteelSupportToWall;
+
+$DetEncZ  =    $Cryostat_z
+                  + 2*($SteelSupport_z + $FoamPadding) + 2*$SpaceSteelSupportToWall;
+
+$posCryoInDetEnc_x = - $DetEncX/2 + $SteelSupport_x + $FoamPadding + $Cryostat_x/2;
+
+
+$RockThickness = 4000;
+
+  # We want the world origin to be vertically centered on active TPC
+  # This is to be added to the x and y position of every volume in volWorld
+
+$OriginXSet =  $DetEncX/2.0
+             - $SteelSupport_x
+             - $FoamPadding
+             - $SteelThickness
+             - $xLArBuffer
+             - $driftTPCActive/2.0;
+
+$OriginYSet =   $DetEncY/2.0
+              - $SpaceSteelSupportToWall
+              - $SteelSupport_y
+              - $FoamPadding
+              - $SteelThickness
+              - $yLArBuffer
+              - $widthTPCActive/2.0;
+
+  # We want the world origin to be at the very front of the fiducial volume.
+  # move it to the front of the enclosure, then back it up through the concrete/foam, 
+  # then through the Cryostat shell, then through the upstream dead LAr (including the
+  # dead LAr on the edge of the TPC)
+  # This is to be added to the z position of every volume in volWorld
+
+$OriginZSet =   $DetEncZ/2.0 
+              - $SpaceSteelSupportToWall
+              - $SteelSupport_z
+              - $FoamPadding
+              - $SteelThickness
+              - $zLArBuffer
+              - $borderCRM;
+
+##################################################################
+############## Field Cage Parameters ###############
+$FieldShaperLongTubeLength  =  $lengthTPCActive;
+$FieldShaperShortTubeLength =  $widthTPCActive;
+$FieldShaperInnerRadius = 0.5; #cm
+$FieldShaperOuterRadius = 2.285; #cm
+$FieldShaperOuterRadiusSlim = 0.75; #cm
+$FieldShaperTorRad = 2.3; #cm
+
+$FieldShaperLength = $FieldShaperLongTubeLength + 2*$FieldShaperOuterRadius+ 2*$FieldShaperTorRad;
+$FieldShaperWidth =  $FieldShaperShortTubeLength + 2*$FieldShaperOuterRadius+ 2*$FieldShaperTorRad;
+
+$FieldShaperSeparation = 6.0; #cm
+$NFieldShapers = ($driftTPCActive/$FieldShaperSeparation) - 1;
+
+$FieldCageSizeX = $FieldShaperSeparation*$NFieldShapers+2;
+$FieldCageSizeY = $FieldShaperWidth+2;
+$FieldCageSizeZ = $FieldShaperLength+2;
+
+
+##################################################################
+############## Cathode Parameters ###############
+$heightCathode=4.0; #cm
+$CathodeBorder=4.0; #cm
+$widthCathode=$widthCRP;
+$lengthCathode=$lengthCRP;
+$widthCathodeVoid=76.35;
+$lengthCathodeVoid=67.0;
+
+
+####################################################################
+######################## ARAPUCA Dimensions ########################
+## in cm
+
+$ArapucaOut_x = 65.0; 
+$ArapucaOut_y = 2.5;
+$ArapucaOut_z = 65.0; 
+$ArapucaIn_x = 60.0;
+$ArapucaIn_y = 2.0;
+$ArapucaIn_z = 60.0;
+$ArapucaAcceptanceWindow_x = 60.0;
+$ArapucaAcceptanceWindow_y = 1.0;
+$ArapucaAcceptanceWindow_z = 60.0;
+$GapPD = 0.5; #Arapuca distance from Cathode Frame
+$FrameToArapucaSpace       =    1.0; #Small vertical gap over laterals to avoid overlap
+$FrameToArapucaSpaceLat    =   10.0; #Arapucas 60 cm behind FC. At this moment, should cover the thickness of Frame + small gap to prevent overlap. VALUE NEEDS TO BE CHECKED!!!
+$VerticalPDdist = 75.0; #distance of arapucas (center to center) in the y direction 
+$FirstFrameVertDist = 40.0; #Vertical distance from top/bottom anode (=204.55+85.3 cm above/below cathode) 
+
+#Positions of the 4 arapucas with respect to the Frame center --> arapucas over the cathode
+$list_posx_bot[0]=-2*$widthCathodeVoid - 2.0*$CathodeBorder + $GapPD + 0.5*$ArapucaOut_x;
+$list_posz_bot[0]= 0.5*$lengthCathodeVoid + $CathodeBorder;
+$list_posx_bot[1]= - $CathodeBorder - $GapPD - 0.5*$ArapucaOut_x;
+$list_posz_bot[1]=-1.5*$lengthCathodeVoid - 2.0*$CathodeBorder;
+$list_posx_bot[2]=-$list_posx_bot[1];
+$list_posz_bot[2]=-$list_posz_bot[1];
+$list_posx_bot[3]=-$list_posx_bot[0];
+$list_posz_bot[3]=-$list_posz_bot[0];
+
+
+#+++++++++++++++++++++++++ End defining variables ++++++++++++++++++++++++++
+
+
+#+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+#+++++++++++++++++++++++++++++++++++++++++ usage +++++++++++++++++++++++++++++++++++++++++
+#+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+sub usage()
+{
+    print "Usage: $0 [-h|--help] [-o|--output <fragments-file>] [-s|--suffix <string>]\n";
+    print "       if -o is omitted, output goes to STDOUT; <fragments-file> is input to make_gdml.pl\n";
+    print "       -s <string> appends the string to the file names; useful for multiple detector versions\n";
+    print "       -h prints this message, then quits\n";
+}
+
+
+sub gen_Extend()
+{
+
+# Create the <define> fragment file name, 
+# add file to list of fragments,
+# and open it
+    $DEF = $basename."_Ext" . $suffix . ".gdml";
+    push (@gdmlFiles, $DEF);
+    $DEF = ">" . $DEF;
+    open(DEF) or die("Could not open file $DEF for writing");
+
+print DEF <<EOF;
+<?xml version='1.0'?>
+<gdml>
+<extension>
+   <color name="magenta"     R="0.0"  G="1.0"  B="0.0"  A="1.0" />
+   <color name="green"       R="0.0"  G="1.0"  B="0.0"  A="1.0" />
+   <color name="red"         R="1.0"  G="0.0"  B="0.0"  A="1.0" />
+   <color name="blue"        R="0.0"  G="0.0"  B="1.0"  A="1.0" />
+   <color name="yellow"      R="1.0"  G="1.0"  B="0.0"  A="1.0" />    
+</extension>
+</gdml>
+EOF
+    close (DEF);
+}
+
+#+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+#++++++++++++++++++++++++++++++++++++++ gen_Define +++++++++++++++++++++++++++++++++++++++
+#+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+sub gen_Define()
+{
+
+# Create the <define> fragment file name, 
+# add file to list of fragments,
+# and open it
+    $DEF = $basename."_Def" . $suffix . ".gdml";
+    push (@gdmlFiles, $DEF);
+    $DEF = ">" . $DEF;
+    open(DEF) or die("Could not open file $DEF for writing");
+
+
+print DEF <<EOF;
+<?xml version='1.0'?>
+<gdml>
+<define>
+
+<!--
+
+
+
+-->
+
+   <position name="posCryoInDetEnc"     unit="cm" x="$posCryoInDetEnc_x" y="0" z="0"/>
+   <position name="posCenter"           unit="cm" x="0" y="0" z="0"/>
+   <rotation name="rUWireAboutX"        unit="deg" x="$wireAngleU" y="0" z="0"/>
+   <rotation name="rVWireAboutX"        unit="deg" x="$wireAngleV" y="0" z="0"/>
+   <rotation name="rPlus90AboutX"       unit="deg" x="90" y="0" z="0"/>
+   <rotation name="rPlus90AboutY"       unit="deg" x="0" y="90" z="0"/>
+   <rotation name="rPlus90AboutXPlus90AboutY" unit="deg" x="90" y="90" z="0"/>
+   <rotation name="rMinus90AboutX"      unit="deg" x="270" y="0" z="0"/>
+   <rotation name="rMinus90AboutY"      unit="deg" x="0" y="270" z="0"/>
+   <rotation name="rMinus90AboutYMinus90AboutX"       unit="deg" x="270" y="270" z="0"/>
+   <rotation name="rPlus180AboutX"	unit="deg" x="180" y="0"   z="0"/>
+   <rotation name="rPlus180AboutY"	unit="deg" x="0" y="180"   z="0"/>
+   <rotation name="rPlus180AboutXPlus180AboutY"	unit="deg" x="180" y="180"   z="0"/>
+   <rotation name="rIdentity"		unit="deg" x="0" y="0"   z="0"/>
+   <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+   <rotation name="rPlus90AboutXPlus180AboutY" unit="deg" x="90" y="180" z="0" />
+   <rotation name="rPlus90AboutXMinux90AboutY" unit="deg" x="90" y="270" z="0" />
+   <rotation name="rPlus90AboutZ" unit="deg" x="0" y="0" z="90" />
+</define>
+</gdml>
+EOF
+    close (DEF);
+}
+
+#+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+#+++++++++++++++++++++++++++++++++++++ gen_Materials +++++++++++++++++++++++++++++++++++++
+#+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+sub gen_Materials()
+{
+
+# Create the <materials> fragment file name,
+# add file to list of output GDML fragments,
+# and open it
+    $MAT = $basename."_Materials" . $suffix . ".gdml";
+    push (@gdmlFiles, $MAT);
+    $MAT = ">" . $MAT;
+
+    open(MAT) or die("Could not open file $MAT for writing");
+
+    # Add any materials special to this geometry by defining a mulitline string
+    # and passing it to the gdmlMaterials::gen_Materials() function.
+my $asmix = <<EOF;
+  <!-- preliminary values -->
+  <material name="AirSteelMixture" formula="AirSteelMixture">
+   <D value=" 0.001205*(1-$FracMassOfSteel) + 7.9300*$FracMassOfSteel " unit="g/cm3"/>
+   <fraction n="$FracMassOfSteel" ref="STEEL_STAINLESS_Fe7Cr2Ni"/>
+   <fraction n="$FracMassOfAir"   ref="Air"/>
+  </material>
+  <material name="vm2000" formula="vm2000">
+    <D value="1.2" unit="g/cm3"/>
+    <composite n="2" ref="carbon"/>
+    <composite n="4" ref="hydrogen"/>
+  </material>
+EOF
+
+    # add the general materials used anywere
+    print MAT gdmlMaterials::gen_Materials( $asmix );
+
+    close(MAT);
+}
+
+
+#+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+#++++++++++++++++++++++++++++++++++++++++ gen_TPC ++++++++++++++++++++++++++++++++++++++++
+#+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+# line clip on the rectangle boundary
+sub lineClip {
+    my $x0  = $_[0];
+    my $y0  = $_[1];
+    my $nx  = $_[2];
+    my $ny  = $_[3];
+    my $rcl = $_[4];
+    my $rcw = $_[5];
+
+    my $tol = 1.0E-4;
+    my @endpts = ();
+    if( abs( nx ) < tol ){
+	push( @endpts, ($x0, 0) );
+	push( @endpts, ($x0, $rcw) );
+	return @endpts;
+    }
+    if( abs( ny ) < tol ){
+	push( @endpts, (0, $y0) );
+	push( @endpts, ($rcl, $y0) );
+	return @endpts;
+    }
+    
+    # left border at x = 0
+    my $y = $y0 - $x0 * $ny/$nx;
+    if( $y >= 0 && $y <= $rcw ){
+	push( @endpts, (0, $y) );
+    }
+
+    # right border at x = l
+    $y = $y0 + ($rcl-$x0) * $ny/$nx;
+    if( $y >= 0 && $y <= $rcw ){
+	push( @endpts, ($rcl, $y) );
+	if( scalar(@endpts) == 4 ){
+	    return @endpts;
+	}
+    }
+
+    # bottom border at y = 0
+    my $x = $x0 - $y0 * $nx/$ny;
+    if( $x >= 0 && $x <= $rcl ){
+	push( @endpts, ($x, 0) );
+	if( scalar(@endpts) == 4 ){
+	    return @endpts;
+	}
+    }
+    
+    # top border at y = w
+    $x = $x0 + ($rcw-$y0)* $nx/$ny;
+    if( $x >= 0 && $x <= $rcl ){
+	push( @endpts, ($x, $rcw) );
+    }
+    
+    return @endpts;
+}
+
+sub gen_Wires
+{
+    my $length = $_[0];  # 
+    my $width  = $_[1];  # 
+    my $nch    = $_[2];  # 
+    my $pitch  = $_[3];  # 
+    my $theta  = $_[4];  # deg
+    my $dia    = $_[5];  #
+    my $w1offx = $_[6];  # offset for wire 1 1st coord
+    my $w1offy = $_[7];  # offset for wire 1 2nd coord
+    
+    $theta  = $theta * pi()/180.0;
+    my @dirw   = (cos($theta), sin($theta));
+    my @dirp   = (cos($theta - pi()/2), sin($theta - pi()/2));
+
+    # calculate
+    my $alpha = $theta;
+    if( $alpha > pi()/2 ){
+	$alpha = pi() - $alpha;
+    }
+    my $dX = $pitch / sin( $alpha );
+    my $dY = $pitch / sin( pi()/2 - $alpha );
+
+    my @orig   = ($w1offx, $w1offy);
+    if( $dirp[0] < 0 ){
+	$orig[0] = $length - $w1offx;
+    }
+    if( $dirp[1] < 0 ){
+	$orig[1] = $width - $w1offy;
+    }
+
+    #print "origin    : @orig\n";
+    #print "pitch dir : @dirp\n";
+    #print "wire dir  : @dirw\n";
+    #print "$length x $width cm2\n";
+
+    # gen wires
+    my @winfo  = ();
+    my $offset = 0; # starting point is now given by w1offx and w1offy
+    foreach my $ch (0..$nch-1){
+	#print "Processing $ch\n";
+
+	# calculate reference point for this strip
+	my @wcn = (0, 0);
+	$wcn[0] = $orig[0] + $offset * $dirp[0];
+	$wcn[1] = $orig[1] + $offset * $dirp[1];
+
+	# line clip on the rectangle boundary
+	@endpts = lineClip( $wcn[0], $wcn[1], $dirw[0], $dirw[1], $length, $width );
+
+	if( scalar(@endpts) != 4 ){
+	    print "Could not find end points for wire $ch : @endpts\n";
+	    $offset = $offset + $pitch;
+	    next;
+	}
+
+	# re-center on the mid-point
+	$endpts[0] -= $length/2;
+	$endpts[2] -= $length/2;
+	$endpts[1] -= $width/2;
+	$endpts[3] -= $width/2;
+
+	# calculate the strip center in the rectangle of CRU
+	$wcn[0] = ($endpts[0] + $endpts[2])/2;
+	$wcn[1] = ($endpts[1] + $endpts[3])/2;
+
+	# calculate the length
+	my $dx = $endpts[0] - $endpts[2];
+	my $dy = $endpts[1] - $endpts[3];
+	my $wlen = sqrt($dx**2 + $dy**2);
+
+	# put all info together
+	my @wire = ($ch, $wcn[0], $wcn[1], $wlen);
+	push( @wire, @endpts );
+	push( @winfo, \@wire);
+	$offset = $offset + $pitch;
+	#last;
+    }
+    return @winfo;
+}
+
+sub split_wires
+{
+    # split wires at y = 0 line (widht / 2)
+    # assumes that the CRU wire plane has been
+    # centered already on 0,0
+    
+    # reference to array of wires
+    my $wires = $_[0];
+    my $width = $_[1];  # split
+    my $theta = $_[2];  # deg
+
+    ###
+    my $yref  = 0;
+    my $nx    = cos($theta * pi()/180.0);
+    my $ny    = sin($theta * pi()/180.0);
+    my $ich1  = 0;
+    my $ich2  = 0;
+    my @winfo1  = (); # lower half of CRU
+    my @winfo2  = (); # upper half of CRU
+
+    foreach my $wire (@$wires){
+	my $x0 = $wire->[1];
+	my $y0 = $wire->[2];
+	my @endpts = ($wire->[4], $wire->[5],
+		      $wire->[6], $wire->[7]);
+
+	# min of two y-values
+	my $y1 = ($endpts[1], $endpts[3])[$endpts[1] > $endpts[3]];
+	# max of two y-values
+	my $y2 = ($endpts[1], $endpts[3])[$endpts[1] < $endpts[3]];
+	if( $y2 < $yref )
+	{
+	    my @wire1 = ($ich1, $x0, $y0, $wire->[3]);
+	    push( @wire1, @endpts );
+	    push( @winfo1, \@wire1);
+	    $ich1++;
+	    next;
+	}
+	elsif( $y1 > $yref )
+	{
+	    my @wire2 = ($ich2, $x0, $y0, $wire->[3]);
+	    push( @wire2, @endpts );
+	    push( @winfo2, \@wire2);
+	    $ich2++;
+	    next;
+	}
+
+	# calculate an intercept point with yref
+	$y  = $yref;
+	$x  = $x0 + ($y - $y0) * $nx/$ny;
+	
+	# make new endpoints
+	my @endpts1 = @endpts;
+	my @endpts2 = @endpts;
+	if( $endpts[1] < $y )
+	{
+	    $endpts1[2] = $x;
+	    $endpts1[3] = $y;
+	    $endpts2[0] = $x;
+	    $endpts2[1] = $y;
+	}
+	else
+	{
+	    $endpts1[0] = $x;
+	    $endpts1[1] = $y;
+	    $endpts2[2] = $x;
+	    $endpts2[3] = $y;
+	}
+	
+	my @wcn1 = (0, 0);
+	$wcn1[0] = ($endpts1[0] + $endpts1[2])/2;
+	$wcn1[1] = ($endpts1[1] + $endpts1[3])/2;
+	my $dx    = $endpts1[0] - $endpts1[2];
+	my $dy    = $endpts1[1] - $endpts1[3];
+	my $wlen1 = sqrt($dx**2 + $dy**2);
+	my @wire1 = ($ich1, $wcn1[0], $wcn1[1], $wlen1);
+	push( @wire1, @endpts1 );
+	push( @winfo1, \@wire1 );
+	$ich1++;
+
+	my @wcn2 = (0, 0);
+	$wcn2[0] = ($endpts2[0] + $endpts2[2])/2;
+	$wcn2[1] = ($endpts2[1] + $endpts2[3])/2;
+	$dx      = $endpts2[0] - $endpts2[2];
+	$dy      = $endpts2[1] - $endpts2[3];
+	my $wlen2 = sqrt($dx**2 + $dy**2);
+	my @wire2 = ($ich2, $wcn2[0], $wcn2[1], $wlen2);
+	push( @wire2, @endpts2 );
+	push( @winfo2, \@wire2 );
+	$ich2++;
+    }
+
+    #return ( \@winfo1, \@winfo2 );
+    foreach my $w (@winfo1){
+	$w->[5] -= (-0.25 * $width);
+	$w->[7] -= (-0.25 * $width);
+	$w->[2]  = 0.5 * ($w->[5]+$w->[7]);
+    }
+
+    foreach my $w (@winfo2){
+	$w->[5] -= (0.25 * $width);
+	$w->[7] -= (0.25 * $width);
+	$w->[2]  = 0.5 * ($w->[5]+$w->[7]);
+    }
+
+    return ( \@winfo1, \@winfo2 );
+}
+
+sub flip_wires
+{
+    # flip generated wires for one CRU by 180 deg
+    # for the 2nd CRU
+
+    # input array
+    my $wires = $_[0];
+    # output array
+    my @winfo = ();
+    foreach my $wire (@$wires){
+	my $xn1 = -$wire->[4];
+	my $yn1 = -$wire->[5];
+	my $xn2 = -$wire->[6];
+	my $yn2 = -$wire->[7];
+	my $xc  = 0.5*($xn1 + $xn2);
+	my $yc  = 0.5*($yn1 + $yn2);
+	my @new_wire = ($wire->[0], $xc, $yc, $wire->[3],
+			$xn1, $yn1, $xn2, $yn2 );
+	push( @winfo, \@new_wire);
+    }
+    return @winfo;
+}
+
+#
+sub gen_crm
+{
+    my $quad   = $_[0]; # CRP quadrant: 0, 1, 2, 3
+    my $winfoU = $_[1];
+    my $winfoV = $_[2];
+
+    my $do_init = $quad;    
+
+    
+    # CRM active volume
+    my $TPCActive_x = $driftTPCActive;
+    my $TPCActive_y = $widthCRP / 2;
+    my $TPCActive_z = $lengthCRP / 2;
+
+    # CRM total volume
+    my $TPC_x = $TPCActive_x + $ReadoutPlane;
+    my $TPC_y = $TPCActive_y;
+    my $TPC_z = $TPCActive_z;
+
+    # readout plane dimensions
+    my $UPlaneLength = $lengthPCBActive;
+    my $VPlaneLength = $lengthPCBActive;
+    my $ZPlaneLength = $lengthPCBActive;
+
+    my $UPlaneWidth  = $widthPCBActive / 2;
+    my $VPlaneWidth  = $widthPCBActive / 2;
+    my $ZPlaneWidth  = $widthPCBActive / 2;
+
+    if( $do_init == 0 ){
+	#print " $UPlaneWidth x $UPlaneLenght\n";
+	print " TPC vol dimensions     : $TPC_x x $TPC_y x $TPC_z\n";
+    }
+    
+    $TPC = $basename."_TPC$quad" . $suffix . ".gdml";
+    push (@gdmlFiles, $TPC);
+    $TPC = ">" . $TPC;
+    open(TPC) or die("Could not open file $TPC for writing");
+
+    # The standard XML prefix and starting the gdml
+print TPC <<EOF;
+    <?xml version='1.0'?>
+	<gdml>
+EOF
+
+    # All the TPC solids save the wires.
+print TPC <<EOF;
+    <solids>
+EOF
+
+if( $do_init == 0 ){ # do it only once
+print TPC <<EOF;
+   <box name="CRM"
+      x="$TPC_x" 
+      y="$TPC_y" 
+      z="$TPC_z"
+      lunit="cm"/>
+   <box name="CRMActive" 
+      x="$TPCActive_x"
+      y="$TPCActive_y"
+      z="$TPCActive_z"
+      lunit="cm"/>
+   <box name="CRMUPlane" 
+      x="$padWidth" 
+      y="$UPlaneWidth" 
+      z="$UPlaneLength"
+      lunit="cm"/>
+   <box name="CRMVPlane" 
+      x="$padWidth" 
+      y="$VPlaneWidth" 
+      z="$VPlaneLength"
+      lunit="cm"/>
+   <box name="CRMZPlane" 
+      x="$padWidth"
+      y="$ZPlaneWidth"
+      z="$ZPlaneLength"
+      lunit="cm"/>
+EOF
+}
+    
+#++++++++++++++++++++++++++++ Wire Solids ++++++++++++++++++++++++++++++
+if($wires_on == 1 ){
+
+	foreach my $wire (@$winfoU){
+	    my $wid = $wire->[0];
+	    my $wln = $wire->[3];
+print TPC <<EOF;
+   <tube name="CRMWireU$wid"
+      rmax="0.5*$padWidth"
+      z="$wln"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+EOF
+	}
+
+	foreach my $wire (@$winfoV){
+	    my $wid = $wire->[0];
+	    my $wln = $wire->[3];
+print TPC <<EOF;
+   <tube name="CRMWireV$wid"
+      rmax="0.5*$padWidth"
+      z="$wln"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+EOF
+	}
+
+
+    # Z wires are all the same length
+print TPC <<EOF;
+   <tube name="CRMWireZ$quad"
+      rmax="0.5*$padWidth"
+      z="$ZPlaneWidth"               
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+EOF
+} # if wires_on
+print TPC <<EOF;
+</solids>
+EOF
+
+# Begin structure and create wire logical volume
+# but do it only once for the volumes that are the same
+# for all CRP quadrants
+print TPC <<EOF;
+  <structure>
+EOF
+if( $do_init == 0 ){ # do it only once
+print TPC <<EOF;
+    <volume name="volTPCActive">
+      <materialref ref="LAr"/>
+      <solidref ref="CRMActive"/>
+      <auxiliary auxtype="SensDet" auxvalue="SimEnergyDeposit"/>
+      <auxiliary auxtype="StepLimit" auxunit="cm" auxvalue="0.5*cm"/>
+      <auxiliary auxtype="Efield" auxunit="V/cm" auxvalue="500*V/cm"/>
+      <colorref ref="blue"/>
+    </volume>
+EOF
+}
+
+
+if($wires_on==1) 
+{
+	foreach my $wire (@$winfoU){
+	my $wid = $wire->[0];
+print TPC <<EOF;
+    <volume name="volTPCWireU$wid">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU$wid"/>
+    </volume>
+EOF
+	}
+
+	foreach my $wire (@$winfoV){
+	    my $wid = $wire->[0];
+print TPC <<EOF;
+    <volume name="volTPCWireV$wid">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV$wid"/>
+    </volume>
+EOF
+	}
+
+print TPC <<EOF;
+    <volume name="volTPCWireZ$quad">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireZ$quad"/>
+    </volume>
+EOF
+}
+
+
+    #
+    # 1st induction plane
+print TPC <<EOF;
+   <volume name="volTPCPlaneU$quad">
+     <materialref ref="LAr"/>
+     <solidref ref="CRMUPlane"/>
+EOF
+if ($wires_on==1) # add wires to U plane 
+{
+    # if the coordinates were computed with a corner at (0,0)
+    # we need to move to plane coordinates
+    my $offsetZ = 0; 
+    my $offsetY = 0; 
+    #
+    foreach my $wire (@$winfoU) {
+	my $wid  = $wire->[0];
+	my $zpos = $wire->[1] + $offsetZ;
+	my $ypos = $wire->[2] + $offsetY;
+print TPC <<EOF;
+     <physvol>
+       <volumeref ref="volTPCWireU$wid"/> 
+       <position name="posWireU$wid" unit="cm" x="0" y="$ypos" z="$zpos"/>
+       <rotationref ref="rUWireAboutX"/> 
+     </physvol>
+EOF
+    }
+}
+print TPC <<EOF;
+   </volume>
+EOF
+
+#
+# 2nd induction plane
+print TPC <<EOF;
+  <volume name="volTPCPlaneV$quad">
+    <materialref ref="LAr"/>
+    <solidref ref="CRMVPlane"/>
+EOF
+
+if ($wires_on==1) # add wires to V plane 
+  {
+    # if the coordinates were computed with a corner at (0,0)
+    # we need to move to plane coordinates
+    my $offsetZ = 0; 
+    my $offsetY = 0; 
+
+    foreach my $wire (@$winfoV) {
+	my $wid  = $wire->[0];
+	my $zpos = $wire->[1] + $offsetZ;
+	my $ypos = $wire->[2] + $offsetY;
+print TPC <<EOF;
+     <physvol>
+       <volumeref ref="volTPCWireV$wid"/> 
+       <position name="posWireV$wid" unit="cm" x="0" y="$ypos" z="$zpos"/>
+       <rotationref ref="rVWireAboutX"/> 
+     </physvol>
+EOF
+    }
+}
+print TPC <<EOF;
+  </volume>
+EOF
+
+# collection plane
+print TPC <<EOF;
+  <volume name="volTPCPlaneZ$quad">
+    <materialref ref="LAr"/>
+    <solidref ref="CRMZPlane"/>
+EOF
+if ($wires_on==1) # add wires to Z plane (plane with wires reading z position)
+  {
+      my $nch   = $nChans{'Col'}/2;
+      my $zdelta = $lengthPCBActive - $wirePitchZ * $nch;
+      if( $zdelta < 0 ){
+	  print " Bad dimensions     : Z delta $zdelta should be positive or 0\n";
+	  $zdelta = 0;
+      }
+
+      my $zoffset = $zdelta;
+      if( $quad > 1 ){ $zoffset = 0; }
+      for($i=0;$i<$nch;++$i)
+       {
+	   my $zpos = $zoffset + ( $i + 0.5) * $wirePitchZ - 0.5 * $lengthPCBActive;
+	   if( (0.5 * $lengthPCBActive - abs($zpos)) < 0 ){
+	       die "Cannot place wire $i in view Z, as plane is too small\n";
+	   }
+	   my $wid = $i + $quad * $nch;
+print TPC <<EOF;
+       <physvol>
+         <volumeref ref="volTPCWireZ$quad"/>
+         <position name="posWireZ$wid" unit="cm" x="0" y="0" z="$zpos"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+EOF
+       }
+}
+print TPC <<EOF;
+  </volume>
+EOF
+
+# offset of the active area from CRP envelope
+my $pcbOffsetY = 999;
+my $pcbOffsetZ = 999;
+if( $quad == 0 ){
+    $pcbOffsetY =  $borderCRP/2;
+    $pcbOffsetZ = ($borderCRP/2 - $gapCRU/4);
+} elsif( $quad == 1 ){
+    $pcbOffsetY =  -$borderCRP/2;
+    $pcbOffsetZ =  ($borderCRP/2 - $gapCRU/4);
+} elsif ( $quad == 2 ){
+    $pcbOffsetY =  $borderCRP/2;
+    $pcbOffsetZ = -($borderCRP/2 - $gapCRU/4);
+} elsif ( $quad == 3 ){
+    $pcbOffsetY = -$borderCRP/2;
+    $pcbOffsetZ = -($borderCRP/2 - $gapCRU/4);
+} else {
+    die "Uknown $quad quadrant index\n";
+}
+
+my @posUplane = (0, 0, 0);
+$posUplane[0] = 0.5*$TPC_x - 2.5*$padWidth;
+$posUplane[1] = $pcbOffsetY;
+$posUplane[2] = $pcbOffsetZ;
+
+my @posVplane = (0, 0, 0);
+$posVplane[0] = 0.5*$TPC_x - 1.5*$padWidth;
+$posVplane[1] = $pcbOffsetY;
+$posVplane[2] = $pcbOffsetZ;
+
+my @posZplane = (0, 0, 0);
+$posZplane[0] = 0.5*$TPC_x - 0.5*$padWidth;
+$posZplane[1] = $pcbOffsetY; 
+$posZplane[2] = $pcbOffsetZ;
+
+my @posTPCActive = (0, 0, 0);
+$posTPCActive[0] = -$ReadoutPlane/2;
+$posTPCActive[1] = 0;
+$posTPCActive[2] = 0;
+
+
+#wrap up the TPC file
+print TPC <<EOF;
+   <volume name="volTPC$quad">
+     <materialref ref="LAr"/>
+       <solidref ref="CRM"/>
+       <physvol>
+       <volumeref ref="volTPCPlaneU$quad"/>
+       <position name="posPlaneU$quad" unit="cm" 
+         x="$posUplane[0]" y="$posUplane[1]" z="$posUplane[2]"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCPlaneV$quad"/>
+       <position name="posPlaneY$quad" unit="cm" 
+         x="$posVplane[0]" y="$posVplane[1]" z="$posVplane[2]"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCPlaneZ$quad"/>
+       <position name="posPlaneZ$quad" unit="cm" 
+         x="$posZplane[0]" y="$posZplane[1]" z="$posZplane[2]"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCActive"/>
+       <position name="posActive$quad" unit="cm" 
+        x="$posTPCActive[0]" y="$posTPCAtive[1]" z="$posTPCActive[2]"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+   </volume>
+EOF
+
+print TPC <<EOF;
+ </structure>
+ </gdml>
+EOF
+
+    close(TPC);
+}
+
+
+sub gen_TopCRP
+{
+    # Total volume covered by CRP envelope
+    my $CRP_x = $driftTPCActive + $ReadoutPlane;
+    my $CRP_y = $widthCRP;
+    my $CRP_z = $lengthCRP;
+    print " CRP vol dimensions     : $CRP_x x $CRP_y x $CRP_z\n";
+
+    # compute wires for 1st and 2nd induction
+    my @winfoU = ();
+    my @winfoV = ();
+    if( $wires_on == 1 ){
+	# normally should do this only once once, but perl is impossible
+	
+	# first CRU
+	my @winfoU1 = gen_Wires( $lengthPCBActive, $widthPCBActive,
+				 $nChans{'Ind1'}, 
+				 $wirePitchU, $wireAngleU, $padWidth,
+				 $offsetUVwire[0], $offsetUVwire[1]);
+	my @winfoV1 = gen_Wires( $lengthPCBActive, $widthPCBActive,
+				 $nChans{'Ind2'}, 
+				 $wirePitchV, $wireAngleV, $padWidth,
+				 $offsetUVwire[0], $offsetUVwire[1]);
+	# second CRU
+	my @winfoU2 = flip_wires( \@winfoU1 );
+	my @winfoV2 = flip_wires( \@winfoV1 );
+	#foreach my $wire (@winfoU2){
+	#printf ("U%d %.3f %.3f %.3f %.3f %.3f %.3f %.3f\n",
+	#$wire->[0], $wire->[1], $wire->[2],
+	#$wire->[3], $wire->[4], $wire->[5],
+	#$wire->[6], $wire->[7]);
+	#} 
+
+	my ($winfoU1a, $winfoU1b) = split_wires( \@winfoU1, $widthPCBActive, $wireAngleU );
+	my ($winfoV1a, $winfoV1b) = split_wires( \@winfoV1, $widthPCBActive, $wireAngleV );
+	
+	my ($winfoU2a, $winfoU2b) = split_wires( \@winfoU2, $widthPCBActive, $wireAngleU );
+	my ($winfoV2a, $winfoV2b) = split_wires( \@winfoV2, $widthPCBActive, $wireAngleV );
+	
+        # put them the same order as volTPCs for a given CRP
+	@winfoU = ($winfoU1a, $winfoU1b, $winfoU2a, $winfoU2b);
+	@winfoV = ($winfoV1a, $winfoV1b, $winfoV2a, $winfoV2b);
+	
+	# assign unique ID to each CRM wire
+	my $wcountU=0;
+	foreach my $crm_wires (@winfoU){
+	    foreach my $wire (@$crm_wires){
+		$wire->[0] = $wcountU;
+		$wcountU++;
+		#printf ("U%d %.3f %.3f %.3f %.3f %.3f %.3f %.3f\n",
+		#$wire->[0], $wire->[1], $wire->[2],
+		#$wire->[3], $wire->[4], $wire->[5],
+		#$wire->[6], $wire->[7]);
+
+	    }
+	}
+	
+	my $wcountV=0;
+	foreach my $crm_wires (@winfoV){
+	    foreach my $wire (@$crm_wires){
+		$wire->[0] = $wcountV;
+		$wcountV++;
+	    }
+	}
+    }
+
+    # generate GDML fragments for 4 CRP quadrants
+    for my $quad (0..3)
+    {
+	if( $wires_on == 1 ){
+	    gen_crm( $quad, $winfoU[$quad], $winfoV[$quad] );
+	} else {
+	    @dummpy = ();
+	    gen_crm( $quad, \@dummy, \@dummy );
+	}
+    }
+}
+
+#+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+#++++++++++++++++++++++++++++++++++++++ gen_FieldCage ++++++++++++++++++++++++++++++++++++
+#+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+sub gen_FieldCage {
+
+    $FieldCage = $basename."_FieldCage" . $suffix . ".gdml";
+    push (@gdmlFiles, $FieldCage);
+    $FieldCage = ">" . $FieldCage;
+    open(FieldCage) or die("Could not open file $FieldCage for writing");
+
+# The standard XML prefix and starting the gdml
+print FieldCage <<EOF;
+   <?xml version='1.0'?>
+   <gdml>
+EOF
+# The printing solids used in the Field Cage
+#print "lengthTPCActive      : $lengthTPCActive \n";
+#print "widthTPCActive       : $widthTPCActive \n";
+
+
+print FieldCage <<EOF;
+<solids>
+     <torus name="FieldShaperCorner" rmin="$FieldShaperInnerRadius" rmax="$FieldShaperOuterRadius" rtor="$FieldShaperTorRad" deltaphi="90" startphi="0" aunit="deg" lunit="cm"/>
+     <tube name="FieldShaperLongtube" rmin="$FieldShaperInnerRadius" rmax="$FieldShaperOuterRadius" z="$FieldShaperLongTubeLength" deltaphi="360" startphi="0" aunit="deg" lunit="cm"/>
+     <tube name="FieldShaperLongtubeSlim" rmin="$FieldShaperInnerRadius" rmax="$FieldShaperOuterRadiusSlim" z="$FieldShaperLongTubeLength" deltaphi="360" startphi="0" aunit="deg" lunit="cm"/>
+     <tube name="FieldShaperShorttube" rmin="$FieldShaperInnerRadius" rmax="$FieldShaperOuterRadius" z="$FieldShaperShortTubeLength" deltaphi="360" startphi="0" aunit="deg" lunit="cm"/>
+
+    <union name="FSunion1">
+      <first ref="FieldShaperLongtube"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos1" unit="cm" x="@{[-$FieldShaperTorRad]}" y="0" z="@{[0.5*$FieldShaperLongTubeLength]}"/>
+		<rotationref ref="rPlus90AboutX"/>
+    </union>
+
+    <union name="FSunion2">
+      <first ref="FSunion1"/>
+      <second ref="FieldShaperShorttube"/>
+   		<position name="esquinapos2" unit="cm" x="@{[-0.5*$FieldShaperShortTubeLength-$FieldShaperTorRad]}" y="0" z="@{[+0.5*$FieldShaperLongTubeLength+$FieldShaperTorRad]}"/>
+   		<rotationref ref="rPlus90AboutY"/>
+    </union>
+
+    <union name="FSunion3">
+      <first ref="FSunion2"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos3" unit="cm" x="@{[-$FieldShaperShortTubeLength-$FieldShaperTorRad]}" y="0" z="@{[0.5*$FieldShaperLongTubeLength]}"/>
+		<rotationref ref="rPlus90AboutXMinux90AboutY"/>
+    </union>
+
+    <union name="FSunion4">
+      <first ref="FSunion3"/>
+      <second ref="FieldShaperLongtube"/>
+   		<position name="esquinapos4" unit="cm" x="@{[-$FieldShaperShortTubeLength-2*$FieldShaperTorRad]}" y="0" z="0"/>
+    </union>
+
+    <union name="FSunion5">
+      <first ref="FSunion4"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos5" unit="cm" x="@{[-$FieldShaperShortTubeLength-$FieldShaperTorRad]}" y="0" z="@{[-0.5*$FieldShaperLongTubeLength]}"/>
+		<rotationref ref="rPlus90AboutXPlus180AboutY"/>
+    </union>
+
+    <union name="FSunion6">
+      <first ref="FSunion5"/>
+      <second ref="FieldShaperShorttube"/>
+   		<position name="esquinapos6" unit="cm" x="@{[-0.5*$FieldShaperShortTubeLength-$FieldShaperTorRad]}" y="0" z="@{[-0.5*$FieldShaperLongTubeLength-$FieldShaperTorRad]}"/>
+		<rotationref ref="rPlus90AboutY"/>
+    </union>
+
+    <union name="FieldShaperSolid">
+      <first ref="FSunion6"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos7" unit="cm" x="@{[-$FieldShaperTorRad]}" y="0" z="@{[-0.5*$FieldShaperLongTubeLength]}"/>
+		<rotationref ref="rPlus90AboutXPlus90AboutY"/>
+    </union>
+    
+    <union name="FSunionSlim1">
+      <first ref="FieldShaperLongtubeSlim"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos8" unit="cm" x="@{[-$FieldShaperTorRad]}" y="0" z="@{[0.5*$FieldShaperLongTubeLength]}"/>
+		<rotationref ref="rPlus90AboutX"/>
+    </union>
+
+    <union name="FSunionSlim2">
+      <first ref="FSunionSlim1"/>
+      <second ref="FieldShaperShorttube"/>
+   		<position name="esquinapos9" unit="cm" x="@{[-0.5*$FieldShaperShortTubeLength-$FieldShaperTorRad]}" y="0" z="@{[+0.5*$FieldShaperLongTubeLength+$FieldShaperTorRad]}"/>
+   		<rotationref ref="rPlus90AboutY"/>
+    </union>
+
+    <union name="FSunionSlim3">
+      <first ref="FSunionSlim2"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos10" unit="cm" x="@{[-$FieldShaperShortTubeLength-$FieldShaperTorRad]}" y="0" z="@{[0.5*$FieldShaperLongTubeLength]}"/>
+		<rotationref ref="rPlus90AboutXMinux90AboutY"/>
+    </union>
+
+    <union name="FSunionSlim4">
+      <first ref="FSunionSlim3"/>
+      <second ref="FieldShaperLongtubeSlim"/>
+   		<position name="esquinapos4" unit="cm" x="@{[-$FieldShaperShortTubeLength-2*$FieldShaperTorRad]}" y="0" z="0"/>
+    </union>
+
+    <union name="FSunionSlim5">
+      <first ref="FSunionSlim4"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos11" unit="cm" x="@{[-$FieldShaperShortTubeLength-$FieldShaperTorRad]}" y="0" z="@{[-0.5*$FieldShaperLongTubeLength]}"/>
+		<rotationref ref="rPlus90AboutXPlus180AboutY"/>
+    </union>
+
+    <union name="FSunionSlim6">
+      <first ref="FSunionSlim5"/>
+      <second ref="FieldShaperShorttube"/>
+   		<position name="esquinapos12" unit="cm" x="@{[-0.5*$FieldShaperShortTubeLength-$FieldShaperTorRad]}" y="0" z="@{[-0.5*$FieldShaperLongTubeLength-$FieldShaperTorRad]}"/>
+		<rotationref ref="rPlus90AboutY"/>
+    </union>
+
+    <union name="FieldShaperSolidSlim">
+      <first ref="FSunionSlim6"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos13" unit="cm" x="@{[-$FieldShaperTorRad]}" y="0" z="@{[-0.5*$FieldShaperLongTubeLength]}"/>
+		<rotationref ref="rPlus90AboutXPlus90AboutY"/>
+    </union>
+    
+</solids>
+
+EOF
+
+print FieldCage <<EOF;
+
+<structure>
+<volume name="volFieldShaper">
+  <materialref ref="ALUMINUM_Al"/>
+  <solidref ref="FieldShaperSolid"/>
+</volume>
+<volume name="volFieldShaperSlim">
+  <materialref ref="ALUMINUM_Al"/>
+  <solidref ref="FieldShaperSolidSlim"/>
+</volume>
+
+</structure>
+
+EOF
+
+print FieldCage <<EOF;
+
+</gdml>
+EOF
+close(FieldCage);
+}
+
+
+
+#+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+#++++++++++++++++++++++++++++++++++++++ gen_Cryostat +++++++++++++++++++++++++++++++++++++
+#+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+sub gen_Cryostat()
+{
+
+# Create the cryostat fragment file name,
+# add file to list of output GDML fragments,
+# and open it
+    $CRYO = $basename."_Cryostat" . $suffix . ".gdml";
+    push (@gdmlFiles, $CRYO);
+    $CRYO = ">" . $CRYO;
+    open(CRYO) or die("Could not open file $CRYO for writing");
+
+
+# The standard XML prefix and starting the gdml
+    print CRYO <<EOF;
+<?xml version='1.0'?>
+<gdml>
+EOF
+
+# All the cryostat solids.
+# External active are two side volumes for generating light outside the field cage (no top or bottom buffers included)
+print CRYO <<EOF;
+<solids>
+    <box name="Cryostat" lunit="cm" 
+      x="$Cryostat_x" 
+      y="$Cryostat_y" 
+      z="$Cryostat_z"/>
+
+    <box name="ArgonInterior" lunit="cm" 
+      x="$Argon_x"
+      y="$Argon_y"
+      z="$Argon_z"/>
+
+    <box name="GaseousArgon" lunit="cm" 
+      x="$HeightGaseousAr - $anodePlateWidth"
+      y="$Argon_y"
+      z="$Argon_z"/>
+
+    <box name="ExternalAuxOut" lunit="cm" 
+      x="$Argon_x - $xLArBuffer"
+      y="$Argon_y - 2*$ArapucaOut_y - 2*$FrameToArapucaSpaceLat"
+      z="$Argon_z"/>
+
+    <box name="ExternalAuxIn" lunit="cm" 
+      x="$Argon_x"
+      y="$FieldCageSizeY"
+      z="$Argon_z + 1"/>
+
+   <subtraction name="ExternalActive">
+      <first ref="ExternalAuxOut"/>
+      <second ref="ExternalAuxIn"/>
+    </subtraction>
+
+    <subtraction name="SteelShell">
+      <first ref="Cryostat"/>
+      <second ref="ArgonInterior"/>
+    </subtraction>
+
+</solids>
+EOF
+
+#PDS
+#Double sided detectors should only be included when both top and bottom volumes become available
+#Optical sensitive volumes cannot be rotated because Larsoft cannot pick up the rotation when obtinaing the lengths needed for the semi-analytic model --> two acceptance windows for single sided lateral and cathode
+print CRYO <<EOF;
+<solids>
+    <box name="ArapucaOut" lunit="cm"
+      x="@{[$ArapucaOut_x]}"
+      y="@{[$ArapucaOut_y]}"
+      z="@{[$ArapucaOut_z]}"/>
+
+    <box name="ArapucaIn" lunit="cm"
+      x="@{[$ArapucaIn_x]}"
+      y="@{[$ArapucaOut_y]}"
+      z="@{[$ArapucaIn_z]}"/>
+
+     <subtraction name="ArapucaWalls">
+      <first  ref="ArapucaOut"/>
+      <second ref="ArapucaIn"/>
+      <position name="posArapucaSub" x="0" y="@{[$ArapucaOut_y/2.0]}" z="0." unit="cm"/>
+      </subtraction>
+
+    <box name="ArapucaAcceptanceWindow" lunit="cm"
+      x="@{[$ArapucaAcceptanceWindow_x]}"
+      y="@{[$ArapucaAcceptanceWindow_y]}"
+      z="@{[$ArapucaAcceptanceWindow_z]}"/>
+
+    <box name="ArapucaDoubleIn" lunit="cm"
+      x="@{[$ArapucaIn_x]}"
+      y="@{[$ArapucaOut_y+1.0]}"
+      z="@{[$ArapucaIn_z]}"/>
+
+     <subtraction name="ArapucaDoubleWalls">
+      <first  ref="ArapucaOut"/>
+      <second ref="ArapucaDoubleIn"/>
+      <position name="posArapucaDoubleSub" x="0" y="0" z="0" unit="cm"/>
+      </subtraction>
+
+    <box name="ArapucaDoubleAcceptanceWindow" lunit="cm"
+      x="@{[$ArapucaOut_y-0.02]}"
+      y="@{[$ArapucaAcceptanceWindow_x]}"
+      z="@{[$ArapucaAcceptanceWindow_z]}"/>
+
+    <box name="ArapucaCathodeAcceptanceWindow" lunit="cm"
+      x="@{[$ArapucaAcceptanceWindow_y]}"
+      y="@{[$ArapucaAcceptanceWindow_x]}"
+      z="@{[$ArapucaAcceptanceWindow_z]}"/>
+
+</solids>
+EOF
+
+# Cryostat structure
+print CRYO <<EOF;
+<structure>
+    <volume name="volSteelShell">
+      <materialref ref="STEEL_STAINLESS_Fe7Cr2Ni" />
+      <solidref ref="SteelShell" />
+    </volume>
+    <volume name="volCathodeGrid">
+      <materialref ref="G10" />
+      <solidref ref="CathodeGrid" />
+    </volume>
+    <volume name="volAnodePlate">
+     <materialref ref="vm2000"/>
+     <solidref ref="AnodePlate"/>
+    </volume>
+    <volume name="volGaseousArgon">
+      <materialref ref="ArGas"/>
+      <solidref ref="GaseousArgon"/>
+    </volume>
+    <volume name="volExternalActive">
+      <materialref ref="LAr"/>
+      <solidref ref="ExternalActive"/>
+      <auxiliary auxtype="SensDet" auxvalue="SimEnergyDeposit"/>
+      <auxiliary auxtype="StepLimit" auxunit="cm" auxvalue="0.5208*cm"/>
+      <auxiliary auxtype="Efield" auxunit="V/cm" auxvalue="0*V/cm"/>
+      <colorref ref="green"/>
+    </volume>
+
+    <volume name="volArapucaShortLat">
+      <materialref ref="G10"/>
+      <solidref ref="ArapucaWalls"/>
+    </volume>
+    <volume name="volOpDetSensitive">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+
+    <volume name="Arapuca">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+
+    <volume name="volArapuca">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaOut"/>
+      <physvol>
+        <volumeref ref="Arapuca"/>
+        <positionref ref="posCenter"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volOpDetSensitive"/>
+        <position name="opdetshift" unit="cm" x="0" y="@{[$ArapucaAcceptanceWindow_y/2.0]}" z="0"/>
+      </physvol>
+    </volume>
+
+EOF
+#including single sided arapucas over the cathode while there is only the top volume
+#if double sided, use
+#    <volume name="volArapucaDouble_$i\-$j\-$p">
+#      <materialref ref="G10" />
+#      <solidref ref="ArapucaDoubleWalls" />
+#    </volume>
+#    <volume name="volOpDetSensitive_ArapucaDouble_$i\-$j\-$p">
+#      <materialref ref="LAr"/>
+#      <solidref ref="ArapucaDoubleAcceptanceWindow"/>
+#    </volume>
+if ($pdsconfig == 0){  #4-pi PDS converage
+for($i=0 ; $i<$nCRM_x/2 ; $i++){ #arapucas over the cathode
+for($j=0 ; $j<$nCRM_z/2 ; $j++){
+for($p=0 ; $p<4 ; $p++){
+  print CRYO <<EOF;
+    <volume name="volArapucaDouble_$i\-$j\-$p">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaDouble_$i\-$j\-$p">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaCathodeAcceptanceWindow"/>
+    </volume>
+EOF
+}
+}
+}
+}
+
+if ($nCRM_x==8){ #arapucas on the laterals
+for($j=0 ; $j<$nCRM_z/2 ; $j++){
+for($p=0 ; $p<8 ; $p++){
+  print CRYO <<EOF;
+    <volume name="volArapucaLat_$j\-$p">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_$j\-$p">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+EOF
+}
+}
+}
+
+if ($pdsconfig == 1){  #Membrane PDS converage
+if ($nCRM_x==8) { #arapucas on the laterals
+for($j=0 ; $j<$nCRM_z/2 ; $j++){
+for($p=8 ; $p<18 ; $p++){
+  print CRYO <<EOF;
+    <volume name="volArapucaLat_$j\-$p">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+    <volume name="volOpDetSensitive_ArapucaLat_$j\-$p">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+EOF
+}
+}
+}
+}
+
+      print CRYO <<EOF;
+
+    <volume name="volCryostat">
+      <materialref ref="LAr" />
+      <solidref ref="Cryostat" />
+      <physvol>
+        <volumeref ref="volGaseousArgon"/>
+        <position name="posGaseousArgon" unit="cm" x="@{[$Argon_x/2-$HeightGaseousAr/2+$anodePlateWidth/2]}" y="0" z="0"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volSteelShell"/>
+        <position name="posSteelShell" unit="cm" x="0" y="0" z="0"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volExternalActive"/>
+        <position name="posExternalActive" unit="cm" x="-$xLArBuffer/2" y="0" z="0"/>
+      </physvol>
+EOF
+
+if ($tpc_on==1) # place TPC inside cryostat
+{
+  $posX =  $Argon_x/2 - $HeightGaseousAr - 0.5*($driftTPCActive + $ReadoutPlane); 
+  $idx = 0;
+  my $CRP_y = $widthCRP;
+  my $CRP_z = $lengthCRP;
+  my $myposTCPY = 0;
+  my $myposTPCZ = 0;
+  my $posZ = -0.5*$Argon_z + $zLArBuffer + 0.5*$CRP_z;
+#Y and Z positions will be given relative to the CRP center
+  for(my $ii=0;$ii<$nCRM_z;$ii++)
+  {
+    if( $ii % 2 == 0 && $ii>0){$posZ += $CRP_z;}
+    my $posY = -0.5*$Argon_y + $yLArBuffer + 0.5*$CRP_y;
+    for(my $jj=0;$jj<$nCRM_x;$jj++)
+    {
+    	if( $jj % 2 == 0 && $jj>0){$posY += $CRP_y;}
+    
+	if($ii%2==0){
+	  if($jj%2==0){
+	    $quad=0;
+	    $myposTPCY = $posY-$CRP_y/4;
+	    $myposTPCZ = $posZ-$CRP_z/4;
+	  }else{
+	    $quad=1;
+	    $myposTPCY = $posY+$CRP_y/4;
+	    $myposTPCZ = $posZ-$CRP_z/4;
+          }
+	}else{
+	  if($jj%2==0){
+	    $quad=2;
+	    $myposTPCY = $posY-$CRP_y/4;
+	    $myposTPCZ = $posZ+$CRP_z/4;
+	  }else{
+	    $quad=3;
+	    $myposTPCY = $posY+$CRP_y/4;
+	    $myposTPCZ = $posZ+$CRP_z/4;
+	    }
+	}
+
+	print CRYO <<EOF;
+      <physvol>
+        <volumeref ref="volTPC$quad"/>
+	<position name="posTopTPC\-$idx" unit="cm"
+           x="$posX" y="$myposTPCY" z="$myposTPCZ"/>
+      </physvol>
+EOF
+       $idx++;
+    }
+  }
+}
+
+#The +50 in the x positions must depend on some other parameter
+  if ( $FieldCage_switch eq "on" ) {
+    for ( $i=0; $i<$NFieldShapers; $i=$i+1 ) {
+    $dist=$i*$FieldShaperSeparation;
+$posX = -$OriginXSet+50+($i-$NFieldShapers*0.5)*$FieldShaperSeparation; 
+	if ($pdsconfig==0){
+		if ($dist>250){
+	print CRYO <<EOF;
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper$i" unit="cm"  x="@{[$posX]}" y="@{[-0.5*$FieldShaperShortTubeLength-$FieldShaperTorRad]}" z="0" />
+     <rotationref ref="rPlus90AboutZ"/>
+  </physvol>
+EOF
+		}else{
+	print CRYO <<EOF;
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper$i" unit="cm"  x="@{[$posX]}" y="@{[-0.5*$FieldShaperShortTubeLength-$FieldShaperTorRad]}" z="0" />
+     <rotationref ref="rPlus90AboutZ"/>
+  </physvol>
+EOF
+		}
+	}else{
+	print CRYO <<EOF;
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper$i" unit="cm"  x="@{[$posX]}" y="@{[-0.5*$FieldShaperShortTubeLength-$FieldShaperTorRad]}" z="0" />
+     <rotationref ref="rPlus90AboutZ"/>
+  </physvol>
+EOF
+	}
+    }
+  }
+
+
+$CathodePosX =-$OriginXSet+50+(-1-$NFieldShapers*0.5)*$FieldShaperSeparation + $tpc_x_disp;
+$CathodePosY = -0.5*$Argon_y + $yLArBuffer + 0.5*$widthCathode;
+$CathodePosZ = -0.5*$Argon_z + $zLArBuffer + 0.5*$lengthCathode;
+$posAnodePlate = 0.5*($driftTPCActive + $nViews*$padWidth) + $anodePlateWidth/2;#right above TPC vol
+
+$idx = 0;
+  if ( $Cathode_switch eq "on" )
+  {
+  for(my $ii=0;$ii<$nCRM_z/2;$ii++)
+  {
+    for(my $jj=0;$jj<$nCRM_x/2;$jj++)
+    {
+	print CRYO <<EOF;
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid\-$idx" unit="cm" x="$CathodePosX" y="@{[$CathodePosY]}" z="@{[$CathodePosZ]}"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate\-$idx" unit="cm" x="$posAnodePlate" y="@{[$CathodePosY]}" z="@{[$CathodePosZ]}"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>    
+EOF
+       $idx++;
+       $CathodePosY += $widthCathode;
+    }
+       $CathodePosZ += $lengthCathode;
+       $CathodePosY = -0.5*$Argon_y + $yLArBuffer + 0.5*$widthCathode;
+  }
+  }
+
+if ($pdsconfig == 0) {  #4-pi PDS converage
+
+#for placing the Arapucas over the cathode
+  $FrameCenter_y=-0.5*$Argon_y + $yLArBuffer + 0.5*$widthCathode;#-1.5*$FrameLenght_x+(4-$nCRM_x/2)/2*$FrameLenght_x;
+  $FrameCenter_x=$CathodePosX;
+  $FrameCenter_z=-0.5*$Argon_z + $zLArBuffer + 0.5*$lengthCathode;#-9.5*$FrameLenght_z+(20-$nCRM_z/2)/2*$FrameLenght_z;
+for($i=0;$i<$nCRM_x/2;$i++){
+for($j=0;$j<$nCRM_z/2;$j++){
+  place_OpDetsCathode($FrameCenter_x, $FrameCenter_y, $FrameCenter_z, $i, $j);
+  $FrameCenter_z+=$lengthCathode;
+}
+  $FrameCenter_y+=$widthCathode;
+  $FrameCenter_z=-0.5*$Argon_z + $zLArBuffer + 0.5*$lengthCathode;
+}
+}
+
+if ($pdsconfig == 0) {  #4-pi PDS converage
+#for placing the Arapucas on laterals
+  if ($nCRM_x==8) {
+    $FrameCenter_x=0.5*($driftTPCActive + $ReadoutPlane) - 0.5*$padWidth; #anode position
+    $FrameCenter_z=-19*$lengthCathode/2+(40-$nCRM_z)/2*$lengthCathode/2;
+    for($j=0;$j<$nCRM_z/2;$j++){#nCRM will give the collumn number (1 collumn per frame)
+      place_OpDetsLateral($FrameCenter_x, $FrameCenter_z, $j);
+      $FrameCenter_z+=$lengthCathode;
+    }
+
+    #16 arapucas, 8 at y=-2.2m and 8 at y=2.2m.
+
+    $FrameCenter_x=0.5*($driftTPCActive + $ReadoutPlane) - 0.5*$padWidth; #anode position
+    $FrameCenter_z=-19*$lengthCathode/2+(40-$nCRM_z)/2*$lengthCathode/2;
+    place_OpDetsShortLateral($FrameCenter_x,-220, $FrameCenter_z);
+    place_OpDetsShortLateral($FrameCenter_x,220, $FrameCenter_z);
+
+    #8 arapucas por cathode, in a similar way as place_OpDetsLateral.
+    #$FrameCenter_x=-0.5*$widthTPCActive+0.5*$widthCathode;
+    #for($j=0;$j<$nCRM_x/2;$j++)
+    #{
+    #  $FrameCenter_y=$posZplane[0];
+    #  $FrameCenter_z=-19*$lengthCathode/2+(40-$nCRM_z)/2*$lengthCathode/2;
+    #  place_OpDetsShortLateral(220,$FrameCenter_y, $FrameCenter_z);
+    #  $FrameCenter_x+=$widthCathode;
+    #}
+  }
+
+} else {  #membrane only PDS converage
+
+if($pdsconfig == 1){
+if ($nCRM_x==8) {
+  $FrameCenter_x=$posZplane[0]; #anode position
+  $FrameCenter_z=-19*$lengthCathode/2+(40-$nCRM_z)/2*$lengthCathode/2;
+for($j=0;$j<$nCRM_z/2;$j++){#nCRM will give the collumn number (1 collumn per frame)
+  place_OpDetsMembOnly($FrameCenter_x, $FrameCenter_z, $j);
+  $FrameCenter_z+=$lengthCathode;
+}
+}
+}
+
+}
+  
+ print CRYO <<EOF;
+    </volume>
+</structure>
+</gdml>
+EOF
+
+close(CRYO);
+}
+
+#+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+#++++++++++++++++++++++++++++++++++++ place_OpDets +++++++++++++++++++++++++++++++++++++++
+#+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+sub place_OpDetsCathode()
+{
+
+    $FrameCenter_x = $_[0];
+    $FrameCenter_y = $_[1];
+    $FrameCenter_z = $_[2];
+    $Frame_x = $_[3];
+    $Frame_z = $_[4];
+
+#Placing Arapucas over the Cathode 
+#If there are both top and bottom volumes --> use double-sided:
+#     <physvol>
+#       <volumeref ref="volOpDetSensitive_ArapucaDouble_$Frame_x\-$Frame_z\-$ara"/>
+#       <position name="posOpArapucaDouble$ara-Frame\-$Frame_x\-$Frame_z" unit="cm" 
+#         x="@{[$Ara_X]}"
+#	 y="@{[$Ara_Y]}" 
+#	 z="@{[$Ara_Z]}"/>
+#     </physvol>
+#else
+for ($ara = 0; $ara<4; $ara++)
+{
+             # All Arapuca centers will have the same Y coordinate
+             # X and Z coordinates are defined with respect to the center of the current Frame
+
+ 	     $Ara_Y = $FrameCenter_y+$list_posx_bot[$ara]; #GEOMETRY IS ROTATED: X--> Y AND Y--> X
+             $Ara_X = $FrameCenter_x;
+ 	     $Ara_Z = $FrameCenter_z+$list_posz_bot[$ara];
+
+	print CRYO <<EOF;
+     <physvol>
+       <volumeref ref="volArapucaDouble_$Frame_x\-$Frame_z\-$ara"/>
+       <position name="posArapucaDouble$ara-Frame\-$Frame_x\-$Frame_z" unit="cm" 
+         x="@{[$Ara_X]}"
+	 y="@{[$Ara_Y]}" 
+	 z="@{[$Ara_Z]}"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaDouble_$Frame_x\-$Frame_z\-$ara"/>
+       <position name="posOpArapucaDouble$ara-Frame\-$Frame_x\-$Frame_z" unit="cm" 
+         x="@{[$Ara_X+0.5*$ArapucaOut_y-0.5*$ArapucaAcceptanceWindow_y-0.01]}"
+	 y="@{[$Ara_Y]}" 
+	 z="@{[$Ara_Z]}"/>
+     </physvol>
+EOF
+
+}#end Ara for-loop
+
+}
+
+
+sub place_OpDetsLateral()
+{
+
+    $FrameCenter_x = $_[0];
+    $FrameCenter_z = $_[1];
+    $Lat_z = $_[2];
+
+#Placing Arapucas on the laterals if nCRM_x=8 -- Single Sided
+for ($ara = 0; $ara<8; $ara++)
+{
+             # Arapucas on laterals
+             # All Arapuca centers on a given collumn will have the same Z coordinate
+             # X coordinates are on the left and right laterals
+             # Y coordinates are defined with respect to the cathode position
+             # There are two collumns per frame on each side.
+
+             if ($ara<4) {$Ara_Y = -0.5*$Argon_y + $FrameToArapucaSpaceLat;
+                         $Ara_YSens = ($Ara_Y+0.5*$ArapucaOut_y-0.5*$ArapucaAcceptanceWindow_y-0.01);
+                         $rot= "rIdentity"; }
+             else {$Ara_Y = 0.5*$Argon_y - $FrameToArapucaSpaceLat;
+                         $Ara_YSens = ($Ara_Y-0.5*$ArapucaOut_y+0.5*$ArapucaAcceptanceWindow_y+0.01);
+                         $rot = "rPlus180AboutX";} #GEOMETRY IS ROTATED: X--> Y AND Y--> X
+             if($ara==0||$ara==4) {$Ara_X = $FrameCenter_x-$FirstFrameVertDist;} #first tile's center 40 cm bellow anode
+             else{$Ara_X-=$VerticalPDdist;} #other tiles separated by VerticalPDdist
+             $Ara_Z = $FrameCenter_z;
+
+    #print " ArapucaPos Lateral $ara :    x=@{[$Ara_X]} y= @{[$Ara_Y]}  z= @{[$Ara_Z]}\n";
+        
+	print CRYO <<EOF;
+     <physvol>
+       <volumeref ref="volArapucaLat_$Lat_z\-$ara"/>
+       <position name="posArapuca$ara-Lat\-$Lat_z" unit="cm" 
+         x="@{[$Ara_X]}"
+	 y="@{[$Ara_Y]}" 
+	 z="@{[$Ara_Z]}"/>
+       <rotationref ref="$rot"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_$Lat_z\-$ara"/>
+       <position name="posOpArapuca$ara-Lat\-$Lat_z" unit="cm" 
+         x="@{[$Ara_X]}"
+	 y="@{[$Ara_YSens]}" 
+	 z="@{[$Ara_Z]}"/>
+     </physvol>
+EOF
+        
+}#end Ara for-loop
+
+}
+
+sub place_OpDetsShortLateral()
+{
+  $FrameCenter_x = $_[0];
+  $FrameCenter_y = $_[1];
+  $FrameCenter_z = $_[2];
+
+  #Placing Arapucas on the laterals if nCRM_x=8 -- Single Sided
+  for ($ara = 0; $ara<8; $ara++)
+  {
+             # Arapucas on the short laterals (along X).
+             # All Arapuca centers on a given collumn will have the same X coordinate
+             # Y coordinates are defined with respect to the cathode position
+             # There are two collumns per frame on each side.
+
+    if ($ara<4) {
+      $Ara_Z = -0.5*$Argon_z + $FrameToArapucaSpaceLat;
+      $Ara_ZSens = ($Ara_Z+0.5*$ArapucaOut_y-0.5*$ArapucaAcceptanceWindow_y-0.01);
+      $rot= "rMinus90AboutX";
+    }
+    else {
+      $Ara_Z = 0.5*$Argon_z - $FrameToArapucaSpaceLat;
+      $Ara_ZSens = ($Ara_Z-0.5*$ArapucaOut_y+0.5*$ArapucaAcceptanceWindow_y+0.01);
+      $rot = "rPlus90AboutX";
+    }
+    #GEOMETRY IS ROTATED: X--> Y AND Y--> X
+    if ($ara==0||$ara==4) {
+      $Ara_X = $FrameCenter_x-$FirstFrameVertDist;;
+    } #first tile's center 40 cm bellow anode
+    else {
+      $Ara_X-=$VerticalPDdist; #drift direction
+    } #other tiles separated by VerticalPDdist
+    $Ara_Y = $FrameCenter_y;
+
+    #print " ArapucaPos ShortLAteral $ara :    x=@{[$Ara_X]} y= @{[$Ara_Y]}  z= @{[$Ara_Z]}\n";
+    print CRYO <<EOF;
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca$ara-ShortLat\-$Lat_z" unit="cm" 
+         x="@{[$Ara_X]}"
+	 y="@{[$Ara_Y]}" 
+	 z="@{[$Ara_Z]}"/>
+       <rotationref ref="$rot"/>
+     </physvol>
+EOF
+        
+}#end Ara for-loop
+
+}
+
+
+
+sub place_OpDetsMembOnly()
+{
+
+    $FrameCenter_x = $_[0];
+    $FrameCenter_z = $_[1];
+    $Lat_z = $_[2];
+
+#Placing Arapucas on the laterals if nCRM_x=8 -- Single Sided
+for ($ara = 0; $ara<18; $ara++)
+{
+             # Arapucas on laterals
+             # All Arapuca centers on a given collumn will have the same Z coordinate
+             # X coordinates are on the left and right laterals
+             # Y coordinates are defined with respect to the cathode position
+             # There are two collumns per frame on each side.
+
+             if($ara<9) {$Ara_Y = -0.5*$Argon_y + $FrameToArapucaSpaceLat;
+                         $Ara_YSens = ($Ara_Y+0.5*$ArapucaOut_y-0.5*$ArapucaAcceptanceWindow_y-0.01);
+                         $rot= "rIdentity"; }
+             else {$Ara_Y = 0.5*$Argon_y - $FrameToArapucaSpaceLat;
+                         $Ara_YSens = ($Ara_Y-0.5*$ArapucaOut_y+0.5*$ArapucaAcceptanceWindow_y+0.01);
+                         $rot = "rPlus180AboutX";} #GEOMETRY IS ROTATED: X--> Y AND Y--> X
+             if($ara==0||$ara==9) {$Ara_X = $FrameCenter_x-$ArapucaOut_x/2;} #first tile's center right below anode
+             else {$Ara_X-=$ArapucaOut_x - $FrameToArapucaSpace;} #other tiles separated by minimal distance + buffer
+             $Ara_Z = $FrameCenter_z;
+
+#        print "lateral arapucas: $Ara_X, $Ara_Y, $Ara_Z \n";
+        
+	print CRYO <<EOF;
+     <physvol>
+       <volumeref ref="volArapucaLat_$Lat_z\-$ara"/>
+       <position name="posArapuca$ara-Lat\-$Lat_z" unit="cm" 
+         x="@{[$Ara_X]}"
+	 y="@{[$Ara_Y]}" 
+	 z="@{[$Ara_Z]}"/>
+       <rotationref ref="$rot"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volOpDetSensitive_ArapucaLat_$Lat_z\-$ara"/>
+       <position name="posOpArapuca$ara-Lat\-$Lat_z" unit="cm" 
+         x="@{[$Ara_X]}"
+	 y="@{[$Ara_YSens]}" 
+	 z="@{[$Ara_Z]}"/>
+     </physvol>
+EOF
+        
+}#end Ara for-loop
+
+
+
+}
+
+
+#+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+#+++++++++++++++++++++++++++++++++++++ gen_Enclosure +++++++++++++++++++++++++++++++++++++
+#+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+sub gen_Enclosure()
+{
+
+# Create the detector enclosure fragment file name,
+# add file to list of output GDML fragments,
+# and open it
+    $ENCL = $basename."_DetEnclosure" . $suffix . ".gdml";
+    push (@gdmlFiles, $ENCL);
+    $ENCL = ">" . $ENCL;
+    open(ENCL) or die("Could not open file $ENCL for writing");
+
+
+# The standard XML prefix and starting the gdml
+    print ENCL <<EOF;
+<?xml version='1.0'?>
+<gdml>
+EOF
+
+
+# All the detector enclosure solids.
+print ENCL <<EOF;
+<solids>
+
+    <box name="CathodeBlock" lunit="cm"
+      x="@{[$heightCathode]}"
+      y="@{[$widthCathode]}"
+      z="@{[$lengthCathode]}" />
+
+    <box name="CathodeVoid" lunit="cm"
+      x="@{[$heightCathode+1.0]}"
+      y="@{[$widthCathodeVoid]}"
+      z="@{[$lengthCathodeVoid]}" />
+
+    <subtraction name="Cathode1">
+      <first ref="CathodeBlock"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub1" x="0" y="@{[-1.5*$widthCathodeVoid-2.0*$CathodeBorder]}" z="@{[-1.5*$lengthCathodeVoid-2.0*$CathodeBorder]}" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode2">
+      <first ref="Cathode1"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub2" x="0" y="@{[-1.5*$widthCathodeVoid-2.0*$CathodeBorder]}" z="@{[-0.5*$lengthCathodeVoid-1.0*$CathodeBorder]}" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode3">
+      <first ref="Cathode2"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub3" x="0" y="@{[-1.5*$widthCathodeVoid-2.0*$CathodeBorder]}" z="@{[0.5*$lengthCathodeVoid+1.0*$CathodeBorder]}" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode4">
+      <first ref="Cathode3"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub4" x="0" y="@{[-1.5*$widthCathodeVoid-2.0*$CathodeBorder]}" z="@{[1.5*$lengthCathodeVoid+2.0*$CathodeBorder]}" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode5">
+      <first ref="Cathode4"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub5" x="0" y="@{[-0.5*$widthCathodeVoid-1.0*$CathodeBorder]}" z="@{[-1.5*$lengthCathodeVoid-2.0*$CathodeBorder]}" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode6">
+      <first ref="Cathode5"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub6" x="0" y="@{[-0.5*$widthCathodeVoid-1.0*$CathodeBorder]}" z="@{[-0.5*$lengthCathodeVoid-1.0*$CathodeBorder]}" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode7">
+      <first ref="Cathode6"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub7" x="0" y="@{[-0.5*$widthCathodeVoid-1.0*$CathodeBorder]}" z="@{[0.5*$lengthCathodeVoid+1.0*$CathodeBorder]}" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode8">
+      <first ref="Cathode7"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub8" x="0" y="@{[-0.5*$widthCathodeVoid-1.0*$CathodeBorder]}" z="@{[1.5*$lengthCathodeVoid+2.0*$CathodeBorder]}" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode9">
+      <first ref="Cathode8"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub9" x="0" y="@{[0.5*$widthCathodeVoid+1.0*$CathodeBorder]}" z="@{[-1.5*$lengthCathodeVoid-2.0*$CathodeBorder]}" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode10">
+      <first ref="Cathode9"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub10" x="0" y="@{[0.5*$widthCathodeVoid+1.0*$CathodeBorder]}" z="@{[-0.5*$lengthCathodeVoid-1.0*$CathodeBorder]}" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode11">
+      <first ref="Cathode10"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub11" x="0" y="@{[0.5*$widthCathodeVoid+1.0*$CathodeBorder]}" z="@{[0.5*$lengthCathodeVoid+1.0*$CathodeBorder]}" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode12">
+      <first ref="Cathode11"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub12" x="0" y="@{[0.5*$widthCathodeVoid+1.0*$CathodeBorder]}" z="@{[1.5*$lengthCathodeVoid+2.0*$CathodeBorder]}" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode13">
+      <first ref="Cathode12"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub13" x="0" y="@{[1.5*$widthCathodeVoid+2.0*$CathodeBorder]}" z="@{[-1.5*$lengthCathodeVoid-2.0*$CathodeBorder]}" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode14">
+      <first ref="Cathode13"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub14" x="0" y="@{[1.5*$widthCathodeVoid+2.0*$CathodeBorder]}" z="@{[-0.5*$lengthCathodeVoid-1.0*$CathodeBorder]}" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode15">
+      <first ref="Cathode14"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub15" x="0" y="@{[1.5*$widthCathodeVoid+2.0*$CathodeBorder]}" z="@{[0.5*$lengthCathodeVoid+1.0*$CathodeBorder]}" unit="cm"/>
+    </subtraction>
+    <subtraction name="CathodeGrid">
+      <first ref="Cathode15"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub16" x="0" y="@{[1.5*$widthCathodeVoid+2.0*$CathodeBorder]}" z="@{[1.5*$lengthCathodeVoid+2.0*$CathodeBorder]}" unit="cm"/>
+    </subtraction>
+
+   <box name="AnodePlate" 
+      x="$anodePlateWidth"
+      y="$widthCathode"
+      z="$lengthCathode"
+      lunit="cm"/>
+
+    <box name="FoamPadBlock" lunit="cm"
+      x="@{[$Cryostat_x + 2*$FoamPadding]}"
+      y="@{[$Cryostat_y + 2*$FoamPadding]}"
+      z="@{[$Cryostat_z + 2*$FoamPadding]}" />
+
+    <subtraction name="FoamPadding">
+      <first ref="FoamPadBlock"/>
+      <second ref="Cryostat"/>
+      <positionref ref="posCenter"/>
+    </subtraction>
+
+    <box name="SteelSupportBlock" lunit="cm"
+      x="@{[$Cryostat_x + 2*$FoamPadding + 2*$SteelSupport_x]}"
+      y="@{[$Cryostat_y + 2*$FoamPadding + 2*$SteelSupport_y]}"
+      z="@{[$Cryostat_z + 2*$FoamPadding + 2*$SteelSupport_z]}" />
+
+    <subtraction name="SteelSupport">
+      <first ref="SteelSupportBlock"/>
+      <second ref="FoamPadBlock"/>
+      <positionref ref="posCenter"/>
+    </subtraction>
+
+    <box name="DetEnclosure" lunit="cm" 
+      x="$DetEncX"
+      y="$DetEncY"
+      z="$DetEncZ"/>
+
+</solids>
+EOF
+
+
+# Detector enclosure structure
+    print ENCL <<EOF;
+<structure>
+    <volume name="volFoamPadding">
+      <materialref ref="fibrous_glass"/>
+      <solidref ref="FoamPadding"/>
+    </volume>
+
+    <volume name="volSteelSupport">
+      <materialref ref="AirSteelMixture"/>
+      <solidref ref="SteelSupport"/>
+    </volume>
+
+    <volume name="volDetEnclosure">
+      <materialref ref="Air"/>
+      <solidref ref="DetEnclosure"/>
+
+       <physvol>
+           <volumeref ref="volFoamPadding"/>
+           <positionref ref="posCryoInDetEnc"/>
+       </physvol>
+       <physvol>
+           <volumeref ref="volSteelSupport"/>
+           <positionref ref="posCryoInDetEnc"/>
+       </physvol>
+       <physvol>
+           <volumeref ref="volCryostat"/>
+           <positionref ref="posCryoInDetEnc"/>
+       </physvol>
+EOF
+
+
+print ENCL <<EOF;
+    </volume>
+EOF
+
+print ENCL <<EOF;
+</structure>
+</gdml>
+EOF
+
+close(ENCL);
+}
+
+
+
+#+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+#+++++++++++++++++++++++++++++++++++++++ gen_World +++++++++++++++++++++++++++++++++++++++
+#+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+sub gen_World()
+{
+
+# Create the WORLD fragment file name,
+# add file to list of output GDML fragments,
+# and open it
+    $WORLD = $basename."_World" . $suffix . ".gdml";
+    push (@gdmlFiles, $WORLD);
+    $WORLD = ">" . $WORLD;
+    open(WORLD) or die("Could not open file $WORLD for writing");
+
+
+# The standard XML prefix and starting the gdml
+    print WORLD <<EOF;
+<?xml version='1.0'?>
+<gdml>
+EOF
+
+
+# All the World solids.
+print WORLD <<EOF;
+<solids>
+    <box name="World" lunit="cm" 
+      x="@{[$DetEncX+2*$RockThickness]}" 
+      y="@{[$DetEncY+2*$RockThickness]}" 
+      z="@{[$DetEncZ+2*$RockThickness]}"/>
+</solids>
+EOF
+
+# World structure
+print WORLD <<EOF;
+<structure>
+    <volume name="volWorld" >
+      <materialref ref="DUSEL_Rock"/>
+      <solidref ref="World"/>
+
+      <physvol>
+        <volumeref ref="volDetEnclosure"/>
+	<position name="posDetEnclosure" unit="cm" x="$OriginXSet" y="$OriginYSet" z="$OriginZSet"/>
+      </physvol>
+
+    </volume>
+</structure>
+</gdml>
+EOF
+
+# make_gdml.pl will take care of <setup/>
+
+close(WORLD);
+}
+
+
+
+#+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+#++++++++++++++++++++++++++++++++++++ write_fragments ++++++++++++++++++++++++++++++++++++
+#+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+sub write_fragments()
+{
+   # This subroutine creates an XML file that summarizes the the subfiles output
+   # by the other sub routines - it is the input file for make_gdml.pl which will
+   # give the final desired GDML file. Specify its name with the output option.
+   # (you can change the name when running make_gdml)
+
+   # This code is taken straigh from the similar MicroBooNE generate script, Thank you.
+
+    if ( ! defined $output )
+    {
+	$output = "-"; # write to STDOUT 
+    }
+
+    # Set up the output file.
+    $OUTPUT = ">" . $output;
+    open(OUTPUT) or die("Could not open file $OUTPUT");
+
+    print OUTPUT <<EOF;
+<?xml version='1.0'?>
+
+<!-- Input to Geometry/gdml/make_gdml.pl; define the GDML fragments
+     that will be zipped together to create a detector description. 
+     -->
+
+<config>
+
+   <constantfiles>
+
+      <!-- These files contain GDML <constant></constant>
+           blocks. They are read in separately, so they can be
+           interpreted into the remaining GDML. See make_gdml.pl for
+           more information. 
+	   -->
+	   
+EOF
+
+    foreach $filename (@defFiles)
+    {
+	print OUTPUT <<EOF;
+      <filename> $filename </filename>
+EOF
+    }
+
+    print OUTPUT <<EOF;
+
+   </constantfiles>
+
+   <gdmlfiles>
+
+      <!-- The GDML file fragments to be zipped together. -->
+
+EOF
+
+    foreach $filename (@gdmlFiles)
+    {
+	print OUTPUT <<EOF;
+      <filename> $filename </filename>
+EOF
+    }
+
+    print OUTPUT <<EOF;
+
+   </gdmlfiles>
+
+</config>
+EOF
+
+    close(OUTPUT);
+}
+
+
+print "Some of the principal parameters for this TPC geometry (unit cm unless noted otherwise)\n";
+print " CRM active area       : $widthCRM_active x $lengthCRM_active\n";
+print " CRM total area        : $widthCRM x $lengthCRM\n";
+print " Wire pitch in U, V, Z : $wirePitchU, $wirePitchV, $wirePitchZ\n";
+print " TPC active volume  : $driftTPCActive x $widthTPCActive x $lengthTPCActive\n";
+print " Argon volume       : ($Argon_x, $Argon_y, $Argon_z) \n"; 
+print " Argon buffer       : ($xLArBuffer, $yLArBuffer, $zLArBuffer) \n"; 
+print " Detector enclosure : $DetEncX x $DetEncY x $DetEncZ\n";
+print " TPC Origin         : ($OriginXSet, $OriginYSet, $OriginZSet) \n";
+print " Field Cage         : $FieldCage_switch \n";
+print " Cathode            : $Cathode_switch \n";
+print " Workspace          : $workspace \n";
+print " Wires              : $wires \n";
+
+# run the sub routines that generate the fragments
+if ( $FieldCage_switch eq "on" ) {  gen_FieldCage();	}
+#if ( $Cathode_switch eq "on" ) {  gen_Cathode();	} #Cathode for now has the same geometry as the Ground Grid
+
+gen_Extend();    # generates the GDML color extension for the refactored geometry 
+gen_Define(); 	 # generates definitions at beginning of GDML
+gen_Materials(); # generates materials to be used
+gen_TopCRP();    # generate TPC for a given unit CRP
+gen_Cryostat();  # 
+gen_Enclosure(); # 
+gen_World();	 # places the enclosure among DUSEL Rock
+write_fragments(); # writes the XML input for make_gdml.pl
+		   # which zips together the final GDML
+print "--- done\n\n\n";
+exit;

--- a/dunecore/Geometry/gdml/make_dunevd.sh
+++ b/dunecore/Geometry/gdml/make_dunevd.sh
@@ -1,0 +1,42 @@
+#3view_30deg 1x8x6 geometry v5, no wires, PDS ref
+perl generate_dunevd10kt_3view_30deg_v5_refactored.pl -o dunevd10kt_3view_30deg_v5_refactored_1x8x6ref_nowires.xml -w=0 -pds=0 -k=3 -s="parts"
+perl make_refactored_gdml.pl -i dunevd10kt_3view_30deg_v5_refactored_1x8x6ref_nowires.xml -o dunevd10kt_3view_30deg_v5_refactored_1x8x6ref_nowires.gdml
+rm dunevd10kt_3view_30deg_v5_refactored_1x8x6ref_nowires.xml
+rm dunevd10kt_*parts.gdml
+
+#3view_30deg 1x8x6 geometry v5, with wires, PDS ref
+perl generate_dunevd10kt_3view_30deg_v5_refactored.pl -o dunevd10kt_3view_30deg_v5_refactored_1x8x6ref.xml -w=1 -pds=0 -k=3 -s="parts"
+perl make_refactored_gdml.pl -i dunevd10kt_3view_30deg_v5_refactored_1x8x6ref.xml -o dunevd10kt_3view_30deg_v5_refactored_1x8x6ref.gdml
+rm dunevd10kt_3view_30deg_v5_refactored_1x8x6ref.xml
+rm dunevd10kt_*parts.gdml
+
+
+#3view_30deg 1x8x14 geometry v5, no wires, PDS ref
+perl generate_dunevd10kt_3view_30deg_v5_refactored.pl -o dunevd10kt_3view_30deg_v5_refactored_1x8x14ref_nowires.xml -w=0 -pds=0 -k=4 -s="parts"
+perl make_refactored_gdml.pl -i dunevd10kt_3view_30deg_v5_refactored_1x8x14ref_nowires.xml -o dunevd10kt_3view_30deg_v5_refactored_1x8x14ref_nowires.gdml
+rm dunevd10kt_3view_30deg_v5_refactored_1x8x14ref_nowires.xml
+rm dunevd10kt_*parts.gdml
+
+#3view_30deg 1x8x14 geometry v5, with wires, PDS ref
+perl generate_dunevd10kt_3view_30deg_v5_refactored.pl -o dunevd10kt_3view_30deg_v5_refactored_1x8x14ref.xml -w=1 -pds=0 -k=4 -s="parts"
+perl make_refactored_gdml.pl -i dunevd10kt_3view_30deg_v5_refactored_1x8x14ref.xml -o dunevd10kt_3view_30deg_v5_refactored_1x8x14ref.gdml
+rm dunevd10kt_3view_30deg_v5_refactored_1x8x14ref.xml
+rm dunevd10kt_*parts.gdml
+
+
+#3view_30deg 1x8x20 geometry v5, no wires, PDS ref
+perl generate_dunevd10kt_3view_30deg_v5_refactored.pl -o dunevd10kt_3view_30deg_v5_refactored_1x8x20ref_nowires.xml -w=0 -pds=0 -k=5 -s="parts"
+perl make_refactored_gdml.pl -i dunevd10kt_3view_30deg_v5_refactored_1x8x20ref_nowires.xml -o dunevd10kt_3view_30deg_v5_refactored_1x8x20ref_nowires.gdml
+rm dunevd10kt_3view_30deg_v5_refactored_1x8x20ref_nowires.xml
+rm dunevd10kt_*parts.gdml
+
+#3view_30deg 1x8x20 geometry v5, with wires, PDS ref
+perl generate_dunevd10kt_3view_30deg_v5_refactored.pl -o dunevd10kt_3view_30deg_v5_refactored_1x8x20ref.xml -w=1 -pds=0 -k=5 -s="parts"
+perl make_refactored_gdml.pl -i dunevd10kt_3view_30deg_v5_refactored_1x8x20ref.xml -o dunevd10kt_3view_30deg_v5_refactored_1x8x20ref.gdml
+rm dunevd10kt_3view_30deg_v5_refactored_1x8x20ref.xml
+rm dunevd10kt_*parts.gdml
+
+
+
+
+


### PR DESCRIPTION
Update the dunevd10kt geometry:
- A new workspace geometry is added, including a full drift volume.
- Cathode and field cage materials have been fixed.
- XArapucas added in the short membrane walls.
- Field cage is now transparent (slim) near the XArapucas in the short walls.
- The distance from the field cage to the membrane XArapucas is now ~70cm.
- The cryostat size has been adjusted, to fix the LAr buffer size on the sides.