### PR TITLE
Introducing 2-drift VD geometry and changes to cathode arapuca layout

### DIFF
--- a/dunecore/Geometry/gdml/dunevd10kt_3view_30deg_v6_refactored_1x8x6.gdml
+++ b/dunecore/Geometry/gdml/dunevd10kt_3view_30deg_v6_refactored_1x8x6.gdml
@@ -1,0 +1,11962 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<gdml_simple_extension xmlns:gdml_simple_extension="http://www.example.org"
+                       xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"          
+                       xs:noNamespaceSchemaLocation="RefactoredGDMLSchema/SimpleExtension.xsd"> 
+
+
+<extension>
+   <color name="magenta"     R="0.0"  G="1.0"  B="0.0"  A="1.0" />
+   <color name="green"       R="0.0"  G="1.0"  B="0.0"  A="1.0" />
+   <color name="red"         R="1.0"  G="0.0"  B="0.0"  A="1.0" />
+   <color name="blue"        R="0.0"  G="0.0"  B="1.0"  A="1.0" />
+   <color name="yellow"      R="1.0"  G="1.0"  B="0.0"  A="1.0" />
+</extension>
+<define>
+
+<!--
+
+
+
+-->
+
+   <position name="posCryoInDetEnc"     unit="cm" x="-50.0000000000001" y="0" z="0"/>
+   <position name="posCenter"           unit="cm" x="0" y="0" z="0"/>
+   <rotation name="rUWireAboutX"        unit="deg" x="150" y="0" z="0"/>
+   <rotation name="rVWireAboutX"        unit="deg" x="30" y="0" z="0"/>
+   <rotation name="rPlus90AboutX"       unit="deg" x="90" y="0" z="0"/>
+   <rotation name="rPlus90AboutY"       unit="deg" x="0" y="90" z="0"/>
+   <rotation name="rPlus90AboutXPlus90AboutY" unit="deg" x="90" y="90" z="0"/>
+   <rotation name="rMinus90AboutX"      unit="deg" x="270" y="0" z="0"/>
+   <rotation name="rMinus90AboutY"      unit="deg" x="0" y="270" z="0"/>
+   <rotation name="rMinus90AboutYMinus90AboutX"       unit="deg" x="270" y="270" z="0"/>
+   <rotation name="rPlus180AboutX"	unit="deg" x="180" y="0"   z="0"/>
+   <rotation name="rPlus180AboutY"	unit="deg" x="0" y="180"   z="0"/>
+   <rotation name="rPlus180AboutXPlus180AboutY"	unit="deg" x="180" y="180"   z="0"/>
+   <rotation name="rIdentity"		unit="deg" x="0" y="0"   z="0"/>
+   <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+   <rotation name="rPlus90AboutXPlus180AboutY" unit="deg" x="90" y="180" z="0" />
+   <rotation name="rPlus90AboutXMinux90AboutY" unit="deg" x="90" y="270" z="0" />
+   <rotation name="rPlus90AboutZ" unit="deg" x="0" y="0" z="90" />
+</define>
+<materials>
+  <element name="videRef" formula="VACUUM" Z="1">  <atom value="1"/> </element>
+  <element name="copper" formula="Cu" Z="29">  <atom value="63.546"/>  </element>
+  <element name="beryllium" formula="Be" Z="4">  <atom value="9.0121831"/>  </element>
+  <element name="bromine" formula="Br" Z="35"> <atom value="79.904"/> </element>
+  <element name="hydrogen" formula="H" Z="1">  <atom value="1.0079"/> </element>
+  <element name="nitrogen" formula="N" Z="7">  <atom value="14.0067"/> </element>
+  <element name="oxygen" formula="O" Z="8">  <atom value="15.999"/> </element>
+  <element name="aluminum" formula="Al" Z="13"> <atom value="26.9815"/>  </element>
+  <element name="silicon" formula="Si" Z="14"> <atom value="28.0855"/>  </element>
+  <element name="carbon" formula="C" Z="6">  <atom value="12.0107"/>  </element>
+  <element name="potassium" formula="K" Z="19"> <atom value="39.0983"/>  </element>
+  <element name="chromium" formula="Cr" Z="24"> <atom value="51.9961"/>  </element>
+  <element name="iron" formula="Fe" Z="26"> <atom value="55.8450"/>  </element>
+  <element name="nickel" formula="Ni" Z="28"> <atom value="58.6934"/>  </element>
+  <element name="calcium" formula="Ca" Z="20"> <atom value="40.078"/>   </element>
+  <element name="magnesium" formula="Mg" Z="12"> <atom value="24.305"/>   </element>
+  <element name="sodium" formula="Na" Z="11"> <atom value="22.99"/>    </element>
+  <element name="titanium" formula="Ti" Z="22"> <atom value="47.867"/>   </element>
+  <element name="argon" formula="Ar" Z="18"> <atom value="39.9480"/>  </element>
+  <element name="sulphur" formula="S" Z="16"> <atom value="32.065"/>  </element>
+  <element name="phosphorus" formula="P" Z="15"> <atom value="30.973"/>  </element>
+
+  <material name="Vacuum" formula="Vacuum">
+   <D value="1.e-25" unit="g/cm3"/>
+   <fraction n="1.0" ref="videRef"/>
+  </material>
+
+  <material name="ALUMINUM_Al" formula="ALUMINUM_Al">
+   <D value="2.6990" unit="g/cm3"/>
+   <fraction n="1.0000" ref="aluminum"/>
+  </material>
+
+  <material name="SILICON_Si" formula="SILICON_Si">
+   <D value="2.3300" unit="g/cm3"/>
+   <fraction n="1.0000" ref="silicon"/>
+  </material>
+
+  <material name="epoxy_resin" formula="C38H40O6Br4">
+   <D value="1.1250" unit="g/cm3"/>
+   <composite n="38" ref="carbon"/>
+   <composite n="40" ref="hydrogen"/>
+   <composite n="6" ref="oxygen"/>
+   <composite n="4" ref="bromine"/>
+  </material>
+
+  <material name="SiO2" formula="SiO2">
+   <D value="2.2" unit="g/cm3"/>
+   <composite n="1" ref="silicon"/>
+   <composite n="2" ref="oxygen"/>
+  </material>
+
+  <material name="Al2O3" formula="Al2O3">
+   <D value="3.97" unit="g/cm3"/>
+   <composite n="2" ref="aluminum"/>
+   <composite n="3" ref="oxygen"/>
+  </material>
+
+  <material name="Fe2O3" formula="Fe2O3">
+   <D value="5.24" unit="g/cm3"/>
+   <composite n="2" ref="iron"/>
+   <composite n="3" ref="oxygen"/>
+  </material>
+
+  <material name="CaO" formula="CaO">
+   <D value="3.35" unit="g/cm3"/>
+   <composite n="1" ref="calcium"/>
+   <composite n="1" ref="oxygen"/>
+  </material>
+
+  <material name="Delrin" formula="CH2O">
+    <D value="1.41" unit="g/cm3"/>
+    <composite n="1" ref="carbon"/>
+    <composite n="2" ref="hydrogen"/>
+    <composite n="1" ref="oxygen"/>
+  </material>
+
+  <material name="MgO" formula="MgO">
+   <D value="3.58" unit="g/cm3"/>
+   <composite n="1" ref="magnesium"/>
+   <composite n="1" ref="oxygen"/>
+  </material>
+
+  <material name="Na2O" formula="Na2O">
+   <D value="2.27" unit="g/cm3"/>
+   <composite n="2" ref="sodium"/>
+   <composite n="1" ref="oxygen"/>
+  </material>
+
+  <material name="TiO2" formula="TiO2">
+   <D value="4.23" unit="g/cm3"/>
+   <composite n="1" ref="titanium"/>
+   <composite n="2" ref="oxygen"/>
+  </material>
+
+  <material name="FeO" formula="FeO">
+   <D value="5.745" unit="g/cm3"/>
+   <composite n="1" ref="iron"/>
+   <composite n="1" ref="oxygen"/>
+  </material>
+
+  <material name="CO2" formula="CO2">
+   <D value="1.562" unit="g/cm3"/>
+   <composite n="1" ref="iron"/>
+   <composite n="2" ref="oxygen"/>
+  </material>
+
+  <material name="P2O5" formula="P2O5">
+   <D value="1.562" unit="g/cm3"/>
+   <composite n="2" ref="phosphorus"/>
+   <composite n="5" ref="oxygen"/>
+  </material>
+
+  <material formula=" " name="DUSEL_Rock">
+    <D value="2.82" unit="g/cm3"/>
+    <fraction n="0.5267" ref="SiO2"/>
+    <fraction n="0.1174" ref="FeO"/>
+    <fraction n="0.1025" ref="Al2O3"/>
+    <fraction n="0.0473" ref="MgO"/>
+    <fraction n="0.0422" ref="CO2"/>
+    <fraction n="0.0382" ref="CaO"/>
+    <fraction n="0.0240" ref="carbon"/>
+    <fraction n="0.0186" ref="sulphur"/>
+    <fraction n="0.0053" ref="Na2O"/>
+    <fraction n="0.00070" ref="P2O5"/>
+    <fraction n="0.0771" ref="oxygen"/>
+  </material> 
+
+  <material formula="Air" name="Air">
+   <D value="0.001205" unit="g/cm3"/>
+   <fraction n="0.781154" ref="nitrogen"/>
+   <fraction n="0.209476" ref="oxygen"/>
+   <fraction n="0.00934" ref="argon"/>
+  </material>
+
+  <material name="fibrous_glass">
+   <D value="2.74351" unit="g/cm3"/>
+   <fraction n="0.600" ref="SiO2"/>
+   <fraction n="0.118" ref="Al2O3"/>
+   <fraction n="0.001" ref="Fe2O3"/>
+   <fraction n="0.224" ref="CaO"/>
+   <fraction n="0.034" ref="MgO"/>
+   <fraction n="0.010" ref="Na2O"/>
+   <fraction n="0.013" ref="TiO2"/>
+  </material>
+
+  <!-- density referenced from EHN1-Cold Cryostats Technical Requirements:
+       https://edms.cern.ch/document/1543254 -->
+  <material name="FD_foam">
+   <D value="0.09" unit="g/cm3"/>
+   <fraction n="0.95" ref="Air"/>
+   <fraction n="0.05" ref="fibrous_glass"/>
+  </material>
+
+  <!-- Foam density is 70 kg / m^3 for the 3x1x1 -->
+  <material name="foam_3x1x1dp">
+   <D value="0.07" unit="g/cm3"/>
+   <fraction n="0.95" ref="Air"/>
+   <fraction n="0.05" ref="fibrous_glass"/>
+  </material>
+
+  <!-- Copied from protodune_v4.gdml -->
+  <material name="foam_protoDUNEdp">
+   <D value="0.135" unit="g/cm3"/>
+   <composite n="17" ref="carbon"/>
+   <composite n="16" ref="hydrogen"/>
+   <composite n="2" ref="nitrogen"/>
+   <composite n="4" ref="oxygen"/>
+  </material>
+
+  <material name="FR4">
+   <D value="1.98281" unit="g/cm3"/>
+   <fraction n="0.47" ref="epoxy_resin"/>
+   <fraction n="0.53" ref="fibrous_glass"/>
+  </material>
+
+  <material name="STEEL_STAINLESS_Fe7Cr2Ni" formula="STEEL_STAINLESS_Fe7Cr2Ni">
+   <D value="7.9300" unit="g/cm3"/>
+   <fraction n="0.0010" ref="carbon"/>
+   <fraction n="0.1792" ref="chromium"/>
+   <fraction n="0.7298" ref="iron"/>
+   <fraction n="0.0900" ref="nickel"/>
+  </material>
+
+  <material name="Copper_Beryllium_alloy25" formula="Copper_Beryllium_alloy25">
+   <D value="8.26" unit="g/cm3"/>
+   <fraction n="0.981" ref="copper"/>
+   <fraction n="0.019" ref="beryllium"/>
+  </material>
+
+  <material name="LAr" formula="LAr">
+   <D value="1.40" unit="g/cm3"/>
+   <fraction n="1.0000" ref="argon"/>
+  </material>
+
+  <material name="ArGas" formula="ArGas">
+   <D value="0.00166" unit="g/cm3"/>
+   <fraction n="1.0" ref="argon"/>
+  </material>
+
+  <material formula=" " name="G10">
+   <D value="1.7" unit="g/cm3"/>
+   <fraction n="0.2805" ref="silicon"/>
+   <fraction n="0.3954" ref="oxygen"/>
+   <fraction n="0.2990" ref="carbon"/>
+   <fraction n="0.0251" ref="hydrogen"/>
+  </material>
+
+  <material formula=" " name="Granite">
+   <D value="2.7" unit="g/cm3"/>
+   <fraction n="0.438" ref="oxygen"/>
+   <fraction n="0.257" ref="silicon"/>
+   <fraction n="0.222" ref="sodium"/>
+   <fraction n="0.049" ref="aluminum"/>
+   <fraction n="0.019" ref="iron"/>
+   <fraction n="0.015" ref="potassium"/>
+  </material>
+
+  <material formula=" " name="ShotRock">
+   <D value="1.62" unit="g/cm3"/>
+   <fraction n="0.438" ref="oxygen"/>
+   <fraction n="0.257" ref="silicon"/>
+   <fraction n="0.222" ref="sodium"/>
+   <fraction n="0.049" ref="aluminum"/>
+   <fraction n="0.019" ref="iron"/>
+   <fraction n="0.015" ref="potassium"/>
+  </material>
+
+  <material formula=" " name="Dirt">
+   <D value="1.7" unit="g/cm3"/>
+   <fraction n="0.438" ref="oxygen"/>
+   <fraction n="0.257" ref="silicon"/>
+   <fraction n="0.222" ref="sodium"/>
+   <fraction n="0.049" ref="aluminum"/>
+   <fraction n="0.019" ref="iron"/>
+   <fraction n="0.015" ref="potassium"/>
+  </material>
+
+  <material formula=" " name="Concrete">
+   <D value="2.3" unit="g/cm3"/>
+   <fraction n="0.530" ref="oxygen"/>
+   <fraction n="0.335" ref="silicon"/>
+   <fraction n="0.060" ref="calcium"/>
+   <fraction n="0.015" ref="sodium"/>
+   <fraction n="0.020" ref="iron"/>
+   <fraction n="0.040" ref="aluminum"/>
+  </material>
+
+  <material formula="H2O" name="Water">
+   <D value="1.0" unit="g/cm3"/>
+   <fraction n="0.1119" ref="hydrogen"/>
+   <fraction n="0.8881" ref="oxygen"/>
+  </material>
+
+  <material formula="Ti" name="Titanium">
+   <D value="4.506" unit="g/cm3"/>
+   <fraction n="1." ref="titanium"/>
+  </material>
+
+  <material name="TPB" formula="TPB">
+   <D value="1.40" unit="g/cm3"/>
+   <fraction n="1.0000" ref="argon"/>
+  </material>
+
+  <material name="Glass">
+   <D value="2.74351" unit="g/cm3"/>
+   <fraction n="0.600" ref="SiO2"/>
+   <fraction n="0.118" ref="Al2O3"/>
+   <fraction n="0.001" ref="Fe2O3"/>
+   <fraction n="0.224" ref="CaO"/>
+   <fraction n="0.034" ref="MgO"/>
+   <fraction n="0.010" ref="Na2O"/>
+   <fraction n="0.013" ref="TiO2"/>
+  </material>
+
+  <material name="Acrylic">
+   <D value="1.19" unit="g/cm3"/>
+   <fraction n="0.600" ref="carbon"/>
+   <fraction n="0.320" ref="oxygen"/>
+   <fraction n="0.080" ref="hydrogen"/>
+  </material>
+
+  <material name="NiGas1atm80K">
+   <D value="0.0039" unit="g/cm3"/>
+   <fraction n="1.000" ref="nitrogen"/>
+  </material>
+
+  <material name="NiGas">
+   <D value="0.001165" unit="g/cm3"/>
+   <fraction n="1.000" ref="nitrogen"/>
+  </material>
+
+  <material name="PolyurethaneFoam">
+   <D value="0.088" unit="g/cm3"/>
+   <composite n="17" ref="carbon"/>
+   <composite n="16" ref="hydrogen"/>
+   <composite n="2" ref="nitrogen"/>
+   <composite n="4" ref="oxygen"/>
+  </material>
+
+  <material name="ProtoDUNEFoam">
+   <D value="0.135" unit="g/cm3"/>
+   <composite n="17" ref="carbon"/>
+   <composite n="16" ref="hydrogen"/>
+   <composite n="2" ref="nitrogen"/>
+   <composite n="4" ref="oxygen"/>
+  </material>
+
+  <material name="LightPolyurethaneFoam">
+   <D value="0.009" unit="g/cm3"/>
+   <composite n="17" ref="carbon"/>
+   <composite n="16" ref="hydrogen"/>
+   <composite n="2" ref="nitrogen"/>
+   <composite n="4" ref="oxygen"/>
+  </material>
+
+  <material name="ProtoDUNEBWFoam">
+   <D value="0.021" unit="g/cm3"/>
+   <composite n="17" ref="carbon"/>
+   <composite n="16" ref="hydrogen"/>
+   <composite n="2" ref="nitrogen"/>
+   <composite n="4" ref="oxygen"/>
+  </material>
+
+  <material name="GlassWool">
+   <D value="0.035" unit="g/cm3"/>
+   <fraction n="0.65" ref="SiO2"/>
+   <fraction n="0.09" ref="Al2O3"/>
+   <fraction n="0.07" ref="CaO"/>
+   <fraction n="0.03" ref="MgO"/>
+   <fraction n="0.16" ref="Na2O"/>
+  </material>
+
+  <material name="Polystyrene">
+   <D value="1.06" unit="g/cm3"/>
+   <composite n="8" ref="carbon"/>
+   <composite n="8" ref="hydrogen"/>
+  </material>
+
+
+
+  <!-- preliminary values -->
+  <material name="AirSteelMixture" formula="AirSteelMixture">
+   <D value="3.9656025" unit="g/cm3"/>
+   <fraction n="0.5" ref="STEEL_STAINLESS_Fe7Cr2Ni"/>
+   <fraction n="0.5"   ref="Air"/>
+  </material>
+  <material name="vm2000" formula="vm2000">
+    <D value="1.2" unit="g/cm3"/>
+    <composite n="2" ref="carbon"/>
+    <composite n="4" ref="hydrogen"/>
+  </material>
+
+</materials>
+<solids>
+     <torus name="FieldShaperCorner" rmin="0.5" rmax="2.285" rtor="2.3" deltaphi="90" startphi="0" aunit="deg" lunit="cm"/>
+     <tube name="FieldShaperLongtube" rmin="0.5" rmax="2.285" z="896.52" deltaphi="360" startphi="0" aunit="deg" lunit="cm"/>
+     <tube name="FieldShaperLongtubeSlim" rmin="0.5" rmax="0.75" z="896.52" deltaphi="360" startphi="0" aunit="deg" lunit="cm"/>
+     <tube name="FieldShaperShorttube" rmin="0.5" rmax="2.285" z="1345.6048" deltaphi="360" startphi="0" aunit="deg" lunit="cm"/>
+     <tube name="FieldShaperShorttubeWindowSlim" rmin="0.5" rmax="0.75" z="670" deltaphi="360" startphi="0" aunit="deg" lunit="cm"/>
+     <tube name="FieldShaperShorttubeWindowNotSlim" rmin="0.5" rmax="2.285" z="337.8024" deltaphi="360" startphi="0" aunit="deg" lunit="cm"/>
+
+
+    <union name="FSunionWindow1">
+      <first ref="FieldShaperShorttubeWindowSlim"/>
+      <second ref="FieldShaperShorttubeWindowNotSlim"/>
+      <position name="posFieldShaperShortTube_shift1" unit="cm" x="0" y="0" z="503.9012"/>
+    </union>
+
+    <union name="FieldShaperShorttubeSlim">
+      <first ref="FSunionWindow1"/>
+      <second ref="FieldShaperShorttubeWindowNotSlim"/>
+      <position name="posFieldShaperShortTube_shift2" unit="cm" x="0" y="0" z="-503.9012"/>
+    </union>
+
+
+
+
+    <union name="FSunion1">
+      <first ref="FieldShaperLongtube"/>
+      <second ref="FieldShaperCorner"/>
+                <position name="esquinapos1" unit="cm" x="-2.3" y="0" z="448.26"/>
+                <rotationref ref="rPlus90AboutX"/>
+    </union>
+
+    <union name="FSunion2">
+      <first ref="FSunion1"/>
+      <second ref="FieldShaperShorttube"/>
+   		<position name="esquinapos2" unit="cm" x="-675.1024" y="0" z="450.56"/>
+   		<rotationref ref="rPlus90AboutY"/>
+    </union>
+
+    <union name="FSunion3">
+      <first ref="FSunion2"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos3" unit="cm" x="-1347.9048" y="0" z="448.26"/>
+		<rotationref ref="rPlus90AboutXMinux90AboutY"/>
+    </union>
+
+    <union name="FSunion4">
+      <first ref="FSunion3"/>
+      <second ref="FieldShaperLongtube"/>
+   		<position name="esquinapos4" unit="cm" x="-1350.2048" y="0" z="0"/>
+    </union>
+
+    <union name="FSunion5">
+      <first ref="FSunion4"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos5" unit="cm" x="-1347.9048" y="0" z="-448.26"/>
+		<rotationref ref="rPlus90AboutXPlus180AboutY"/>
+    </union>
+
+    <union name="FSunion6">
+      <first ref="FSunion5"/>
+      <second ref="FieldShaperShorttube"/>
+   		<position name="esquinapos6" unit="cm" x="-675.1024" y="0" z="-450.56"/>
+		<rotationref ref="rPlus90AboutY"/>
+    </union>
+
+    <union name="FieldShaperSolid">
+      <first ref="FSunion6"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos7" unit="cm" x="-2.3" y="0" z="-448.26"/>
+		<rotationref ref="rPlus90AboutXPlus90AboutY"/>
+    </union>
+
+    <union name="FSunionSlim1">
+      <first ref="FieldShaperLongtubeSlim"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos8" unit="cm" x="-2.3" y="0" z="448.26"/>
+		<rotationref ref="rPlus90AboutX"/>
+    </union>
+
+    <union name="FSunionSlim2">
+      <first ref="FSunionSlim1"/>
+      <second ref="FieldShaperShorttubeSlim"/>
+   		<position name="esquinapos9" unit="cm" x="-675.1024" y="0" z="450.56"/>
+   		<rotationref ref="rPlus90AboutY"/>
+    </union>
+
+    <union name="FSunionSlim3">
+      <first ref="FSunionSlim2"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos10" unit="cm" x="-1347.9048" y="0" z="448.26"/>
+		<rotationref ref="rPlus90AboutXMinux90AboutY"/>
+    </union>
+
+    <union name="FSunionSlim4">
+      <first ref="FSunionSlim3"/>
+      <second ref="FieldShaperLongtubeSlim"/>
+   		<position name="esquinapos4" unit="cm" x="-1350.2048" y="0" z="0"/>
+    </union>
+
+    <union name="FSunionSlim5">
+      <first ref="FSunionSlim4"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos11" unit="cm" x="-1347.9048" y="0" z="-448.26"/>
+		<rotationref ref="rPlus90AboutXPlus180AboutY"/>
+    </union>
+
+    <union name="FSunionSlim6">
+      <first ref="FSunionSlim5"/>
+      <second ref="FieldShaperShorttubeSlim"/>
+   		<position name="esquinapos12" unit="cm" x="-675.1024" y="0" z="-450.56"/>
+		<rotationref ref="rPlus90AboutY"/>
+    </union>
+
+    <union name="FieldShaperSolidSlim">
+      <first ref="FSunionSlim6"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos13" unit="cm" x="-2.3" y="0" z="-448.26"/>
+		<rotationref ref="rPlus90AboutXPlus90AboutY"/>
+    </union>
+
+
+   <box name="CRM"
+      x="650.08"
+      y="167.7006"
+      z="148.92"
+      lunit="cm"/>
+   <box name="CRMUPlane"
+      x="0.02"
+      y="167.7006"
+      z="148.92"
+      lunit="cm"/>
+   <box name="CRMVPlane"
+      x="0.02"
+      y="167.7006"
+      z="148.92"
+      lunit="cm"/>
+   <box name="CRMZPlane"
+      x="0.02"
+      y="167.7006"
+      z="148.92"
+      lunit="cm"/>
+   <box name="CRMActive"
+      x="650"
+      y="167.7006"
+      z="148.92"
+      lunit="cm"/>
+   <tube name="CRMWireU0"
+      rmax="0.5*0.02"
+      z="0.883345911860126"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU1"
+      rmax="0.5*0.02"
+      z="2.65003773558038"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU2"
+      rmax="0.5*0.02"
+      z="4.41672955930064"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU3"
+      rmax="0.5*0.02"
+      z="6.18342138302089"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU4"
+      rmax="0.5*0.02"
+      z="7.95011320674115"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU5"
+      rmax="0.5*0.02"
+      z="9.7168050304614"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU6"
+      rmax="0.5*0.02"
+      z="11.4834968541817"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU7"
+      rmax="0.5*0.02"
+      z="13.2501886779019"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU8"
+      rmax="0.5*0.02"
+      z="15.0168805016222"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU9"
+      rmax="0.5*0.02"
+      z="16.7835723253424"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU10"
+      rmax="0.5*0.02"
+      z="18.5502641490627"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU11"
+      rmax="0.5*0.02"
+      z="20.3169559727829"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU12"
+      rmax="0.5*0.02"
+      z="22.0836477965032"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU13"
+      rmax="0.5*0.02"
+      z="23.8503396202234"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU14"
+      rmax="0.5*0.02"
+      z="25.6170314439437"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU15"
+      rmax="0.5*0.02"
+      z="27.383723267664"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU16"
+      rmax="0.5*0.02"
+      z="29.1504150913842"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU17"
+      rmax="0.5*0.02"
+      z="30.9171069151045"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU18"
+      rmax="0.5*0.02"
+      z="32.6837987388247"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU19"
+      rmax="0.5*0.02"
+      z="34.450490562545"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU20"
+      rmax="0.5*0.02"
+      z="36.2171823862652"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU21"
+      rmax="0.5*0.02"
+      z="37.9838742099855"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU22"
+      rmax="0.5*0.02"
+      z="39.7505660337058"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU23"
+      rmax="0.5*0.02"
+      z="41.517257857426"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU24"
+      rmax="0.5*0.02"
+      z="43.2839496811463"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU25"
+      rmax="0.5*0.02"
+      z="45.0506415048665"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU26"
+      rmax="0.5*0.02"
+      z="46.8173333285868"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU27"
+      rmax="0.5*0.02"
+      z="48.584025152307"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU28"
+      rmax="0.5*0.02"
+      z="50.3507169760273"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU29"
+      rmax="0.5*0.02"
+      z="52.1174087997475"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU30"
+      rmax="0.5*0.02"
+      z="53.8841006234678"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU31"
+      rmax="0.5*0.02"
+      z="55.6507924471881"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU32"
+      rmax="0.5*0.02"
+      z="57.4174842709083"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU33"
+      rmax="0.5*0.02"
+      z="59.1841760946286"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU34"
+      rmax="0.5*0.02"
+      z="60.9508679183488"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU35"
+      rmax="0.5*0.02"
+      z="62.7175597420691"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU36"
+      rmax="0.5*0.02"
+      z="64.4842515657894"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU37"
+      rmax="0.5*0.02"
+      z="66.2509433895096"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU38"
+      rmax="0.5*0.02"
+      z="68.0176352132299"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU39"
+      rmax="0.5*0.02"
+      z="69.7843270369501"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU40"
+      rmax="0.5*0.02"
+      z="71.5510188606704"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU41"
+      rmax="0.5*0.02"
+      z="73.3177106843906"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU42"
+      rmax="0.5*0.02"
+      z="75.0844025081109"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU43"
+      rmax="0.5*0.02"
+      z="76.8510943318311"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU44"
+      rmax="0.5*0.02"
+      z="78.6177861555514"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU45"
+      rmax="0.5*0.02"
+      z="80.3844779792717"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU46"
+      rmax="0.5*0.02"
+      z="82.1511698029919"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU47"
+      rmax="0.5*0.02"
+      z="83.9178616267122"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU48"
+      rmax="0.5*0.02"
+      z="85.6845534504324"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU49"
+      rmax="0.5*0.02"
+      z="87.4512452741527"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU50"
+      rmax="0.5*0.02"
+      z="89.2179370978729"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU51"
+      rmax="0.5*0.02"
+      z="90.9846289215932"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU52"
+      rmax="0.5*0.02"
+      z="92.7513207453134"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU53"
+      rmax="0.5*0.02"
+      z="94.5180125690337"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU54"
+      rmax="0.5*0.02"
+      z="96.284704392754"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU55"
+      rmax="0.5*0.02"
+      z="98.0513962164742"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU56"
+      rmax="0.5*0.02"
+      z="99.8180880401945"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU57"
+      rmax="0.5*0.02"
+      z="101.584779863915"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU58"
+      rmax="0.5*0.02"
+      z="103.351471687635"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU59"
+      rmax="0.5*0.02"
+      z="105.118163511355"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU60"
+      rmax="0.5*0.02"
+      z="106.884855335075"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU61"
+      rmax="0.5*0.02"
+      z="108.651547158796"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU62"
+      rmax="0.5*0.02"
+      z="110.418238982516"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU63"
+      rmax="0.5*0.02"
+      z="112.184930806236"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU64"
+      rmax="0.5*0.02"
+      z="113.951622629957"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU65"
+      rmax="0.5*0.02"
+      z="115.718314453677"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU66"
+      rmax="0.5*0.02"
+      z="117.485006277397"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU67"
+      rmax="0.5*0.02"
+      z="119.251698101117"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU68"
+      rmax="0.5*0.02"
+      z="121.018389924838"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU69"
+      rmax="0.5*0.02"
+      z="122.785081748558"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU70"
+      rmax="0.5*0.02"
+      z="124.551773572278"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU71"
+      rmax="0.5*0.02"
+      z="126.318465395998"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU72"
+      rmax="0.5*0.02"
+      z="128.085157219719"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU73"
+      rmax="0.5*0.02"
+      z="129.851849043439"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU74"
+      rmax="0.5*0.02"
+      z="131.618540867159"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU75"
+      rmax="0.5*0.02"
+      z="133.385232690879"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU76"
+      rmax="0.5*0.02"
+      z="135.1519245146"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU77"
+      rmax="0.5*0.02"
+      z="136.91861633832"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU78"
+      rmax="0.5*0.02"
+      z="138.68530816204"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU79"
+      rmax="0.5*0.02"
+      z="140.45199998576"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU80"
+      rmax="0.5*0.02"
+      z="142.218691809481"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU81"
+      rmax="0.5*0.02"
+      z="143.985383633201"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU82"
+      rmax="0.5*0.02"
+      z="145.752075456921"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU83"
+      rmax="0.5*0.02"
+      z="147.518767280641"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU84"
+      rmax="0.5*0.02"
+      z="149.285459104362"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU85"
+      rmax="0.5*0.02"
+      z="151.052150928082"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU86"
+      rmax="0.5*0.02"
+      z="152.818842751802"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU87"
+      rmax="0.5*0.02"
+      z="154.585534575522"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU88"
+      rmax="0.5*0.02"
+      z="156.352226399243"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU89"
+      rmax="0.5*0.02"
+      z="158.118918222963"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU90"
+      rmax="0.5*0.02"
+      z="159.885610046683"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU91"
+      rmax="0.5*0.02"
+      z="161.652301870403"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU92"
+      rmax="0.5*0.02"
+      z="163.418993694124"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU93"
+      rmax="0.5*0.02"
+      z="165.185685517844"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU94"
+      rmax="0.5*0.02"
+      z="166.952377341564"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU95"
+      rmax="0.5*0.02"
+      z="168.719069165284"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU96"
+      rmax="0.5*0.02"
+      z="170.485760989005"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU97"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU98"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU99"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU100"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU101"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU102"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU103"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU104"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU105"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU106"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU107"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU108"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU109"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU110"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU111"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU112"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU113"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU114"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU115"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU116"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU117"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU118"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU119"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU120"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU121"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU122"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU123"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU124"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU125"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU126"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU127"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU128"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU129"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU130"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU131"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU132"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU133"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU134"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU135"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU136"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU137"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU138"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU139"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU140"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU141"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU142"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU143"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU144"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU145"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU146"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU147"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU148"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU149"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU150"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU151"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU152"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU153"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU154"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU155"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU156"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU157"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU158"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU159"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU160"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU161"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU162"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU163"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU164"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU165"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU166"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU167"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU168"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU169"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU170"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU171"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU172"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU173"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU174"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU175"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU176"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU177"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU178"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU179"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU180"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU181"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU182"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU183"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU184"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU185"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU186"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU187"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU188"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU189"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU190"
+      rmax="0.5*0.02"
+      z="171.074658263579"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU191"
+      rmax="0.5*0.02"
+      z="169.307966439858"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU192"
+      rmax="0.5*0.02"
+      z="167.541274616138"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU193"
+      rmax="0.5*0.02"
+      z="165.774582792418"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU194"
+      rmax="0.5*0.02"
+      z="164.007890968698"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU195"
+      rmax="0.5*0.02"
+      z="162.241199144977"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU196"
+      rmax="0.5*0.02"
+      z="160.474507321257"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU197"
+      rmax="0.5*0.02"
+      z="158.707815497537"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU198"
+      rmax="0.5*0.02"
+      z="156.941123673817"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU199"
+      rmax="0.5*0.02"
+      z="155.174431850097"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU200"
+      rmax="0.5*0.02"
+      z="153.407740026376"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU201"
+      rmax="0.5*0.02"
+      z="151.641048202656"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU202"
+      rmax="0.5*0.02"
+      z="149.874356378936"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU203"
+      rmax="0.5*0.02"
+      z="148.107664555216"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU204"
+      rmax="0.5*0.02"
+      z="146.340972731495"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU205"
+      rmax="0.5*0.02"
+      z="144.574280907775"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU206"
+      rmax="0.5*0.02"
+      z="142.807589084055"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU207"
+      rmax="0.5*0.02"
+      z="141.040897260335"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU208"
+      rmax="0.5*0.02"
+      z="139.274205436614"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU209"
+      rmax="0.5*0.02"
+      z="137.507513612894"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU210"
+      rmax="0.5*0.02"
+      z="135.740821789174"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU211"
+      rmax="0.5*0.02"
+      z="133.974129965454"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU212"
+      rmax="0.5*0.02"
+      z="132.207438141734"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU213"
+      rmax="0.5*0.02"
+      z="130.440746318013"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU214"
+      rmax="0.5*0.02"
+      z="128.674054494293"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU215"
+      rmax="0.5*0.02"
+      z="126.907362670573"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU216"
+      rmax="0.5*0.02"
+      z="125.140670846853"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU217"
+      rmax="0.5*0.02"
+      z="123.373979023133"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU218"
+      rmax="0.5*0.02"
+      z="121.607287199412"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU219"
+      rmax="0.5*0.02"
+      z="119.840595375692"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU220"
+      rmax="0.5*0.02"
+      z="118.073903551972"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU221"
+      rmax="0.5*0.02"
+      z="116.307211728252"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU222"
+      rmax="0.5*0.02"
+      z="114.540519904531"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU223"
+      rmax="0.5*0.02"
+      z="112.773828080811"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU224"
+      rmax="0.5*0.02"
+      z="111.007136257091"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU225"
+      rmax="0.5*0.02"
+      z="109.240444433371"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU226"
+      rmax="0.5*0.02"
+      z="107.47375260965"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU227"
+      rmax="0.5*0.02"
+      z="105.70706078593"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU228"
+      rmax="0.5*0.02"
+      z="103.94036896221"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU229"
+      rmax="0.5*0.02"
+      z="102.17367713849"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU230"
+      rmax="0.5*0.02"
+      z="100.40698531477"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU231"
+      rmax="0.5*0.02"
+      z="98.6402934910494"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU232"
+      rmax="0.5*0.02"
+      z="96.8736016673292"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU233"
+      rmax="0.5*0.02"
+      z="95.106909843609"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU234"
+      rmax="0.5*0.02"
+      z="93.3402180198887"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU235"
+      rmax="0.5*0.02"
+      z="91.5735261961685"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU236"
+      rmax="0.5*0.02"
+      z="89.8068343724483"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU237"
+      rmax="0.5*0.02"
+      z="88.040142548728"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU238"
+      rmax="0.5*0.02"
+      z="86.2734507250078"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU239"
+      rmax="0.5*0.02"
+      z="84.5067589012876"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU240"
+      rmax="0.5*0.02"
+      z="82.7400670775674"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU241"
+      rmax="0.5*0.02"
+      z="80.9733752538472"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU242"
+      rmax="0.5*0.02"
+      z="79.2066834301269"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU243"
+      rmax="0.5*0.02"
+      z="77.4399916064067"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU244"
+      rmax="0.5*0.02"
+      z="75.6732997826865"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU245"
+      rmax="0.5*0.02"
+      z="73.9066079589663"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU246"
+      rmax="0.5*0.02"
+      z="72.1399161352461"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU247"
+      rmax="0.5*0.02"
+      z="70.3732243115258"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU248"
+      rmax="0.5*0.02"
+      z="68.6065324878056"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU249"
+      rmax="0.5*0.02"
+      z="66.8398406640853"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU250"
+      rmax="0.5*0.02"
+      z="65.0731488403651"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU251"
+      rmax="0.5*0.02"
+      z="63.3064570166449"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU252"
+      rmax="0.5*0.02"
+      z="61.5397651929247"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU253"
+      rmax="0.5*0.02"
+      z="59.7730733692045"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU254"
+      rmax="0.5*0.02"
+      z="58.0063815454843"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU255"
+      rmax="0.5*0.02"
+      z="56.239689721764"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU256"
+      rmax="0.5*0.02"
+      z="54.4729978980438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU257"
+      rmax="0.5*0.02"
+      z="52.7063060743236"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU258"
+      rmax="0.5*0.02"
+      z="50.9396142506034"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU259"
+      rmax="0.5*0.02"
+      z="49.1729224268832"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU260"
+      rmax="0.5*0.02"
+      z="47.406230603163"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU261"
+      rmax="0.5*0.02"
+      z="45.6395387794427"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU262"
+      rmax="0.5*0.02"
+      z="43.8728469557225"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU263"
+      rmax="0.5*0.02"
+      z="42.1061551320022"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU264"
+      rmax="0.5*0.02"
+      z="40.339463308282"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU265"
+      rmax="0.5*0.02"
+      z="38.5727714845618"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU266"
+      rmax="0.5*0.02"
+      z="36.8060796608416"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU267"
+      rmax="0.5*0.02"
+      z="35.0393878371214"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU268"
+      rmax="0.5*0.02"
+      z="33.2726960134011"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU269"
+      rmax="0.5*0.02"
+      z="31.5060041896809"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU270"
+      rmax="0.5*0.02"
+      z="29.7393123659607"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU271"
+      rmax="0.5*0.02"
+      z="27.9726205422405"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU272"
+      rmax="0.5*0.02"
+      z="26.2059287185202"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU273"
+      rmax="0.5*0.02"
+      z="24.4392368948"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU274"
+      rmax="0.5*0.02"
+      z="22.6725450710797"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU275"
+      rmax="0.5*0.02"
+      z="20.9058532473595"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU276"
+      rmax="0.5*0.02"
+      z="19.1391614236393"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU277"
+      rmax="0.5*0.02"
+      z="17.3724695999191"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU278"
+      rmax="0.5*0.02"
+      z="15.6057777761989"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU279"
+      rmax="0.5*0.02"
+      z="13.8390859524787"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU280"
+      rmax="0.5*0.02"
+      z="12.0723941287584"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU281"
+      rmax="0.5*0.02"
+      z="10.3057023050382"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU282"
+      rmax="0.5*0.02"
+      z="8.53901048131801"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU283"
+      rmax="0.5*0.02"
+      z="6.7723186575978"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU284"
+      rmax="0.5*0.02"
+      z="5.00562683387757"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireU285"
+      rmax="0.5*0.02"
+      z="3.23893501015734"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV0"
+      rmax="0.5*0.02"
+      z="0.883345911860106"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV1"
+      rmax="0.5*0.02"
+      z="2.6500377355804"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV2"
+      rmax="0.5*0.02"
+      z="4.41672955930062"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV3"
+      rmax="0.5*0.02"
+      z="6.18342138302091"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV4"
+      rmax="0.5*0.02"
+      z="7.95011320674114"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV5"
+      rmax="0.5*0.02"
+      z="9.71680503046143"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV6"
+      rmax="0.5*0.02"
+      z="11.4834968541816"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV7"
+      rmax="0.5*0.02"
+      z="13.2501886779019"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV8"
+      rmax="0.5*0.02"
+      z="15.0168805016222"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV9"
+      rmax="0.5*0.02"
+      z="16.7835723253424"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV10"
+      rmax="0.5*0.02"
+      z="18.5502641490627"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV11"
+      rmax="0.5*0.02"
+      z="20.3169559727829"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV12"
+      rmax="0.5*0.02"
+      z="22.0836477965032"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV13"
+      rmax="0.5*0.02"
+      z="23.8503396202235"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV14"
+      rmax="0.5*0.02"
+      z="25.6170314439437"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV15"
+      rmax="0.5*0.02"
+      z="27.383723267664"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV16"
+      rmax="0.5*0.02"
+      z="29.1504150913842"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV17"
+      rmax="0.5*0.02"
+      z="30.9171069151045"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV18"
+      rmax="0.5*0.02"
+      z="32.6837987388247"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV19"
+      rmax="0.5*0.02"
+      z="34.450490562545"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV20"
+      rmax="0.5*0.02"
+      z="36.2171823862652"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV21"
+      rmax="0.5*0.02"
+      z="37.9838742099855"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV22"
+      rmax="0.5*0.02"
+      z="39.7505660337057"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV23"
+      rmax="0.5*0.02"
+      z="41.517257857426"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV24"
+      rmax="0.5*0.02"
+      z="43.2839496811462"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV25"
+      rmax="0.5*0.02"
+      z="45.0506415048665"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV26"
+      rmax="0.5*0.02"
+      z="46.8173333285868"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV27"
+      rmax="0.5*0.02"
+      z="48.584025152307"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV28"
+      rmax="0.5*0.02"
+      z="50.3507169760273"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV29"
+      rmax="0.5*0.02"
+      z="52.1174087997476"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV30"
+      rmax="0.5*0.02"
+      z="53.8841006234678"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV31"
+      rmax="0.5*0.02"
+      z="55.6507924471881"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV32"
+      rmax="0.5*0.02"
+      z="57.4174842709083"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV33"
+      rmax="0.5*0.02"
+      z="59.1841760946286"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV34"
+      rmax="0.5*0.02"
+      z="60.9508679183488"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV35"
+      rmax="0.5*0.02"
+      z="62.7175597420691"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV36"
+      rmax="0.5*0.02"
+      z="64.4842515657893"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV37"
+      rmax="0.5*0.02"
+      z="66.2509433895096"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV38"
+      rmax="0.5*0.02"
+      z="68.0176352132298"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV39"
+      rmax="0.5*0.02"
+      z="69.7843270369501"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV40"
+      rmax="0.5*0.02"
+      z="71.5510188606703"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV41"
+      rmax="0.5*0.02"
+      z="73.3177106843906"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV42"
+      rmax="0.5*0.02"
+      z="75.0844025081108"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV43"
+      rmax="0.5*0.02"
+      z="76.8510943318311"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV44"
+      rmax="0.5*0.02"
+      z="78.6177861555514"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV45"
+      rmax="0.5*0.02"
+      z="80.3844779792717"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV46"
+      rmax="0.5*0.02"
+      z="82.1511698029919"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV47"
+      rmax="0.5*0.02"
+      z="83.9178616267122"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV48"
+      rmax="0.5*0.02"
+      z="85.6845534504325"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV49"
+      rmax="0.5*0.02"
+      z="87.4512452741527"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV50"
+      rmax="0.5*0.02"
+      z="89.2179370978729"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV51"
+      rmax="0.5*0.02"
+      z="90.9846289215932"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV52"
+      rmax="0.5*0.02"
+      z="92.7513207453135"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV53"
+      rmax="0.5*0.02"
+      z="94.5180125690337"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV54"
+      rmax="0.5*0.02"
+      z="96.2847043927539"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV55"
+      rmax="0.5*0.02"
+      z="98.0513962164742"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV56"
+      rmax="0.5*0.02"
+      z="99.8180880401945"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV57"
+      rmax="0.5*0.02"
+      z="101.584779863915"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV58"
+      rmax="0.5*0.02"
+      z="103.351471687635"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV59"
+      rmax="0.5*0.02"
+      z="105.118163511355"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV60"
+      rmax="0.5*0.02"
+      z="106.884855335075"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV61"
+      rmax="0.5*0.02"
+      z="108.651547158796"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV62"
+      rmax="0.5*0.02"
+      z="110.418238982516"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV63"
+      rmax="0.5*0.02"
+      z="112.184930806236"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV64"
+      rmax="0.5*0.02"
+      z="113.951622629957"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV65"
+      rmax="0.5*0.02"
+      z="115.718314453677"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV66"
+      rmax="0.5*0.02"
+      z="117.485006277397"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV67"
+      rmax="0.5*0.02"
+      z="119.251698101117"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV68"
+      rmax="0.5*0.02"
+      z="121.018389924838"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV69"
+      rmax="0.5*0.02"
+      z="122.785081748558"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV70"
+      rmax="0.5*0.02"
+      z="124.551773572278"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV71"
+      rmax="0.5*0.02"
+      z="126.318465395998"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV72"
+      rmax="0.5*0.02"
+      z="128.085157219719"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV73"
+      rmax="0.5*0.02"
+      z="129.851849043439"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV74"
+      rmax="0.5*0.02"
+      z="131.618540867159"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV75"
+      rmax="0.5*0.02"
+      z="133.385232690879"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV76"
+      rmax="0.5*0.02"
+      z="135.1519245146"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV77"
+      rmax="0.5*0.02"
+      z="136.91861633832"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV78"
+      rmax="0.5*0.02"
+      z="138.68530816204"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV79"
+      rmax="0.5*0.02"
+      z="140.45199998576"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV80"
+      rmax="0.5*0.02"
+      z="142.218691809481"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV81"
+      rmax="0.5*0.02"
+      z="143.985383633201"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV82"
+      rmax="0.5*0.02"
+      z="145.752075456921"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV83"
+      rmax="0.5*0.02"
+      z="147.518767280641"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV84"
+      rmax="0.5*0.02"
+      z="149.285459104362"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV85"
+      rmax="0.5*0.02"
+      z="151.052150928082"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV86"
+      rmax="0.5*0.02"
+      z="152.818842751802"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV87"
+      rmax="0.5*0.02"
+      z="154.585534575522"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV88"
+      rmax="0.5*0.02"
+      z="156.352226399243"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV89"
+      rmax="0.5*0.02"
+      z="158.118918222963"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV90"
+      rmax="0.5*0.02"
+      z="159.885610046683"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV91"
+      rmax="0.5*0.02"
+      z="161.652301870403"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV92"
+      rmax="0.5*0.02"
+      z="163.418993694124"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV93"
+      rmax="0.5*0.02"
+      z="165.185685517844"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV94"
+      rmax="0.5*0.02"
+      z="166.952377341564"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV95"
+      rmax="0.5*0.02"
+      z="168.719069165284"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV96"
+      rmax="0.5*0.02"
+      z="170.485760989005"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV97"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV98"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV99"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV100"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV101"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV102"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV103"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV104"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV105"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV106"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV107"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV108"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV109"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV110"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV111"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV112"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV113"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV114"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV115"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV116"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV117"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV118"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV119"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV120"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV121"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV122"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV123"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV124"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV125"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV126"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV127"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV128"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV129"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV130"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV131"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV132"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV133"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV134"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV135"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV136"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV137"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV138"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV139"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV140"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV141"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV142"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV143"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV144"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV145"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV146"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV147"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV148"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV149"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV150"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV151"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV152"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV153"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV154"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV155"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV156"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV157"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV158"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV159"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV160"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV161"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV162"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV163"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV164"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV165"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV166"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV167"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV168"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV169"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV170"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV171"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV172"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV173"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV174"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV175"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV176"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV177"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV178"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV179"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV180"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV181"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV182"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV183"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV184"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV185"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV186"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV187"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV188"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV189"
+      rmax="0.5*0.02"
+      z="171.958004175438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV190"
+      rmax="0.5*0.02"
+      z="171.074658263579"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV191"
+      rmax="0.5*0.02"
+      z="169.307966439858"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV192"
+      rmax="0.5*0.02"
+      z="167.541274616138"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV193"
+      rmax="0.5*0.02"
+      z="165.774582792418"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV194"
+      rmax="0.5*0.02"
+      z="164.007890968698"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV195"
+      rmax="0.5*0.02"
+      z="162.241199144977"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV196"
+      rmax="0.5*0.02"
+      z="160.474507321257"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV197"
+      rmax="0.5*0.02"
+      z="158.707815497537"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV198"
+      rmax="0.5*0.02"
+      z="156.941123673817"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV199"
+      rmax="0.5*0.02"
+      z="155.174431850097"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV200"
+      rmax="0.5*0.02"
+      z="153.407740026376"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV201"
+      rmax="0.5*0.02"
+      z="151.641048202656"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV202"
+      rmax="0.5*0.02"
+      z="149.874356378936"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV203"
+      rmax="0.5*0.02"
+      z="148.107664555216"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV204"
+      rmax="0.5*0.02"
+      z="146.340972731495"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV205"
+      rmax="0.5*0.02"
+      z="144.574280907775"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV206"
+      rmax="0.5*0.02"
+      z="142.807589084055"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV207"
+      rmax="0.5*0.02"
+      z="141.040897260335"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV208"
+      rmax="0.5*0.02"
+      z="139.274205436614"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV209"
+      rmax="0.5*0.02"
+      z="137.507513612894"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV210"
+      rmax="0.5*0.02"
+      z="135.740821789174"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV211"
+      rmax="0.5*0.02"
+      z="133.974129965454"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV212"
+      rmax="0.5*0.02"
+      z="132.207438141734"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV213"
+      rmax="0.5*0.02"
+      z="130.440746318013"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV214"
+      rmax="0.5*0.02"
+      z="128.674054494293"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV215"
+      rmax="0.5*0.02"
+      z="126.907362670573"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV216"
+      rmax="0.5*0.02"
+      z="125.140670846853"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV217"
+      rmax="0.5*0.02"
+      z="123.373979023133"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV218"
+      rmax="0.5*0.02"
+      z="121.607287199412"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV219"
+      rmax="0.5*0.02"
+      z="119.840595375692"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV220"
+      rmax="0.5*0.02"
+      z="118.073903551972"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV221"
+      rmax="0.5*0.02"
+      z="116.307211728252"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV222"
+      rmax="0.5*0.02"
+      z="114.540519904531"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV223"
+      rmax="0.5*0.02"
+      z="112.773828080811"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV224"
+      rmax="0.5*0.02"
+      z="111.007136257091"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV225"
+      rmax="0.5*0.02"
+      z="109.240444433371"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV226"
+      rmax="0.5*0.02"
+      z="107.47375260965"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV227"
+      rmax="0.5*0.02"
+      z="105.70706078593"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV228"
+      rmax="0.5*0.02"
+      z="103.94036896221"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV229"
+      rmax="0.5*0.02"
+      z="102.17367713849"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV230"
+      rmax="0.5*0.02"
+      z="100.40698531477"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV231"
+      rmax="0.5*0.02"
+      z="98.6402934910494"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV232"
+      rmax="0.5*0.02"
+      z="96.8736016673292"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV233"
+      rmax="0.5*0.02"
+      z="95.106909843609"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV234"
+      rmax="0.5*0.02"
+      z="93.3402180198887"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV235"
+      rmax="0.5*0.02"
+      z="91.5735261961685"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV236"
+      rmax="0.5*0.02"
+      z="89.8068343724483"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV237"
+      rmax="0.5*0.02"
+      z="88.040142548728"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV238"
+      rmax="0.5*0.02"
+      z="86.2734507250078"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV239"
+      rmax="0.5*0.02"
+      z="84.5067589012876"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV240"
+      rmax="0.5*0.02"
+      z="82.7400670775674"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV241"
+      rmax="0.5*0.02"
+      z="80.9733752538472"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV242"
+      rmax="0.5*0.02"
+      z="79.2066834301269"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV243"
+      rmax="0.5*0.02"
+      z="77.4399916064067"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV244"
+      rmax="0.5*0.02"
+      z="75.6732997826865"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV245"
+      rmax="0.5*0.02"
+      z="73.9066079589663"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV246"
+      rmax="0.5*0.02"
+      z="72.1399161352461"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV247"
+      rmax="0.5*0.02"
+      z="70.3732243115258"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV248"
+      rmax="0.5*0.02"
+      z="68.6065324878056"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV249"
+      rmax="0.5*0.02"
+      z="66.8398406640853"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV250"
+      rmax="0.5*0.02"
+      z="65.0731488403651"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV251"
+      rmax="0.5*0.02"
+      z="63.3064570166449"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV252"
+      rmax="0.5*0.02"
+      z="61.5397651929247"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV253"
+      rmax="0.5*0.02"
+      z="59.7730733692045"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV254"
+      rmax="0.5*0.02"
+      z="58.0063815454843"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV255"
+      rmax="0.5*0.02"
+      z="56.239689721764"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV256"
+      rmax="0.5*0.02"
+      z="54.4729978980438"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV257"
+      rmax="0.5*0.02"
+      z="52.7063060743236"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV258"
+      rmax="0.5*0.02"
+      z="50.9396142506034"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV259"
+      rmax="0.5*0.02"
+      z="49.1729224268832"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV260"
+      rmax="0.5*0.02"
+      z="47.4062306031629"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV261"
+      rmax="0.5*0.02"
+      z="45.6395387794427"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV262"
+      rmax="0.5*0.02"
+      z="43.8728469557225"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV263"
+      rmax="0.5*0.02"
+      z="42.1061551320022"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV264"
+      rmax="0.5*0.02"
+      z="40.339463308282"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV265"
+      rmax="0.5*0.02"
+      z="38.5727714845618"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV266"
+      rmax="0.5*0.02"
+      z="36.8060796608416"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV267"
+      rmax="0.5*0.02"
+      z="35.0393878371214"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV268"
+      rmax="0.5*0.02"
+      z="33.2726960134011"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV269"
+      rmax="0.5*0.02"
+      z="31.5060041896809"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV270"
+      rmax="0.5*0.02"
+      z="29.7393123659607"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV271"
+      rmax="0.5*0.02"
+      z="27.9726205422405"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV272"
+      rmax="0.5*0.02"
+      z="26.2059287185203"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV273"
+      rmax="0.5*0.02"
+      z="24.4392368948"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV274"
+      rmax="0.5*0.02"
+      z="22.6725450710797"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV275"
+      rmax="0.5*0.02"
+      z="20.9058532473596"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV276"
+      rmax="0.5*0.02"
+      z="19.1391614236393"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV277"
+      rmax="0.5*0.02"
+      z="17.3724695999191"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV278"
+      rmax="0.5*0.02"
+      z="15.6057777761989"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV279"
+      rmax="0.5*0.02"
+      z="13.8390859524787"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV280"
+      rmax="0.5*0.02"
+      z="12.0723941287584"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV281"
+      rmax="0.5*0.02"
+      z="10.3057023050382"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV282"
+      rmax="0.5*0.02"
+      z="8.53901048131802"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV283"
+      rmax="0.5*0.02"
+      z="6.7723186575978"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV284"
+      rmax="0.5*0.02"
+      z="5.00562683387757"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireV285"
+      rmax="0.5*0.02"
+      z="3.23893501015735"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+   <tube name="CRMWireZ"
+      rmax="0.5*0.02"
+      z="167.7006"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+
+    <box name="ArapucaOut" lunit="cm"
+      x="65"
+      y="2.5"
+      z="65"/>
+
+    <box name="ArapucaIn" lunit="cm"
+      x="60"
+      y="2.5"
+      z="60"/>
+
+     <subtraction name="ArapucaWalls">
+      <first  ref="ArapucaOut"/>
+      <second ref="ArapucaIn"/>
+      <position name="posArapucaSub" x="0" y="1.25" z="0." unit="cm"/>
+      </subtraction>
+
+    <box name="ArapucaAcceptanceWindow" lunit="cm"
+      x="60"
+      y="1"
+      z="60"/>
+
+    <box name="ArapucaDoubleIn" lunit="cm"
+      x="60"
+      y="3.5"
+      z="60"/>
+
+     <subtraction name="ArapucaDoubleWalls">
+      <first  ref="ArapucaOut"/>
+      <second ref="ArapucaDoubleIn"/>
+      <position name="posArapucaDoubleSub" x="0" y="0" z="0" unit="cm"/>
+      </subtraction>
+
+    <box name="ArapucaDoubleAcceptanceWindow" lunit="cm"
+      x="60"
+      y="2.48"
+      z="60"/>
+
+
+    <box name="Cryostat" lunit="cm"
+      x="850.32"
+      y="1507.8448"
+      z="1110.76"/>
+
+    <box name="ArgonInterior" lunit="cm"
+      x="850.08"
+      y="1507.6048"
+      z="1110.52"/>
+
+    <box name="GaseousArgon" lunit="cm"
+      x="99.99"
+      y="1507.6048"
+      z="1110.52"/>
+
+    <subtraction name="SteelShell">
+      <first ref="Cryostat"/>
+      <second ref="ArgonInterior"/>
+    </subtraction>
+
+
+
+    <box name="CathodeBlock" lunit="cm"
+      x="4"
+      y="336.4012"
+      z="298.84" />
+
+    <box name="CathodeVoid" lunit="cm"
+      x="5"
+      y="76.35"
+      z="67" />
+
+    <subtraction name="Cathode1">
+      <first ref="CathodeBlock"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub1" x="0" y="-122.525" z="-108.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode2">
+      <first ref="Cathode1"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub2" x="0" y="-122.525" z="-37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode3">
+      <first ref="Cathode2"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub3" x="0" y="-122.525" z="37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode4">
+      <first ref="Cathode3"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub4" x="0" y="-122.525" z="108.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode5">
+      <first ref="Cathode4"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub5" x="0" y="-42.175" z="-108.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode6">
+      <first ref="Cathode5"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub6" x="0" y="-42.175" z="-37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode7">
+      <first ref="Cathode6"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub7" x="0" y="-42.175" z="37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode8">
+      <first ref="Cathode7"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub8" x="0" y="-42.175" z="108.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode9">
+      <first ref="Cathode8"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub9" x="0" y="42.175" z="-108.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode10">
+      <first ref="Cathode9"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub10" x="0" y="42.175" z="-37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode11">
+      <first ref="Cathode10"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub11" x="0" y="42.175" z="37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode12">
+      <first ref="Cathode11"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub12" x="0" y="42.175" z="108.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode13">
+      <first ref="Cathode12"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub13" x="0" y="122.525" z="-108.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode14">
+      <first ref="Cathode13"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub14" x="0" y="122.525" z="-37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode15">
+      <first ref="Cathode14"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub15" x="0" y="122.525" z="37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="CathodeGrid">
+      <first ref="Cathode15"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub16" x="0" y="122.525" z="108.5" unit="cm"/>
+    </subtraction>
+
+   <box name="AnodePlate"
+      x="0.01"
+      y="336.4012"
+      z="298.84"
+      lunit="cm"/>
+
+    <box name="FoamPadBlock" lunit="cm"
+      x="1010.32"
+      y="1667.8448"
+      z="1270.76" />
+
+    <subtraction name="FoamPadding">
+      <first ref="FoamPadBlock"/>
+      <second ref="Cryostat"/>
+      <positionref ref="posCenter"/>
+    </subtraction>
+
+    <box name="SteelSupportBlock" lunit="cm"
+      x="1210.32"
+      y="1867.8448"
+      z="1470.76" />
+
+    <subtraction name="SteelSupport">
+      <first ref="SteelSupportBlock"/>
+      <second ref="FoamPadBlock"/>
+      <positionref ref="posCenter"/>
+    </subtraction>
+
+    <box name="DetEnclosure" lunit="cm"
+      x="1310.32"
+      y="2067.8448"
+      z="1670.76"/>
+
+
+    <box name="World" lunit="cm"
+      x="9310.32"
+      y="10067.8448"
+      z="9670.76"/>
+</solids>
+<structure>
+<volume name="volFieldShaper">
+  <materialref ref="ALUMINUM_Al"/>
+  <solidref ref="FieldShaperSolid"/>
+</volume>
+<volume name="volFieldShaperSlim">
+  <materialref ref="ALUMINUM_Al"/>
+  <solidref ref="FieldShaperSolidSlim"/>
+</volume>
+
+
+    <volume name="volTPCActive">
+      <materialref ref="LAr"/>
+      <solidref ref="CRMActive"/>
+      <auxiliary auxtype="SensDet" auxvalue="SimEnergyDeposit"/>
+      <auxiliary auxtype="StepLimit" auxunit="cm" auxvalue="0.5208*cm"/>
+      <auxiliary auxtype="Efield" auxunit="V/cm" auxvalue="500*V/cm"/>
+      <colorref ref="blue"/>
+    </volume>
+    <volume name="volTPCWireU0">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU0"/>
+    </volume>
+    <volume name="volTPCWireU1">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU1"/>
+    </volume>
+    <volume name="volTPCWireU2">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU2"/>
+    </volume>
+    <volume name="volTPCWireU3">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU3"/>
+    </volume>
+    <volume name="volTPCWireU4">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU4"/>
+    </volume>
+    <volume name="volTPCWireU5">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU5"/>
+    </volume>
+    <volume name="volTPCWireU6">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU6"/>
+    </volume>
+    <volume name="volTPCWireU7">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU7"/>
+    </volume>
+    <volume name="volTPCWireU8">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU8"/>
+    </volume>
+    <volume name="volTPCWireU9">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU9"/>
+    </volume>
+    <volume name="volTPCWireU10">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU10"/>
+    </volume>
+    <volume name="volTPCWireU11">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU11"/>
+    </volume>
+    <volume name="volTPCWireU12">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU12"/>
+    </volume>
+    <volume name="volTPCWireU13">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU13"/>
+    </volume>
+    <volume name="volTPCWireU14">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU14"/>
+    </volume>
+    <volume name="volTPCWireU15">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU15"/>
+    </volume>
+    <volume name="volTPCWireU16">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU16"/>
+    </volume>
+    <volume name="volTPCWireU17">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU17"/>
+    </volume>
+    <volume name="volTPCWireU18">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU18"/>
+    </volume>
+    <volume name="volTPCWireU19">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU19"/>
+    </volume>
+    <volume name="volTPCWireU20">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU20"/>
+    </volume>
+    <volume name="volTPCWireU21">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU21"/>
+    </volume>
+    <volume name="volTPCWireU22">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU22"/>
+    </volume>
+    <volume name="volTPCWireU23">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU23"/>
+    </volume>
+    <volume name="volTPCWireU24">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU24"/>
+    </volume>
+    <volume name="volTPCWireU25">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU25"/>
+    </volume>
+    <volume name="volTPCWireU26">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU26"/>
+    </volume>
+    <volume name="volTPCWireU27">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU27"/>
+    </volume>
+    <volume name="volTPCWireU28">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU28"/>
+    </volume>
+    <volume name="volTPCWireU29">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU29"/>
+    </volume>
+    <volume name="volTPCWireU30">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU30"/>
+    </volume>
+    <volume name="volTPCWireU31">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU31"/>
+    </volume>
+    <volume name="volTPCWireU32">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU32"/>
+    </volume>
+    <volume name="volTPCWireU33">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU33"/>
+    </volume>
+    <volume name="volTPCWireU34">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU34"/>
+    </volume>
+    <volume name="volTPCWireU35">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU35"/>
+    </volume>
+    <volume name="volTPCWireU36">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU36"/>
+    </volume>
+    <volume name="volTPCWireU37">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU37"/>
+    </volume>
+    <volume name="volTPCWireU38">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU38"/>
+    </volume>
+    <volume name="volTPCWireU39">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU39"/>
+    </volume>
+    <volume name="volTPCWireU40">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU40"/>
+    </volume>
+    <volume name="volTPCWireU41">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU41"/>
+    </volume>
+    <volume name="volTPCWireU42">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU42"/>
+    </volume>
+    <volume name="volTPCWireU43">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU43"/>
+    </volume>
+    <volume name="volTPCWireU44">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU44"/>
+    </volume>
+    <volume name="volTPCWireU45">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU45"/>
+    </volume>
+    <volume name="volTPCWireU46">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU46"/>
+    </volume>
+    <volume name="volTPCWireU47">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU47"/>
+    </volume>
+    <volume name="volTPCWireU48">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU48"/>
+    </volume>
+    <volume name="volTPCWireU49">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU49"/>
+    </volume>
+    <volume name="volTPCWireU50">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU50"/>
+    </volume>
+    <volume name="volTPCWireU51">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU51"/>
+    </volume>
+    <volume name="volTPCWireU52">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU52"/>
+    </volume>
+    <volume name="volTPCWireU53">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU53"/>
+    </volume>
+    <volume name="volTPCWireU54">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU54"/>
+    </volume>
+    <volume name="volTPCWireU55">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU55"/>
+    </volume>
+    <volume name="volTPCWireU56">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU56"/>
+    </volume>
+    <volume name="volTPCWireU57">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU57"/>
+    </volume>
+    <volume name="volTPCWireU58">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU58"/>
+    </volume>
+    <volume name="volTPCWireU59">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU59"/>
+    </volume>
+    <volume name="volTPCWireU60">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU60"/>
+    </volume>
+    <volume name="volTPCWireU61">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU61"/>
+    </volume>
+    <volume name="volTPCWireU62">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU62"/>
+    </volume>
+    <volume name="volTPCWireU63">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU63"/>
+    </volume>
+    <volume name="volTPCWireU64">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU64"/>
+    </volume>
+    <volume name="volTPCWireU65">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU65"/>
+    </volume>
+    <volume name="volTPCWireU66">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU66"/>
+    </volume>
+    <volume name="volTPCWireU67">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU67"/>
+    </volume>
+    <volume name="volTPCWireU68">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU68"/>
+    </volume>
+    <volume name="volTPCWireU69">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU69"/>
+    </volume>
+    <volume name="volTPCWireU70">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU70"/>
+    </volume>
+    <volume name="volTPCWireU71">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU71"/>
+    </volume>
+    <volume name="volTPCWireU72">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU72"/>
+    </volume>
+    <volume name="volTPCWireU73">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU73"/>
+    </volume>
+    <volume name="volTPCWireU74">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU74"/>
+    </volume>
+    <volume name="volTPCWireU75">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU75"/>
+    </volume>
+    <volume name="volTPCWireU76">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU76"/>
+    </volume>
+    <volume name="volTPCWireU77">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU77"/>
+    </volume>
+    <volume name="volTPCWireU78">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU78"/>
+    </volume>
+    <volume name="volTPCWireU79">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU79"/>
+    </volume>
+    <volume name="volTPCWireU80">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU80"/>
+    </volume>
+    <volume name="volTPCWireU81">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU81"/>
+    </volume>
+    <volume name="volTPCWireU82">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU82"/>
+    </volume>
+    <volume name="volTPCWireU83">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU83"/>
+    </volume>
+    <volume name="volTPCWireU84">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU84"/>
+    </volume>
+    <volume name="volTPCWireU85">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU85"/>
+    </volume>
+    <volume name="volTPCWireU86">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU86"/>
+    </volume>
+    <volume name="volTPCWireU87">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU87"/>
+    </volume>
+    <volume name="volTPCWireU88">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU88"/>
+    </volume>
+    <volume name="volTPCWireU89">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU89"/>
+    </volume>
+    <volume name="volTPCWireU90">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU90"/>
+    </volume>
+    <volume name="volTPCWireU91">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU91"/>
+    </volume>
+    <volume name="volTPCWireU92">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU92"/>
+    </volume>
+    <volume name="volTPCWireU93">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU93"/>
+    </volume>
+    <volume name="volTPCWireU94">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU94"/>
+    </volume>
+    <volume name="volTPCWireU95">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU95"/>
+    </volume>
+    <volume name="volTPCWireU96">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU96"/>
+    </volume>
+    <volume name="volTPCWireU97">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU97"/>
+    </volume>
+    <volume name="volTPCWireU98">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU98"/>
+    </volume>
+    <volume name="volTPCWireU99">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU99"/>
+    </volume>
+    <volume name="volTPCWireU100">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU100"/>
+    </volume>
+    <volume name="volTPCWireU101">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU101"/>
+    </volume>
+    <volume name="volTPCWireU102">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU102"/>
+    </volume>
+    <volume name="volTPCWireU103">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU103"/>
+    </volume>
+    <volume name="volTPCWireU104">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU104"/>
+    </volume>
+    <volume name="volTPCWireU105">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU105"/>
+    </volume>
+    <volume name="volTPCWireU106">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU106"/>
+    </volume>
+    <volume name="volTPCWireU107">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU107"/>
+    </volume>
+    <volume name="volTPCWireU108">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU108"/>
+    </volume>
+    <volume name="volTPCWireU109">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU109"/>
+    </volume>
+    <volume name="volTPCWireU110">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU110"/>
+    </volume>
+    <volume name="volTPCWireU111">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU111"/>
+    </volume>
+    <volume name="volTPCWireU112">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU112"/>
+    </volume>
+    <volume name="volTPCWireU113">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU113"/>
+    </volume>
+    <volume name="volTPCWireU114">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU114"/>
+    </volume>
+    <volume name="volTPCWireU115">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU115"/>
+    </volume>
+    <volume name="volTPCWireU116">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU116"/>
+    </volume>
+    <volume name="volTPCWireU117">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU117"/>
+    </volume>
+    <volume name="volTPCWireU118">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU118"/>
+    </volume>
+    <volume name="volTPCWireU119">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU119"/>
+    </volume>
+    <volume name="volTPCWireU120">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU120"/>
+    </volume>
+    <volume name="volTPCWireU121">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU121"/>
+    </volume>
+    <volume name="volTPCWireU122">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU122"/>
+    </volume>
+    <volume name="volTPCWireU123">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU123"/>
+    </volume>
+    <volume name="volTPCWireU124">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU124"/>
+    </volume>
+    <volume name="volTPCWireU125">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU125"/>
+    </volume>
+    <volume name="volTPCWireU126">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU126"/>
+    </volume>
+    <volume name="volTPCWireU127">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU127"/>
+    </volume>
+    <volume name="volTPCWireU128">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU128"/>
+    </volume>
+    <volume name="volTPCWireU129">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU129"/>
+    </volume>
+    <volume name="volTPCWireU130">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU130"/>
+    </volume>
+    <volume name="volTPCWireU131">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU131"/>
+    </volume>
+    <volume name="volTPCWireU132">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU132"/>
+    </volume>
+    <volume name="volTPCWireU133">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU133"/>
+    </volume>
+    <volume name="volTPCWireU134">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU134"/>
+    </volume>
+    <volume name="volTPCWireU135">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU135"/>
+    </volume>
+    <volume name="volTPCWireU136">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU136"/>
+    </volume>
+    <volume name="volTPCWireU137">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU137"/>
+    </volume>
+    <volume name="volTPCWireU138">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU138"/>
+    </volume>
+    <volume name="volTPCWireU139">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU139"/>
+    </volume>
+    <volume name="volTPCWireU140">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU140"/>
+    </volume>
+    <volume name="volTPCWireU141">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU141"/>
+    </volume>
+    <volume name="volTPCWireU142">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU142"/>
+    </volume>
+    <volume name="volTPCWireU143">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU143"/>
+    </volume>
+    <volume name="volTPCWireU144">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU144"/>
+    </volume>
+    <volume name="volTPCWireU145">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU145"/>
+    </volume>
+    <volume name="volTPCWireU146">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU146"/>
+    </volume>
+    <volume name="volTPCWireU147">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU147"/>
+    </volume>
+    <volume name="volTPCWireU148">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU148"/>
+    </volume>
+    <volume name="volTPCWireU149">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU149"/>
+    </volume>
+    <volume name="volTPCWireU150">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU150"/>
+    </volume>
+    <volume name="volTPCWireU151">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU151"/>
+    </volume>
+    <volume name="volTPCWireU152">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU152"/>
+    </volume>
+    <volume name="volTPCWireU153">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU153"/>
+    </volume>
+    <volume name="volTPCWireU154">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU154"/>
+    </volume>
+    <volume name="volTPCWireU155">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU155"/>
+    </volume>
+    <volume name="volTPCWireU156">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU156"/>
+    </volume>
+    <volume name="volTPCWireU157">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU157"/>
+    </volume>
+    <volume name="volTPCWireU158">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU158"/>
+    </volume>
+    <volume name="volTPCWireU159">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU159"/>
+    </volume>
+    <volume name="volTPCWireU160">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU160"/>
+    </volume>
+    <volume name="volTPCWireU161">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU161"/>
+    </volume>
+    <volume name="volTPCWireU162">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU162"/>
+    </volume>
+    <volume name="volTPCWireU163">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU163"/>
+    </volume>
+    <volume name="volTPCWireU164">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU164"/>
+    </volume>
+    <volume name="volTPCWireU165">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU165"/>
+    </volume>
+    <volume name="volTPCWireU166">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU166"/>
+    </volume>
+    <volume name="volTPCWireU167">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU167"/>
+    </volume>
+    <volume name="volTPCWireU168">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU168"/>
+    </volume>
+    <volume name="volTPCWireU169">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU169"/>
+    </volume>
+    <volume name="volTPCWireU170">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU170"/>
+    </volume>
+    <volume name="volTPCWireU171">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU171"/>
+    </volume>
+    <volume name="volTPCWireU172">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU172"/>
+    </volume>
+    <volume name="volTPCWireU173">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU173"/>
+    </volume>
+    <volume name="volTPCWireU174">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU174"/>
+    </volume>
+    <volume name="volTPCWireU175">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU175"/>
+    </volume>
+    <volume name="volTPCWireU176">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU176"/>
+    </volume>
+    <volume name="volTPCWireU177">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU177"/>
+    </volume>
+    <volume name="volTPCWireU178">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU178"/>
+    </volume>
+    <volume name="volTPCWireU179">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU179"/>
+    </volume>
+    <volume name="volTPCWireU180">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU180"/>
+    </volume>
+    <volume name="volTPCWireU181">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU181"/>
+    </volume>
+    <volume name="volTPCWireU182">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU182"/>
+    </volume>
+    <volume name="volTPCWireU183">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU183"/>
+    </volume>
+    <volume name="volTPCWireU184">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU184"/>
+    </volume>
+    <volume name="volTPCWireU185">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU185"/>
+    </volume>
+    <volume name="volTPCWireU186">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU186"/>
+    </volume>
+    <volume name="volTPCWireU187">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU187"/>
+    </volume>
+    <volume name="volTPCWireU188">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU188"/>
+    </volume>
+    <volume name="volTPCWireU189">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU189"/>
+    </volume>
+    <volume name="volTPCWireU190">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU190"/>
+    </volume>
+    <volume name="volTPCWireU191">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU191"/>
+    </volume>
+    <volume name="volTPCWireU192">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU192"/>
+    </volume>
+    <volume name="volTPCWireU193">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU193"/>
+    </volume>
+    <volume name="volTPCWireU194">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU194"/>
+    </volume>
+    <volume name="volTPCWireU195">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU195"/>
+    </volume>
+    <volume name="volTPCWireU196">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU196"/>
+    </volume>
+    <volume name="volTPCWireU197">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU197"/>
+    </volume>
+    <volume name="volTPCWireU198">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU198"/>
+    </volume>
+    <volume name="volTPCWireU199">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU199"/>
+    </volume>
+    <volume name="volTPCWireU200">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU200"/>
+    </volume>
+    <volume name="volTPCWireU201">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU201"/>
+    </volume>
+    <volume name="volTPCWireU202">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU202"/>
+    </volume>
+    <volume name="volTPCWireU203">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU203"/>
+    </volume>
+    <volume name="volTPCWireU204">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU204"/>
+    </volume>
+    <volume name="volTPCWireU205">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU205"/>
+    </volume>
+    <volume name="volTPCWireU206">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU206"/>
+    </volume>
+    <volume name="volTPCWireU207">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU207"/>
+    </volume>
+    <volume name="volTPCWireU208">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU208"/>
+    </volume>
+    <volume name="volTPCWireU209">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU209"/>
+    </volume>
+    <volume name="volTPCWireU210">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU210"/>
+    </volume>
+    <volume name="volTPCWireU211">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU211"/>
+    </volume>
+    <volume name="volTPCWireU212">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU212"/>
+    </volume>
+    <volume name="volTPCWireU213">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU213"/>
+    </volume>
+    <volume name="volTPCWireU214">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU214"/>
+    </volume>
+    <volume name="volTPCWireU215">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU215"/>
+    </volume>
+    <volume name="volTPCWireU216">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU216"/>
+    </volume>
+    <volume name="volTPCWireU217">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU217"/>
+    </volume>
+    <volume name="volTPCWireU218">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU218"/>
+    </volume>
+    <volume name="volTPCWireU219">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU219"/>
+    </volume>
+    <volume name="volTPCWireU220">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU220"/>
+    </volume>
+    <volume name="volTPCWireU221">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU221"/>
+    </volume>
+    <volume name="volTPCWireU222">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU222"/>
+    </volume>
+    <volume name="volTPCWireU223">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU223"/>
+    </volume>
+    <volume name="volTPCWireU224">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU224"/>
+    </volume>
+    <volume name="volTPCWireU225">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU225"/>
+    </volume>
+    <volume name="volTPCWireU226">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU226"/>
+    </volume>
+    <volume name="volTPCWireU227">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU227"/>
+    </volume>
+    <volume name="volTPCWireU228">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU228"/>
+    </volume>
+    <volume name="volTPCWireU229">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU229"/>
+    </volume>
+    <volume name="volTPCWireU230">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU230"/>
+    </volume>
+    <volume name="volTPCWireU231">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU231"/>
+    </volume>
+    <volume name="volTPCWireU232">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU232"/>
+    </volume>
+    <volume name="volTPCWireU233">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU233"/>
+    </volume>
+    <volume name="volTPCWireU234">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU234"/>
+    </volume>
+    <volume name="volTPCWireU235">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU235"/>
+    </volume>
+    <volume name="volTPCWireU236">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU236"/>
+    </volume>
+    <volume name="volTPCWireU237">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU237"/>
+    </volume>
+    <volume name="volTPCWireU238">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU238"/>
+    </volume>
+    <volume name="volTPCWireU239">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU239"/>
+    </volume>
+    <volume name="volTPCWireU240">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU240"/>
+    </volume>
+    <volume name="volTPCWireU241">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU241"/>
+    </volume>
+    <volume name="volTPCWireU242">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU242"/>
+    </volume>
+    <volume name="volTPCWireU243">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU243"/>
+    </volume>
+    <volume name="volTPCWireU244">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU244"/>
+    </volume>
+    <volume name="volTPCWireU245">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU245"/>
+    </volume>
+    <volume name="volTPCWireU246">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU246"/>
+    </volume>
+    <volume name="volTPCWireU247">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU247"/>
+    </volume>
+    <volume name="volTPCWireU248">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU248"/>
+    </volume>
+    <volume name="volTPCWireU249">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU249"/>
+    </volume>
+    <volume name="volTPCWireU250">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU250"/>
+    </volume>
+    <volume name="volTPCWireU251">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU251"/>
+    </volume>
+    <volume name="volTPCWireU252">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU252"/>
+    </volume>
+    <volume name="volTPCWireU253">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU253"/>
+    </volume>
+    <volume name="volTPCWireU254">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU254"/>
+    </volume>
+    <volume name="volTPCWireU255">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU255"/>
+    </volume>
+    <volume name="volTPCWireU256">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU256"/>
+    </volume>
+    <volume name="volTPCWireU257">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU257"/>
+    </volume>
+    <volume name="volTPCWireU258">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU258"/>
+    </volume>
+    <volume name="volTPCWireU259">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU259"/>
+    </volume>
+    <volume name="volTPCWireU260">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU260"/>
+    </volume>
+    <volume name="volTPCWireU261">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU261"/>
+    </volume>
+    <volume name="volTPCWireU262">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU262"/>
+    </volume>
+    <volume name="volTPCWireU263">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU263"/>
+    </volume>
+    <volume name="volTPCWireU264">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU264"/>
+    </volume>
+    <volume name="volTPCWireU265">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU265"/>
+    </volume>
+    <volume name="volTPCWireU266">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU266"/>
+    </volume>
+    <volume name="volTPCWireU267">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU267"/>
+    </volume>
+    <volume name="volTPCWireU268">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU268"/>
+    </volume>
+    <volume name="volTPCWireU269">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU269"/>
+    </volume>
+    <volume name="volTPCWireU270">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU270"/>
+    </volume>
+    <volume name="volTPCWireU271">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU271"/>
+    </volume>
+    <volume name="volTPCWireU272">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU272"/>
+    </volume>
+    <volume name="volTPCWireU273">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU273"/>
+    </volume>
+    <volume name="volTPCWireU274">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU274"/>
+    </volume>
+    <volume name="volTPCWireU275">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU275"/>
+    </volume>
+    <volume name="volTPCWireU276">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU276"/>
+    </volume>
+    <volume name="volTPCWireU277">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU277"/>
+    </volume>
+    <volume name="volTPCWireU278">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU278"/>
+    </volume>
+    <volume name="volTPCWireU279">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU279"/>
+    </volume>
+    <volume name="volTPCWireU280">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU280"/>
+    </volume>
+    <volume name="volTPCWireU281">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU281"/>
+    </volume>
+    <volume name="volTPCWireU282">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU282"/>
+    </volume>
+    <volume name="volTPCWireU283">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU283"/>
+    </volume>
+    <volume name="volTPCWireU284">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU284"/>
+    </volume>
+    <volume name="volTPCWireU285">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU285"/>
+    </volume>
+    <volume name="volTPCWireV0">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV0"/>
+    </volume>
+    <volume name="volTPCWireV1">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV1"/>
+    </volume>
+    <volume name="volTPCWireV2">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV2"/>
+    </volume>
+    <volume name="volTPCWireV3">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV3"/>
+    </volume>
+    <volume name="volTPCWireV4">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV4"/>
+    </volume>
+    <volume name="volTPCWireV5">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV5"/>
+    </volume>
+    <volume name="volTPCWireV6">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV6"/>
+    </volume>
+    <volume name="volTPCWireV7">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV7"/>
+    </volume>
+    <volume name="volTPCWireV8">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV8"/>
+    </volume>
+    <volume name="volTPCWireV9">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV9"/>
+    </volume>
+    <volume name="volTPCWireV10">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV10"/>
+    </volume>
+    <volume name="volTPCWireV11">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV11"/>
+    </volume>
+    <volume name="volTPCWireV12">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV12"/>
+    </volume>
+    <volume name="volTPCWireV13">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV13"/>
+    </volume>
+    <volume name="volTPCWireV14">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV14"/>
+    </volume>
+    <volume name="volTPCWireV15">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV15"/>
+    </volume>
+    <volume name="volTPCWireV16">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV16"/>
+    </volume>
+    <volume name="volTPCWireV17">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV17"/>
+    </volume>
+    <volume name="volTPCWireV18">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV18"/>
+    </volume>
+    <volume name="volTPCWireV19">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV19"/>
+    </volume>
+    <volume name="volTPCWireV20">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV20"/>
+    </volume>
+    <volume name="volTPCWireV21">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV21"/>
+    </volume>
+    <volume name="volTPCWireV22">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV22"/>
+    </volume>
+    <volume name="volTPCWireV23">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV23"/>
+    </volume>
+    <volume name="volTPCWireV24">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV24"/>
+    </volume>
+    <volume name="volTPCWireV25">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV25"/>
+    </volume>
+    <volume name="volTPCWireV26">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV26"/>
+    </volume>
+    <volume name="volTPCWireV27">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV27"/>
+    </volume>
+    <volume name="volTPCWireV28">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV28"/>
+    </volume>
+    <volume name="volTPCWireV29">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV29"/>
+    </volume>
+    <volume name="volTPCWireV30">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV30"/>
+    </volume>
+    <volume name="volTPCWireV31">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV31"/>
+    </volume>
+    <volume name="volTPCWireV32">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV32"/>
+    </volume>
+    <volume name="volTPCWireV33">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV33"/>
+    </volume>
+    <volume name="volTPCWireV34">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV34"/>
+    </volume>
+    <volume name="volTPCWireV35">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV35"/>
+    </volume>
+    <volume name="volTPCWireV36">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV36"/>
+    </volume>
+    <volume name="volTPCWireV37">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV37"/>
+    </volume>
+    <volume name="volTPCWireV38">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV38"/>
+    </volume>
+    <volume name="volTPCWireV39">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV39"/>
+    </volume>
+    <volume name="volTPCWireV40">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV40"/>
+    </volume>
+    <volume name="volTPCWireV41">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV41"/>
+    </volume>
+    <volume name="volTPCWireV42">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV42"/>
+    </volume>
+    <volume name="volTPCWireV43">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV43"/>
+    </volume>
+    <volume name="volTPCWireV44">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV44"/>
+    </volume>
+    <volume name="volTPCWireV45">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV45"/>
+    </volume>
+    <volume name="volTPCWireV46">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV46"/>
+    </volume>
+    <volume name="volTPCWireV47">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV47"/>
+    </volume>
+    <volume name="volTPCWireV48">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV48"/>
+    </volume>
+    <volume name="volTPCWireV49">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV49"/>
+    </volume>
+    <volume name="volTPCWireV50">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV50"/>
+    </volume>
+    <volume name="volTPCWireV51">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV51"/>
+    </volume>
+    <volume name="volTPCWireV52">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV52"/>
+    </volume>
+    <volume name="volTPCWireV53">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV53"/>
+    </volume>
+    <volume name="volTPCWireV54">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV54"/>
+    </volume>
+    <volume name="volTPCWireV55">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV55"/>
+    </volume>
+    <volume name="volTPCWireV56">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV56"/>
+    </volume>
+    <volume name="volTPCWireV57">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV57"/>
+    </volume>
+    <volume name="volTPCWireV58">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV58"/>
+    </volume>
+    <volume name="volTPCWireV59">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV59"/>
+    </volume>
+    <volume name="volTPCWireV60">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV60"/>
+    </volume>
+    <volume name="volTPCWireV61">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV61"/>
+    </volume>
+    <volume name="volTPCWireV62">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV62"/>
+    </volume>
+    <volume name="volTPCWireV63">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV63"/>
+    </volume>
+    <volume name="volTPCWireV64">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV64"/>
+    </volume>
+    <volume name="volTPCWireV65">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV65"/>
+    </volume>
+    <volume name="volTPCWireV66">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV66"/>
+    </volume>
+    <volume name="volTPCWireV67">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV67"/>
+    </volume>
+    <volume name="volTPCWireV68">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV68"/>
+    </volume>
+    <volume name="volTPCWireV69">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV69"/>
+    </volume>
+    <volume name="volTPCWireV70">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV70"/>
+    </volume>
+    <volume name="volTPCWireV71">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV71"/>
+    </volume>
+    <volume name="volTPCWireV72">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV72"/>
+    </volume>
+    <volume name="volTPCWireV73">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV73"/>
+    </volume>
+    <volume name="volTPCWireV74">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV74"/>
+    </volume>
+    <volume name="volTPCWireV75">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV75"/>
+    </volume>
+    <volume name="volTPCWireV76">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV76"/>
+    </volume>
+    <volume name="volTPCWireV77">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV77"/>
+    </volume>
+    <volume name="volTPCWireV78">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV78"/>
+    </volume>
+    <volume name="volTPCWireV79">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV79"/>
+    </volume>
+    <volume name="volTPCWireV80">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV80"/>
+    </volume>
+    <volume name="volTPCWireV81">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV81"/>
+    </volume>
+    <volume name="volTPCWireV82">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV82"/>
+    </volume>
+    <volume name="volTPCWireV83">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV83"/>
+    </volume>
+    <volume name="volTPCWireV84">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV84"/>
+    </volume>
+    <volume name="volTPCWireV85">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV85"/>
+    </volume>
+    <volume name="volTPCWireV86">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV86"/>
+    </volume>
+    <volume name="volTPCWireV87">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV87"/>
+    </volume>
+    <volume name="volTPCWireV88">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV88"/>
+    </volume>
+    <volume name="volTPCWireV89">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV89"/>
+    </volume>
+    <volume name="volTPCWireV90">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV90"/>
+    </volume>
+    <volume name="volTPCWireV91">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV91"/>
+    </volume>
+    <volume name="volTPCWireV92">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV92"/>
+    </volume>
+    <volume name="volTPCWireV93">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV93"/>
+    </volume>
+    <volume name="volTPCWireV94">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV94"/>
+    </volume>
+    <volume name="volTPCWireV95">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV95"/>
+    </volume>
+    <volume name="volTPCWireV96">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV96"/>
+    </volume>
+    <volume name="volTPCWireV97">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV97"/>
+    </volume>
+    <volume name="volTPCWireV98">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV98"/>
+    </volume>
+    <volume name="volTPCWireV99">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV99"/>
+    </volume>
+    <volume name="volTPCWireV100">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV100"/>
+    </volume>
+    <volume name="volTPCWireV101">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV101"/>
+    </volume>
+    <volume name="volTPCWireV102">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV102"/>
+    </volume>
+    <volume name="volTPCWireV103">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV103"/>
+    </volume>
+    <volume name="volTPCWireV104">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV104"/>
+    </volume>
+    <volume name="volTPCWireV105">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV105"/>
+    </volume>
+    <volume name="volTPCWireV106">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV106"/>
+    </volume>
+    <volume name="volTPCWireV107">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV107"/>
+    </volume>
+    <volume name="volTPCWireV108">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV108"/>
+    </volume>
+    <volume name="volTPCWireV109">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV109"/>
+    </volume>
+    <volume name="volTPCWireV110">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV110"/>
+    </volume>
+    <volume name="volTPCWireV111">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV111"/>
+    </volume>
+    <volume name="volTPCWireV112">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV112"/>
+    </volume>
+    <volume name="volTPCWireV113">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV113"/>
+    </volume>
+    <volume name="volTPCWireV114">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV114"/>
+    </volume>
+    <volume name="volTPCWireV115">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV115"/>
+    </volume>
+    <volume name="volTPCWireV116">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV116"/>
+    </volume>
+    <volume name="volTPCWireV117">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV117"/>
+    </volume>
+    <volume name="volTPCWireV118">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV118"/>
+    </volume>
+    <volume name="volTPCWireV119">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV119"/>
+    </volume>
+    <volume name="volTPCWireV120">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV120"/>
+    </volume>
+    <volume name="volTPCWireV121">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV121"/>
+    </volume>
+    <volume name="volTPCWireV122">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV122"/>
+    </volume>
+    <volume name="volTPCWireV123">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV123"/>
+    </volume>
+    <volume name="volTPCWireV124">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV124"/>
+    </volume>
+    <volume name="volTPCWireV125">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV125"/>
+    </volume>
+    <volume name="volTPCWireV126">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV126"/>
+    </volume>
+    <volume name="volTPCWireV127">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV127"/>
+    </volume>
+    <volume name="volTPCWireV128">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV128"/>
+    </volume>
+    <volume name="volTPCWireV129">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV129"/>
+    </volume>
+    <volume name="volTPCWireV130">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV130"/>
+    </volume>
+    <volume name="volTPCWireV131">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV131"/>
+    </volume>
+    <volume name="volTPCWireV132">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV132"/>
+    </volume>
+    <volume name="volTPCWireV133">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV133"/>
+    </volume>
+    <volume name="volTPCWireV134">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV134"/>
+    </volume>
+    <volume name="volTPCWireV135">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV135"/>
+    </volume>
+    <volume name="volTPCWireV136">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV136"/>
+    </volume>
+    <volume name="volTPCWireV137">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV137"/>
+    </volume>
+    <volume name="volTPCWireV138">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV138"/>
+    </volume>
+    <volume name="volTPCWireV139">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV139"/>
+    </volume>
+    <volume name="volTPCWireV140">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV140"/>
+    </volume>
+    <volume name="volTPCWireV141">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV141"/>
+    </volume>
+    <volume name="volTPCWireV142">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV142"/>
+    </volume>
+    <volume name="volTPCWireV143">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV143"/>
+    </volume>
+    <volume name="volTPCWireV144">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV144"/>
+    </volume>
+    <volume name="volTPCWireV145">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV145"/>
+    </volume>
+    <volume name="volTPCWireV146">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV146"/>
+    </volume>
+    <volume name="volTPCWireV147">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV147"/>
+    </volume>
+    <volume name="volTPCWireV148">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV148"/>
+    </volume>
+    <volume name="volTPCWireV149">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV149"/>
+    </volume>
+    <volume name="volTPCWireV150">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV150"/>
+    </volume>
+    <volume name="volTPCWireV151">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV151"/>
+    </volume>
+    <volume name="volTPCWireV152">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV152"/>
+    </volume>
+    <volume name="volTPCWireV153">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV153"/>
+    </volume>
+    <volume name="volTPCWireV154">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV154"/>
+    </volume>
+    <volume name="volTPCWireV155">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV155"/>
+    </volume>
+    <volume name="volTPCWireV156">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV156"/>
+    </volume>
+    <volume name="volTPCWireV157">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV157"/>
+    </volume>
+    <volume name="volTPCWireV158">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV158"/>
+    </volume>
+    <volume name="volTPCWireV159">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV159"/>
+    </volume>
+    <volume name="volTPCWireV160">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV160"/>
+    </volume>
+    <volume name="volTPCWireV161">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV161"/>
+    </volume>
+    <volume name="volTPCWireV162">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV162"/>
+    </volume>
+    <volume name="volTPCWireV163">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV163"/>
+    </volume>
+    <volume name="volTPCWireV164">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV164"/>
+    </volume>
+    <volume name="volTPCWireV165">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV165"/>
+    </volume>
+    <volume name="volTPCWireV166">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV166"/>
+    </volume>
+    <volume name="volTPCWireV167">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV167"/>
+    </volume>
+    <volume name="volTPCWireV168">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV168"/>
+    </volume>
+    <volume name="volTPCWireV169">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV169"/>
+    </volume>
+    <volume name="volTPCWireV170">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV170"/>
+    </volume>
+    <volume name="volTPCWireV171">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV171"/>
+    </volume>
+    <volume name="volTPCWireV172">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV172"/>
+    </volume>
+    <volume name="volTPCWireV173">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV173"/>
+    </volume>
+    <volume name="volTPCWireV174">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV174"/>
+    </volume>
+    <volume name="volTPCWireV175">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV175"/>
+    </volume>
+    <volume name="volTPCWireV176">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV176"/>
+    </volume>
+    <volume name="volTPCWireV177">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV177"/>
+    </volume>
+    <volume name="volTPCWireV178">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV178"/>
+    </volume>
+    <volume name="volTPCWireV179">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV179"/>
+    </volume>
+    <volume name="volTPCWireV180">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV180"/>
+    </volume>
+    <volume name="volTPCWireV181">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV181"/>
+    </volume>
+    <volume name="volTPCWireV182">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV182"/>
+    </volume>
+    <volume name="volTPCWireV183">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV183"/>
+    </volume>
+    <volume name="volTPCWireV184">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV184"/>
+    </volume>
+    <volume name="volTPCWireV185">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV185"/>
+    </volume>
+    <volume name="volTPCWireV186">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV186"/>
+    </volume>
+    <volume name="volTPCWireV187">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV187"/>
+    </volume>
+    <volume name="volTPCWireV188">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV188"/>
+    </volume>
+    <volume name="volTPCWireV189">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV189"/>
+    </volume>
+    <volume name="volTPCWireV190">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV190"/>
+    </volume>
+    <volume name="volTPCWireV191">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV191"/>
+    </volume>
+    <volume name="volTPCWireV192">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV192"/>
+    </volume>
+    <volume name="volTPCWireV193">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV193"/>
+    </volume>
+    <volume name="volTPCWireV194">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV194"/>
+    </volume>
+    <volume name="volTPCWireV195">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV195"/>
+    </volume>
+    <volume name="volTPCWireV196">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV196"/>
+    </volume>
+    <volume name="volTPCWireV197">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV197"/>
+    </volume>
+    <volume name="volTPCWireV198">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV198"/>
+    </volume>
+    <volume name="volTPCWireV199">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV199"/>
+    </volume>
+    <volume name="volTPCWireV200">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV200"/>
+    </volume>
+    <volume name="volTPCWireV201">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV201"/>
+    </volume>
+    <volume name="volTPCWireV202">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV202"/>
+    </volume>
+    <volume name="volTPCWireV203">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV203"/>
+    </volume>
+    <volume name="volTPCWireV204">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV204"/>
+    </volume>
+    <volume name="volTPCWireV205">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV205"/>
+    </volume>
+    <volume name="volTPCWireV206">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV206"/>
+    </volume>
+    <volume name="volTPCWireV207">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV207"/>
+    </volume>
+    <volume name="volTPCWireV208">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV208"/>
+    </volume>
+    <volume name="volTPCWireV209">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV209"/>
+    </volume>
+    <volume name="volTPCWireV210">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV210"/>
+    </volume>
+    <volume name="volTPCWireV211">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV211"/>
+    </volume>
+    <volume name="volTPCWireV212">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV212"/>
+    </volume>
+    <volume name="volTPCWireV213">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV213"/>
+    </volume>
+    <volume name="volTPCWireV214">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV214"/>
+    </volume>
+    <volume name="volTPCWireV215">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV215"/>
+    </volume>
+    <volume name="volTPCWireV216">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV216"/>
+    </volume>
+    <volume name="volTPCWireV217">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV217"/>
+    </volume>
+    <volume name="volTPCWireV218">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV218"/>
+    </volume>
+    <volume name="volTPCWireV219">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV219"/>
+    </volume>
+    <volume name="volTPCWireV220">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV220"/>
+    </volume>
+    <volume name="volTPCWireV221">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV221"/>
+    </volume>
+    <volume name="volTPCWireV222">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV222"/>
+    </volume>
+    <volume name="volTPCWireV223">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV223"/>
+    </volume>
+    <volume name="volTPCWireV224">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV224"/>
+    </volume>
+    <volume name="volTPCWireV225">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV225"/>
+    </volume>
+    <volume name="volTPCWireV226">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV226"/>
+    </volume>
+    <volume name="volTPCWireV227">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV227"/>
+    </volume>
+    <volume name="volTPCWireV228">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV228"/>
+    </volume>
+    <volume name="volTPCWireV229">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV229"/>
+    </volume>
+    <volume name="volTPCWireV230">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV230"/>
+    </volume>
+    <volume name="volTPCWireV231">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV231"/>
+    </volume>
+    <volume name="volTPCWireV232">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV232"/>
+    </volume>
+    <volume name="volTPCWireV233">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV233"/>
+    </volume>
+    <volume name="volTPCWireV234">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV234"/>
+    </volume>
+    <volume name="volTPCWireV235">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV235"/>
+    </volume>
+    <volume name="volTPCWireV236">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV236"/>
+    </volume>
+    <volume name="volTPCWireV237">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV237"/>
+    </volume>
+    <volume name="volTPCWireV238">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV238"/>
+    </volume>
+    <volume name="volTPCWireV239">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV239"/>
+    </volume>
+    <volume name="volTPCWireV240">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV240"/>
+    </volume>
+    <volume name="volTPCWireV241">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV241"/>
+    </volume>
+    <volume name="volTPCWireV242">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV242"/>
+    </volume>
+    <volume name="volTPCWireV243">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV243"/>
+    </volume>
+    <volume name="volTPCWireV244">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV244"/>
+    </volume>
+    <volume name="volTPCWireV245">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV245"/>
+    </volume>
+    <volume name="volTPCWireV246">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV246"/>
+    </volume>
+    <volume name="volTPCWireV247">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV247"/>
+    </volume>
+    <volume name="volTPCWireV248">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV248"/>
+    </volume>
+    <volume name="volTPCWireV249">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV249"/>
+    </volume>
+    <volume name="volTPCWireV250">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV250"/>
+    </volume>
+    <volume name="volTPCWireV251">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV251"/>
+    </volume>
+    <volume name="volTPCWireV252">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV252"/>
+    </volume>
+    <volume name="volTPCWireV253">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV253"/>
+    </volume>
+    <volume name="volTPCWireV254">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV254"/>
+    </volume>
+    <volume name="volTPCWireV255">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV255"/>
+    </volume>
+    <volume name="volTPCWireV256">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV256"/>
+    </volume>
+    <volume name="volTPCWireV257">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV257"/>
+    </volume>
+    <volume name="volTPCWireV258">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV258"/>
+    </volume>
+    <volume name="volTPCWireV259">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV259"/>
+    </volume>
+    <volume name="volTPCWireV260">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV260"/>
+    </volume>
+    <volume name="volTPCWireV261">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV261"/>
+    </volume>
+    <volume name="volTPCWireV262">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV262"/>
+    </volume>
+    <volume name="volTPCWireV263">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV263"/>
+    </volume>
+    <volume name="volTPCWireV264">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV264"/>
+    </volume>
+    <volume name="volTPCWireV265">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV265"/>
+    </volume>
+    <volume name="volTPCWireV266">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV266"/>
+    </volume>
+    <volume name="volTPCWireV267">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV267"/>
+    </volume>
+    <volume name="volTPCWireV268">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV268"/>
+    </volume>
+    <volume name="volTPCWireV269">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV269"/>
+    </volume>
+    <volume name="volTPCWireV270">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV270"/>
+    </volume>
+    <volume name="volTPCWireV271">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV271"/>
+    </volume>
+    <volume name="volTPCWireV272">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV272"/>
+    </volume>
+    <volume name="volTPCWireV273">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV273"/>
+    </volume>
+    <volume name="volTPCWireV274">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV274"/>
+    </volume>
+    <volume name="volTPCWireV275">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV275"/>
+    </volume>
+    <volume name="volTPCWireV276">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV276"/>
+    </volume>
+    <volume name="volTPCWireV277">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV277"/>
+    </volume>
+    <volume name="volTPCWireV278">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV278"/>
+    </volume>
+    <volume name="volTPCWireV279">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV279"/>
+    </volume>
+    <volume name="volTPCWireV280">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV280"/>
+    </volume>
+    <volume name="volTPCWireV281">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV281"/>
+    </volume>
+    <volume name="volTPCWireV282">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV282"/>
+    </volume>
+    <volume name="volTPCWireV283">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV283"/>
+    </volume>
+    <volume name="volTPCWireV284">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV284"/>
+    </volume>
+    <volume name="volTPCWireV285">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV285"/>
+    </volume>
+    <volume name="volTPCWireZ">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireZ"/>
+    </volume>
+   <volume name="volTPCPlaneU">
+     <materialref ref="LAr"/>
+     <solidref ref="CRMUPlane"/>
+     <physvol>
+       <volumeref ref="volTPCWireU0"/>
+       <position name="posWireU0" unit="cm" x="0" y="-83.6970251487471" z="-74.0775"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU1"/>
+       <position name="posWireU1" unit="cm" x="0" y="-83.255352192817" z="-73.3125"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU2"/>
+       <position name="posWireU2" unit="cm" x="0" y="-82.8136792368869" z="-72.5475"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU3"/>
+       <position name="posWireU3" unit="cm" x="0" y="-82.3720062809569" z="-71.7825"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU4"/>
+       <position name="posWireU4" unit="cm" x="0" y="-81.9303333250268" z="-71.0175"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU5"/>
+       <position name="posWireU5" unit="cm" x="0" y="-81.4886603690967" z="-70.2525"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU6"/>
+       <position name="posWireU6" unit="cm" x="0" y="-81.0469874131667" z="-69.4875"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU7"/>
+       <position name="posWireU7" unit="cm" x="0" y="-80.6053144572366" z="-68.7225"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU8"/>
+       <position name="posWireU8" unit="cm" x="0" y="-80.1636415013066" z="-67.9575"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU9"/>
+       <position name="posWireU9" unit="cm" x="0" y="-79.7219685453765" z="-67.1925"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU10"/>
+       <position name="posWireU10" unit="cm" x="0" y="-79.2802955894464" z="-66.4275"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU11"/>
+       <position name="posWireU11" unit="cm" x="0" y="-78.8386226335164" z="-65.6625"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU12"/>
+       <position name="posWireU12" unit="cm" x="0" y="-78.3969496775863" z="-64.8975"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU13"/>
+       <position name="posWireU13" unit="cm" x="0" y="-77.9552767216562" z="-64.1325"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU14"/>
+       <position name="posWireU14" unit="cm" x="0" y="-77.5136037657262" z="-63.3675"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU15"/>
+       <position name="posWireU15" unit="cm" x="0" y="-77.0719308097961" z="-62.6025"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU16"/>
+       <position name="posWireU16" unit="cm" x="0" y="-76.630257853866" z="-61.8375"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU17"/>
+       <position name="posWireU17" unit="cm" x="0" y="-76.188584897936" z="-61.0725"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU18"/>
+       <position name="posWireU18" unit="cm" x="0" y="-75.7469119420059" z="-60.3075"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU19"/>
+       <position name="posWireU19" unit="cm" x="0" y="-75.3052389860758" z="-59.5425"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU20"/>
+       <position name="posWireU20" unit="cm" x="0" y="-74.8635660301458" z="-58.7775"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU21"/>
+       <position name="posWireU21" unit="cm" x="0" y="-74.4218930742157" z="-58.0125"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU22"/>
+       <position name="posWireU22" unit="cm" x="0" y="-73.9802201182857" z="-57.2475"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU23"/>
+       <position name="posWireU23" unit="cm" x="0" y="-73.5385471623556" z="-56.4825"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU24"/>
+       <position name="posWireU24" unit="cm" x="0" y="-73.0968742064255" z="-55.7175"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU25"/>
+       <position name="posWireU25" unit="cm" x="0" y="-72.6552012504955" z="-54.9525"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU26"/>
+       <position name="posWireU26" unit="cm" x="0" y="-72.2135282945654" z="-54.1875"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU27"/>
+       <position name="posWireU27" unit="cm" x="0" y="-71.7718553386353" z="-53.4225"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU28"/>
+       <position name="posWireU28" unit="cm" x="0" y="-71.3301823827053" z="-52.6575"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU29"/>
+       <position name="posWireU29" unit="cm" x="0" y="-70.8885094267752" z="-51.8925"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU30"/>
+       <position name="posWireU30" unit="cm" x="0" y="-70.4468364708451" z="-51.1275"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU31"/>
+       <position name="posWireU31" unit="cm" x="0" y="-70.0051635149151" z="-50.3625"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU32"/>
+       <position name="posWireU32" unit="cm" x="0" y="-69.563490558985" z="-49.5975"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU33"/>
+       <position name="posWireU33" unit="cm" x="0" y="-69.121817603055" z="-48.8325"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU34"/>
+       <position name="posWireU34" unit="cm" x="0" y="-68.6801446471249" z="-48.0675"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU35"/>
+       <position name="posWireU35" unit="cm" x="0" y="-68.2384716911948" z="-47.3025"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU36"/>
+       <position name="posWireU36" unit="cm" x="0" y="-67.7967987352648" z="-46.5375"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU37"/>
+       <position name="posWireU37" unit="cm" x="0" y="-67.3551257793347" z="-45.7725"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU38"/>
+       <position name="posWireU38" unit="cm" x="0" y="-66.9134528234046" z="-45.0075"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU39"/>
+       <position name="posWireU39" unit="cm" x="0" y="-66.4717798674746" z="-44.2425"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU40"/>
+       <position name="posWireU40" unit="cm" x="0" y="-66.0301069115445" z="-43.4775"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU41"/>
+       <position name="posWireU41" unit="cm" x="0" y="-65.5884339556144" z="-42.7125"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU42"/>
+       <position name="posWireU42" unit="cm" x="0" y="-65.1467609996844" z="-41.9475"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU43"/>
+       <position name="posWireU43" unit="cm" x="0" y="-64.7050880437543" z="-41.1825"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU44"/>
+       <position name="posWireU44" unit="cm" x="0" y="-64.2634150878243" z="-40.4175"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU45"/>
+       <position name="posWireU45" unit="cm" x="0" y="-63.8217421318942" z="-39.6525"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU46"/>
+       <position name="posWireU46" unit="cm" x="0" y="-63.3800691759641" z="-38.8875"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU47"/>
+       <position name="posWireU47" unit="cm" x="0" y="-62.9383962200341" z="-38.1225"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU48"/>
+       <position name="posWireU48" unit="cm" x="0" y="-62.496723264104" z="-37.3575"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU49"/>
+       <position name="posWireU49" unit="cm" x="0" y="-62.0550503081739" z="-36.5925"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU50"/>
+       <position name="posWireU50" unit="cm" x="0" y="-61.6133773522439" z="-35.8275"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU51"/>
+       <position name="posWireU51" unit="cm" x="0" y="-61.1717043963138" z="-35.0625"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU52"/>
+       <position name="posWireU52" unit="cm" x="0" y="-60.7300314403837" z="-34.2975"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU53"/>
+       <position name="posWireU53" unit="cm" x="0" y="-60.2883584844537" z="-33.5325"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU54"/>
+       <position name="posWireU54" unit="cm" x="0" y="-59.8466855285236" z="-32.7675"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU55"/>
+       <position name="posWireU55" unit="cm" x="0" y="-59.4050125725935" z="-32.0025"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU56"/>
+       <position name="posWireU56" unit="cm" x="0" y="-58.9633396166635" z="-31.2375"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU57"/>
+       <position name="posWireU57" unit="cm" x="0" y="-58.5216666607334" z="-30.4725"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU58"/>
+       <position name="posWireU58" unit="cm" x="0" y="-58.0799937048034" z="-29.7075"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU59"/>
+       <position name="posWireU59" unit="cm" x="0" y="-57.6383207488733" z="-28.9425"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU60"/>
+       <position name="posWireU60" unit="cm" x="0" y="-57.1966477929432" z="-28.1775"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU61"/>
+       <position name="posWireU61" unit="cm" x="0" y="-56.7549748370132" z="-27.4125"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU62"/>
+       <position name="posWireU62" unit="cm" x="0" y="-56.3133018810831" z="-26.6475"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU63"/>
+       <position name="posWireU63" unit="cm" x="0" y="-55.871628925153" z="-25.8825"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU64"/>
+       <position name="posWireU64" unit="cm" x="0" y="-55.429955969223" z="-25.1175"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU65"/>
+       <position name="posWireU65" unit="cm" x="0" y="-54.9882830132929" z="-24.3525"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU66"/>
+       <position name="posWireU66" unit="cm" x="0" y="-54.5466100573628" z="-23.5875"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU67"/>
+       <position name="posWireU67" unit="cm" x="0" y="-54.1049371014328" z="-22.8225"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU68"/>
+       <position name="posWireU68" unit="cm" x="0" y="-53.6632641455027" z="-22.0575"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU69"/>
+       <position name="posWireU69" unit="cm" x="0" y="-53.2215911895726" z="-21.2925"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU70"/>
+       <position name="posWireU70" unit="cm" x="0" y="-52.7799182336426" z="-20.5275"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU71"/>
+       <position name="posWireU71" unit="cm" x="0" y="-52.3382452777125" z="-19.7625"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU72"/>
+       <position name="posWireU72" unit="cm" x="0" y="-51.8965723217825" z="-18.9975"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU73"/>
+       <position name="posWireU73" unit="cm" x="0" y="-51.4548993658524" z="-18.2325"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU74"/>
+       <position name="posWireU74" unit="cm" x="0" y="-51.0132264099223" z="-17.4675"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU75"/>
+       <position name="posWireU75" unit="cm" x="0" y="-50.5715534539923" z="-16.7025"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU76"/>
+       <position name="posWireU76" unit="cm" x="0" y="-50.1298804980622" z="-15.9375"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU77"/>
+       <position name="posWireU77" unit="cm" x="0" y="-49.6882075421321" z="-15.1725"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU78"/>
+       <position name="posWireU78" unit="cm" x="0" y="-49.2465345862021" z="-14.4075"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU79"/>
+       <position name="posWireU79" unit="cm" x="0" y="-48.804861630272" z="-13.6425"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU80"/>
+       <position name="posWireU80" unit="cm" x="0" y="-48.3631886743419" z="-12.8775"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU81"/>
+       <position name="posWireU81" unit="cm" x="0" y="-47.9215157184119" z="-12.1125"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU82"/>
+       <position name="posWireU82" unit="cm" x="0" y="-47.4798427624818" z="-11.3475"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU83"/>
+       <position name="posWireU83" unit="cm" x="0" y="-47.0381698065518" z="-10.5825"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU84"/>
+       <position name="posWireU84" unit="cm" x="0" y="-46.5964968506217" z="-9.81749999999995"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU85"/>
+       <position name="posWireU85" unit="cm" x="0" y="-46.1548238946916" z="-9.05249999999995"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU86"/>
+       <position name="posWireU86" unit="cm" x="0" y="-45.7131509387616" z="-8.28749999999995"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU87"/>
+       <position name="posWireU87" unit="cm" x="0" y="-45.2714779828315" z="-7.52249999999995"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU88"/>
+       <position name="posWireU88" unit="cm" x="0" y="-44.8298050269014" z="-6.75749999999995"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU89"/>
+       <position name="posWireU89" unit="cm" x="0" y="-44.3881320709714" z="-5.99249999999995"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU90"/>
+       <position name="posWireU90" unit="cm" x="0" y="-43.9464591150413" z="-5.22749999999995"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU91"/>
+       <position name="posWireU91" unit="cm" x="0" y="-43.5047861591112" z="-4.46249999999995"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU92"/>
+       <position name="posWireU92" unit="cm" x="0" y="-43.0631132031812" z="-3.69749999999995"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU93"/>
+       <position name="posWireU93" unit="cm" x="0" y="-42.6214402472511" z="-2.93249999999995"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU94"/>
+       <position name="posWireU94" unit="cm" x="0" y="-42.1797672913211" z="-2.16749999999995"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU95"/>
+       <position name="posWireU95" unit="cm" x="0" y="-41.738094335391" z="-1.40249999999995"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU96"/>
+       <position name="posWireU96" unit="cm" x="0" y="-41.2964213794609" z="-0.637499999999946"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU97"/>
+       <position name="posWireU97" unit="cm" x="0" y="-40.7811362642091" z="0"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU98"/>
+       <position name="posWireU98" unit="cm" x="0" y="-39.897790352349" z="0"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU99"/>
+       <position name="posWireU99" unit="cm" x="0" y="-39.0144444404889" z="0"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU100"/>
+       <position name="posWireU100" unit="cm" x="0" y="-38.1310985286288" z="0"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU101"/>
+       <position name="posWireU101" unit="cm" x="0" y="-37.2477526167686" z="0"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU102"/>
+       <position name="posWireU102" unit="cm" x="0" y="-36.3644067049085" z="0"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU103"/>
+       <position name="posWireU103" unit="cm" x="0" y="-35.4810607930484" z="0"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU104"/>
+       <position name="posWireU104" unit="cm" x="0" y="-34.5977148811883" z="0"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU105"/>
+       <position name="posWireU105" unit="cm" x="0" y="-33.7143689693281" z="0"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU106"/>
+       <position name="posWireU106" unit="cm" x="0" y="-32.831023057468" z="0"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU107"/>
+       <position name="posWireU107" unit="cm" x="0" y="-31.9476771456079" z="0"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU108"/>
+       <position name="posWireU108" unit="cm" x="0" y="-31.0643312337477" z="0"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU109"/>
+       <position name="posWireU109" unit="cm" x="0" y="-30.1809853218876" z="0"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU110"/>
+       <position name="posWireU110" unit="cm" x="0" y="-29.2976394100275" z="0"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU111"/>
+       <position name="posWireU111" unit="cm" x="0" y="-28.4142934981674" z="0"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU112"/>
+       <position name="posWireU112" unit="cm" x="0" y="-27.5309475863072" z="0"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU113"/>
+       <position name="posWireU113" unit="cm" x="0" y="-26.6476016744471" z="0"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU114"/>
+       <position name="posWireU114" unit="cm" x="0" y="-25.764255762587" z="0"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU115"/>
+       <position name="posWireU115" unit="cm" x="0" y="-24.8809098507268" z="0"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU116"/>
+       <position name="posWireU116" unit="cm" x="0" y="-23.9975639388667" z="0"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU117"/>
+       <position name="posWireU117" unit="cm" x="0" y="-23.1142180270066" z="0"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU118"/>
+       <position name="posWireU118" unit="cm" x="0" y="-22.2308721151465" z="0"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU119"/>
+       <position name="posWireU119" unit="cm" x="0" y="-21.3475262032863" z="0"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU120"/>
+       <position name="posWireU120" unit="cm" x="0" y="-20.4641802914262" z="0"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU121"/>
+       <position name="posWireU121" unit="cm" x="0" y="-19.5808343795661" z="0"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU122"/>
+       <position name="posWireU122" unit="cm" x="0" y="-18.697488467706" z="0"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU123"/>
+       <position name="posWireU123" unit="cm" x="0" y="-17.8141425558458" z="0"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU124"/>
+       <position name="posWireU124" unit="cm" x="0" y="-16.9307966439857" z="0"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU125"/>
+       <position name="posWireU125" unit="cm" x="0" y="-16.0474507321256" z="0"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU126"/>
+       <position name="posWireU126" unit="cm" x="0" y="-15.1641048202654" z="0"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU127"/>
+       <position name="posWireU127" unit="cm" x="0" y="-14.2807589084053" z="0"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU128"/>
+       <position name="posWireU128" unit="cm" x="0" y="-13.3974129965452" z="0"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU129"/>
+       <position name="posWireU129" unit="cm" x="0" y="-12.5140670846851" z="0"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU130"/>
+       <position name="posWireU130" unit="cm" x="0" y="-11.6307211728249" z="0"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU131"/>
+       <position name="posWireU131" unit="cm" x="0" y="-10.7473752609648" z="0"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU132"/>
+       <position name="posWireU132" unit="cm" x="0" y="-9.86402934910468" z="0"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU133"/>
+       <position name="posWireU133" unit="cm" x="0" y="-8.98068343724455" z="0"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU134"/>
+       <position name="posWireU134" unit="cm" x="0" y="-8.09733752538442" z="0"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU135"/>
+       <position name="posWireU135" unit="cm" x="0" y="-7.2139916135243" z="0"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU136"/>
+       <position name="posWireU136" unit="cm" x="0" y="-6.33064570166416" z="0"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU137"/>
+       <position name="posWireU137" unit="cm" x="0" y="-5.44729978980403" z="0"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU138"/>
+       <position name="posWireU138" unit="cm" x="0" y="-4.56395387794391" z="0"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU139"/>
+       <position name="posWireU139" unit="cm" x="0" y="-3.68060796608378" z="0"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU140"/>
+       <position name="posWireU140" unit="cm" x="0" y="-2.79726205422365" z="0"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU141"/>
+       <position name="posWireU141" unit="cm" x="0" y="-1.91391614236353" z="0"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU142"/>
+       <position name="posWireU142" unit="cm" x="0" y="-1.0305702305034" z="0"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU143"/>
+       <position name="posWireU143" unit="cm" x="0" y="-0.147224318643268" z="0"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU144"/>
+       <position name="posWireU144" unit="cm" x="0" y="0.736121593216858" z="0"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU145"/>
+       <position name="posWireU145" unit="cm" x="0" y="1.619467505077" z="0"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU146"/>
+       <position name="posWireU146" unit="cm" x="0" y="2.50281341693712" z="0"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU147"/>
+       <position name="posWireU147" unit="cm" x="0" y="3.38615932879726" z="0"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU148"/>
+       <position name="posWireU148" unit="cm" x="0" y="4.26950524065738" z="0"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU149"/>
+       <position name="posWireU149" unit="cm" x="0" y="5.15285115251751" z="0"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU150"/>
+       <position name="posWireU150" unit="cm" x="0" y="6.03619706437765" z="0"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU151"/>
+       <position name="posWireU151" unit="cm" x="0" y="6.91954297623776" z="0"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU152"/>
+       <position name="posWireU152" unit="cm" x="0" y="7.80288888809789" z="0"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU153"/>
+       <position name="posWireU153" unit="cm" x="0" y="8.68623479995803" z="0"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU154"/>
+       <position name="posWireU154" unit="cm" x="0" y="9.56958071181815" z="0"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU155"/>
+       <position name="posWireU155" unit="cm" x="0" y="10.4529266236783" z="0"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU156"/>
+       <position name="posWireU156" unit="cm" x="0" y="11.3362725355384" z="0"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU157"/>
+       <position name="posWireU157" unit="cm" x="0" y="12.2196184473985" z="0"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU158"/>
+       <position name="posWireU158" unit="cm" x="0" y="13.1029643592587" z="0"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU159"/>
+       <position name="posWireU159" unit="cm" x="0" y="13.9863102711188" z="0"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU160"/>
+       <position name="posWireU160" unit="cm" x="0" y="14.8696561829789" z="0"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU161"/>
+       <position name="posWireU161" unit="cm" x="0" y="15.753002094839" z="0"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU162"/>
+       <position name="posWireU162" unit="cm" x="0" y="16.6363480066992" z="0"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU163"/>
+       <position name="posWireU163" unit="cm" x="0" y="17.5196939185593" z="0"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU164"/>
+       <position name="posWireU164" unit="cm" x="0" y="18.4030398304194" z="0"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU165"/>
+       <position name="posWireU165" unit="cm" x="0" y="19.2863857422796" z="0"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU166"/>
+       <position name="posWireU166" unit="cm" x="0" y="20.1697316541397" z="0"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU167"/>
+       <position name="posWireU167" unit="cm" x="0" y="21.0530775659998" z="0"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU168"/>
+       <position name="posWireU168" unit="cm" x="0" y="21.9364234778599" z="0"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU169"/>
+       <position name="posWireU169" unit="cm" x="0" y="22.81976938972" z="0"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU170"/>
+       <position name="posWireU170" unit="cm" x="0" y="23.7031153015801" z="0"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU171"/>
+       <position name="posWireU171" unit="cm" x="0" y="24.5864612134402" z="0"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU172"/>
+       <position name="posWireU172" unit="cm" x="0" y="25.4698071253003" z="0"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU173"/>
+       <position name="posWireU173" unit="cm" x="0" y="26.3531530371605" z="0"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU174"/>
+       <position name="posWireU174" unit="cm" x="0" y="27.2364989490206" z="0"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU175"/>
+       <position name="posWireU175" unit="cm" x="0" y="28.1198448608807" z="0"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU176"/>
+       <position name="posWireU176" unit="cm" x="0" y="29.0031907727408" z="0"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU177"/>
+       <position name="posWireU177" unit="cm" x="0" y="29.8865366846009" z="0"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU178"/>
+       <position name="posWireU178" unit="cm" x="0" y="30.769882596461" z="0"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU179"/>
+       <position name="posWireU179" unit="cm" x="0" y="31.6532285083211" z="0"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU180"/>
+       <position name="posWireU180" unit="cm" x="0" y="32.5365744201812" z="0"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU181"/>
+       <position name="posWireU181" unit="cm" x="0" y="33.4199203320414" z="0"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU182"/>
+       <position name="posWireU182" unit="cm" x="0" y="34.3032662439015" z="0"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU183"/>
+       <position name="posWireU183" unit="cm" x="0" y="35.1866121557616" z="0"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU184"/>
+       <position name="posWireU184" unit="cm" x="0" y="36.0699580676217" z="0"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU185"/>
+       <position name="posWireU185" unit="cm" x="0" y="36.9533039794818" z="0"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU186"/>
+       <position name="posWireU186" unit="cm" x="0" y="37.8366498913419" z="0"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU187"/>
+       <position name="posWireU187" unit="cm" x="0" y="38.719995803202" z="0"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU188"/>
+       <position name="posWireU188" unit="cm" x="0" y="39.6033417150621" z="0"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU189"/>
+       <position name="posWireU189" unit="cm" x="0" y="40.4866876269222" z="0"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU190"/>
+       <position name="posWireU190" unit="cm" x="0" y="41.1491970608175" z="0.382499999999759"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU191"/>
+       <position name="posWireU191" unit="cm" x="0" y="41.5908700167475" z="1.14749999999976"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU192"/>
+       <position name="posWireU192" unit="cm" x="0" y="42.0325429726776" z="1.91249999999975"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU193"/>
+       <position name="posWireU193" unit="cm" x="0" y="42.4742159286076" z="2.67749999999972"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU194"/>
+       <position name="posWireU194" unit="cm" x="0" y="42.9158888845377" z="3.44249999999973"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU195"/>
+       <position name="posWireU195" unit="cm" x="0" y="43.3575618404678" z="4.20749999999971"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU196"/>
+       <position name="posWireU196" unit="cm" x="0" y="43.7992347963978" z="4.97249999999969"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU197"/>
+       <position name="posWireU197" unit="cm" x="0" y="44.2409077523279" z="5.73749999999968"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU198"/>
+       <position name="posWireU198" unit="cm" x="0" y="44.6825807082579" z="6.50249999999967"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU199"/>
+       <position name="posWireU199" unit="cm" x="0" y="45.124253664188" z="7.26749999999965"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU200"/>
+       <position name="posWireU200" unit="cm" x="0" y="45.565926620118" z="8.03249999999964"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU201"/>
+       <position name="posWireU201" unit="cm" x="0" y="46.0075995760481" z="8.79749999999962"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU202"/>
+       <position name="posWireU202" unit="cm" x="0" y="46.4492725319781" z="9.56249999999961"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU203"/>
+       <position name="posWireU203" unit="cm" x="0" y="46.8909454879082" z="10.3274999999996"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU204"/>
+       <position name="posWireU204" unit="cm" x="0" y="47.3326184438382" z="11.0924999999996"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU205"/>
+       <position name="posWireU205" unit="cm" x="0" y="47.7742913997683" z="11.8574999999996"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU206"/>
+       <position name="posWireU206" unit="cm" x="0" y="48.2159643556984" z="12.6224999999995"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU207"/>
+       <position name="posWireU207" unit="cm" x="0" y="48.6576373116284" z="13.3874999999996"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU208"/>
+       <position name="posWireU208" unit="cm" x="0" y="49.0993102675585" z="14.1524999999995"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU209"/>
+       <position name="posWireU209" unit="cm" x="0" y="49.5409832234885" z="14.9174999999995"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU210"/>
+       <position name="posWireU210" unit="cm" x="0" y="49.9826561794186" z="15.6824999999995"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU211"/>
+       <position name="posWireU211" unit="cm" x="0" y="50.4243291353486" z="16.4474999999995"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU212"/>
+       <position name="posWireU212" unit="cm" x="0" y="50.8660020912787" z="17.2124999999995"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU213"/>
+       <position name="posWireU213" unit="cm" x="0" y="51.3076750472087" z="17.9774999999995"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU214"/>
+       <position name="posWireU214" unit="cm" x="0" y="51.7493480031388" z="18.7424999999994"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU215"/>
+       <position name="posWireU215" unit="cm" x="0" y="52.1910209590689" z="19.5074999999994"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU216"/>
+       <position name="posWireU216" unit="cm" x="0" y="52.6326939149989" z="20.2724999999994"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU217"/>
+       <position name="posWireU217" unit="cm" x="0" y="53.074366870929" z="21.0374999999994"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU218"/>
+       <position name="posWireU218" unit="cm" x="0" y="53.516039826859" z="21.8024999999994"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU219"/>
+       <position name="posWireU219" unit="cm" x="0" y="53.9577127827891" z="22.5674999999994"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU220"/>
+       <position name="posWireU220" unit="cm" x="0" y="54.3993857387191" z="23.3324999999994"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU221"/>
+       <position name="posWireU221" unit="cm" x="0" y="54.8410586946492" z="24.0974999999994"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU222"/>
+       <position name="posWireU222" unit="cm" x="0" y="55.2827316505793" z="24.8624999999993"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU223"/>
+       <position name="posWireU223" unit="cm" x="0" y="55.7244046065093" z="25.6274999999993"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU224"/>
+       <position name="posWireU224" unit="cm" x="0" y="56.1660775624394" z="26.3924999999993"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU225"/>
+       <position name="posWireU225" unit="cm" x="0" y="56.6077505183694" z="27.1574999999993"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU226"/>
+       <position name="posWireU226" unit="cm" x="0" y="57.0494234742995" z="27.9224999999993"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU227"/>
+       <position name="posWireU227" unit="cm" x="0" y="57.4910964302295" z="28.6874999999993"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU228"/>
+       <position name="posWireU228" unit="cm" x="0" y="57.9327693861596" z="29.4524999999993"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU229"/>
+       <position name="posWireU229" unit="cm" x="0" y="58.3744423420896" z="30.2174999999992"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU230"/>
+       <position name="posWireU230" unit="cm" x="0" y="58.8161152980197" z="30.9824999999992"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU231"/>
+       <position name="posWireU231" unit="cm" x="0" y="59.2577882539497" z="31.7474999999992"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU232"/>
+       <position name="posWireU232" unit="cm" x="0" y="59.6994612098798" z="32.5124999999992"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU233"/>
+       <position name="posWireU233" unit="cm" x="0" y="60.1411341658099" z="33.2774999999992"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU234"/>
+       <position name="posWireU234" unit="cm" x="0" y="60.5828071217399" z="34.0424999999992"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU235"/>
+       <position name="posWireU235" unit="cm" x="0" y="61.02448007767" z="34.8074999999992"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU236"/>
+       <position name="posWireU236" unit="cm" x="0" y="61.4661530336" z="35.5724999999992"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU237"/>
+       <position name="posWireU237" unit="cm" x="0" y="61.9078259895301" z="36.3374999999991"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU238"/>
+       <position name="posWireU238" unit="cm" x="0" y="62.3494989454601" z="37.1024999999991"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU239"/>
+       <position name="posWireU239" unit="cm" x="0" y="62.7911719013902" z="37.8674999999991"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU240"/>
+       <position name="posWireU240" unit="cm" x="0" y="63.2328448573203" z="38.6324999999991"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU241"/>
+       <position name="posWireU241" unit="cm" x="0" y="63.6745178132503" z="39.3974999999991"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU242"/>
+       <position name="posWireU242" unit="cm" x="0" y="64.1161907691804" z="40.1624999999991"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU243"/>
+       <position name="posWireU243" unit="cm" x="0" y="64.5578637251104" z="40.927499999999"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU244"/>
+       <position name="posWireU244" unit="cm" x="0" y="64.9995366810405" z="41.692499999999"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU245"/>
+       <position name="posWireU245" unit="cm" x="0" y="65.4412096369705" z="42.457499999999"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU246"/>
+       <position name="posWireU246" unit="cm" x="0" y="65.8828825929006" z="43.222499999999"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU247"/>
+       <position name="posWireU247" unit="cm" x="0" y="66.3245555488307" z="43.987499999999"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU248"/>
+       <position name="posWireU248" unit="cm" x="0" y="66.7662285047607" z="44.752499999999"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU249"/>
+       <position name="posWireU249" unit="cm" x="0" y="67.2079014606908" z="45.517499999999"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU250"/>
+       <position name="posWireU250" unit="cm" x="0" y="67.6495744166208" z="46.282499999999"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU251"/>
+       <position name="posWireU251" unit="cm" x="0" y="68.0912473725509" z="47.0474999999989"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU252"/>
+       <position name="posWireU252" unit="cm" x="0" y="68.5329203284809" z="47.8124999999989"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU253"/>
+       <position name="posWireU253" unit="cm" x="0" y="68.974593284411" z="48.5774999999989"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU254"/>
+       <position name="posWireU254" unit="cm" x="0" y="69.416266240341" z="49.3424999999989"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU255"/>
+       <position name="posWireU255" unit="cm" x="0" y="69.8579391962711" z="50.1074999999989"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU256"/>
+       <position name="posWireU256" unit="cm" x="0" y="70.2996121522011" z="50.8724999999989"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU257"/>
+       <position name="posWireU257" unit="cm" x="0" y="70.7412851081312" z="51.6374999999989"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU258"/>
+       <position name="posWireU258" unit="cm" x="0" y="71.1829580640613" z="52.4024999999988"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU259"/>
+       <position name="posWireU259" unit="cm" x="0" y="71.6246310199913" z="53.1674999999988"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU260"/>
+       <position name="posWireU260" unit="cm" x="0" y="72.0663039759214" z="53.9324999999988"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU261"/>
+       <position name="posWireU261" unit="cm" x="0" y="72.5079769318514" z="54.6974999999988"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU262"/>
+       <position name="posWireU262" unit="cm" x="0" y="72.9496498877815" z="55.4624999999988"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU263"/>
+       <position name="posWireU263" unit="cm" x="0" y="73.3913228437115" z="56.2274999999988"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU264"/>
+       <position name="posWireU264" unit="cm" x="0" y="73.8329957996416" z="56.9924999999988"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU265"/>
+       <position name="posWireU265" unit="cm" x="0" y="74.2746687555717" z="57.7574999999988"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU266"/>
+       <position name="posWireU266" unit="cm" x="0" y="74.7163417115017" z="58.5224999999987"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU267"/>
+       <position name="posWireU267" unit="cm" x="0" y="75.1580146674318" z="59.2874999999987"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU268"/>
+       <position name="posWireU268" unit="cm" x="0" y="75.5996876233618" z="60.0524999999987"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU269"/>
+       <position name="posWireU269" unit="cm" x="0" y="76.0413605792919" z="60.8174999999987"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU270"/>
+       <position name="posWireU270" unit="cm" x="0" y="76.4830335352219" z="61.5824999999987"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU271"/>
+       <position name="posWireU271" unit="cm" x="0" y="76.924706491152" z="62.3474999999987"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU272"/>
+       <position name="posWireU272" unit="cm" x="0" y="77.366379447082" z="63.1124999999986"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU273"/>
+       <position name="posWireU273" unit="cm" x="0" y="77.8080524030121" z="63.8774999999986"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU274"/>
+       <position name="posWireU274" unit="cm" x="0" y="78.2497253589422" z="64.6424999999986"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU275"/>
+       <position name="posWireU275" unit="cm" x="0" y="78.6913983148722" z="65.4074999999986"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU276"/>
+       <position name="posWireU276" unit="cm" x="0" y="79.1330712708023" z="66.1724999999986"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU277"/>
+       <position name="posWireU277" unit="cm" x="0" y="79.5747442267323" z="66.9374999999986"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU278"/>
+       <position name="posWireU278" unit="cm" x="0" y="80.0164171826624" z="67.7024999999986"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU279"/>
+       <position name="posWireU279" unit="cm" x="0" y="80.4580901385924" z="68.4674999999986"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU280"/>
+       <position name="posWireU280" unit="cm" x="0" y="80.8997630945225" z="69.2324999999986"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU281"/>
+       <position name="posWireU281" unit="cm" x="0" y="81.3414360504525" z="69.9974999999985"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU282"/>
+       <position name="posWireU282" unit="cm" x="0" y="81.7831090063826" z="70.7624999999985"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU283"/>
+       <position name="posWireU283" unit="cm" x="0" y="82.2247819623126" z="71.5274999999985"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU284"/>
+       <position name="posWireU284" unit="cm" x="0" y="82.6664549182427" z="72.2924999999985"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireU285"/>
+       <position name="posWireU285" unit="cm" x="0" y="83.1081278741728" z="73.0574999999985"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+   </volume>
+  <volume name="volTPCPlaneV">
+    <materialref ref="LAr"/>
+    <solidref ref="CRMVPlane"/>
+     <physvol>
+       <volumeref ref="volTPCWireV0"/>
+       <position name="posWireV0" unit="cm" x="0" y="83.6970251487471" z="-74.0775"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV1"/>
+       <position name="posWireV1" unit="cm" x="0" y="83.255352192817" z="-73.3125"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV2"/>
+       <position name="posWireV2" unit="cm" x="0" y="82.8136792368869" z="-72.5475"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV3"/>
+       <position name="posWireV3" unit="cm" x="0" y="82.3720062809569" z="-71.7825"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV4"/>
+       <position name="posWireV4" unit="cm" x="0" y="81.9303333250268" z="-71.0175"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV5"/>
+       <position name="posWireV5" unit="cm" x="0" y="81.4886603690967" z="-70.2525"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV6"/>
+       <position name="posWireV6" unit="cm" x="0" y="81.0469874131667" z="-69.4875"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV7"/>
+       <position name="posWireV7" unit="cm" x="0" y="80.6053144572366" z="-68.7225"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV8"/>
+       <position name="posWireV8" unit="cm" x="0" y="80.1636415013066" z="-67.9575"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV9"/>
+       <position name="posWireV9" unit="cm" x="0" y="79.7219685453765" z="-67.1925"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV10"/>
+       <position name="posWireV10" unit="cm" x="0" y="79.2802955894464" z="-66.4275"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV11"/>
+       <position name="posWireV11" unit="cm" x="0" y="78.8386226335164" z="-65.6625"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV12"/>
+       <position name="posWireV12" unit="cm" x="0" y="78.3969496775863" z="-64.8975"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV13"/>
+       <position name="posWireV13" unit="cm" x="0" y="77.9552767216562" z="-64.1325"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV14"/>
+       <position name="posWireV14" unit="cm" x="0" y="77.5136037657262" z="-63.3675"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV15"/>
+       <position name="posWireV15" unit="cm" x="0" y="77.0719308097961" z="-62.6025"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV16"/>
+       <position name="posWireV16" unit="cm" x="0" y="76.630257853866" z="-61.8375"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV17"/>
+       <position name="posWireV17" unit="cm" x="0" y="76.188584897936" z="-61.0725"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV18"/>
+       <position name="posWireV18" unit="cm" x="0" y="75.7469119420059" z="-60.3075"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV19"/>
+       <position name="posWireV19" unit="cm" x="0" y="75.3052389860758" z="-59.5425"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV20"/>
+       <position name="posWireV20" unit="cm" x="0" y="74.8635660301458" z="-58.7775"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV21"/>
+       <position name="posWireV21" unit="cm" x="0" y="74.4218930742157" z="-58.0125"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV22"/>
+       <position name="posWireV22" unit="cm" x="0" y="73.9802201182857" z="-57.2475"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV23"/>
+       <position name="posWireV23" unit="cm" x="0" y="73.5385471623556" z="-56.4825"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV24"/>
+       <position name="posWireV24" unit="cm" x="0" y="73.0968742064255" z="-55.7175"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV25"/>
+       <position name="posWireV25" unit="cm" x="0" y="72.6552012504955" z="-54.9525"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV26"/>
+       <position name="posWireV26" unit="cm" x="0" y="72.2135282945654" z="-54.1875"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV27"/>
+       <position name="posWireV27" unit="cm" x="0" y="71.7718553386353" z="-53.4225"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV28"/>
+       <position name="posWireV28" unit="cm" x="0" y="71.3301823827053" z="-52.6575"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV29"/>
+       <position name="posWireV29" unit="cm" x="0" y="70.8885094267752" z="-51.8925"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV30"/>
+       <position name="posWireV30" unit="cm" x="0" y="70.4468364708452" z="-51.1275"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV31"/>
+       <position name="posWireV31" unit="cm" x="0" y="70.0051635149151" z="-50.3625"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV32"/>
+       <position name="posWireV32" unit="cm" x="0" y="69.563490558985" z="-49.5975"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV33"/>
+       <position name="posWireV33" unit="cm" x="0" y="69.121817603055" z="-48.8325"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV34"/>
+       <position name="posWireV34" unit="cm" x="0" y="68.6801446471249" z="-48.0675"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV35"/>
+       <position name="posWireV35" unit="cm" x="0" y="68.2384716911948" z="-47.3025"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV36"/>
+       <position name="posWireV36" unit="cm" x="0" y="67.7967987352648" z="-46.5375"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV37"/>
+       <position name="posWireV37" unit="cm" x="0" y="67.3551257793347" z="-45.7725"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV38"/>
+       <position name="posWireV38" unit="cm" x="0" y="66.9134528234046" z="-45.0075"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV39"/>
+       <position name="posWireV39" unit="cm" x="0" y="66.4717798674746" z="-44.2425"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV40"/>
+       <position name="posWireV40" unit="cm" x="0" y="66.0301069115445" z="-43.4775"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV41"/>
+       <position name="posWireV41" unit="cm" x="0" y="65.5884339556144" z="-42.7125"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV42"/>
+       <position name="posWireV42" unit="cm" x="0" y="65.1467609996844" z="-41.9475"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV43"/>
+       <position name="posWireV43" unit="cm" x="0" y="64.7050880437543" z="-41.1825"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV44"/>
+       <position name="posWireV44" unit="cm" x="0" y="64.2634150878243" z="-40.4175"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV45"/>
+       <position name="posWireV45" unit="cm" x="0" y="63.8217421318942" z="-39.6525"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV46"/>
+       <position name="posWireV46" unit="cm" x="0" y="63.3800691759641" z="-38.8875"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV47"/>
+       <position name="posWireV47" unit="cm" x="0" y="62.9383962200341" z="-38.1225"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV48"/>
+       <position name="posWireV48" unit="cm" x="0" y="62.496723264104" z="-37.3575"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV49"/>
+       <position name="posWireV49" unit="cm" x="0" y="62.0550503081739" z="-36.5925"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV50"/>
+       <position name="posWireV50" unit="cm" x="0" y="61.6133773522439" z="-35.8275"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV51"/>
+       <position name="posWireV51" unit="cm" x="0" y="61.1717043963138" z="-35.0625"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV52"/>
+       <position name="posWireV52" unit="cm" x="0" y="60.7300314403837" z="-34.2975"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV53"/>
+       <position name="posWireV53" unit="cm" x="0" y="60.2883584844537" z="-33.5325"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV54"/>
+       <position name="posWireV54" unit="cm" x="0" y="59.8466855285236" z="-32.7675"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV55"/>
+       <position name="posWireV55" unit="cm" x="0" y="59.4050125725935" z="-32.0025"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV56"/>
+       <position name="posWireV56" unit="cm" x="0" y="58.9633396166635" z="-31.2375"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV57"/>
+       <position name="posWireV57" unit="cm" x="0" y="58.5216666607334" z="-30.4725"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV58"/>
+       <position name="posWireV58" unit="cm" x="0" y="58.0799937048034" z="-29.7075"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV59"/>
+       <position name="posWireV59" unit="cm" x="0" y="57.6383207488733" z="-28.9425"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV60"/>
+       <position name="posWireV60" unit="cm" x="0" y="57.1966477929432" z="-28.1775"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV61"/>
+       <position name="posWireV61" unit="cm" x="0" y="56.7549748370132" z="-27.4125"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV62"/>
+       <position name="posWireV62" unit="cm" x="0" y="56.3133018810831" z="-26.6475"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV63"/>
+       <position name="posWireV63" unit="cm" x="0" y="55.871628925153" z="-25.8825"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV64"/>
+       <position name="posWireV64" unit="cm" x="0" y="55.429955969223" z="-25.1175"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV65"/>
+       <position name="posWireV65" unit="cm" x="0" y="54.9882830132929" z="-24.3525"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV66"/>
+       <position name="posWireV66" unit="cm" x="0" y="54.5466100573628" z="-23.5875"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV67"/>
+       <position name="posWireV67" unit="cm" x="0" y="54.1049371014328" z="-22.8225"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV68"/>
+       <position name="posWireV68" unit="cm" x="0" y="53.6632641455027" z="-22.0575"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV69"/>
+       <position name="posWireV69" unit="cm" x="0" y="53.2215911895726" z="-21.2925"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV70"/>
+       <position name="posWireV70" unit="cm" x="0" y="52.7799182336426" z="-20.5275"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV71"/>
+       <position name="posWireV71" unit="cm" x="0" y="52.3382452777125" z="-19.7625"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV72"/>
+       <position name="posWireV72" unit="cm" x="0" y="51.8965723217825" z="-18.9975"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV73"/>
+       <position name="posWireV73" unit="cm" x="0" y="51.4548993658524" z="-18.2325"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV74"/>
+       <position name="posWireV74" unit="cm" x="0" y="51.0132264099223" z="-17.4675"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV75"/>
+       <position name="posWireV75" unit="cm" x="0" y="50.5715534539923" z="-16.7025"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV76"/>
+       <position name="posWireV76" unit="cm" x="0" y="50.1298804980622" z="-15.9375"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV77"/>
+       <position name="posWireV77" unit="cm" x="0" y="49.6882075421321" z="-15.1725"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV78"/>
+       <position name="posWireV78" unit="cm" x="0" y="49.2465345862021" z="-14.4075"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV79"/>
+       <position name="posWireV79" unit="cm" x="0" y="48.804861630272" z="-13.6425"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV80"/>
+       <position name="posWireV80" unit="cm" x="0" y="48.3631886743419" z="-12.8775"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV81"/>
+       <position name="posWireV81" unit="cm" x="0" y="47.9215157184119" z="-12.1125"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV82"/>
+       <position name="posWireV82" unit="cm" x="0" y="47.4798427624818" z="-11.3475"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV83"/>
+       <position name="posWireV83" unit="cm" x="0" y="47.0381698065518" z="-10.5825"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV84"/>
+       <position name="posWireV84" unit="cm" x="0" y="46.5964968506217" z="-9.81749999999995"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV85"/>
+       <position name="posWireV85" unit="cm" x="0" y="46.1548238946916" z="-9.05249999999995"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV86"/>
+       <position name="posWireV86" unit="cm" x="0" y="45.7131509387616" z="-8.28749999999995"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV87"/>
+       <position name="posWireV87" unit="cm" x="0" y="45.2714779828315" z="-7.52249999999995"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV88"/>
+       <position name="posWireV88" unit="cm" x="0" y="44.8298050269014" z="-6.75749999999995"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV89"/>
+       <position name="posWireV89" unit="cm" x="0" y="44.3881320709714" z="-5.99249999999995"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV90"/>
+       <position name="posWireV90" unit="cm" x="0" y="43.9464591150413" z="-5.22749999999995"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV91"/>
+       <position name="posWireV91" unit="cm" x="0" y="43.5047861591112" z="-4.46249999999995"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV92"/>
+       <position name="posWireV92" unit="cm" x="0" y="43.0631132031812" z="-3.69749999999995"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV93"/>
+       <position name="posWireV93" unit="cm" x="0" y="42.6214402472511" z="-2.93249999999996"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV94"/>
+       <position name="posWireV94" unit="cm" x="0" y="42.179767291321" z="-2.16749999999995"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV95"/>
+       <position name="posWireV95" unit="cm" x="0" y="41.738094335391" z="-1.40249999999996"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV96"/>
+       <position name="posWireV96" unit="cm" x="0" y="41.2964213794609" z="-0.637499999999946"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV97"/>
+       <position name="posWireV97" unit="cm" x="0" y="40.7811362642091" z="0"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV98"/>
+       <position name="posWireV98" unit="cm" x="0" y="39.897790352349" z="0"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV99"/>
+       <position name="posWireV99" unit="cm" x="0" y="39.0144444404889" z="0"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV100"/>
+       <position name="posWireV100" unit="cm" x="0" y="38.1310985286288" z="0"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV101"/>
+       <position name="posWireV101" unit="cm" x="0" y="37.2477526167686" z="0"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV102"/>
+       <position name="posWireV102" unit="cm" x="0" y="36.3644067049085" z="0"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV103"/>
+       <position name="posWireV103" unit="cm" x="0" y="35.4810607930484" z="0"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV104"/>
+       <position name="posWireV104" unit="cm" x="0" y="34.5977148811883" z="0"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV105"/>
+       <position name="posWireV105" unit="cm" x="0" y="33.7143689693281" z="0"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV106"/>
+       <position name="posWireV106" unit="cm" x="0" y="32.831023057468" z="0"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV107"/>
+       <position name="posWireV107" unit="cm" x="0" y="31.9476771456079" z="0"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV108"/>
+       <position name="posWireV108" unit="cm" x="0" y="31.0643312337477" z="0"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV109"/>
+       <position name="posWireV109" unit="cm" x="0" y="30.1809853218876" z="0"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV110"/>
+       <position name="posWireV110" unit="cm" x="0" y="29.2976394100275" z="0"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV111"/>
+       <position name="posWireV111" unit="cm" x="0" y="28.4142934981674" z="0"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV112"/>
+       <position name="posWireV112" unit="cm" x="0" y="27.5309475863072" z="0"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV113"/>
+       <position name="posWireV113" unit="cm" x="0" y="26.6476016744471" z="0"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV114"/>
+       <position name="posWireV114" unit="cm" x="0" y="25.764255762587" z="0"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV115"/>
+       <position name="posWireV115" unit="cm" x="0" y="24.8809098507268" z="0"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV116"/>
+       <position name="posWireV116" unit="cm" x="0" y="23.9975639388667" z="0"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV117"/>
+       <position name="posWireV117" unit="cm" x="0" y="23.1142180270066" z="0"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV118"/>
+       <position name="posWireV118" unit="cm" x="0" y="22.2308721151465" z="0"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV119"/>
+       <position name="posWireV119" unit="cm" x="0" y="21.3475262032863" z="0"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV120"/>
+       <position name="posWireV120" unit="cm" x="0" y="20.4641802914262" z="0"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV121"/>
+       <position name="posWireV121" unit="cm" x="0" y="19.5808343795661" z="0"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV122"/>
+       <position name="posWireV122" unit="cm" x="0" y="18.697488467706" z="0"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV123"/>
+       <position name="posWireV123" unit="cm" x="0" y="17.8141425558458" z="0"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV124"/>
+       <position name="posWireV124" unit="cm" x="0" y="16.9307966439857" z="0"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV125"/>
+       <position name="posWireV125" unit="cm" x="0" y="16.0474507321256" z="0"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV126"/>
+       <position name="posWireV126" unit="cm" x="0" y="15.1641048202654" z="0"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV127"/>
+       <position name="posWireV127" unit="cm" x="0" y="14.2807589084053" z="0"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV128"/>
+       <position name="posWireV128" unit="cm" x="0" y="13.3974129965452" z="0"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV129"/>
+       <position name="posWireV129" unit="cm" x="0" y="12.5140670846851" z="0"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV130"/>
+       <position name="posWireV130" unit="cm" x="0" y="11.6307211728249" z="0"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV131"/>
+       <position name="posWireV131" unit="cm" x="0" y="10.7473752609648" z="0"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV132"/>
+       <position name="posWireV132" unit="cm" x="0" y="9.86402934910467" z="0"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV133"/>
+       <position name="posWireV133" unit="cm" x="0" y="8.98068343724454" z="0"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV134"/>
+       <position name="posWireV134" unit="cm" x="0" y="8.09733752538442" z="0"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV135"/>
+       <position name="posWireV135" unit="cm" x="0" y="7.2139916135243" z="0"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV136"/>
+       <position name="posWireV136" unit="cm" x="0" y="6.33064570166416" z="0"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV137"/>
+       <position name="posWireV137" unit="cm" x="0" y="5.44729978980404" z="0"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV138"/>
+       <position name="posWireV138" unit="cm" x="0" y="4.5639538779439" z="0"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV139"/>
+       <position name="posWireV139" unit="cm" x="0" y="3.68060796608379" z="0"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV140"/>
+       <position name="posWireV140" unit="cm" x="0" y="2.79726205422365" z="0"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV141"/>
+       <position name="posWireV141" unit="cm" x="0" y="1.91391614236352" z="0"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV142"/>
+       <position name="posWireV142" unit="cm" x="0" y="1.03057023050339" z="0"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV143"/>
+       <position name="posWireV143" unit="cm" x="0" y="0.147224318643268" z="0"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV144"/>
+       <position name="posWireV144" unit="cm" x="0" y="-0.736121593216858" z="0"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV145"/>
+       <position name="posWireV145" unit="cm" x="0" y="-1.61946750507699" z="0"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV146"/>
+       <position name="posWireV146" unit="cm" x="0" y="-2.50281341693713" z="0"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV147"/>
+       <position name="posWireV147" unit="cm" x="0" y="-3.38615932879726" z="0"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV148"/>
+       <position name="posWireV148" unit="cm" x="0" y="-4.26950524065738" z="0"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV149"/>
+       <position name="posWireV149" unit="cm" x="0" y="-5.15285115251752" z="0"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV150"/>
+       <position name="posWireV150" unit="cm" x="0" y="-6.03619706437764" z="0"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV151"/>
+       <position name="posWireV151" unit="cm" x="0" y="-6.91954297623776" z="0"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV152"/>
+       <position name="posWireV152" unit="cm" x="0" y="-7.80288888809789" z="0"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV153"/>
+       <position name="posWireV153" unit="cm" x="0" y="-8.68623479995803" z="0"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV154"/>
+       <position name="posWireV154" unit="cm" x="0" y="-9.56958071181815" z="0"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV155"/>
+       <position name="posWireV155" unit="cm" x="0" y="-10.4529266236783" z="0"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV156"/>
+       <position name="posWireV156" unit="cm" x="0" y="-11.3362725355384" z="0"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV157"/>
+       <position name="posWireV157" unit="cm" x="0" y="-12.2196184473985" z="0"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV158"/>
+       <position name="posWireV158" unit="cm" x="0" y="-13.1029643592587" z="0"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV159"/>
+       <position name="posWireV159" unit="cm" x="0" y="-13.9863102711188" z="0"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV160"/>
+       <position name="posWireV160" unit="cm" x="0" y="-14.8696561829789" z="0"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV161"/>
+       <position name="posWireV161" unit="cm" x="0" y="-15.7530020948391" z="0"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV162"/>
+       <position name="posWireV162" unit="cm" x="0" y="-16.6363480066992" z="0"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV163"/>
+       <position name="posWireV163" unit="cm" x="0" y="-17.5196939185593" z="0"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV164"/>
+       <position name="posWireV164" unit="cm" x="0" y="-18.4030398304194" z="0"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV165"/>
+       <position name="posWireV165" unit="cm" x="0" y="-19.2863857422796" z="0"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV166"/>
+       <position name="posWireV166" unit="cm" x="0" y="-20.1697316541397" z="0"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV167"/>
+       <position name="posWireV167" unit="cm" x="0" y="-21.0530775659998" z="0"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV168"/>
+       <position name="posWireV168" unit="cm" x="0" y="-21.9364234778599" z="0"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV169"/>
+       <position name="posWireV169" unit="cm" x="0" y="-22.81976938972" z="0"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV170"/>
+       <position name="posWireV170" unit="cm" x="0" y="-23.7031153015801" z="0"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV171"/>
+       <position name="posWireV171" unit="cm" x="0" y="-24.5864612134402" z="0"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV172"/>
+       <position name="posWireV172" unit="cm" x="0" y="-25.4698071253004" z="0"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV173"/>
+       <position name="posWireV173" unit="cm" x="0" y="-26.3531530371605" z="0"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV174"/>
+       <position name="posWireV174" unit="cm" x="0" y="-27.2364989490206" z="0"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV175"/>
+       <position name="posWireV175" unit="cm" x="0" y="-28.1198448608807" z="0"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV176"/>
+       <position name="posWireV176" unit="cm" x="0" y="-29.0031907727408" z="0"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV177"/>
+       <position name="posWireV177" unit="cm" x="0" y="-29.8865366846009" z="0"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV178"/>
+       <position name="posWireV178" unit="cm" x="0" y="-30.769882596461" z="0"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV179"/>
+       <position name="posWireV179" unit="cm" x="0" y="-31.6532285083211" z="0"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV180"/>
+       <position name="posWireV180" unit="cm" x="0" y="-32.5365744201812" z="0"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV181"/>
+       <position name="posWireV181" unit="cm" x="0" y="-33.4199203320414" z="0"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV182"/>
+       <position name="posWireV182" unit="cm" x="0" y="-34.3032662439015" z="0"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV183"/>
+       <position name="posWireV183" unit="cm" x="0" y="-35.1866121557616" z="0"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV184"/>
+       <position name="posWireV184" unit="cm" x="0" y="-36.0699580676217" z="0"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV185"/>
+       <position name="posWireV185" unit="cm" x="0" y="-36.9533039794818" z="0"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV186"/>
+       <position name="posWireV186" unit="cm" x="0" y="-37.8366498913419" z="0"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV187"/>
+       <position name="posWireV187" unit="cm" x="0" y="-38.719995803202" z="0"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV188"/>
+       <position name="posWireV188" unit="cm" x="0" y="-39.6033417150621" z="0"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV189"/>
+       <position name="posWireV189" unit="cm" x="0" y="-40.4866876269222" z="0"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV190"/>
+       <position name="posWireV190" unit="cm" x="0" y="-41.1491970608175" z="0.382499999999759"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV191"/>
+       <position name="posWireV191" unit="cm" x="0" y="-41.5908700167475" z="1.14749999999976"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV192"/>
+       <position name="posWireV192" unit="cm" x="0" y="-42.0325429726776" z="1.91249999999975"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV193"/>
+       <position name="posWireV193" unit="cm" x="0" y="-42.4742159286076" z="2.67749999999972"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV194"/>
+       <position name="posWireV194" unit="cm" x="0" y="-42.9158888845377" z="3.44249999999973"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV195"/>
+       <position name="posWireV195" unit="cm" x="0" y="-43.3575618404678" z="4.20749999999971"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV196"/>
+       <position name="posWireV196" unit="cm" x="0" y="-43.7992347963978" z="4.97249999999969"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV197"/>
+       <position name="posWireV197" unit="cm" x="0" y="-44.2409077523279" z="5.73749999999968"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV198"/>
+       <position name="posWireV198" unit="cm" x="0" y="-44.6825807082579" z="6.50249999999967"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV199"/>
+       <position name="posWireV199" unit="cm" x="0" y="-45.124253664188" z="7.26749999999965"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV200"/>
+       <position name="posWireV200" unit="cm" x="0" y="-45.565926620118" z="8.03249999999964"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV201"/>
+       <position name="posWireV201" unit="cm" x="0" y="-46.0075995760481" z="8.79749999999962"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV202"/>
+       <position name="posWireV202" unit="cm" x="0" y="-46.4492725319781" z="9.56249999999961"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV203"/>
+       <position name="posWireV203" unit="cm" x="0" y="-46.8909454879082" z="10.3274999999996"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV204"/>
+       <position name="posWireV204" unit="cm" x="0" y="-47.3326184438382" z="11.0924999999996"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV205"/>
+       <position name="posWireV205" unit="cm" x="0" y="-47.7742913997683" z="11.8574999999996"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV206"/>
+       <position name="posWireV206" unit="cm" x="0" y="-48.2159643556984" z="12.6224999999995"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV207"/>
+       <position name="posWireV207" unit="cm" x="0" y="-48.6576373116284" z="13.3874999999996"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV208"/>
+       <position name="posWireV208" unit="cm" x="0" y="-49.0993102675585" z="14.1524999999995"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV209"/>
+       <position name="posWireV209" unit="cm" x="0" y="-49.5409832234885" z="14.9174999999995"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV210"/>
+       <position name="posWireV210" unit="cm" x="0" y="-49.9826561794186" z="15.6824999999995"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV211"/>
+       <position name="posWireV211" unit="cm" x="0" y="-50.4243291353486" z="16.4474999999995"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV212"/>
+       <position name="posWireV212" unit="cm" x="0" y="-50.8660020912787" z="17.2124999999995"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV213"/>
+       <position name="posWireV213" unit="cm" x="0" y="-51.3076750472087" z="17.9774999999995"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV214"/>
+       <position name="posWireV214" unit="cm" x="0" y="-51.7493480031388" z="18.7424999999994"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV215"/>
+       <position name="posWireV215" unit="cm" x="0" y="-52.1910209590689" z="19.5074999999994"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV216"/>
+       <position name="posWireV216" unit="cm" x="0" y="-52.6326939149989" z="20.2724999999994"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV217"/>
+       <position name="posWireV217" unit="cm" x="0" y="-53.074366870929" z="21.0374999999994"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV218"/>
+       <position name="posWireV218" unit="cm" x="0" y="-53.516039826859" z="21.8024999999994"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV219"/>
+       <position name="posWireV219" unit="cm" x="0" y="-53.9577127827891" z="22.5674999999994"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV220"/>
+       <position name="posWireV220" unit="cm" x="0" y="-54.3993857387191" z="23.3324999999994"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV221"/>
+       <position name="posWireV221" unit="cm" x="0" y="-54.8410586946492" z="24.0974999999994"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV222"/>
+       <position name="posWireV222" unit="cm" x="0" y="-55.2827316505793" z="24.8624999999993"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV223"/>
+       <position name="posWireV223" unit="cm" x="0" y="-55.7244046065093" z="25.6274999999993"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV224"/>
+       <position name="posWireV224" unit="cm" x="0" y="-56.1660775624394" z="26.3924999999993"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV225"/>
+       <position name="posWireV225" unit="cm" x="0" y="-56.6077505183694" z="27.1574999999993"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV226"/>
+       <position name="posWireV226" unit="cm" x="0" y="-57.0494234742995" z="27.9224999999993"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV227"/>
+       <position name="posWireV227" unit="cm" x="0" y="-57.4910964302295" z="28.6874999999993"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV228"/>
+       <position name="posWireV228" unit="cm" x="0" y="-57.9327693861596" z="29.4524999999993"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV229"/>
+       <position name="posWireV229" unit="cm" x="0" y="-58.3744423420896" z="30.2174999999992"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV230"/>
+       <position name="posWireV230" unit="cm" x="0" y="-58.8161152980197" z="30.9824999999992"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV231"/>
+       <position name="posWireV231" unit="cm" x="0" y="-59.2577882539497" z="31.7474999999992"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV232"/>
+       <position name="posWireV232" unit="cm" x="0" y="-59.6994612098798" z="32.5124999999992"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV233"/>
+       <position name="posWireV233" unit="cm" x="0" y="-60.1411341658099" z="33.2774999999992"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV234"/>
+       <position name="posWireV234" unit="cm" x="0" y="-60.5828071217399" z="34.0424999999992"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV235"/>
+       <position name="posWireV235" unit="cm" x="0" y="-61.02448007767" z="34.8074999999992"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV236"/>
+       <position name="posWireV236" unit="cm" x="0" y="-61.4661530336" z="35.5724999999992"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV237"/>
+       <position name="posWireV237" unit="cm" x="0" y="-61.9078259895301" z="36.3374999999991"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV238"/>
+       <position name="posWireV238" unit="cm" x="0" y="-62.3494989454601" z="37.1024999999991"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV239"/>
+       <position name="posWireV239" unit="cm" x="0" y="-62.7911719013902" z="37.8674999999991"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV240"/>
+       <position name="posWireV240" unit="cm" x="0" y="-63.2328448573203" z="38.6324999999991"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV241"/>
+       <position name="posWireV241" unit="cm" x="0" y="-63.6745178132503" z="39.3974999999991"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV242"/>
+       <position name="posWireV242" unit="cm" x="0" y="-64.1161907691804" z="40.1624999999991"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV243"/>
+       <position name="posWireV243" unit="cm" x="0" y="-64.5578637251104" z="40.927499999999"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV244"/>
+       <position name="posWireV244" unit="cm" x="0" y="-64.9995366810405" z="41.692499999999"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV245"/>
+       <position name="posWireV245" unit="cm" x="0" y="-65.4412096369705" z="42.457499999999"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV246"/>
+       <position name="posWireV246" unit="cm" x="0" y="-65.8828825929006" z="43.222499999999"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV247"/>
+       <position name="posWireV247" unit="cm" x="0" y="-66.3245555488307" z="43.987499999999"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV248"/>
+       <position name="posWireV248" unit="cm" x="0" y="-66.7662285047607" z="44.752499999999"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV249"/>
+       <position name="posWireV249" unit="cm" x="0" y="-67.2079014606908" z="45.517499999999"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV250"/>
+       <position name="posWireV250" unit="cm" x="0" y="-67.6495744166208" z="46.282499999999"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV251"/>
+       <position name="posWireV251" unit="cm" x="0" y="-68.0912473725509" z="47.0474999999989"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV252"/>
+       <position name="posWireV252" unit="cm" x="0" y="-68.5329203284809" z="47.8124999999989"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV253"/>
+       <position name="posWireV253" unit="cm" x="0" y="-68.974593284411" z="48.5774999999989"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV254"/>
+       <position name="posWireV254" unit="cm" x="0" y="-69.416266240341" z="49.3424999999989"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV255"/>
+       <position name="posWireV255" unit="cm" x="0" y="-69.8579391962711" z="50.1074999999989"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV256"/>
+       <position name="posWireV256" unit="cm" x="0" y="-70.2996121522011" z="50.8724999999989"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV257"/>
+       <position name="posWireV257" unit="cm" x="0" y="-70.7412851081312" z="51.6374999999989"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV258"/>
+       <position name="posWireV258" unit="cm" x="0" y="-71.1829580640613" z="52.4024999999988"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV259"/>
+       <position name="posWireV259" unit="cm" x="0" y="-71.6246310199913" z="53.1674999999988"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV260"/>
+       <position name="posWireV260" unit="cm" x="0" y="-72.0663039759214" z="53.9324999999988"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV261"/>
+       <position name="posWireV261" unit="cm" x="0" y="-72.5079769318514" z="54.6974999999988"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV262"/>
+       <position name="posWireV262" unit="cm" x="0" y="-72.9496498877815" z="55.4624999999988"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV263"/>
+       <position name="posWireV263" unit="cm" x="0" y="-73.3913228437115" z="56.2274999999988"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV264"/>
+       <position name="posWireV264" unit="cm" x="0" y="-73.8329957996416" z="56.9924999999988"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV265"/>
+       <position name="posWireV265" unit="cm" x="0" y="-74.2746687555717" z="57.7574999999988"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV266"/>
+       <position name="posWireV266" unit="cm" x="0" y="-74.7163417115017" z="58.5224999999987"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV267"/>
+       <position name="posWireV267" unit="cm" x="0" y="-75.1580146674318" z="59.2874999999987"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV268"/>
+       <position name="posWireV268" unit="cm" x="0" y="-75.5996876233618" z="60.0524999999987"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV269"/>
+       <position name="posWireV269" unit="cm" x="0" y="-76.0413605792919" z="60.8174999999987"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV270"/>
+       <position name="posWireV270" unit="cm" x="0" y="-76.4830335352219" z="61.5824999999987"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV271"/>
+       <position name="posWireV271" unit="cm" x="0" y="-76.924706491152" z="62.3474999999987"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV272"/>
+       <position name="posWireV272" unit="cm" x="0" y="-77.366379447082" z="63.1124999999986"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV273"/>
+       <position name="posWireV273" unit="cm" x="0" y="-77.8080524030121" z="63.8774999999986"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV274"/>
+       <position name="posWireV274" unit="cm" x="0" y="-78.2497253589422" z="64.6424999999986"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV275"/>
+       <position name="posWireV275" unit="cm" x="0" y="-78.6913983148722" z="65.4074999999986"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV276"/>
+       <position name="posWireV276" unit="cm" x="0" y="-79.1330712708023" z="66.1724999999986"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV277"/>
+       <position name="posWireV277" unit="cm" x="0" y="-79.5747442267323" z="66.9374999999986"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV278"/>
+       <position name="posWireV278" unit="cm" x="0" y="-80.0164171826624" z="67.7024999999986"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV279"/>
+       <position name="posWireV279" unit="cm" x="0" y="-80.4580901385924" z="68.4674999999986"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV280"/>
+       <position name="posWireV280" unit="cm" x="0" y="-80.8997630945225" z="69.2324999999986"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV281"/>
+       <position name="posWireV281" unit="cm" x="0" y="-81.3414360504525" z="69.9974999999985"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV282"/>
+       <position name="posWireV282" unit="cm" x="0" y="-81.7831090063826" z="70.7624999999985"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV283"/>
+       <position name="posWireV283" unit="cm" x="0" y="-82.2247819623126" z="71.5274999999985"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV284"/>
+       <position name="posWireV284" unit="cm" x="0" y="-82.6664549182427" z="72.2924999999985"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCWireV285"/>
+       <position name="posWireV285" unit="cm" x="0" y="-83.1081278741728" z="73.0574999999985"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+  </volume>
+  <volume name="volTPCPlaneZ">
+    <materialref ref="LAr"/>
+    <solidref ref="CRMZPlane"/>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ0" unit="cm" x="0" y="0" z="-74.205"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ1" unit="cm" x="0" y="0" z="-73.695"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ2" unit="cm" x="0" y="0" z="-73.185"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ3" unit="cm" x="0" y="0" z="-72.675"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ4" unit="cm" x="0" y="0" z="-72.165"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ5" unit="cm" x="0" y="0" z="-71.655"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ6" unit="cm" x="0" y="0" z="-71.145"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ7" unit="cm" x="0" y="0" z="-70.635"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ8" unit="cm" x="0" y="0" z="-70.125"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ9" unit="cm" x="0" y="0" z="-69.615"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ10" unit="cm" x="0" y="0" z="-69.105"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ11" unit="cm" x="0" y="0" z="-68.595"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ12" unit="cm" x="0" y="0" z="-68.085"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ13" unit="cm" x="0" y="0" z="-67.575"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ14" unit="cm" x="0" y="0" z="-67.065"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ15" unit="cm" x="0" y="0" z="-66.555"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ16" unit="cm" x="0" y="0" z="-66.045"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ17" unit="cm" x="0" y="0" z="-65.535"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ18" unit="cm" x="0" y="0" z="-65.025"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ19" unit="cm" x="0" y="0" z="-64.515"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ20" unit="cm" x="0" y="0" z="-64.005"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ21" unit="cm" x="0" y="0" z="-63.495"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ22" unit="cm" x="0" y="0" z="-62.985"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ23" unit="cm" x="0" y="0" z="-62.475"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ24" unit="cm" x="0" y="0" z="-61.965"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ25" unit="cm" x="0" y="0" z="-61.455"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ26" unit="cm" x="0" y="0" z="-60.945"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ27" unit="cm" x="0" y="0" z="-60.435"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ28" unit="cm" x="0" y="0" z="-59.925"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ29" unit="cm" x="0" y="0" z="-59.415"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ30" unit="cm" x="0" y="0" z="-58.905"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ31" unit="cm" x="0" y="0" z="-58.395"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ32" unit="cm" x="0" y="0" z="-57.885"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ33" unit="cm" x="0" y="0" z="-57.375"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ34" unit="cm" x="0" y="0" z="-56.865"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ35" unit="cm" x="0" y="0" z="-56.355"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ36" unit="cm" x="0" y="0" z="-55.845"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ37" unit="cm" x="0" y="0" z="-55.335"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ38" unit="cm" x="0" y="0" z="-54.825"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ39" unit="cm" x="0" y="0" z="-54.315"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ40" unit="cm" x="0" y="0" z="-53.805"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ41" unit="cm" x="0" y="0" z="-53.295"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ42" unit="cm" x="0" y="0" z="-52.785"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ43" unit="cm" x="0" y="0" z="-52.275"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ44" unit="cm" x="0" y="0" z="-51.765"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ45" unit="cm" x="0" y="0" z="-51.255"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ46" unit="cm" x="0" y="0" z="-50.745"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ47" unit="cm" x="0" y="0" z="-50.235"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ48" unit="cm" x="0" y="0" z="-49.725"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ49" unit="cm" x="0" y="0" z="-49.215"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ50" unit="cm" x="0" y="0" z="-48.705"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ51" unit="cm" x="0" y="0" z="-48.195"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ52" unit="cm" x="0" y="0" z="-47.685"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ53" unit="cm" x="0" y="0" z="-47.175"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ54" unit="cm" x="0" y="0" z="-46.665"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ55" unit="cm" x="0" y="0" z="-46.155"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ56" unit="cm" x="0" y="0" z="-45.645"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ57" unit="cm" x="0" y="0" z="-45.135"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ58" unit="cm" x="0" y="0" z="-44.625"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ59" unit="cm" x="0" y="0" z="-44.115"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ60" unit="cm" x="0" y="0" z="-43.605"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ61" unit="cm" x="0" y="0" z="-43.095"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ62" unit="cm" x="0" y="0" z="-42.585"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ63" unit="cm" x="0" y="0" z="-42.075"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ64" unit="cm" x="0" y="0" z="-41.565"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ65" unit="cm" x="0" y="0" z="-41.055"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ66" unit="cm" x="0" y="0" z="-40.545"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ67" unit="cm" x="0" y="0" z="-40.035"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ68" unit="cm" x="0" y="0" z="-39.525"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ69" unit="cm" x="0" y="0" z="-39.015"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ70" unit="cm" x="0" y="0" z="-38.505"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ71" unit="cm" x="0" y="0" z="-37.995"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ72" unit="cm" x="0" y="0" z="-37.485"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ73" unit="cm" x="0" y="0" z="-36.975"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ74" unit="cm" x="0" y="0" z="-36.465"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ75" unit="cm" x="0" y="0" z="-35.955"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ76" unit="cm" x="0" y="0" z="-35.445"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ77" unit="cm" x="0" y="0" z="-34.935"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ78" unit="cm" x="0" y="0" z="-34.425"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ79" unit="cm" x="0" y="0" z="-33.915"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ80" unit="cm" x="0" y="0" z="-33.405"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ81" unit="cm" x="0" y="0" z="-32.895"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ82" unit="cm" x="0" y="0" z="-32.385"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ83" unit="cm" x="0" y="0" z="-31.875"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ84" unit="cm" x="0" y="0" z="-31.365"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ85" unit="cm" x="0" y="0" z="-30.855"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ86" unit="cm" x="0" y="0" z="-30.345"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ87" unit="cm" x="0" y="0" z="-29.835"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ88" unit="cm" x="0" y="0" z="-29.325"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ89" unit="cm" x="0" y="0" z="-28.815"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ90" unit="cm" x="0" y="0" z="-28.305"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ91" unit="cm" x="0" y="0" z="-27.795"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ92" unit="cm" x="0" y="0" z="-27.285"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ93" unit="cm" x="0" y="0" z="-26.775"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ94" unit="cm" x="0" y="0" z="-26.265"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ95" unit="cm" x="0" y="0" z="-25.755"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ96" unit="cm" x="0" y="0" z="-25.245"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ97" unit="cm" x="0" y="0" z="-24.735"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ98" unit="cm" x="0" y="0" z="-24.225"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ99" unit="cm" x="0" y="0" z="-23.715"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ100" unit="cm" x="0" y="0" z="-23.205"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ101" unit="cm" x="0" y="0" z="-22.695"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ102" unit="cm" x="0" y="0" z="-22.185"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ103" unit="cm" x="0" y="0" z="-21.675"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ104" unit="cm" x="0" y="0" z="-21.165"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ105" unit="cm" x="0" y="0" z="-20.655"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ106" unit="cm" x="0" y="0" z="-20.145"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ107" unit="cm" x="0" y="0" z="-19.635"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ108" unit="cm" x="0" y="0" z="-19.125"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ109" unit="cm" x="0" y="0" z="-18.615"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ110" unit="cm" x="0" y="0" z="-18.105"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ111" unit="cm" x="0" y="0" z="-17.595"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ112" unit="cm" x="0" y="0" z="-17.085"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ113" unit="cm" x="0" y="0" z="-16.575"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ114" unit="cm" x="0" y="0" z="-16.065"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ115" unit="cm" x="0" y="0" z="-15.555"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ116" unit="cm" x="0" y="0" z="-15.045"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ117" unit="cm" x="0" y="0" z="-14.535"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ118" unit="cm" x="0" y="0" z="-14.025"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ119" unit="cm" x="0" y="0" z="-13.515"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ120" unit="cm" x="0" y="0" z="-13.005"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ121" unit="cm" x="0" y="0" z="-12.495"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ122" unit="cm" x="0" y="0" z="-11.985"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ123" unit="cm" x="0" y="0" z="-11.475"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ124" unit="cm" x="0" y="0" z="-10.965"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ125" unit="cm" x="0" y="0" z="-10.455"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ126" unit="cm" x="0" y="0" z="-9.945"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ127" unit="cm" x="0" y="0" z="-9.435"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ128" unit="cm" x="0" y="0" z="-8.925"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ129" unit="cm" x="0" y="0" z="-8.415"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ130" unit="cm" x="0" y="0" z="-7.905"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ131" unit="cm" x="0" y="0" z="-7.395"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ132" unit="cm" x="0" y="0" z="-6.885"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ133" unit="cm" x="0" y="0" z="-6.375"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ134" unit="cm" x="0" y="0" z="-5.865"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ135" unit="cm" x="0" y="0" z="-5.355"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ136" unit="cm" x="0" y="0" z="-4.845"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ137" unit="cm" x="0" y="0" z="-4.335"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ138" unit="cm" x="0" y="0" z="-3.825"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ139" unit="cm" x="0" y="0" z="-3.315"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ140" unit="cm" x="0" y="0" z="-2.805"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ141" unit="cm" x="0" y="0" z="-2.295"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ142" unit="cm" x="0" y="0" z="-1.785"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ143" unit="cm" x="0" y="0" z="-1.275"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ144" unit="cm" x="0" y="0" z="-0.765"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ145" unit="cm" x="0" y="0" z="-0.255"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ146" unit="cm" x="0" y="0" z="0.255"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ147" unit="cm" x="0" y="0" z="0.765"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ148" unit="cm" x="0" y="0" z="1.275"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ149" unit="cm" x="0" y="0" z="1.785"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ150" unit="cm" x="0" y="0" z="2.295"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ151" unit="cm" x="0" y="0" z="2.805"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ152" unit="cm" x="0" y="0" z="3.315"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ153" unit="cm" x="0" y="0" z="3.825"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ154" unit="cm" x="0" y="0" z="4.335"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ155" unit="cm" x="0" y="0" z="4.845"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ156" unit="cm" x="0" y="0" z="5.355"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ157" unit="cm" x="0" y="0" z="5.865"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ158" unit="cm" x="0" y="0" z="6.375"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ159" unit="cm" x="0" y="0" z="6.885"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ160" unit="cm" x="0" y="0" z="7.395"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ161" unit="cm" x="0" y="0" z="7.905"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ162" unit="cm" x="0" y="0" z="8.415"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ163" unit="cm" x="0" y="0" z="8.925"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ164" unit="cm" x="0" y="0" z="9.435"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ165" unit="cm" x="0" y="0" z="9.945"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ166" unit="cm" x="0" y="0" z="10.455"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ167" unit="cm" x="0" y="0" z="10.965"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ168" unit="cm" x="0" y="0" z="11.475"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ169" unit="cm" x="0" y="0" z="11.985"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ170" unit="cm" x="0" y="0" z="12.495"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ171" unit="cm" x="0" y="0" z="13.005"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ172" unit="cm" x="0" y="0" z="13.515"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ173" unit="cm" x="0" y="0" z="14.025"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ174" unit="cm" x="0" y="0" z="14.535"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ175" unit="cm" x="0" y="0" z="15.045"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ176" unit="cm" x="0" y="0" z="15.555"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ177" unit="cm" x="0" y="0" z="16.065"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ178" unit="cm" x="0" y="0" z="16.575"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ179" unit="cm" x="0" y="0" z="17.085"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ180" unit="cm" x="0" y="0" z="17.595"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ181" unit="cm" x="0" y="0" z="18.105"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ182" unit="cm" x="0" y="0" z="18.615"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ183" unit="cm" x="0" y="0" z="19.125"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ184" unit="cm" x="0" y="0" z="19.635"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ185" unit="cm" x="0" y="0" z="20.145"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ186" unit="cm" x="0" y="0" z="20.655"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ187" unit="cm" x="0" y="0" z="21.165"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ188" unit="cm" x="0" y="0" z="21.675"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ189" unit="cm" x="0" y="0" z="22.185"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ190" unit="cm" x="0" y="0" z="22.695"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ191" unit="cm" x="0" y="0" z="23.205"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ192" unit="cm" x="0" y="0" z="23.715"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ193" unit="cm" x="0" y="0" z="24.225"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ194" unit="cm" x="0" y="0" z="24.735"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ195" unit="cm" x="0" y="0" z="25.245"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ196" unit="cm" x="0" y="0" z="25.755"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ197" unit="cm" x="0" y="0" z="26.265"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ198" unit="cm" x="0" y="0" z="26.775"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ199" unit="cm" x="0" y="0" z="27.285"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ200" unit="cm" x="0" y="0" z="27.795"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ201" unit="cm" x="0" y="0" z="28.305"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ202" unit="cm" x="0" y="0" z="28.815"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ203" unit="cm" x="0" y="0" z="29.325"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ204" unit="cm" x="0" y="0" z="29.835"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ205" unit="cm" x="0" y="0" z="30.345"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ206" unit="cm" x="0" y="0" z="30.855"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ207" unit="cm" x="0" y="0" z="31.365"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ208" unit="cm" x="0" y="0" z="31.875"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ209" unit="cm" x="0" y="0" z="32.385"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ210" unit="cm" x="0" y="0" z="32.895"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ211" unit="cm" x="0" y="0" z="33.405"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ212" unit="cm" x="0" y="0" z="33.915"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ213" unit="cm" x="0" y="0" z="34.425"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ214" unit="cm" x="0" y="0" z="34.935"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ215" unit="cm" x="0" y="0" z="35.445"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ216" unit="cm" x="0" y="0" z="35.955"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ217" unit="cm" x="0" y="0" z="36.465"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ218" unit="cm" x="0" y="0" z="36.975"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ219" unit="cm" x="0" y="0" z="37.485"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ220" unit="cm" x="0" y="0" z="37.995"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ221" unit="cm" x="0" y="0" z="38.505"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ222" unit="cm" x="0" y="0" z="39.015"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ223" unit="cm" x="0" y="0" z="39.525"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ224" unit="cm" x="0" y="0" z="40.035"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ225" unit="cm" x="0" y="0" z="40.545"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ226" unit="cm" x="0" y="0" z="41.055"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ227" unit="cm" x="0" y="0" z="41.565"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ228" unit="cm" x="0" y="0" z="42.075"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ229" unit="cm" x="0" y="0" z="42.585"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ230" unit="cm" x="0" y="0" z="43.095"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ231" unit="cm" x="0" y="0" z="43.605"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ232" unit="cm" x="0" y="0" z="44.115"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ233" unit="cm" x="0" y="0" z="44.625"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ234" unit="cm" x="0" y="0" z="45.135"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ235" unit="cm" x="0" y="0" z="45.645"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ236" unit="cm" x="0" y="0" z="46.155"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ237" unit="cm" x="0" y="0" z="46.665"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ238" unit="cm" x="0" y="0" z="47.175"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ239" unit="cm" x="0" y="0" z="47.685"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ240" unit="cm" x="0" y="0" z="48.195"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ241" unit="cm" x="0" y="0" z="48.705"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ242" unit="cm" x="0" y="0" z="49.215"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ243" unit="cm" x="0" y="0" z="49.725"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ244" unit="cm" x="0" y="0" z="50.235"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ245" unit="cm" x="0" y="0" z="50.745"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ246" unit="cm" x="0" y="0" z="51.255"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ247" unit="cm" x="0" y="0" z="51.765"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ248" unit="cm" x="0" y="0" z="52.275"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ249" unit="cm" x="0" y="0" z="52.785"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ250" unit="cm" x="0" y="0" z="53.295"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ251" unit="cm" x="0" y="0" z="53.805"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ252" unit="cm" x="0" y="0" z="54.315"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ253" unit="cm" x="0" y="0" z="54.825"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ254" unit="cm" x="0" y="0" z="55.335"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ255" unit="cm" x="0" y="0" z="55.845"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ256" unit="cm" x="0" y="0" z="56.355"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ257" unit="cm" x="0" y="0" z="56.865"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ258" unit="cm" x="0" y="0" z="57.375"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ259" unit="cm" x="0" y="0" z="57.885"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ260" unit="cm" x="0" y="0" z="58.395"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ261" unit="cm" x="0" y="0" z="58.905"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ262" unit="cm" x="0" y="0" z="59.415"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ263" unit="cm" x="0" y="0" z="59.925"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ264" unit="cm" x="0" y="0" z="60.435"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ265" unit="cm" x="0" y="0" z="60.945"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ266" unit="cm" x="0" y="0" z="61.455"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ267" unit="cm" x="0" y="0" z="61.965"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ268" unit="cm" x="0" y="0" z="62.475"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ269" unit="cm" x="0" y="0" z="62.985"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ270" unit="cm" x="0" y="0" z="63.495"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ271" unit="cm" x="0" y="0" z="64.005"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ272" unit="cm" x="0" y="0" z="64.515"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ273" unit="cm" x="0" y="0" z="65.025"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ274" unit="cm" x="0" y="0" z="65.535"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ275" unit="cm" x="0" y="0" z="66.045"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ276" unit="cm" x="0" y="0" z="66.555"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ277" unit="cm" x="0" y="0" z="67.065"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ278" unit="cm" x="0" y="0" z="67.575"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ279" unit="cm" x="0" y="0" z="68.085"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ280" unit="cm" x="0" y="0" z="68.595"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ281" unit="cm" x="0" y="0" z="69.105"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ282" unit="cm" x="0" y="0" z="69.615"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ283" unit="cm" x="0" y="0" z="70.125"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ284" unit="cm" x="0" y="0" z="70.635"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ285" unit="cm" x="0" y="0" z="71.145"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ286" unit="cm" x="0" y="0" z="71.655"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ287" unit="cm" x="0" y="0" z="72.165"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ288" unit="cm" x="0" y="0" z="72.675"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ289" unit="cm" x="0" y="0" z="73.185"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ290" unit="cm" x="0" y="0" z="73.695"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ291" unit="cm" x="0" y="0" z="74.205"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+  </volume>
+   <volume name="volTPC">
+     <materialref ref="LAr"/>
+       <solidref ref="CRM"/>
+       <physvol>
+       <volumeref ref="volTPCPlaneU"/>
+       <position name="posPlaneU" unit="cm"
+         x="324.99" y="0" z="0"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCPlaneV"/>
+       <position name="posPlaneY" unit="cm"
+         x="325.01" y="0" z="0"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCPlaneZ"/>
+       <position name="posPlaneZ" unit="cm"
+         x="325.03" y="0" z="0"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCActive"/>
+       <position name="posActive" unit="cm"
+        x="-0.04" y="0" z="0"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+   </volume>
+ 
+    <volume name="volSteelShell">
+      <materialref ref="STEEL_STAINLESS_Fe7Cr2Ni" />
+      <solidref ref="SteelShell" />
+    </volume>
+    <volume name="volCathodeGrid">
+      <materialref ref="G10" />
+      <solidref ref="CathodeGrid" />
+    </volume>
+    <volume name="volAnodePlate">
+     <materialref ref="vm2000"/>
+     <solidref ref="AnodePlate"/>
+    </volume>
+    <volume name="volGaseousArgon">
+      <materialref ref="ArGas"/>
+      <solidref ref="GaseousArgon"/>
+    </volume>
+
+    <volume name="volOpDetSensitive">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+
+    <volume name="Arapuca">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+
+    <volume name="volArapuca">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaOut"/>
+      <physvol>
+        <volumeref ref="Arapuca"/>
+        <positionref ref="posCenter"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volOpDetSensitive"/>
+        <position name="opdetshift" unit="cm" x="0" y="0.5" z="0"/>
+      </physvol>
+    </volume>
+
+    <volume name="volCryostat">
+      <materialref ref="LAr" />
+      <solidref ref="Cryostat" />
+      <auxiliary auxtype="SensDet" auxvalue="SimEnergyDeposit"/>
+      <auxiliary auxtype="StepLimit" auxunit="cm" auxvalue="0.5208*cm"/>
+      <auxiliary auxtype="Efield" auxunit="V/cm" auxvalue="0*V/cm"/>
+
+      <physvol>
+        <volumeref ref="volGaseousArgon"/>
+        <position name="posGaseousArgon" unit="cm" x="375.045" y="0" z="0"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volSteelShell"/>
+        <position name="posSteelShell" unit="cm" x="0" y="0" z="0"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-0" unit="cm"
+           x="0" y="-588.4521" z="-373.3"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-1" unit="cm"
+           x="0" y="-420.7515" z="-373.3"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-2" unit="cm"
+           x="0" y="-252.0509" z="-373.3"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-3" unit="cm"
+           x="0" y="-84.3502999999999" z="-373.3"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-4" unit="cm"
+           x="0" y="84.3503000000001" z="-373.3"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-5" unit="cm"
+           x="0" y="252.0509" z="-373.3"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-6" unit="cm"
+           x="0" y="420.7515" z="-373.3"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-7" unit="cm"
+           x="0" y="588.4521" z="-373.3"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-8" unit="cm"
+           x="0" y="-588.4521" z="-224.38"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-9" unit="cm"
+           x="0" y="-420.7515" z="-224.38"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-10" unit="cm"
+           x="0" y="-252.0509" z="-224.38"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-11" unit="cm"
+           x="0" y="-84.3502999999999" z="-224.38"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-12" unit="cm"
+           x="0" y="84.3503000000001" z="-224.38"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-13" unit="cm"
+           x="0" y="252.0509" z="-224.38"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-14" unit="cm"
+           x="0" y="420.7515" z="-224.38"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-15" unit="cm"
+           x="0" y="588.4521" z="-224.38"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-16" unit="cm"
+           x="0" y="-588.4521" z="-74.46"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-17" unit="cm"
+           x="0" y="-420.7515" z="-74.46"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-18" unit="cm"
+           x="0" y="-252.0509" z="-74.46"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-19" unit="cm"
+           x="0" y="-84.3502999999999" z="-74.46"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-20" unit="cm"
+           x="0" y="84.3503000000001" z="-74.46"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-21" unit="cm"
+           x="0" y="252.0509" z="-74.46"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-22" unit="cm"
+           x="0" y="420.7515" z="-74.46"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-23" unit="cm"
+           x="0" y="588.4521" z="-74.46"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-24" unit="cm"
+           x="0" y="-588.4521" z="74.46"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-25" unit="cm"
+           x="0" y="-420.7515" z="74.46"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-26" unit="cm"
+           x="0" y="-252.0509" z="74.46"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-27" unit="cm"
+           x="0" y="-84.3502999999999" z="74.46"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-28" unit="cm"
+           x="0" y="84.3503000000001" z="74.46"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-29" unit="cm"
+           x="0" y="252.0509" z="74.46"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-30" unit="cm"
+           x="0" y="420.7515" z="74.46"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-31" unit="cm"
+           x="0" y="588.4521" z="74.46"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-32" unit="cm"
+           x="0" y="-588.4521" z="224.38"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-33" unit="cm"
+           x="0" y="-420.7515" z="224.38"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-34" unit="cm"
+           x="0" y="-252.0509" z="224.38"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-35" unit="cm"
+           x="0" y="-84.3502999999999" z="224.38"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-36" unit="cm"
+           x="0" y="84.3503000000001" z="224.38"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-37" unit="cm"
+           x="0" y="252.0509" z="224.38"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-38" unit="cm"
+           x="0" y="420.7515" z="224.38"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-39" unit="cm"
+           x="0" y="588.4521" z="224.38"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-40" unit="cm"
+           x="0" y="-588.4521" z="373.3"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-41" unit="cm"
+           x="0" y="-420.7515" z="373.3"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-42" unit="cm"
+           x="0" y="-252.0509" z="373.3"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-43" unit="cm"
+           x="0" y="-84.3502999999999" z="373.3"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-44" unit="cm"
+           x="0" y="84.3503000000001" z="373.3"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-45" unit="cm"
+           x="0" y="252.0509" z="373.3"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-46" unit="cm"
+           x="0" y="420.7515" z="373.3"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-47" unit="cm"
+           x="0" y="588.4521" z="373.3"/>
+      </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaper"/>
+      <position name="posFieldShaper_0" unit="cm"  x="-322.04" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaper"/>
+      <position name="posFieldShaper_1" unit="cm"  x="-316.04" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaper"/>
+      <position name="posFieldShaper_2" unit="cm"  x="-310.04" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaper"/>
+      <position name="posFieldShaper_3" unit="cm"  x="-304.04" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaper"/>
+      <position name="posFieldShaper_4" unit="cm"  x="-298.04" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaper"/>
+      <position name="posFieldShaper_5" unit="cm"  x="-292.04" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaper"/>
+      <position name="posFieldShaper_6" unit="cm"  x="-286.04" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaper"/>
+      <position name="posFieldShaper_7" unit="cm"  x="-280.04" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaper"/>
+      <position name="posFieldShaper_8" unit="cm"  x="-274.04" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaper"/>
+      <position name="posFieldShaper_9" unit="cm"  x="-268.04" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaper"/>
+      <position name="posFieldShaper_10" unit="cm"  x="-262.04" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaper"/>
+      <position name="posFieldShaper_11" unit="cm"  x="-256.04" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaper"/>
+      <position name="posFieldShaper_12" unit="cm"  x="-250.04" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaper"/>
+      <position name="posFieldShaper_13" unit="cm"  x="-244.04" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaper"/>
+      <position name="posFieldShaper_14" unit="cm"  x="-238.04" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaper"/>
+      <position name="posFieldShaper_15" unit="cm"  x="-232.04" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaper"/>
+      <position name="posFieldShaper_16" unit="cm"  x="-226.04" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaper"/>
+      <position name="posFieldShaper_17" unit="cm"  x="-220.04" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaper"/>
+      <position name="posFieldShaper_18" unit="cm"  x="-214.04" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaper"/>
+      <position name="posFieldShaper_19" unit="cm"  x="-208.04" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaper"/>
+      <position name="posFieldShaper_20" unit="cm"  x="-202.04" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaper"/>
+      <position name="posFieldShaper_21" unit="cm"  x="-196.04" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaper"/>
+      <position name="posFieldShaper_22" unit="cm"  x="-190.04" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaper"/>
+      <position name="posFieldShaper_23" unit="cm"  x="-184.04" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaper"/>
+      <position name="posFieldShaper_24" unit="cm"  x="-178.04" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaper"/>
+      <position name="posFieldShaper_25" unit="cm"  x="-172.04" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaper"/>
+      <position name="posFieldShaper_26" unit="cm"  x="-166.04" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaper"/>
+      <position name="posFieldShaper_27" unit="cm"  x="-160.04" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaper"/>
+      <position name="posFieldShaper_28" unit="cm"  x="-154.04" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaper"/>
+      <position name="posFieldShaper_29" unit="cm"  x="-148.04" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaper"/>
+      <position name="posFieldShaper_30" unit="cm"  x="-142.04" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaper"/>
+      <position name="posFieldShaper_31" unit="cm"  x="-136.04" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaper"/>
+      <position name="posFieldShaper_32" unit="cm"  x="-130.04" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaper"/>
+      <position name="posFieldShaper_33" unit="cm"  x="-124.04" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaper"/>
+      <position name="posFieldShaper_34" unit="cm"  x="-118.04" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaper"/>
+      <position name="posFieldShaper_35" unit="cm"  x="-112.04" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaper"/>
+      <position name="posFieldShaper_36" unit="cm"  x="-106.04" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaper"/>
+      <position name="posFieldShaper_37" unit="cm"  x="-100.04" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaper"/>
+      <position name="posFieldShaper_38" unit="cm"  x="-94.04" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaper"/>
+      <position name="posFieldShaper_39" unit="cm"  x="-88.04" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaper"/>
+      <position name="posFieldShaper_40" unit="cm"  x="-82.04" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaper"/>
+      <position name="posFieldShaper_41" unit="cm"  x="-76.04" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_42" unit="cm"  x="-70.04" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_43" unit="cm"  x="-64.04" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_44" unit="cm"  x="-58.04" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_45" unit="cm"  x="-52.04" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_46" unit="cm"  x="-46.04" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_47" unit="cm"  x="-40.04" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_48" unit="cm"  x="-34.04" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_49" unit="cm"  x="-28.04" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_50" unit="cm"  x="-22.04" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_51" unit="cm"  x="-16.04" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_52" unit="cm"  x="-10.04" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_53" unit="cm"  x="-4.04000000000002" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_54" unit="cm"  x="1.95999999999998" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_55" unit="cm"  x="7.95999999999998" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_56" unit="cm"  x="13.96" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_57" unit="cm"  x="19.96" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_58" unit="cm"  x="25.96" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_59" unit="cm"  x="31.96" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_60" unit="cm"  x="37.96" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_61" unit="cm"  x="43.96" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_62" unit="cm"  x="49.96" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_63" unit="cm"  x="55.96" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_64" unit="cm"  x="61.96" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_65" unit="cm"  x="67.96" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_66" unit="cm"  x="73.96" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_67" unit="cm"  x="79.96" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_68" unit="cm"  x="85.96" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_69" unit="cm"  x="91.96" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_70" unit="cm"  x="97.96" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_71" unit="cm"  x="103.96" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_72" unit="cm"  x="109.96" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_73" unit="cm"  x="115.96" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_74" unit="cm"  x="121.96" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_75" unit="cm"  x="127.96" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_76" unit="cm"  x="133.96" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_77" unit="cm"  x="139.96" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_78" unit="cm"  x="145.96" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_79" unit="cm"  x="151.96" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_80" unit="cm"  x="157.96" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_81" unit="cm"  x="163.96" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_82" unit="cm"  x="169.96" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_83" unit="cm"  x="175.96" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_84" unit="cm"  x="181.96" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_85" unit="cm"  x="187.96" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_86" unit="cm"  x="193.96" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_87" unit="cm"  x="199.96" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_88" unit="cm"  x="205.96" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_89" unit="cm"  x="211.96" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_90" unit="cm"  x="217.96" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_91" unit="cm"  x="223.96" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_92" unit="cm"  x="229.96" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_93" unit="cm"  x="235.96" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_94" unit="cm"  x="241.96" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_95" unit="cm"  x="247.96" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_96" unit="cm"  x="253.96" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_97" unit="cm"  x="259.96" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_98" unit="cm"  x="265.96" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_99" unit="cm"  x="271.96" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_100" unit="cm"  x="277.96" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_101" unit="cm"  x="283.96" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_102" unit="cm"  x="289.96" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_103" unit="cm"  x="295.96" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_104" unit="cm"  x="301.96" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_105" unit="cm"  x="307.96" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_106" unit="cm"  x="313.96" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_107" unit="cm"  x="319.96" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-0" unit="cm" x="-327.04" y="-504.6018" z="-298.84"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-0" unit="cm" x="325.045" y="-504.6018" z="-298.84"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-1" unit="cm" x="-327.04" y="-168.2006" z="-298.84"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-1" unit="cm" x="325.045" y="-168.2006" z="-298.84"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-2" unit="cm" x="-327.04" y="168.2006" z="-298.84"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-2" unit="cm" x="325.045" y="168.2006" z="-298.84"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-3" unit="cm" x="-327.04" y="504.6018" z="-298.84"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-3" unit="cm" x="325.045" y="504.6018" z="-298.84"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-4" unit="cm" x="-327.04" y="-504.6018" z="0"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-4" unit="cm" x="325.045" y="-504.6018" z="0"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-5" unit="cm" x="-327.04" y="-168.2006" z="0"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-5" unit="cm" x="325.045" y="-168.2006" z="0"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-6" unit="cm" x="-327.04" y="168.2006" z="0"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-6" unit="cm" x="325.045" y="168.2006" z="0"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-7" unit="cm" x="-327.04" y="504.6018" z="0"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-7" unit="cm" x="325.045" y="504.6018" z="0"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-8" unit="cm" x="-327.04" y="-504.6018" z="298.84"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-8" unit="cm" x="325.045" y="-504.6018" z="298.84"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-9" unit="cm" x="-327.04" y="-168.2006" z="298.84"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-9" unit="cm" x="325.045" y="-168.2006" z="298.84"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-10" unit="cm" x="-327.04" y="168.2006" z="298.84"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-10" unit="cm" x="325.045" y="168.2006" z="298.84"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-11" unit="cm" x="-327.04" y="504.6018" z="298.84"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-11" unit="cm" x="325.045" y="504.6018" z="298.84"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+	<volumeref ref="volArapuca"/>
+       <position name="posArapucaDouble0-Frame-0-0" unit="cm"
+         x="-327.04"
+	 y="-541.6018"
+	 z="-261.34"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+	<volumeref ref="volArapuca"/>
+       <position name="posArapucaDouble1-Frame-0-0" unit="cm"
+         x="-327.04"
+	 y="-541.6018"
+	 z="-336.34"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+	<volumeref ref="volArapuca"/>
+       <position name="posArapucaDouble2-Frame-0-0" unit="cm"
+         x="-327.04"
+	 y="-467.6018"
+	 z="-190.34"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+	<volumeref ref="volArapuca"/>
+       <position name="posArapucaDouble3-Frame-0-0" unit="cm"
+         x="-327.04"
+	 y="-376.9018"
+	 z="-336.34"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+	<volumeref ref="volArapuca"/>
+       <position name="posArapucaDouble0-Frame-0-1" unit="cm"
+         x="-327.04"
+	 y="-541.6018"
+	 z="37.5"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+	<volumeref ref="volArapuca"/>
+       <position name="posArapucaDouble1-Frame-0-1" unit="cm"
+         x="-327.04"
+	 y="-541.6018"
+	 z="-108.5"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+	<volumeref ref="volArapuca"/>
+       <position name="posArapucaDouble2-Frame-0-1" unit="cm"
+         x="-327.04"
+	 y="-467.6018"
+	 z="108.5"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+	<volumeref ref="volArapuca"/>
+       <position name="posArapucaDouble3-Frame-0-1" unit="cm"
+         x="-327.04"
+	 y="-376.9018"
+	 z="-37.5"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+	<volumeref ref="volArapuca"/>
+       <position name="posArapucaDouble0-Frame-0-2" unit="cm"
+         x="-327.04"
+	 y="-541.6018"
+	 z="336.34"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+	<volumeref ref="volArapuca"/>
+       <position name="posArapucaDouble1-Frame-0-2" unit="cm"
+         x="-327.04"
+	 y="-541.6018"
+	 z="190.34"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+	<volumeref ref="volArapuca"/>
+       <position name="posArapucaDouble2-Frame-0-2" unit="cm"
+         x="-327.04"
+	 y="-467.6018"
+	 z="336.34"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+	<volumeref ref="volArapuca"/>
+       <position name="posArapucaDouble3-Frame-0-2" unit="cm"
+         x="-327.04"
+	 y="-376.9018"
+	 z="261.34"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+	<volumeref ref="volArapuca"/>
+       <position name="posArapucaDouble0-Frame-1-0" unit="cm"
+         x="-327.04"
+	 y="-295.9006"
+	 z="-261.34"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+	<volumeref ref="volArapuca"/>
+       <position name="posArapucaDouble1-Frame-1-0" unit="cm"
+         x="-327.04"
+	 y="-205.2006"
+	 z="-336.34"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+	<volumeref ref="volArapuca"/>
+       <position name="posArapucaDouble2-Frame-1-0" unit="cm"
+         x="-327.04"
+	 y="-131.2006"
+	 z="-190.34"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+	<volumeref ref="volArapuca"/>
+       <position name="posArapucaDouble3-Frame-1-0" unit="cm"
+         x="-327.04"
+	 y="-40.5006"
+	 z="-336.34"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+	<volumeref ref="volArapuca"/>
+       <position name="posArapucaDouble0-Frame-1-1" unit="cm"
+         x="-327.04"
+	 y="-295.9006"
+	 z="37.5"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+	<volumeref ref="volArapuca"/>
+       <position name="posArapucaDouble1-Frame-1-1" unit="cm"
+         x="-327.04"
+	 y="-205.2006"
+	 z="-108.5"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+	<volumeref ref="volArapuca"/>
+       <position name="posArapucaDouble2-Frame-1-1" unit="cm"
+         x="-327.04"
+	 y="-131.2006"
+	 z="108.5"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+	<volumeref ref="volArapuca"/>
+       <position name="posArapucaDouble3-Frame-1-1" unit="cm"
+         x="-327.04"
+	 y="-40.5006"
+	 z="-37.5"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+	<volumeref ref="volArapuca"/>
+       <position name="posArapucaDouble0-Frame-1-2" unit="cm"
+         x="-327.04"
+	 y="-295.9006"
+	 z="336.34"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+	<volumeref ref="volArapuca"/>
+       <position name="posArapucaDouble1-Frame-1-2" unit="cm"
+         x="-327.04"
+	 y="-205.2006"
+	 z="190.34"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+	<volumeref ref="volArapuca"/>
+       <position name="posArapucaDouble2-Frame-1-2" unit="cm"
+         x="-327.04"
+	 y="-131.2006"
+	 z="336.34"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+	<volumeref ref="volArapuca"/>
+       <position name="posArapucaDouble3-Frame-1-2" unit="cm"
+         x="-327.04"
+	 y="-40.5006"
+	 z="261.34"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+	<volumeref ref="volArapuca"/>
+       <position name="posArapucaDouble0-Frame-2-0" unit="cm"
+         x="-327.04"
+	 y="40.5006"
+	 z="-261.34"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+	<volumeref ref="volArapuca"/>
+       <position name="posArapucaDouble1-Frame-2-0" unit="cm"
+         x="-327.04"
+	 y="131.2006"
+	 z="-336.34"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+	<volumeref ref="volArapuca"/>
+       <position name="posArapucaDouble2-Frame-2-0" unit="cm"
+         x="-327.04"
+	 y="205.2006"
+	 z="-190.34"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+	<volumeref ref="volArapuca"/>
+       <position name="posArapucaDouble3-Frame-2-0" unit="cm"
+         x="-327.04"
+	 y="295.9006"
+	 z="-336.34"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+	<volumeref ref="volArapuca"/>
+       <position name="posArapucaDouble0-Frame-2-1" unit="cm"
+         x="-327.04"
+	 y="40.5006"
+	 z="37.5"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+	<volumeref ref="volArapuca"/>
+       <position name="posArapucaDouble1-Frame-2-1" unit="cm"
+         x="-327.04"
+	 y="131.2006"
+	 z="-108.5"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+	<volumeref ref="volArapuca"/>
+       <position name="posArapucaDouble2-Frame-2-1" unit="cm"
+         x="-327.04"
+	 y="205.2006"
+	 z="108.5"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+	<volumeref ref="volArapuca"/>
+       <position name="posArapucaDouble3-Frame-2-1" unit="cm"
+         x="-327.04"
+	 y="295.9006"
+	 z="-37.5"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+	<volumeref ref="volArapuca"/>
+       <position name="posArapucaDouble0-Frame-2-2" unit="cm"
+         x="-327.04"
+	 y="40.5006"
+	 z="336.34"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+	<volumeref ref="volArapuca"/>
+       <position name="posArapucaDouble1-Frame-2-2" unit="cm"
+         x="-327.04"
+	 y="131.2006"
+	 z="190.34"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+	<volumeref ref="volArapuca"/>
+       <position name="posArapucaDouble2-Frame-2-2" unit="cm"
+         x="-327.04"
+	 y="205.2006"
+	 z="336.34"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+	<volumeref ref="volArapuca"/>
+       <position name="posArapucaDouble3-Frame-2-2" unit="cm"
+         x="-327.04"
+	 y="295.9006"
+	 z="261.34"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+	<volumeref ref="volArapuca"/>
+       <position name="posArapucaDouble0-Frame-3-0" unit="cm"
+         x="-327.04"
+	 y="376.9018"
+	 z="-261.34"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+	<volumeref ref="volArapuca"/>
+       <position name="posArapucaDouble1-Frame-3-0" unit="cm"
+         x="-327.04"
+	 y="467.6018"
+	 z="-336.34"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+	<volumeref ref="volArapuca"/>
+       <position name="posArapucaDouble2-Frame-3-0" unit="cm"
+         x="-327.04"
+	 y="541.6018"
+	 z="-190.34"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+	<volumeref ref="volArapuca"/>
+       <position name="posArapucaDouble3-Frame-3-0" unit="cm"
+         x="-327.04"
+	 y="541.6018"
+	 z="-336.34"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+	<volumeref ref="volArapuca"/>
+       <position name="posArapucaDouble0-Frame-3-1" unit="cm"
+         x="-327.04"
+	 y="376.9018"
+	 z="37.5"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+	<volumeref ref="volArapuca"/>
+       <position name="posArapucaDouble1-Frame-3-1" unit="cm"
+         x="-327.04"
+	 y="467.6018"
+	 z="-108.5"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+	<volumeref ref="volArapuca"/>
+       <position name="posArapucaDouble2-Frame-3-1" unit="cm"
+         x="-327.04"
+	 y="541.6018"
+	 z="108.5"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+	<volumeref ref="volArapuca"/>
+       <position name="posArapucaDouble3-Frame-3-1" unit="cm"
+         x="-327.04"
+	 y="541.6018"
+	 z="-37.5"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+	<volumeref ref="volArapuca"/>
+       <position name="posArapucaDouble0-Frame-3-2" unit="cm"
+         x="-327.04"
+	 y="376.9018"
+	 z="336.34"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+	<volumeref ref="volArapuca"/>
+       <position name="posArapucaDouble1-Frame-3-2" unit="cm"
+         x="-327.04"
+	 y="467.6018"
+	 z="190.34"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+	<volumeref ref="volArapuca"/>
+       <position name="posArapucaDouble2-Frame-3-2" unit="cm"
+         x="-327.04"
+	 y="541.6018"
+	 z="336.34"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+	<volumeref ref="volArapuca"/>
+       <position name="posArapucaDouble3-Frame-3-2" unit="cm"
+         x="-327.04"
+	 y="541.6018"
+	 z="261.34"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca0-Lat-0" unit="cm"
+         x="285.03"
+	 y="-743.8024"
+	 z="-298.84"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca1-Lat-0" unit="cm"
+         x="210.03"
+	 y="-743.8024"
+	 z="-298.84"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca2-Lat-0" unit="cm"
+         x="135.03"
+	 y="-743.8024"
+	 z="-298.84"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca3-Lat-0" unit="cm"
+         x="60.03"
+	 y="-743.8024"
+	 z="-298.84"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca4-Lat-0" unit="cm"
+         x="285.03"
+	 y="743.8024"
+	 z="-298.84"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca5-Lat-0" unit="cm"
+         x="210.03"
+	 y="743.8024"
+	 z="-298.84"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca6-Lat-0" unit="cm"
+         x="135.03"
+	 y="743.8024"
+	 z="-298.84"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca7-Lat-0" unit="cm"
+         x="60.03"
+	 y="743.8024"
+	 z="-298.84"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca0-Lat-1" unit="cm"
+         x="285.03"
+	 y="-743.8024"
+	 z="-1.13686837721616e-13"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca1-Lat-1" unit="cm"
+         x="210.03"
+	 y="-743.8024"
+	 z="-1.13686837721616e-13"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca2-Lat-1" unit="cm"
+         x="135.03"
+	 y="-743.8024"
+	 z="-1.13686837721616e-13"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca3-Lat-1" unit="cm"
+         x="60.03"
+	 y="-743.8024"
+	 z="-1.13686837721616e-13"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca4-Lat-1" unit="cm"
+         x="285.03"
+	 y="743.8024"
+	 z="-1.13686837721616e-13"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca5-Lat-1" unit="cm"
+         x="210.03"
+	 y="743.8024"
+	 z="-1.13686837721616e-13"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca6-Lat-1" unit="cm"
+         x="135.03"
+	 y="743.8024"
+	 z="-1.13686837721616e-13"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca7-Lat-1" unit="cm"
+         x="60.03"
+	 y="743.8024"
+	 z="-1.13686837721616e-13"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca0-Lat-2" unit="cm"
+         x="285.03"
+	 y="-743.8024"
+	 z="298.84"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca1-Lat-2" unit="cm"
+         x="210.03"
+	 y="-743.8024"
+	 z="298.84"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca2-Lat-2" unit="cm"
+         x="135.03"
+	 y="-743.8024"
+	 z="298.84"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca3-Lat-2" unit="cm"
+         x="60.03"
+	 y="-743.8024"
+	 z="298.84"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca4-Lat-2" unit="cm"
+         x="285.03"
+	 y="743.8024"
+	 z="298.84"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca5-Lat-2" unit="cm"
+         x="210.03"
+	 y="743.8024"
+	 z="298.84"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca6-Lat-2" unit="cm"
+         x="135.03"
+	 y="743.8024"
+	 z="298.84"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca7-Lat-2" unit="cm"
+         x="60.03"
+	 y="743.8024"
+	 z="298.84"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca0-ShortLat-220" unit="cm"
+         x="285.03"
+	 y="-220"
+	 z="-545.26"/>
+       <rotationref ref="rMinus90AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca1-ShortLat-220" unit="cm"
+         x="210.03"
+	 y="-220"
+	 z="-545.26"/>
+       <rotationref ref="rMinus90AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca2-ShortLat-220" unit="cm"
+         x="135.03"
+	 y="-220"
+	 z="-545.26"/>
+       <rotationref ref="rMinus90AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca3-ShortLat-220" unit="cm"
+         x="60.03"
+	 y="-220"
+	 z="-545.26"/>
+       <rotationref ref="rMinus90AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca4-ShortLat-220" unit="cm"
+         x="285.03"
+	 y="-220"
+	 z="545.26"/>
+       <rotationref ref="rPlus90AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca5-ShortLat-220" unit="cm"
+         x="210.03"
+	 y="-220"
+	 z="545.26"/>
+       <rotationref ref="rPlus90AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca6-ShortLat-220" unit="cm"
+         x="135.03"
+	 y="-220"
+	 z="545.26"/>
+       <rotationref ref="rPlus90AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca7-ShortLat-220" unit="cm"
+         x="60.03"
+	 y="-220"
+	 z="545.26"/>
+       <rotationref ref="rPlus90AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca0-ShortLat220" unit="cm"
+         x="285.03"
+	 y="220"
+	 z="-545.26"/>
+       <rotationref ref="rMinus90AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca1-ShortLat220" unit="cm"
+         x="210.03"
+	 y="220"
+	 z="-545.26"/>
+       <rotationref ref="rMinus90AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca2-ShortLat220" unit="cm"
+         x="135.03"
+	 y="220"
+	 z="-545.26"/>
+       <rotationref ref="rMinus90AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca3-ShortLat220" unit="cm"
+         x="60.03"
+	 y="220"
+	 z="-545.26"/>
+       <rotationref ref="rMinus90AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca4-ShortLat220" unit="cm"
+         x="285.03"
+	 y="220"
+	 z="545.26"/>
+       <rotationref ref="rPlus90AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca5-ShortLat220" unit="cm"
+         x="210.03"
+	 y="220"
+	 z="545.26"/>
+       <rotationref ref="rPlus90AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca6-ShortLat220" unit="cm"
+         x="135.03"
+	 y="220"
+	 z="545.26"/>
+       <rotationref ref="rPlus90AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca7-ShortLat220" unit="cm"
+         x="60.03"
+	 y="220"
+	 z="545.26"/>
+       <rotationref ref="rPlus90AboutX"/>
+     </physvol>
+    </volume>
+
+    <volume name="volFoamPadding">
+      <materialref ref="fibrous_glass"/>
+      <solidref ref="FoamPadding"/>
+    </volume>
+
+    <volume name="volSteelSupport">
+      <materialref ref="AirSteelMixture"/>
+      <solidref ref="SteelSupport"/>
+    </volume>
+
+    <volume name="volDetEnclosure">
+      <materialref ref="Air"/>
+      <solidref ref="DetEnclosure"/>
+
+       <physvol>
+           <volumeref ref="volFoamPadding"/>
+           <positionref ref="posCryoInDetEnc"/>
+       </physvol>
+       <physvol>
+           <volumeref ref="volSteelSupport"/>
+           <positionref ref="posCryoInDetEnc"/>
+       </physvol>
+       <physvol>
+           <volumeref ref="volCryostat"/>
+           <positionref ref="posCryoInDetEnc"/>
+       </physvol>
+    </volume>
+
+    <volume name="volWorld" >
+      <materialref ref="DUSEL_Rock"/>
+      <solidref ref="World"/>
+
+      <physvol>
+        <volumeref ref="volDetEnclosure"/>
+	<position name="posDetEnclosure" unit="cm" x="50.04" y="-1.13686837721616e-13" z="448.26"/>
+      </physvol>
+
+    </volume>
+</structure>
+
+  <setup name="Default" version="1.0">
+    <world ref="volWorld"/>
+  </setup>
+
+</gdml_simple_extension>

--- a/dunecore/Geometry/gdml/dunevd10kt_3view_30deg_v6_refactored_1x8x6.gdml
+++ b/dunecore/Geometry/gdml/dunevd10kt_3view_30deg_v6_refactored_1x8x6.gdml
@@ -164,7 +164,7 @@
     <fraction n="0.0053" ref="Na2O"/>
     <fraction n="0.00070" ref="P2O5"/>
     <fraction n="0.0771" ref="oxygen"/>
-  </material> 
+  </material>
 
   <material formula="Air" name="Air">
    <D value="0.001205" unit="g/cm3"/>
@@ -190,6 +190,16 @@
    <D value="0.09" unit="g/cm3"/>
    <fraction n="0.95" ref="Air"/>
    <fraction n="0.05" ref="fibrous_glass"/>
+  </material>
+
+  <!-- USE THIS NOW for FD and protoDUNEs - Juergen Reichenbacher (6/13/2023) -->
+  <!-- Foam density is 90 kg / m^3 for the assayed protoDUNE R-PUF at SD Mines -->
+  <material name="foam_protoDUNE_RPUF_assayedSample">
+   <D value="0.09" unit="g/cm3"/>
+   <composite n="54" ref="carbon"/>
+   <composite n="60" ref="hydrogen"/>
+   <composite n="4" ref="nitrogen"/>
+   <composite n="15" ref="oxygen"/>
   </material>
 
   <!-- Foam density is 70 kg / m^3 for the 3x1x1 -->
@@ -11214,14 +11224,14 @@
        <position name="posArapucaDouble0-Frame-0-0" unit="cm"
          x="-327.04"
 	 y="-541.6018"
-	 z="-261.34"/>
+	 z="-336.34"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
 	<volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-0-0" unit="cm"
          x="-327.04"
-	 y="-541.6018"
+	 y="-467.6018"
 	 z="-336.34"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
@@ -11229,7 +11239,7 @@
 	<volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-0-0" unit="cm"
          x="-327.04"
-	 y="-467.6018"
+	 y="-541.6018"
 	 z="-190.34"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
@@ -11238,7 +11248,7 @@
        <position name="posArapucaDouble3-Frame-0-0" unit="cm"
          x="-327.04"
 	 y="-376.9018"
-	 z="-336.34"/>
+	 z="-261.34"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
@@ -11246,14 +11256,14 @@
        <position name="posArapucaDouble0-Frame-0-1" unit="cm"
          x="-327.04"
 	 y="-541.6018"
-	 z="37.5"/>
+	 z="-37.5"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
 	<volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-0-1" unit="cm"
          x="-327.04"
-	 y="-541.6018"
+	 y="-467.6018"
 	 z="-108.5"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
@@ -11261,7 +11271,7 @@
 	<volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-0-1" unit="cm"
          x="-327.04"
-	 y="-467.6018"
+	 y="-541.6018"
 	 z="108.5"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
@@ -11270,7 +11280,7 @@
        <position name="posArapucaDouble3-Frame-0-1" unit="cm"
          x="-327.04"
 	 y="-376.9018"
-	 z="-37.5"/>
+	 z="37.5"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
@@ -11278,14 +11288,14 @@
        <position name="posArapucaDouble0-Frame-0-2" unit="cm"
          x="-327.04"
 	 y="-541.6018"
-	 z="336.34"/>
+	 z="261.34"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
 	<volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-0-2" unit="cm"
          x="-327.04"
-	 y="-541.6018"
+	 y="-467.6018"
 	 z="190.34"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
@@ -11293,7 +11303,7 @@
 	<volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-0-2" unit="cm"
          x="-327.04"
-	 y="-467.6018"
+	 y="-541.6018"
 	 z="336.34"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
@@ -11302,7 +11312,7 @@
        <position name="posArapucaDouble3-Frame-0-2" unit="cm"
          x="-327.04"
 	 y="-376.9018"
-	 z="261.34"/>
+	 z="336.34"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
@@ -11310,14 +11320,14 @@
        <position name="posArapucaDouble0-Frame-1-0" unit="cm"
          x="-327.04"
 	 y="-295.9006"
-	 z="-261.34"/>
+	 z="-336.34"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
 	<volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-1-0" unit="cm"
          x="-327.04"
-	 y="-205.2006"
+	 y="-131.2006"
 	 z="-336.34"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
@@ -11325,7 +11335,7 @@
 	<volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-1-0" unit="cm"
          x="-327.04"
-	 y="-131.2006"
+	 y="-205.2006"
 	 z="-190.34"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
@@ -11334,7 +11344,7 @@
        <position name="posArapucaDouble3-Frame-1-0" unit="cm"
          x="-327.04"
 	 y="-40.5006"
-	 z="-336.34"/>
+	 z="-261.34"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
@@ -11342,14 +11352,14 @@
        <position name="posArapucaDouble0-Frame-1-1" unit="cm"
          x="-327.04"
 	 y="-295.9006"
-	 z="37.5"/>
+	 z="-37.5"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
 	<volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-1-1" unit="cm"
          x="-327.04"
-	 y="-205.2006"
+	 y="-131.2006"
 	 z="-108.5"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
@@ -11357,7 +11367,7 @@
 	<volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-1-1" unit="cm"
          x="-327.04"
-	 y="-131.2006"
+	 y="-205.2006"
 	 z="108.5"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
@@ -11366,7 +11376,7 @@
        <position name="posArapucaDouble3-Frame-1-1" unit="cm"
          x="-327.04"
 	 y="-40.5006"
-	 z="-37.5"/>
+	 z="37.5"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
@@ -11374,14 +11384,14 @@
        <position name="posArapucaDouble0-Frame-1-2" unit="cm"
          x="-327.04"
 	 y="-295.9006"
-	 z="336.34"/>
+	 z="261.34"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
 	<volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-1-2" unit="cm"
          x="-327.04"
-	 y="-205.2006"
+	 y="-131.2006"
 	 z="190.34"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
@@ -11389,7 +11399,7 @@
 	<volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-1-2" unit="cm"
          x="-327.04"
-	 y="-131.2006"
+	 y="-205.2006"
 	 z="336.34"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
@@ -11398,7 +11408,7 @@
        <position name="posArapucaDouble3-Frame-1-2" unit="cm"
          x="-327.04"
 	 y="-40.5006"
-	 z="261.34"/>
+	 z="336.34"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
@@ -11406,14 +11416,14 @@
        <position name="posArapucaDouble0-Frame-2-0" unit="cm"
          x="-327.04"
 	 y="40.5006"
-	 z="-261.34"/>
+	 z="-336.34"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
 	<volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-2-0" unit="cm"
          x="-327.04"
-	 y="131.2006"
+	 y="205.2006"
 	 z="-336.34"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
@@ -11421,7 +11431,7 @@
 	<volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-2-0" unit="cm"
          x="-327.04"
-	 y="205.2006"
+	 y="131.2006"
 	 z="-190.34"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
@@ -11430,7 +11440,7 @@
        <position name="posArapucaDouble3-Frame-2-0" unit="cm"
          x="-327.04"
 	 y="295.9006"
-	 z="-336.34"/>
+	 z="-261.34"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
@@ -11438,14 +11448,14 @@
        <position name="posArapucaDouble0-Frame-2-1" unit="cm"
          x="-327.04"
 	 y="40.5006"
-	 z="37.5"/>
+	 z="-37.5"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
 	<volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-2-1" unit="cm"
          x="-327.04"
-	 y="131.2006"
+	 y="205.2006"
 	 z="-108.5"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
@@ -11453,7 +11463,7 @@
 	<volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-2-1" unit="cm"
          x="-327.04"
-	 y="205.2006"
+	 y="131.2006"
 	 z="108.5"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
@@ -11462,7 +11472,7 @@
        <position name="posArapucaDouble3-Frame-2-1" unit="cm"
          x="-327.04"
 	 y="295.9006"
-	 z="-37.5"/>
+	 z="37.5"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
@@ -11470,14 +11480,14 @@
        <position name="posArapucaDouble0-Frame-2-2" unit="cm"
          x="-327.04"
 	 y="40.5006"
-	 z="336.34"/>
+	 z="261.34"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
 	<volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-2-2" unit="cm"
          x="-327.04"
-	 y="131.2006"
+	 y="205.2006"
 	 z="190.34"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
@@ -11485,7 +11495,7 @@
 	<volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-2-2" unit="cm"
          x="-327.04"
-	 y="205.2006"
+	 y="131.2006"
 	 z="336.34"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
@@ -11494,7 +11504,7 @@
        <position name="posArapucaDouble3-Frame-2-2" unit="cm"
          x="-327.04"
 	 y="295.9006"
-	 z="261.34"/>
+	 z="336.34"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
@@ -11502,14 +11512,14 @@
        <position name="posArapucaDouble0-Frame-3-0" unit="cm"
          x="-327.04"
 	 y="376.9018"
-	 z="-261.34"/>
+	 z="-336.34"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
 	<volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-3-0" unit="cm"
          x="-327.04"
-	 y="467.6018"
+	 y="541.6018"
 	 z="-336.34"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
@@ -11517,7 +11527,7 @@
 	<volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-3-0" unit="cm"
          x="-327.04"
-	 y="541.6018"
+	 y="467.6018"
 	 z="-190.34"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
@@ -11526,7 +11536,7 @@
        <position name="posArapucaDouble3-Frame-3-0" unit="cm"
          x="-327.04"
 	 y="541.6018"
-	 z="-336.34"/>
+	 z="-261.34"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
@@ -11534,14 +11544,14 @@
        <position name="posArapucaDouble0-Frame-3-1" unit="cm"
          x="-327.04"
 	 y="376.9018"
-	 z="37.5"/>
+	 z="-37.5"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
 	<volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-3-1" unit="cm"
          x="-327.04"
-	 y="467.6018"
+	 y="541.6018"
 	 z="-108.5"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
@@ -11549,7 +11559,7 @@
 	<volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-3-1" unit="cm"
          x="-327.04"
-	 y="541.6018"
+	 y="467.6018"
 	 z="108.5"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
@@ -11558,7 +11568,7 @@
        <position name="posArapucaDouble3-Frame-3-1" unit="cm"
          x="-327.04"
 	 y="541.6018"
-	 z="-37.5"/>
+	 z="37.5"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
@@ -11566,14 +11576,14 @@
        <position name="posArapucaDouble0-Frame-3-2" unit="cm"
          x="-327.04"
 	 y="376.9018"
-	 z="336.34"/>
+	 z="261.34"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
 	<volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-3-2" unit="cm"
          x="-327.04"
-	 y="467.6018"
+	 y="541.6018"
 	 z="190.34"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
@@ -11581,7 +11591,7 @@
 	<volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-3-2" unit="cm"
          x="-327.04"
-	 y="541.6018"
+	 y="467.6018"
 	 z="336.34"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
@@ -11590,7 +11600,7 @@
        <position name="posArapucaDouble3-Frame-3-2" unit="cm"
          x="-327.04"
 	 y="541.6018"
-	 z="261.34"/>
+	 z="336.34"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>

--- a/dunecore/Geometry/gdml/dunevd10kt_3view_30deg_v6_refactored_1x8x6_nowires.gdml
+++ b/dunecore/Geometry/gdml/dunevd10kt_3view_30deg_v6_refactored_1x8x6_nowires.gdml
@@ -1,0 +1,2485 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<gdml_simple_extension xmlns:gdml_simple_extension="http://www.example.org"
+                       xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"          
+                       xs:noNamespaceSchemaLocation="RefactoredGDMLSchema/SimpleExtension.xsd"> 
+
+
+<extension>
+   <color name="magenta"     R="0.0"  G="1.0"  B="0.0"  A="1.0" />
+   <color name="green"       R="0.0"  G="1.0"  B="0.0"  A="1.0" />
+   <color name="red"         R="1.0"  G="0.0"  B="0.0"  A="1.0" />
+   <color name="blue"        R="0.0"  G="0.0"  B="1.0"  A="1.0" />
+   <color name="yellow"      R="1.0"  G="1.0"  B="0.0"  A="1.0" />
+</extension>
+<define>
+
+<!--
+
+
+
+-->
+
+   <position name="posCryoInDetEnc"     unit="cm" x="-50.0000000000001" y="0" z="0"/>
+   <position name="posCenter"           unit="cm" x="0" y="0" z="0"/>
+   <rotation name="rUWireAboutX"        unit="deg" x="150" y="0" z="0"/>
+   <rotation name="rVWireAboutX"        unit="deg" x="30" y="0" z="0"/>
+   <rotation name="rPlus90AboutX"       unit="deg" x="90" y="0" z="0"/>
+   <rotation name="rPlus90AboutY"       unit="deg" x="0" y="90" z="0"/>
+   <rotation name="rPlus90AboutXPlus90AboutY" unit="deg" x="90" y="90" z="0"/>
+   <rotation name="rMinus90AboutX"      unit="deg" x="270" y="0" z="0"/>
+   <rotation name="rMinus90AboutY"      unit="deg" x="0" y="270" z="0"/>
+   <rotation name="rMinus90AboutYMinus90AboutX"       unit="deg" x="270" y="270" z="0"/>
+   <rotation name="rPlus180AboutX"	unit="deg" x="180" y="0"   z="0"/>
+   <rotation name="rPlus180AboutY"	unit="deg" x="0" y="180"   z="0"/>
+   <rotation name="rPlus180AboutXPlus180AboutY"	unit="deg" x="180" y="180"   z="0"/>
+   <rotation name="rIdentity"		unit="deg" x="0" y="0"   z="0"/>
+   <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+   <rotation name="rPlus90AboutXPlus180AboutY" unit="deg" x="90" y="180" z="0" />
+   <rotation name="rPlus90AboutXMinux90AboutY" unit="deg" x="90" y="270" z="0" />
+   <rotation name="rPlus90AboutZ" unit="deg" x="0" y="0" z="90" />
+</define>
+<materials>
+  <element name="videRef" formula="VACUUM" Z="1">  <atom value="1"/> </element>
+  <element name="copper" formula="Cu" Z="29">  <atom value="63.546"/>  </element>
+  <element name="beryllium" formula="Be" Z="4">  <atom value="9.0121831"/>  </element>
+  <element name="bromine" formula="Br" Z="35"> <atom value="79.904"/> </element>
+  <element name="hydrogen" formula="H" Z="1">  <atom value="1.0079"/> </element>
+  <element name="nitrogen" formula="N" Z="7">  <atom value="14.0067"/> </element>
+  <element name="oxygen" formula="O" Z="8">  <atom value="15.999"/> </element>
+  <element name="aluminum" formula="Al" Z="13"> <atom value="26.9815"/>  </element>
+  <element name="silicon" formula="Si" Z="14"> <atom value="28.0855"/>  </element>
+  <element name="carbon" formula="C" Z="6">  <atom value="12.0107"/>  </element>
+  <element name="potassium" formula="K" Z="19"> <atom value="39.0983"/>  </element>
+  <element name="chromium" formula="Cr" Z="24"> <atom value="51.9961"/>  </element>
+  <element name="iron" formula="Fe" Z="26"> <atom value="55.8450"/>  </element>
+  <element name="nickel" formula="Ni" Z="28"> <atom value="58.6934"/>  </element>
+  <element name="calcium" formula="Ca" Z="20"> <atom value="40.078"/>   </element>
+  <element name="magnesium" formula="Mg" Z="12"> <atom value="24.305"/>   </element>
+  <element name="sodium" formula="Na" Z="11"> <atom value="22.99"/>    </element>
+  <element name="titanium" formula="Ti" Z="22"> <atom value="47.867"/>   </element>
+  <element name="argon" formula="Ar" Z="18"> <atom value="39.9480"/>  </element>
+  <element name="sulphur" formula="S" Z="16"> <atom value="32.065"/>  </element>
+  <element name="phosphorus" formula="P" Z="15"> <atom value="30.973"/>  </element>
+
+  <material name="Vacuum" formula="Vacuum">
+   <D value="1.e-25" unit="g/cm3"/>
+   <fraction n="1.0" ref="videRef"/>
+  </material>
+
+  <material name="ALUMINUM_Al" formula="ALUMINUM_Al">
+   <D value="2.6990" unit="g/cm3"/>
+   <fraction n="1.0000" ref="aluminum"/>
+  </material>
+
+  <material name="SILICON_Si" formula="SILICON_Si">
+   <D value="2.3300" unit="g/cm3"/>
+   <fraction n="1.0000" ref="silicon"/>
+  </material>
+
+  <material name="epoxy_resin" formula="C38H40O6Br4">
+   <D value="1.1250" unit="g/cm3"/>
+   <composite n="38" ref="carbon"/>
+   <composite n="40" ref="hydrogen"/>
+   <composite n="6" ref="oxygen"/>
+   <composite n="4" ref="bromine"/>
+  </material>
+
+  <material name="SiO2" formula="SiO2">
+   <D value="2.2" unit="g/cm3"/>
+   <composite n="1" ref="silicon"/>
+   <composite n="2" ref="oxygen"/>
+  </material>
+
+  <material name="Al2O3" formula="Al2O3">
+   <D value="3.97" unit="g/cm3"/>
+   <composite n="2" ref="aluminum"/>
+   <composite n="3" ref="oxygen"/>
+  </material>
+
+  <material name="Fe2O3" formula="Fe2O3">
+   <D value="5.24" unit="g/cm3"/>
+   <composite n="2" ref="iron"/>
+   <composite n="3" ref="oxygen"/>
+  </material>
+
+  <material name="CaO" formula="CaO">
+   <D value="3.35" unit="g/cm3"/>
+   <composite n="1" ref="calcium"/>
+   <composite n="1" ref="oxygen"/>
+  </material>
+
+  <material name="Delrin" formula="CH2O">
+    <D value="1.41" unit="g/cm3"/>
+    <composite n="1" ref="carbon"/>
+    <composite n="2" ref="hydrogen"/>
+    <composite n="1" ref="oxygen"/>
+  </material>
+
+  <material name="MgO" formula="MgO">
+   <D value="3.58" unit="g/cm3"/>
+   <composite n="1" ref="magnesium"/>
+   <composite n="1" ref="oxygen"/>
+  </material>
+
+  <material name="Na2O" formula="Na2O">
+   <D value="2.27" unit="g/cm3"/>
+   <composite n="2" ref="sodium"/>
+   <composite n="1" ref="oxygen"/>
+  </material>
+
+  <material name="TiO2" formula="TiO2">
+   <D value="4.23" unit="g/cm3"/>
+   <composite n="1" ref="titanium"/>
+   <composite n="2" ref="oxygen"/>
+  </material>
+
+  <material name="FeO" formula="FeO">
+   <D value="5.745" unit="g/cm3"/>
+   <composite n="1" ref="iron"/>
+   <composite n="1" ref="oxygen"/>
+  </material>
+
+  <material name="CO2" formula="CO2">
+   <D value="1.562" unit="g/cm3"/>
+   <composite n="1" ref="iron"/>
+   <composite n="2" ref="oxygen"/>
+  </material>
+
+  <material name="P2O5" formula="P2O5">
+   <D value="1.562" unit="g/cm3"/>
+   <composite n="2" ref="phosphorus"/>
+   <composite n="5" ref="oxygen"/>
+  </material>
+
+  <material formula=" " name="DUSEL_Rock">
+    <D value="2.82" unit="g/cm3"/>
+    <fraction n="0.5267" ref="SiO2"/>
+    <fraction n="0.1174" ref="FeO"/>
+    <fraction n="0.1025" ref="Al2O3"/>
+    <fraction n="0.0473" ref="MgO"/>
+    <fraction n="0.0422" ref="CO2"/>
+    <fraction n="0.0382" ref="CaO"/>
+    <fraction n="0.0240" ref="carbon"/>
+    <fraction n="0.0186" ref="sulphur"/>
+    <fraction n="0.0053" ref="Na2O"/>
+    <fraction n="0.00070" ref="P2O5"/>
+    <fraction n="0.0771" ref="oxygen"/>
+  </material> 
+
+  <material formula="Air" name="Air">
+   <D value="0.001205" unit="g/cm3"/>
+   <fraction n="0.781154" ref="nitrogen"/>
+   <fraction n="0.209476" ref="oxygen"/>
+   <fraction n="0.00934" ref="argon"/>
+  </material>
+
+  <material name="fibrous_glass">
+   <D value="2.74351" unit="g/cm3"/>
+   <fraction n="0.600" ref="SiO2"/>
+   <fraction n="0.118" ref="Al2O3"/>
+   <fraction n="0.001" ref="Fe2O3"/>
+   <fraction n="0.224" ref="CaO"/>
+   <fraction n="0.034" ref="MgO"/>
+   <fraction n="0.010" ref="Na2O"/>
+   <fraction n="0.013" ref="TiO2"/>
+  </material>
+
+  <!-- density referenced from EHN1-Cold Cryostats Technical Requirements:
+       https://edms.cern.ch/document/1543254 -->
+  <material name="FD_foam">
+   <D value="0.09" unit="g/cm3"/>
+   <fraction n="0.95" ref="Air"/>
+   <fraction n="0.05" ref="fibrous_glass"/>
+  </material>
+
+  <!-- Foam density is 70 kg / m^3 for the 3x1x1 -->
+  <material name="foam_3x1x1dp">
+   <D value="0.07" unit="g/cm3"/>
+   <fraction n="0.95" ref="Air"/>
+   <fraction n="0.05" ref="fibrous_glass"/>
+  </material>
+
+  <!-- Copied from protodune_v4.gdml -->
+  <material name="foam_protoDUNEdp">
+   <D value="0.135" unit="g/cm3"/>
+   <composite n="17" ref="carbon"/>
+   <composite n="16" ref="hydrogen"/>
+   <composite n="2" ref="nitrogen"/>
+   <composite n="4" ref="oxygen"/>
+  </material>
+
+  <material name="FR4">
+   <D value="1.98281" unit="g/cm3"/>
+   <fraction n="0.47" ref="epoxy_resin"/>
+   <fraction n="0.53" ref="fibrous_glass"/>
+  </material>
+
+  <material name="STEEL_STAINLESS_Fe7Cr2Ni" formula="STEEL_STAINLESS_Fe7Cr2Ni">
+   <D value="7.9300" unit="g/cm3"/>
+   <fraction n="0.0010" ref="carbon"/>
+   <fraction n="0.1792" ref="chromium"/>
+   <fraction n="0.7298" ref="iron"/>
+   <fraction n="0.0900" ref="nickel"/>
+  </material>
+
+  <material name="Copper_Beryllium_alloy25" formula="Copper_Beryllium_alloy25">
+   <D value="8.26" unit="g/cm3"/>
+   <fraction n="0.981" ref="copper"/>
+   <fraction n="0.019" ref="beryllium"/>
+  </material>
+
+  <material name="LAr" formula="LAr">
+   <D value="1.40" unit="g/cm3"/>
+   <fraction n="1.0000" ref="argon"/>
+  </material>
+
+  <material name="ArGas" formula="ArGas">
+   <D value="0.00166" unit="g/cm3"/>
+   <fraction n="1.0" ref="argon"/>
+  </material>
+
+  <material formula=" " name="G10">
+   <D value="1.7" unit="g/cm3"/>
+   <fraction n="0.2805" ref="silicon"/>
+   <fraction n="0.3954" ref="oxygen"/>
+   <fraction n="0.2990" ref="carbon"/>
+   <fraction n="0.0251" ref="hydrogen"/>
+  </material>
+
+  <material formula=" " name="Granite">
+   <D value="2.7" unit="g/cm3"/>
+   <fraction n="0.438" ref="oxygen"/>
+   <fraction n="0.257" ref="silicon"/>
+   <fraction n="0.222" ref="sodium"/>
+   <fraction n="0.049" ref="aluminum"/>
+   <fraction n="0.019" ref="iron"/>
+   <fraction n="0.015" ref="potassium"/>
+  </material>
+
+  <material formula=" " name="ShotRock">
+   <D value="1.62" unit="g/cm3"/>
+   <fraction n="0.438" ref="oxygen"/>
+   <fraction n="0.257" ref="silicon"/>
+   <fraction n="0.222" ref="sodium"/>
+   <fraction n="0.049" ref="aluminum"/>
+   <fraction n="0.019" ref="iron"/>
+   <fraction n="0.015" ref="potassium"/>
+  </material>
+
+  <material formula=" " name="Dirt">
+   <D value="1.7" unit="g/cm3"/>
+   <fraction n="0.438" ref="oxygen"/>
+   <fraction n="0.257" ref="silicon"/>
+   <fraction n="0.222" ref="sodium"/>
+   <fraction n="0.049" ref="aluminum"/>
+   <fraction n="0.019" ref="iron"/>
+   <fraction n="0.015" ref="potassium"/>
+  </material>
+
+  <material formula=" " name="Concrete">
+   <D value="2.3" unit="g/cm3"/>
+   <fraction n="0.530" ref="oxygen"/>
+   <fraction n="0.335" ref="silicon"/>
+   <fraction n="0.060" ref="calcium"/>
+   <fraction n="0.015" ref="sodium"/>
+   <fraction n="0.020" ref="iron"/>
+   <fraction n="0.040" ref="aluminum"/>
+  </material>
+
+  <material formula="H2O" name="Water">
+   <D value="1.0" unit="g/cm3"/>
+   <fraction n="0.1119" ref="hydrogen"/>
+   <fraction n="0.8881" ref="oxygen"/>
+  </material>
+
+  <material formula="Ti" name="Titanium">
+   <D value="4.506" unit="g/cm3"/>
+   <fraction n="1." ref="titanium"/>
+  </material>
+
+  <material name="TPB" formula="TPB">
+   <D value="1.40" unit="g/cm3"/>
+   <fraction n="1.0000" ref="argon"/>
+  </material>
+
+  <material name="Glass">
+   <D value="2.74351" unit="g/cm3"/>
+   <fraction n="0.600" ref="SiO2"/>
+   <fraction n="0.118" ref="Al2O3"/>
+   <fraction n="0.001" ref="Fe2O3"/>
+   <fraction n="0.224" ref="CaO"/>
+   <fraction n="0.034" ref="MgO"/>
+   <fraction n="0.010" ref="Na2O"/>
+   <fraction n="0.013" ref="TiO2"/>
+  </material>
+
+  <material name="Acrylic">
+   <D value="1.19" unit="g/cm3"/>
+   <fraction n="0.600" ref="carbon"/>
+   <fraction n="0.320" ref="oxygen"/>
+   <fraction n="0.080" ref="hydrogen"/>
+  </material>
+
+  <material name="NiGas1atm80K">
+   <D value="0.0039" unit="g/cm3"/>
+   <fraction n="1.000" ref="nitrogen"/>
+  </material>
+
+  <material name="NiGas">
+   <D value="0.001165" unit="g/cm3"/>
+   <fraction n="1.000" ref="nitrogen"/>
+  </material>
+
+  <material name="PolyurethaneFoam">
+   <D value="0.088" unit="g/cm3"/>
+   <composite n="17" ref="carbon"/>
+   <composite n="16" ref="hydrogen"/>
+   <composite n="2" ref="nitrogen"/>
+   <composite n="4" ref="oxygen"/>
+  </material>
+
+  <material name="ProtoDUNEFoam">
+   <D value="0.135" unit="g/cm3"/>
+   <composite n="17" ref="carbon"/>
+   <composite n="16" ref="hydrogen"/>
+   <composite n="2" ref="nitrogen"/>
+   <composite n="4" ref="oxygen"/>
+  </material>
+
+  <material name="LightPolyurethaneFoam">
+   <D value="0.009" unit="g/cm3"/>
+   <composite n="17" ref="carbon"/>
+   <composite n="16" ref="hydrogen"/>
+   <composite n="2" ref="nitrogen"/>
+   <composite n="4" ref="oxygen"/>
+  </material>
+
+  <material name="ProtoDUNEBWFoam">
+   <D value="0.021" unit="g/cm3"/>
+   <composite n="17" ref="carbon"/>
+   <composite n="16" ref="hydrogen"/>
+   <composite n="2" ref="nitrogen"/>
+   <composite n="4" ref="oxygen"/>
+  </material>
+
+  <material name="GlassWool">
+   <D value="0.035" unit="g/cm3"/>
+   <fraction n="0.65" ref="SiO2"/>
+   <fraction n="0.09" ref="Al2O3"/>
+   <fraction n="0.07" ref="CaO"/>
+   <fraction n="0.03" ref="MgO"/>
+   <fraction n="0.16" ref="Na2O"/>
+  </material>
+
+  <material name="Polystyrene">
+   <D value="1.06" unit="g/cm3"/>
+   <composite n="8" ref="carbon"/>
+   <composite n="8" ref="hydrogen"/>
+  </material>
+
+
+
+  <!-- preliminary values -->
+  <material name="AirSteelMixture" formula="AirSteelMixture">
+   <D value="3.9656025" unit="g/cm3"/>
+   <fraction n="0.5" ref="STEEL_STAINLESS_Fe7Cr2Ni"/>
+   <fraction n="0.5"   ref="Air"/>
+  </material>
+  <material name="vm2000" formula="vm2000">
+    <D value="1.2" unit="g/cm3"/>
+    <composite n="2" ref="carbon"/>
+    <composite n="4" ref="hydrogen"/>
+  </material>
+
+</materials>
+<solids>
+     <torus name="FieldShaperCorner" rmin="0.5" rmax="2.285" rtor="2.3" deltaphi="90" startphi="0" aunit="deg" lunit="cm"/>
+     <tube name="FieldShaperLongtube" rmin="0.5" rmax="2.285" z="896.52" deltaphi="360" startphi="0" aunit="deg" lunit="cm"/>
+     <tube name="FieldShaperLongtubeSlim" rmin="0.5" rmax="0.75" z="896.52" deltaphi="360" startphi="0" aunit="deg" lunit="cm"/>
+     <tube name="FieldShaperShorttube" rmin="0.5" rmax="2.285" z="1345.6048" deltaphi="360" startphi="0" aunit="deg" lunit="cm"/>
+     <tube name="FieldShaperShorttubeWindowSlim" rmin="0.5" rmax="0.75" z="670" deltaphi="360" startphi="0" aunit="deg" lunit="cm"/>
+     <tube name="FieldShaperShorttubeWindowNotSlim" rmin="0.5" rmax="2.285" z="337.8024" deltaphi="360" startphi="0" aunit="deg" lunit="cm"/>
+
+
+    <union name="FSunionWindow1">
+      <first ref="FieldShaperShorttubeWindowSlim"/>
+      <second ref="FieldShaperShorttubeWindowNotSlim"/>
+      <position name="posFieldShaperShortTube_shift1" unit="cm" x="0" y="0" z="503.9012"/>
+    </union>
+
+    <union name="FieldShaperShorttubeSlim">
+      <first ref="FSunionWindow1"/>
+      <second ref="FieldShaperShorttubeWindowNotSlim"/>
+      <position name="posFieldShaperShortTube_shift2" unit="cm" x="0" y="0" z="-503.9012"/>
+    </union>
+
+
+
+
+    <union name="FSunion1">
+      <first ref="FieldShaperLongtube"/>
+      <second ref="FieldShaperCorner"/>
+                <position name="esquinapos1" unit="cm" x="-2.3" y="0" z="448.26"/>
+                <rotationref ref="rPlus90AboutX"/>
+    </union>
+
+    <union name="FSunion2">
+      <first ref="FSunion1"/>
+      <second ref="FieldShaperShorttube"/>
+   		<position name="esquinapos2" unit="cm" x="-675.1024" y="0" z="450.56"/>
+   		<rotationref ref="rPlus90AboutY"/>
+    </union>
+
+    <union name="FSunion3">
+      <first ref="FSunion2"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos3" unit="cm" x="-1347.9048" y="0" z="448.26"/>
+		<rotationref ref="rPlus90AboutXMinux90AboutY"/>
+    </union>
+
+    <union name="FSunion4">
+      <first ref="FSunion3"/>
+      <second ref="FieldShaperLongtube"/>
+   		<position name="esquinapos4" unit="cm" x="-1350.2048" y="0" z="0"/>
+    </union>
+
+    <union name="FSunion5">
+      <first ref="FSunion4"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos5" unit="cm" x="-1347.9048" y="0" z="-448.26"/>
+		<rotationref ref="rPlus90AboutXPlus180AboutY"/>
+    </union>
+
+    <union name="FSunion6">
+      <first ref="FSunion5"/>
+      <second ref="FieldShaperShorttube"/>
+   		<position name="esquinapos6" unit="cm" x="-675.1024" y="0" z="-450.56"/>
+		<rotationref ref="rPlus90AboutY"/>
+    </union>
+
+    <union name="FieldShaperSolid">
+      <first ref="FSunion6"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos7" unit="cm" x="-2.3" y="0" z="-448.26"/>
+		<rotationref ref="rPlus90AboutXPlus90AboutY"/>
+    </union>
+
+    <union name="FSunionSlim1">
+      <first ref="FieldShaperLongtubeSlim"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos8" unit="cm" x="-2.3" y="0" z="448.26"/>
+		<rotationref ref="rPlus90AboutX"/>
+    </union>
+
+    <union name="FSunionSlim2">
+      <first ref="FSunionSlim1"/>
+      <second ref="FieldShaperShorttubeSlim"/>
+   		<position name="esquinapos9" unit="cm" x="-675.1024" y="0" z="450.56"/>
+   		<rotationref ref="rPlus90AboutY"/>
+    </union>
+
+    <union name="FSunionSlim3">
+      <first ref="FSunionSlim2"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos10" unit="cm" x="-1347.9048" y="0" z="448.26"/>
+		<rotationref ref="rPlus90AboutXMinux90AboutY"/>
+    </union>
+
+    <union name="FSunionSlim4">
+      <first ref="FSunionSlim3"/>
+      <second ref="FieldShaperLongtubeSlim"/>
+   		<position name="esquinapos4" unit="cm" x="-1350.2048" y="0" z="0"/>
+    </union>
+
+    <union name="FSunionSlim5">
+      <first ref="FSunionSlim4"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos11" unit="cm" x="-1347.9048" y="0" z="-448.26"/>
+		<rotationref ref="rPlus90AboutXPlus180AboutY"/>
+    </union>
+
+    <union name="FSunionSlim6">
+      <first ref="FSunionSlim5"/>
+      <second ref="FieldShaperShorttubeSlim"/>
+   		<position name="esquinapos12" unit="cm" x="-675.1024" y="0" z="-450.56"/>
+		<rotationref ref="rPlus90AboutY"/>
+    </union>
+
+    <union name="FieldShaperSolidSlim">
+      <first ref="FSunionSlim6"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos13" unit="cm" x="-2.3" y="0" z="-448.26"/>
+		<rotationref ref="rPlus90AboutXPlus90AboutY"/>
+    </union>
+
+
+   <box name="CRM"
+      x="650.08"
+      y="167.7006"
+      z="148.92"
+      lunit="cm"/>
+   <box name="CRMUPlane"
+      x="0.02"
+      y="167.7006"
+      z="148.92"
+      lunit="cm"/>
+   <box name="CRMVPlane"
+      x="0.02"
+      y="167.7006"
+      z="148.92"
+      lunit="cm"/>
+   <box name="CRMZPlane"
+      x="0.02"
+      y="167.7006"
+      z="148.92"
+      lunit="cm"/>
+   <box name="CRMActive"
+      x="650"
+      y="167.7006"
+      z="148.92"
+      lunit="cm"/>
+
+    <box name="ArapucaOut" lunit="cm"
+      x="65"
+      y="2.5"
+      z="65"/>
+
+    <box name="ArapucaIn" lunit="cm"
+      x="60"
+      y="2.5"
+      z="60"/>
+
+     <subtraction name="ArapucaWalls">
+      <first  ref="ArapucaOut"/>
+      <second ref="ArapucaIn"/>
+      <position name="posArapucaSub" x="0" y="1.25" z="0." unit="cm"/>
+      </subtraction>
+
+    <box name="ArapucaAcceptanceWindow" lunit="cm"
+      x="60"
+      y="1"
+      z="60"/>
+
+    <box name="ArapucaDoubleIn" lunit="cm"
+      x="60"
+      y="3.5"
+      z="60"/>
+
+     <subtraction name="ArapucaDoubleWalls">
+      <first  ref="ArapucaOut"/>
+      <second ref="ArapucaDoubleIn"/>
+      <position name="posArapucaDoubleSub" x="0" y="0" z="0" unit="cm"/>
+      </subtraction>
+
+    <box name="ArapucaDoubleAcceptanceWindow" lunit="cm"
+      x="60"
+      y="2.48"
+      z="60"/>
+
+
+    <box name="Cryostat" lunit="cm"
+      x="850.32"
+      y="1507.8448"
+      z="1110.76"/>
+
+    <box name="ArgonInterior" lunit="cm"
+      x="850.08"
+      y="1507.6048"
+      z="1110.52"/>
+
+    <box name="GaseousArgon" lunit="cm"
+      x="99.99"
+      y="1507.6048"
+      z="1110.52"/>
+
+    <subtraction name="SteelShell">
+      <first ref="Cryostat"/>
+      <second ref="ArgonInterior"/>
+    </subtraction>
+
+
+
+    <box name="CathodeBlock" lunit="cm"
+      x="4"
+      y="336.4012"
+      z="298.84" />
+
+    <box name="CathodeVoid" lunit="cm"
+      x="5"
+      y="76.35"
+      z="67" />
+
+    <subtraction name="Cathode1">
+      <first ref="CathodeBlock"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub1" x="0" y="-122.525" z="-108.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode2">
+      <first ref="Cathode1"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub2" x="0" y="-122.525" z="-37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode3">
+      <first ref="Cathode2"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub3" x="0" y="-122.525" z="37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode4">
+      <first ref="Cathode3"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub4" x="0" y="-122.525" z="108.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode5">
+      <first ref="Cathode4"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub5" x="0" y="-42.175" z="-108.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode6">
+      <first ref="Cathode5"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub6" x="0" y="-42.175" z="-37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode7">
+      <first ref="Cathode6"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub7" x="0" y="-42.175" z="37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode8">
+      <first ref="Cathode7"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub8" x="0" y="-42.175" z="108.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode9">
+      <first ref="Cathode8"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub9" x="0" y="42.175" z="-108.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode10">
+      <first ref="Cathode9"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub10" x="0" y="42.175" z="-37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode11">
+      <first ref="Cathode10"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub11" x="0" y="42.175" z="37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode12">
+      <first ref="Cathode11"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub12" x="0" y="42.175" z="108.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode13">
+      <first ref="Cathode12"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub13" x="0" y="122.525" z="-108.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode14">
+      <first ref="Cathode13"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub14" x="0" y="122.525" z="-37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode15">
+      <first ref="Cathode14"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub15" x="0" y="122.525" z="37.5" unit="cm"/>
+    </subtraction>
+    <subtraction name="CathodeGrid">
+      <first ref="Cathode15"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub16" x="0" y="122.525" z="108.5" unit="cm"/>
+    </subtraction>
+
+   <box name="AnodePlate"
+      x="0.01"
+      y="336.4012"
+      z="298.84"
+      lunit="cm"/>
+
+    <box name="FoamPadBlock" lunit="cm"
+      x="1010.32"
+      y="1667.8448"
+      z="1270.76" />
+
+    <subtraction name="FoamPadding">
+      <first ref="FoamPadBlock"/>
+      <second ref="Cryostat"/>
+      <positionref ref="posCenter"/>
+    </subtraction>
+
+    <box name="SteelSupportBlock" lunit="cm"
+      x="1210.32"
+      y="1867.8448"
+      z="1470.76" />
+
+    <subtraction name="SteelSupport">
+      <first ref="SteelSupportBlock"/>
+      <second ref="FoamPadBlock"/>
+      <positionref ref="posCenter"/>
+    </subtraction>
+
+    <box name="DetEnclosure" lunit="cm"
+      x="1310.32"
+      y="2067.8448"
+      z="1670.76"/>
+
+
+    <box name="World" lunit="cm"
+      x="9310.32"
+      y="10067.8448"
+      z="9670.76"/>
+</solids>
+<structure>
+<volume name="volFieldShaper">
+  <materialref ref="ALUMINUM_Al"/>
+  <solidref ref="FieldShaperSolid"/>
+</volume>
+<volume name="volFieldShaperSlim">
+  <materialref ref="ALUMINUM_Al"/>
+  <solidref ref="FieldShaperSolidSlim"/>
+</volume>
+
+
+    <volume name="volTPCActive">
+      <materialref ref="LAr"/>
+      <solidref ref="CRMActive"/>
+      <auxiliary auxtype="SensDet" auxvalue="SimEnergyDeposit"/>
+      <auxiliary auxtype="StepLimit" auxunit="cm" auxvalue="0.5208*cm"/>
+      <auxiliary auxtype="Efield" auxunit="V/cm" auxvalue="500*V/cm"/>
+      <colorref ref="blue"/>
+    </volume>
+   <volume name="volTPCPlaneU">
+     <materialref ref="LAr"/>
+     <solidref ref="CRMUPlane"/>
+   </volume>
+  <volume name="volTPCPlaneV">
+    <materialref ref="LAr"/>
+    <solidref ref="CRMVPlane"/>
+  </volume>
+  <volume name="volTPCPlaneZ">
+    <materialref ref="LAr"/>
+    <solidref ref="CRMZPlane"/>
+  </volume>
+   <volume name="volTPC">
+     <materialref ref="LAr"/>
+       <solidref ref="CRM"/>
+       <physvol>
+       <volumeref ref="volTPCPlaneU"/>
+       <position name="posPlaneU" unit="cm"
+         x="324.99" y="0" z="0"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCPlaneV"/>
+       <position name="posPlaneY" unit="cm"
+         x="325.01" y="0" z="0"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCPlaneZ"/>
+       <position name="posPlaneZ" unit="cm"
+         x="325.03" y="0" z="0"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCActive"/>
+       <position name="posActive" unit="cm"
+        x="-0.04" y="0" z="0"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+   </volume>
+ 
+    <volume name="volSteelShell">
+      <materialref ref="STEEL_STAINLESS_Fe7Cr2Ni" />
+      <solidref ref="SteelShell" />
+    </volume>
+    <volume name="volCathodeGrid">
+      <materialref ref="G10" />
+      <solidref ref="CathodeGrid" />
+    </volume>
+    <volume name="volAnodePlate">
+     <materialref ref="vm2000"/>
+     <solidref ref="AnodePlate"/>
+    </volume>
+    <volume name="volGaseousArgon">
+      <materialref ref="ArGas"/>
+      <solidref ref="GaseousArgon"/>
+    </volume>
+
+    <volume name="volOpDetSensitive">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+
+    <volume name="Arapuca">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+
+    <volume name="volArapuca">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaOut"/>
+      <physvol>
+        <volumeref ref="Arapuca"/>
+        <positionref ref="posCenter"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volOpDetSensitive"/>
+        <position name="opdetshift" unit="cm" x="0" y="0.5" z="0"/>
+      </physvol>
+    </volume>
+
+    <volume name="volCryostat">
+      <materialref ref="LAr" />
+      <solidref ref="Cryostat" />
+      <auxiliary auxtype="SensDet" auxvalue="SimEnergyDeposit"/>
+      <auxiliary auxtype="StepLimit" auxunit="cm" auxvalue="0.5208*cm"/>
+      <auxiliary auxtype="Efield" auxunit="V/cm" auxvalue="0*V/cm"/>
+
+      <physvol>
+        <volumeref ref="volGaseousArgon"/>
+        <position name="posGaseousArgon" unit="cm" x="375.045" y="0" z="0"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volSteelShell"/>
+        <position name="posSteelShell" unit="cm" x="0" y="0" z="0"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-0" unit="cm"
+           x="0" y="-588.4521" z="-373.3"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-1" unit="cm"
+           x="0" y="-420.7515" z="-373.3"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-2" unit="cm"
+           x="0" y="-252.0509" z="-373.3"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-3" unit="cm"
+           x="0" y="-84.3502999999999" z="-373.3"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-4" unit="cm"
+           x="0" y="84.3503000000001" z="-373.3"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-5" unit="cm"
+           x="0" y="252.0509" z="-373.3"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-6" unit="cm"
+           x="0" y="420.7515" z="-373.3"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-7" unit="cm"
+           x="0" y="588.4521" z="-373.3"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-8" unit="cm"
+           x="0" y="-588.4521" z="-224.38"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-9" unit="cm"
+           x="0" y="-420.7515" z="-224.38"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-10" unit="cm"
+           x="0" y="-252.0509" z="-224.38"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-11" unit="cm"
+           x="0" y="-84.3502999999999" z="-224.38"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-12" unit="cm"
+           x="0" y="84.3503000000001" z="-224.38"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-13" unit="cm"
+           x="0" y="252.0509" z="-224.38"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-14" unit="cm"
+           x="0" y="420.7515" z="-224.38"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-15" unit="cm"
+           x="0" y="588.4521" z="-224.38"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-16" unit="cm"
+           x="0" y="-588.4521" z="-74.46"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-17" unit="cm"
+           x="0" y="-420.7515" z="-74.46"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-18" unit="cm"
+           x="0" y="-252.0509" z="-74.46"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-19" unit="cm"
+           x="0" y="-84.3502999999999" z="-74.46"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-20" unit="cm"
+           x="0" y="84.3503000000001" z="-74.46"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-21" unit="cm"
+           x="0" y="252.0509" z="-74.46"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-22" unit="cm"
+           x="0" y="420.7515" z="-74.46"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-23" unit="cm"
+           x="0" y="588.4521" z="-74.46"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-24" unit="cm"
+           x="0" y="-588.4521" z="74.46"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-25" unit="cm"
+           x="0" y="-420.7515" z="74.46"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-26" unit="cm"
+           x="0" y="-252.0509" z="74.46"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-27" unit="cm"
+           x="0" y="-84.3502999999999" z="74.46"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-28" unit="cm"
+           x="0" y="84.3503000000001" z="74.46"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-29" unit="cm"
+           x="0" y="252.0509" z="74.46"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-30" unit="cm"
+           x="0" y="420.7515" z="74.46"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-31" unit="cm"
+           x="0" y="588.4521" z="74.46"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-32" unit="cm"
+           x="0" y="-588.4521" z="224.38"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-33" unit="cm"
+           x="0" y="-420.7515" z="224.38"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-34" unit="cm"
+           x="0" y="-252.0509" z="224.38"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-35" unit="cm"
+           x="0" y="-84.3502999999999" z="224.38"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-36" unit="cm"
+           x="0" y="84.3503000000001" z="224.38"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-37" unit="cm"
+           x="0" y="252.0509" z="224.38"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-38" unit="cm"
+           x="0" y="420.7515" z="224.38"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-39" unit="cm"
+           x="0" y="588.4521" z="224.38"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-40" unit="cm"
+           x="0" y="-588.4521" z="373.3"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-41" unit="cm"
+           x="0" y="-420.7515" z="373.3"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-42" unit="cm"
+           x="0" y="-252.0509" z="373.3"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-43" unit="cm"
+           x="0" y="-84.3502999999999" z="373.3"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-44" unit="cm"
+           x="0" y="84.3503000000001" z="373.3"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-45" unit="cm"
+           x="0" y="252.0509" z="373.3"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-46" unit="cm"
+           x="0" y="420.7515" z="373.3"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC-47" unit="cm"
+           x="0" y="588.4521" z="373.3"/>
+      </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaper"/>
+      <position name="posFieldShaper_0" unit="cm"  x="-322.04" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaper"/>
+      <position name="posFieldShaper_1" unit="cm"  x="-316.04" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaper"/>
+      <position name="posFieldShaper_2" unit="cm"  x="-310.04" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaper"/>
+      <position name="posFieldShaper_3" unit="cm"  x="-304.04" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaper"/>
+      <position name="posFieldShaper_4" unit="cm"  x="-298.04" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaper"/>
+      <position name="posFieldShaper_5" unit="cm"  x="-292.04" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaper"/>
+      <position name="posFieldShaper_6" unit="cm"  x="-286.04" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaper"/>
+      <position name="posFieldShaper_7" unit="cm"  x="-280.04" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaper"/>
+      <position name="posFieldShaper_8" unit="cm"  x="-274.04" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaper"/>
+      <position name="posFieldShaper_9" unit="cm"  x="-268.04" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaper"/>
+      <position name="posFieldShaper_10" unit="cm"  x="-262.04" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaper"/>
+      <position name="posFieldShaper_11" unit="cm"  x="-256.04" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaper"/>
+      <position name="posFieldShaper_12" unit="cm"  x="-250.04" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaper"/>
+      <position name="posFieldShaper_13" unit="cm"  x="-244.04" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaper"/>
+      <position name="posFieldShaper_14" unit="cm"  x="-238.04" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaper"/>
+      <position name="posFieldShaper_15" unit="cm"  x="-232.04" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaper"/>
+      <position name="posFieldShaper_16" unit="cm"  x="-226.04" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaper"/>
+      <position name="posFieldShaper_17" unit="cm"  x="-220.04" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaper"/>
+      <position name="posFieldShaper_18" unit="cm"  x="-214.04" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaper"/>
+      <position name="posFieldShaper_19" unit="cm"  x="-208.04" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaper"/>
+      <position name="posFieldShaper_20" unit="cm"  x="-202.04" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaper"/>
+      <position name="posFieldShaper_21" unit="cm"  x="-196.04" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaper"/>
+      <position name="posFieldShaper_22" unit="cm"  x="-190.04" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaper"/>
+      <position name="posFieldShaper_23" unit="cm"  x="-184.04" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaper"/>
+      <position name="posFieldShaper_24" unit="cm"  x="-178.04" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaper"/>
+      <position name="posFieldShaper_25" unit="cm"  x="-172.04" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaper"/>
+      <position name="posFieldShaper_26" unit="cm"  x="-166.04" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaper"/>
+      <position name="posFieldShaper_27" unit="cm"  x="-160.04" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaper"/>
+      <position name="posFieldShaper_28" unit="cm"  x="-154.04" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaper"/>
+      <position name="posFieldShaper_29" unit="cm"  x="-148.04" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaper"/>
+      <position name="posFieldShaper_30" unit="cm"  x="-142.04" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaper"/>
+      <position name="posFieldShaper_31" unit="cm"  x="-136.04" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaper"/>
+      <position name="posFieldShaper_32" unit="cm"  x="-130.04" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaper"/>
+      <position name="posFieldShaper_33" unit="cm"  x="-124.04" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaper"/>
+      <position name="posFieldShaper_34" unit="cm"  x="-118.04" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaper"/>
+      <position name="posFieldShaper_35" unit="cm"  x="-112.04" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaper"/>
+      <position name="posFieldShaper_36" unit="cm"  x="-106.04" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaper"/>
+      <position name="posFieldShaper_37" unit="cm"  x="-100.04" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaper"/>
+      <position name="posFieldShaper_38" unit="cm"  x="-94.04" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaper"/>
+      <position name="posFieldShaper_39" unit="cm"  x="-88.04" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaper"/>
+      <position name="posFieldShaper_40" unit="cm"  x="-82.04" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaper"/>
+      <position name="posFieldShaper_41" unit="cm"  x="-76.04" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_42" unit="cm"  x="-70.04" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_43" unit="cm"  x="-64.04" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_44" unit="cm"  x="-58.04" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_45" unit="cm"  x="-52.04" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_46" unit="cm"  x="-46.04" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_47" unit="cm"  x="-40.04" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_48" unit="cm"  x="-34.04" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_49" unit="cm"  x="-28.04" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_50" unit="cm"  x="-22.04" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_51" unit="cm"  x="-16.04" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_52" unit="cm"  x="-10.04" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_53" unit="cm"  x="-4.04000000000002" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_54" unit="cm"  x="1.95999999999998" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_55" unit="cm"  x="7.95999999999998" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_56" unit="cm"  x="13.96" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_57" unit="cm"  x="19.96" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_58" unit="cm"  x="25.96" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_59" unit="cm"  x="31.96" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_60" unit="cm"  x="37.96" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_61" unit="cm"  x="43.96" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_62" unit="cm"  x="49.96" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_63" unit="cm"  x="55.96" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_64" unit="cm"  x="61.96" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_65" unit="cm"  x="67.96" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_66" unit="cm"  x="73.96" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_67" unit="cm"  x="79.96" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_68" unit="cm"  x="85.96" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_69" unit="cm"  x="91.96" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_70" unit="cm"  x="97.96" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_71" unit="cm"  x="103.96" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_72" unit="cm"  x="109.96" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_73" unit="cm"  x="115.96" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_74" unit="cm"  x="121.96" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_75" unit="cm"  x="127.96" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_76" unit="cm"  x="133.96" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_77" unit="cm"  x="139.96" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_78" unit="cm"  x="145.96" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_79" unit="cm"  x="151.96" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_80" unit="cm"  x="157.96" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_81" unit="cm"  x="163.96" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_82" unit="cm"  x="169.96" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_83" unit="cm"  x="175.96" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_84" unit="cm"  x="181.96" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_85" unit="cm"  x="187.96" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_86" unit="cm"  x="193.96" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_87" unit="cm"  x="199.96" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_88" unit="cm"  x="205.96" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_89" unit="cm"  x="211.96" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_90" unit="cm"  x="217.96" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_91" unit="cm"  x="223.96" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_92" unit="cm"  x="229.96" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_93" unit="cm"  x="235.96" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_94" unit="cm"  x="241.96" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_95" unit="cm"  x="247.96" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_96" unit="cm"  x="253.96" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_97" unit="cm"  x="259.96" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_98" unit="cm"  x="265.96" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_99" unit="cm"  x="271.96" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_100" unit="cm"  x="277.96" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_101" unit="cm"  x="283.96" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_102" unit="cm"  x="289.96" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_103" unit="cm"  x="295.96" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_104" unit="cm"  x="301.96" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_105" unit="cm"  x="307.96" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_106" unit="cm"  x="313.96" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_107" unit="cm"  x="319.96" y="-675.1024" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-0" unit="cm" x="-327.04" y="-504.6018" z="-298.84"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-0" unit="cm" x="325.045" y="-504.6018" z="-298.84"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-1" unit="cm" x="-327.04" y="-168.2006" z="-298.84"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-1" unit="cm" x="325.045" y="-168.2006" z="-298.84"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-2" unit="cm" x="-327.04" y="168.2006" z="-298.84"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-2" unit="cm" x="325.045" y="168.2006" z="-298.84"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-3" unit="cm" x="-327.04" y="504.6018" z="-298.84"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-3" unit="cm" x="325.045" y="504.6018" z="-298.84"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-4" unit="cm" x="-327.04" y="-504.6018" z="0"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-4" unit="cm" x="325.045" y="-504.6018" z="0"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-5" unit="cm" x="-327.04" y="-168.2006" z="0"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-5" unit="cm" x="325.045" y="-168.2006" z="0"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-6" unit="cm" x="-327.04" y="168.2006" z="0"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-6" unit="cm" x="325.045" y="168.2006" z="0"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-7" unit="cm" x="-327.04" y="504.6018" z="0"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-7" unit="cm" x="325.045" y="504.6018" z="0"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-8" unit="cm" x="-327.04" y="-504.6018" z="298.84"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-8" unit="cm" x="325.045" y="-504.6018" z="298.84"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-9" unit="cm" x="-327.04" y="-168.2006" z="298.84"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-9" unit="cm" x="325.045" y="-168.2006" z="298.84"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-10" unit="cm" x="-327.04" y="168.2006" z="298.84"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-10" unit="cm" x="325.045" y="168.2006" z="298.84"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid-11" unit="cm" x="-327.04" y="504.6018" z="298.84"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate-11" unit="cm" x="325.045" y="504.6018" z="298.84"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+	<volumeref ref="volArapuca"/>
+       <position name="posArapucaDouble0-Frame-0-0" unit="cm"
+         x="-327.04"
+	 y="-541.6018"
+	 z="-261.34"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+	<volumeref ref="volArapuca"/>
+       <position name="posArapucaDouble1-Frame-0-0" unit="cm"
+         x="-327.04"
+	 y="-541.6018"
+	 z="-336.34"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+	<volumeref ref="volArapuca"/>
+       <position name="posArapucaDouble2-Frame-0-0" unit="cm"
+         x="-327.04"
+	 y="-467.6018"
+	 z="-190.34"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+	<volumeref ref="volArapuca"/>
+       <position name="posArapucaDouble3-Frame-0-0" unit="cm"
+         x="-327.04"
+	 y="-376.9018"
+	 z="-336.34"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+	<volumeref ref="volArapuca"/>
+       <position name="posArapucaDouble0-Frame-0-1" unit="cm"
+         x="-327.04"
+	 y="-541.6018"
+	 z="37.5"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+	<volumeref ref="volArapuca"/>
+       <position name="posArapucaDouble1-Frame-0-1" unit="cm"
+         x="-327.04"
+	 y="-541.6018"
+	 z="-108.5"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+	<volumeref ref="volArapuca"/>
+       <position name="posArapucaDouble2-Frame-0-1" unit="cm"
+         x="-327.04"
+	 y="-467.6018"
+	 z="108.5"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+	<volumeref ref="volArapuca"/>
+       <position name="posArapucaDouble3-Frame-0-1" unit="cm"
+         x="-327.04"
+	 y="-376.9018"
+	 z="-37.5"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+	<volumeref ref="volArapuca"/>
+       <position name="posArapucaDouble0-Frame-0-2" unit="cm"
+         x="-327.04"
+	 y="-541.6018"
+	 z="336.34"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+	<volumeref ref="volArapuca"/>
+       <position name="posArapucaDouble1-Frame-0-2" unit="cm"
+         x="-327.04"
+	 y="-541.6018"
+	 z="190.34"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+	<volumeref ref="volArapuca"/>
+       <position name="posArapucaDouble2-Frame-0-2" unit="cm"
+         x="-327.04"
+	 y="-467.6018"
+	 z="336.34"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+	<volumeref ref="volArapuca"/>
+       <position name="posArapucaDouble3-Frame-0-2" unit="cm"
+         x="-327.04"
+	 y="-376.9018"
+	 z="261.34"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+	<volumeref ref="volArapuca"/>
+       <position name="posArapucaDouble0-Frame-1-0" unit="cm"
+         x="-327.04"
+	 y="-295.9006"
+	 z="-261.34"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+	<volumeref ref="volArapuca"/>
+       <position name="posArapucaDouble1-Frame-1-0" unit="cm"
+         x="-327.04"
+	 y="-205.2006"
+	 z="-336.34"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+	<volumeref ref="volArapuca"/>
+       <position name="posArapucaDouble2-Frame-1-0" unit="cm"
+         x="-327.04"
+	 y="-131.2006"
+	 z="-190.34"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+	<volumeref ref="volArapuca"/>
+       <position name="posArapucaDouble3-Frame-1-0" unit="cm"
+         x="-327.04"
+	 y="-40.5006"
+	 z="-336.34"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+	<volumeref ref="volArapuca"/>
+       <position name="posArapucaDouble0-Frame-1-1" unit="cm"
+         x="-327.04"
+	 y="-295.9006"
+	 z="37.5"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+	<volumeref ref="volArapuca"/>
+       <position name="posArapucaDouble1-Frame-1-1" unit="cm"
+         x="-327.04"
+	 y="-205.2006"
+	 z="-108.5"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+	<volumeref ref="volArapuca"/>
+       <position name="posArapucaDouble2-Frame-1-1" unit="cm"
+         x="-327.04"
+	 y="-131.2006"
+	 z="108.5"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+	<volumeref ref="volArapuca"/>
+       <position name="posArapucaDouble3-Frame-1-1" unit="cm"
+         x="-327.04"
+	 y="-40.5006"
+	 z="-37.5"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+	<volumeref ref="volArapuca"/>
+       <position name="posArapucaDouble0-Frame-1-2" unit="cm"
+         x="-327.04"
+	 y="-295.9006"
+	 z="336.34"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+	<volumeref ref="volArapuca"/>
+       <position name="posArapucaDouble1-Frame-1-2" unit="cm"
+         x="-327.04"
+	 y="-205.2006"
+	 z="190.34"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+	<volumeref ref="volArapuca"/>
+       <position name="posArapucaDouble2-Frame-1-2" unit="cm"
+         x="-327.04"
+	 y="-131.2006"
+	 z="336.34"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+	<volumeref ref="volArapuca"/>
+       <position name="posArapucaDouble3-Frame-1-2" unit="cm"
+         x="-327.04"
+	 y="-40.5006"
+	 z="261.34"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+	<volumeref ref="volArapuca"/>
+       <position name="posArapucaDouble0-Frame-2-0" unit="cm"
+         x="-327.04"
+	 y="40.5006"
+	 z="-261.34"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+	<volumeref ref="volArapuca"/>
+       <position name="posArapucaDouble1-Frame-2-0" unit="cm"
+         x="-327.04"
+	 y="131.2006"
+	 z="-336.34"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+	<volumeref ref="volArapuca"/>
+       <position name="posArapucaDouble2-Frame-2-0" unit="cm"
+         x="-327.04"
+	 y="205.2006"
+	 z="-190.34"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+	<volumeref ref="volArapuca"/>
+       <position name="posArapucaDouble3-Frame-2-0" unit="cm"
+         x="-327.04"
+	 y="295.9006"
+	 z="-336.34"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+	<volumeref ref="volArapuca"/>
+       <position name="posArapucaDouble0-Frame-2-1" unit="cm"
+         x="-327.04"
+	 y="40.5006"
+	 z="37.5"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+	<volumeref ref="volArapuca"/>
+       <position name="posArapucaDouble1-Frame-2-1" unit="cm"
+         x="-327.04"
+	 y="131.2006"
+	 z="-108.5"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+	<volumeref ref="volArapuca"/>
+       <position name="posArapucaDouble2-Frame-2-1" unit="cm"
+         x="-327.04"
+	 y="205.2006"
+	 z="108.5"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+	<volumeref ref="volArapuca"/>
+       <position name="posArapucaDouble3-Frame-2-1" unit="cm"
+         x="-327.04"
+	 y="295.9006"
+	 z="-37.5"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+	<volumeref ref="volArapuca"/>
+       <position name="posArapucaDouble0-Frame-2-2" unit="cm"
+         x="-327.04"
+	 y="40.5006"
+	 z="336.34"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+	<volumeref ref="volArapuca"/>
+       <position name="posArapucaDouble1-Frame-2-2" unit="cm"
+         x="-327.04"
+	 y="131.2006"
+	 z="190.34"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+	<volumeref ref="volArapuca"/>
+       <position name="posArapucaDouble2-Frame-2-2" unit="cm"
+         x="-327.04"
+	 y="205.2006"
+	 z="336.34"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+	<volumeref ref="volArapuca"/>
+       <position name="posArapucaDouble3-Frame-2-2" unit="cm"
+         x="-327.04"
+	 y="295.9006"
+	 z="261.34"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+	<volumeref ref="volArapuca"/>
+       <position name="posArapucaDouble0-Frame-3-0" unit="cm"
+         x="-327.04"
+	 y="376.9018"
+	 z="-261.34"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+	<volumeref ref="volArapuca"/>
+       <position name="posArapucaDouble1-Frame-3-0" unit="cm"
+         x="-327.04"
+	 y="467.6018"
+	 z="-336.34"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+	<volumeref ref="volArapuca"/>
+       <position name="posArapucaDouble2-Frame-3-0" unit="cm"
+         x="-327.04"
+	 y="541.6018"
+	 z="-190.34"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+	<volumeref ref="volArapuca"/>
+       <position name="posArapucaDouble3-Frame-3-0" unit="cm"
+         x="-327.04"
+	 y="541.6018"
+	 z="-336.34"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+	<volumeref ref="volArapuca"/>
+       <position name="posArapucaDouble0-Frame-3-1" unit="cm"
+         x="-327.04"
+	 y="376.9018"
+	 z="37.5"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+	<volumeref ref="volArapuca"/>
+       <position name="posArapucaDouble1-Frame-3-1" unit="cm"
+         x="-327.04"
+	 y="467.6018"
+	 z="-108.5"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+	<volumeref ref="volArapuca"/>
+       <position name="posArapucaDouble2-Frame-3-1" unit="cm"
+         x="-327.04"
+	 y="541.6018"
+	 z="108.5"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+	<volumeref ref="volArapuca"/>
+       <position name="posArapucaDouble3-Frame-3-1" unit="cm"
+         x="-327.04"
+	 y="541.6018"
+	 z="-37.5"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+	<volumeref ref="volArapuca"/>
+       <position name="posArapucaDouble0-Frame-3-2" unit="cm"
+         x="-327.04"
+	 y="376.9018"
+	 z="336.34"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+	<volumeref ref="volArapuca"/>
+       <position name="posArapucaDouble1-Frame-3-2" unit="cm"
+         x="-327.04"
+	 y="467.6018"
+	 z="190.34"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+	<volumeref ref="volArapuca"/>
+       <position name="posArapucaDouble2-Frame-3-2" unit="cm"
+         x="-327.04"
+	 y="541.6018"
+	 z="336.34"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+	<volumeref ref="volArapuca"/>
+       <position name="posArapucaDouble3-Frame-3-2" unit="cm"
+         x="-327.04"
+	 y="541.6018"
+	 z="261.34"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca0-Lat-0" unit="cm"
+         x="285.03"
+	 y="-743.8024"
+	 z="-298.84"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca1-Lat-0" unit="cm"
+         x="210.03"
+	 y="-743.8024"
+	 z="-298.84"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca2-Lat-0" unit="cm"
+         x="135.03"
+	 y="-743.8024"
+	 z="-298.84"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca3-Lat-0" unit="cm"
+         x="60.03"
+	 y="-743.8024"
+	 z="-298.84"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca4-Lat-0" unit="cm"
+         x="285.03"
+	 y="743.8024"
+	 z="-298.84"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca5-Lat-0" unit="cm"
+         x="210.03"
+	 y="743.8024"
+	 z="-298.84"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca6-Lat-0" unit="cm"
+         x="135.03"
+	 y="743.8024"
+	 z="-298.84"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca7-Lat-0" unit="cm"
+         x="60.03"
+	 y="743.8024"
+	 z="-298.84"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca0-Lat-1" unit="cm"
+         x="285.03"
+	 y="-743.8024"
+	 z="-1.13686837721616e-13"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca1-Lat-1" unit="cm"
+         x="210.03"
+	 y="-743.8024"
+	 z="-1.13686837721616e-13"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca2-Lat-1" unit="cm"
+         x="135.03"
+	 y="-743.8024"
+	 z="-1.13686837721616e-13"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca3-Lat-1" unit="cm"
+         x="60.03"
+	 y="-743.8024"
+	 z="-1.13686837721616e-13"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca4-Lat-1" unit="cm"
+         x="285.03"
+	 y="743.8024"
+	 z="-1.13686837721616e-13"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca5-Lat-1" unit="cm"
+         x="210.03"
+	 y="743.8024"
+	 z="-1.13686837721616e-13"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca6-Lat-1" unit="cm"
+         x="135.03"
+	 y="743.8024"
+	 z="-1.13686837721616e-13"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca7-Lat-1" unit="cm"
+         x="60.03"
+	 y="743.8024"
+	 z="-1.13686837721616e-13"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca0-Lat-2" unit="cm"
+         x="285.03"
+	 y="-743.8024"
+	 z="298.84"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca1-Lat-2" unit="cm"
+         x="210.03"
+	 y="-743.8024"
+	 z="298.84"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca2-Lat-2" unit="cm"
+         x="135.03"
+	 y="-743.8024"
+	 z="298.84"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca3-Lat-2" unit="cm"
+         x="60.03"
+	 y="-743.8024"
+	 z="298.84"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca4-Lat-2" unit="cm"
+         x="285.03"
+	 y="743.8024"
+	 z="298.84"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca5-Lat-2" unit="cm"
+         x="210.03"
+	 y="743.8024"
+	 z="298.84"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca6-Lat-2" unit="cm"
+         x="135.03"
+	 y="743.8024"
+	 z="298.84"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca7-Lat-2" unit="cm"
+         x="60.03"
+	 y="743.8024"
+	 z="298.84"/>
+       <rotationref ref="rPlus180AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca0-ShortLat-220" unit="cm"
+         x="285.03"
+	 y="-220"
+	 z="-545.26"/>
+       <rotationref ref="rMinus90AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca1-ShortLat-220" unit="cm"
+         x="210.03"
+	 y="-220"
+	 z="-545.26"/>
+       <rotationref ref="rMinus90AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca2-ShortLat-220" unit="cm"
+         x="135.03"
+	 y="-220"
+	 z="-545.26"/>
+       <rotationref ref="rMinus90AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca3-ShortLat-220" unit="cm"
+         x="60.03"
+	 y="-220"
+	 z="-545.26"/>
+       <rotationref ref="rMinus90AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca4-ShortLat-220" unit="cm"
+         x="285.03"
+	 y="-220"
+	 z="545.26"/>
+       <rotationref ref="rPlus90AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca5-ShortLat-220" unit="cm"
+         x="210.03"
+	 y="-220"
+	 z="545.26"/>
+       <rotationref ref="rPlus90AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca6-ShortLat-220" unit="cm"
+         x="135.03"
+	 y="-220"
+	 z="545.26"/>
+       <rotationref ref="rPlus90AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca7-ShortLat-220" unit="cm"
+         x="60.03"
+	 y="-220"
+	 z="545.26"/>
+       <rotationref ref="rPlus90AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca0-ShortLat220" unit="cm"
+         x="285.03"
+	 y="220"
+	 z="-545.26"/>
+       <rotationref ref="rMinus90AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca1-ShortLat220" unit="cm"
+         x="210.03"
+	 y="220"
+	 z="-545.26"/>
+       <rotationref ref="rMinus90AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca2-ShortLat220" unit="cm"
+         x="135.03"
+	 y="220"
+	 z="-545.26"/>
+       <rotationref ref="rMinus90AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca3-ShortLat220" unit="cm"
+         x="60.03"
+	 y="220"
+	 z="-545.26"/>
+       <rotationref ref="rMinus90AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca4-ShortLat220" unit="cm"
+         x="285.03"
+	 y="220"
+	 z="545.26"/>
+       <rotationref ref="rPlus90AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca5-ShortLat220" unit="cm"
+         x="210.03"
+	 y="220"
+	 z="545.26"/>
+       <rotationref ref="rPlus90AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca6-ShortLat220" unit="cm"
+         x="135.03"
+	 y="220"
+	 z="545.26"/>
+       <rotationref ref="rPlus90AboutX"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca7-ShortLat220" unit="cm"
+         x="60.03"
+	 y="220"
+	 z="545.26"/>
+       <rotationref ref="rPlus90AboutX"/>
+     </physvol>
+    </volume>
+
+    <volume name="volFoamPadding">
+      <materialref ref="fibrous_glass"/>
+      <solidref ref="FoamPadding"/>
+    </volume>
+
+    <volume name="volSteelSupport">
+      <materialref ref="AirSteelMixture"/>
+      <solidref ref="SteelSupport"/>
+    </volume>
+
+    <volume name="volDetEnclosure">
+      <materialref ref="Air"/>
+      <solidref ref="DetEnclosure"/>
+
+       <physvol>
+           <volumeref ref="volFoamPadding"/>
+           <positionref ref="posCryoInDetEnc"/>
+       </physvol>
+       <physvol>
+           <volumeref ref="volSteelSupport"/>
+           <positionref ref="posCryoInDetEnc"/>
+       </physvol>
+       <physvol>
+           <volumeref ref="volCryostat"/>
+           <positionref ref="posCryoInDetEnc"/>
+       </physvol>
+    </volume>
+
+    <volume name="volWorld" >
+      <materialref ref="DUSEL_Rock"/>
+      <solidref ref="World"/>
+
+      <physvol>
+        <volumeref ref="volDetEnclosure"/>
+	<position name="posDetEnclosure" unit="cm" x="50.04" y="-1.13686837721616e-13" z="448.26"/>
+      </physvol>
+
+    </volume>
+</structure>
+
+  <setup name="Default" version="1.0">
+    <world ref="volWorld"/>
+  </setup>
+
+</gdml_simple_extension>

--- a/dunecore/Geometry/gdml/dunevd10kt_3view_30deg_v6_refactored_1x8x6_nowires.gdml
+++ b/dunecore/Geometry/gdml/dunevd10kt_3view_30deg_v6_refactored_1x8x6_nowires.gdml
@@ -164,7 +164,7 @@
     <fraction n="0.0053" ref="Na2O"/>
     <fraction n="0.00070" ref="P2O5"/>
     <fraction n="0.0771" ref="oxygen"/>
-  </material> 
+  </material>
 
   <material formula="Air" name="Air">
    <D value="0.001205" unit="g/cm3"/>
@@ -190,6 +190,16 @@
    <D value="0.09" unit="g/cm3"/>
    <fraction n="0.95" ref="Air"/>
    <fraction n="0.05" ref="fibrous_glass"/>
+  </material>
+
+  <!-- USE THIS NOW for FD and protoDUNEs - Juergen Reichenbacher (6/13/2023) -->
+  <!-- Foam density is 90 kg / m^3 for the assayed protoDUNE R-PUF at SD Mines -->
+  <material name="foam_protoDUNE_RPUF_assayedSample">
+   <D value="0.09" unit="g/cm3"/>
+   <composite n="54" ref="carbon"/>
+   <composite n="60" ref="hydrogen"/>
+   <composite n="4" ref="nitrogen"/>
+   <composite n="15" ref="oxygen"/>
   </material>
 
   <!-- Foam density is 70 kg / m^3 for the 3x1x1 -->
@@ -1737,14 +1747,14 @@
        <position name="posArapucaDouble0-Frame-0-0" unit="cm"
          x="-327.04"
 	 y="-541.6018"
-	 z="-261.34"/>
+	 z="-336.34"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
 	<volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-0-0" unit="cm"
          x="-327.04"
-	 y="-541.6018"
+	 y="-467.6018"
 	 z="-336.34"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
@@ -1752,7 +1762,7 @@
 	<volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-0-0" unit="cm"
          x="-327.04"
-	 y="-467.6018"
+	 y="-541.6018"
 	 z="-190.34"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
@@ -1761,7 +1771,7 @@
        <position name="posArapucaDouble3-Frame-0-0" unit="cm"
          x="-327.04"
 	 y="-376.9018"
-	 z="-336.34"/>
+	 z="-261.34"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
@@ -1769,14 +1779,14 @@
        <position name="posArapucaDouble0-Frame-0-1" unit="cm"
          x="-327.04"
 	 y="-541.6018"
-	 z="37.5"/>
+	 z="-37.5"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
 	<volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-0-1" unit="cm"
          x="-327.04"
-	 y="-541.6018"
+	 y="-467.6018"
 	 z="-108.5"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
@@ -1784,7 +1794,7 @@
 	<volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-0-1" unit="cm"
          x="-327.04"
-	 y="-467.6018"
+	 y="-541.6018"
 	 z="108.5"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
@@ -1793,7 +1803,7 @@
        <position name="posArapucaDouble3-Frame-0-1" unit="cm"
          x="-327.04"
 	 y="-376.9018"
-	 z="-37.5"/>
+	 z="37.5"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
@@ -1801,14 +1811,14 @@
        <position name="posArapucaDouble0-Frame-0-2" unit="cm"
          x="-327.04"
 	 y="-541.6018"
-	 z="336.34"/>
+	 z="261.34"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
 	<volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-0-2" unit="cm"
          x="-327.04"
-	 y="-541.6018"
+	 y="-467.6018"
 	 z="190.34"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
@@ -1816,7 +1826,7 @@
 	<volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-0-2" unit="cm"
          x="-327.04"
-	 y="-467.6018"
+	 y="-541.6018"
 	 z="336.34"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
@@ -1825,7 +1835,7 @@
        <position name="posArapucaDouble3-Frame-0-2" unit="cm"
          x="-327.04"
 	 y="-376.9018"
-	 z="261.34"/>
+	 z="336.34"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
@@ -1833,14 +1843,14 @@
        <position name="posArapucaDouble0-Frame-1-0" unit="cm"
          x="-327.04"
 	 y="-295.9006"
-	 z="-261.34"/>
+	 z="-336.34"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
 	<volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-1-0" unit="cm"
          x="-327.04"
-	 y="-205.2006"
+	 y="-131.2006"
 	 z="-336.34"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
@@ -1848,7 +1858,7 @@
 	<volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-1-0" unit="cm"
          x="-327.04"
-	 y="-131.2006"
+	 y="-205.2006"
 	 z="-190.34"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
@@ -1857,7 +1867,7 @@
        <position name="posArapucaDouble3-Frame-1-0" unit="cm"
          x="-327.04"
 	 y="-40.5006"
-	 z="-336.34"/>
+	 z="-261.34"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
@@ -1865,14 +1875,14 @@
        <position name="posArapucaDouble0-Frame-1-1" unit="cm"
          x="-327.04"
 	 y="-295.9006"
-	 z="37.5"/>
+	 z="-37.5"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
 	<volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-1-1" unit="cm"
          x="-327.04"
-	 y="-205.2006"
+	 y="-131.2006"
 	 z="-108.5"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
@@ -1880,7 +1890,7 @@
 	<volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-1-1" unit="cm"
          x="-327.04"
-	 y="-131.2006"
+	 y="-205.2006"
 	 z="108.5"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
@@ -1889,7 +1899,7 @@
        <position name="posArapucaDouble3-Frame-1-1" unit="cm"
          x="-327.04"
 	 y="-40.5006"
-	 z="-37.5"/>
+	 z="37.5"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
@@ -1897,14 +1907,14 @@
        <position name="posArapucaDouble0-Frame-1-2" unit="cm"
          x="-327.04"
 	 y="-295.9006"
-	 z="336.34"/>
+	 z="261.34"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
 	<volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-1-2" unit="cm"
          x="-327.04"
-	 y="-205.2006"
+	 y="-131.2006"
 	 z="190.34"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
@@ -1912,7 +1922,7 @@
 	<volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-1-2" unit="cm"
          x="-327.04"
-	 y="-131.2006"
+	 y="-205.2006"
 	 z="336.34"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
@@ -1921,7 +1931,7 @@
        <position name="posArapucaDouble3-Frame-1-2" unit="cm"
          x="-327.04"
 	 y="-40.5006"
-	 z="261.34"/>
+	 z="336.34"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
@@ -1929,14 +1939,14 @@
        <position name="posArapucaDouble0-Frame-2-0" unit="cm"
          x="-327.04"
 	 y="40.5006"
-	 z="-261.34"/>
+	 z="-336.34"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
 	<volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-2-0" unit="cm"
          x="-327.04"
-	 y="131.2006"
+	 y="205.2006"
 	 z="-336.34"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
@@ -1944,7 +1954,7 @@
 	<volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-2-0" unit="cm"
          x="-327.04"
-	 y="205.2006"
+	 y="131.2006"
 	 z="-190.34"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
@@ -1953,7 +1963,7 @@
        <position name="posArapucaDouble3-Frame-2-0" unit="cm"
          x="-327.04"
 	 y="295.9006"
-	 z="-336.34"/>
+	 z="-261.34"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
@@ -1961,14 +1971,14 @@
        <position name="posArapucaDouble0-Frame-2-1" unit="cm"
          x="-327.04"
 	 y="40.5006"
-	 z="37.5"/>
+	 z="-37.5"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
 	<volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-2-1" unit="cm"
          x="-327.04"
-	 y="131.2006"
+	 y="205.2006"
 	 z="-108.5"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
@@ -1976,7 +1986,7 @@
 	<volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-2-1" unit="cm"
          x="-327.04"
-	 y="205.2006"
+	 y="131.2006"
 	 z="108.5"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
@@ -1985,7 +1995,7 @@
        <position name="posArapucaDouble3-Frame-2-1" unit="cm"
          x="-327.04"
 	 y="295.9006"
-	 z="-37.5"/>
+	 z="37.5"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
@@ -1993,14 +2003,14 @@
        <position name="posArapucaDouble0-Frame-2-2" unit="cm"
          x="-327.04"
 	 y="40.5006"
-	 z="336.34"/>
+	 z="261.34"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
 	<volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-2-2" unit="cm"
          x="-327.04"
-	 y="131.2006"
+	 y="205.2006"
 	 z="190.34"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
@@ -2008,7 +2018,7 @@
 	<volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-2-2" unit="cm"
          x="-327.04"
-	 y="205.2006"
+	 y="131.2006"
 	 z="336.34"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
@@ -2017,7 +2027,7 @@
        <position name="posArapucaDouble3-Frame-2-2" unit="cm"
          x="-327.04"
 	 y="295.9006"
-	 z="261.34"/>
+	 z="336.34"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
@@ -2025,14 +2035,14 @@
        <position name="posArapucaDouble0-Frame-3-0" unit="cm"
          x="-327.04"
 	 y="376.9018"
-	 z="-261.34"/>
+	 z="-336.34"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
 	<volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-3-0" unit="cm"
          x="-327.04"
-	 y="467.6018"
+	 y="541.6018"
 	 z="-336.34"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
@@ -2040,7 +2050,7 @@
 	<volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-3-0" unit="cm"
          x="-327.04"
-	 y="541.6018"
+	 y="467.6018"
 	 z="-190.34"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
@@ -2049,7 +2059,7 @@
        <position name="posArapucaDouble3-Frame-3-0" unit="cm"
          x="-327.04"
 	 y="541.6018"
-	 z="-336.34"/>
+	 z="-261.34"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
@@ -2057,14 +2067,14 @@
        <position name="posArapucaDouble0-Frame-3-1" unit="cm"
          x="-327.04"
 	 y="376.9018"
-	 z="37.5"/>
+	 z="-37.5"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
 	<volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-3-1" unit="cm"
          x="-327.04"
-	 y="467.6018"
+	 y="541.6018"
 	 z="-108.5"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
@@ -2072,7 +2082,7 @@
 	<volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-3-1" unit="cm"
          x="-327.04"
-	 y="541.6018"
+	 y="467.6018"
 	 z="108.5"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
@@ -2081,7 +2091,7 @@
        <position name="posArapucaDouble3-Frame-3-1" unit="cm"
          x="-327.04"
 	 y="541.6018"
-	 z="-37.5"/>
+	 z="37.5"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
@@ -2089,14 +2099,14 @@
        <position name="posArapucaDouble0-Frame-3-2" unit="cm"
          x="-327.04"
 	 y="376.9018"
-	 z="336.34"/>
+	 z="261.34"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>
 	<volumeref ref="volArapuca"/>
        <position name="posArapucaDouble1-Frame-3-2" unit="cm"
          x="-327.04"
-	 y="467.6018"
+	 y="541.6018"
 	 z="190.34"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
@@ -2104,7 +2114,7 @@
 	<volumeref ref="volArapuca"/>
        <position name="posArapucaDouble2-Frame-3-2" unit="cm"
          x="-327.04"
-	 y="541.6018"
+	 y="467.6018"
 	 z="336.34"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
@@ -2113,7 +2123,7 @@
        <position name="posArapucaDouble3-Frame-3-2" unit="cm"
          x="-327.04"
 	 y="541.6018"
-	 z="261.34"/>
+	 z="336.34"/>
        <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
      </physvol>
      <physvol>

--- a/dunecore/Geometry/gdml/generate_dunevd10kt_3view_30deg_v6_refactored.pl
+++ b/dunecore/Geometry/gdml/generate_dunevd10kt_3view_30deg_v6_refactored.pl
@@ -158,46 +158,46 @@ $lengthCRM = $lengthPCBActive + 2 * $borderCRM;
 $borderCRP = 0.5; # cm
 
 # number of CRMs in y and z
-$nCRM_x   = 4 * 2;
+$nCRM_y   = 4 * 2;
 $nCRM_z   = 20 * 2;
 
 # create a smaller geometry
 if( $workspace == 1 )
 {
-    $nCRM_x = 1 * 2;
+    $nCRM_y = 1 * 2;
     $nCRM_z = 1 * 2;
 }
 
 # create a smaller geometry
 if( $workspace == 2 )
 {
-    $nCRM_x = 2 * 2;
+    $nCRM_y = 2 * 2;
     $nCRM_z = 2 * 2;
 }
 
 # create a smaller geometry (1x8x6)
 if( $workspace == 3 )
 {
-    $nCRM_x = 4 * 2;
+    $nCRM_y = 4 * 2;
     $nCRM_z = 3 * 2;
 }
 
 # create pds geometry (1x8x14)
 if( $workspace == 4 )
 {
-    $nCRM_x = 4 * 2;
+    $nCRM_y = 4 * 2;
     $nCRM_z = 7 * 2;
 }
 # create full geometry with only one drift volume
 if( $workspace == 5 )
 {
-    $nCRM_x = 4 * 2;
+    $nCRM_y = 4 * 2;
     $nCRM_z = 20 * 2;
 }
 
 # calculate tpc area based on number of CRMs and their dimensions
 # each CRP should have a 2x2 CRMs
-$widthTPCActive  = $nCRM_x * $widthCRM + $nCRM_x * $borderCRP;  # around 1200 for full module
+$widthTPCActive  = $nCRM_y * $widthCRM + $nCRM_y * $borderCRP;  # around 1200 for full module
 $lengthTPCActive = $nCRM_z * $lengthCRM + $nCRM_z * $borderCRP; # around 6000 for full module
 
 # active volume dimensions
@@ -971,7 +971,7 @@ print FieldCage <<EOF;
      <tube name="FieldShaperShorttube" rmin="$FieldShaperInnerRadius" rmax="$FieldShaperOuterRadius" z="$FieldShaperShortTubeLength" deltaphi="360" startphi="0" aunit="deg" lunit="cm"/>
 EOF
 
-if ($nCRM_x==8){
+if ($nCRM_y==8){
 
 #Create "windows" for the XArapucas in the short walls.
 print FieldCage <<EOF;
@@ -1317,7 +1317,7 @@ if ($tpc_on==1) # place TPC inside croysotat offsetting each pair of CRMs by bor
 	}
     }
     my $posY = -0.5*$Argon_y + $yLArBuffer + 0.5*$widthCRM;
-    for(my $jj=0;$jj<$nCRM_x;$jj++)
+    for(my $jj=0;$jj<$nCRM_y;$jj++)
     {
 	if( $jj % 2 == 0 ){
 	    $posY += $borderCRP;
@@ -1386,7 +1386,7 @@ $idx = 0;
   {
   for(my $ii=0;$ii<$nCRM_z/2;$ii++)
   {
-    for(my $jj=0;$jj<$nCRM_x/2;$jj++)
+    for(my $jj=0;$jj<$nCRM_y/2;$jj++)
     {
 	print CRYO <<EOF;
       <physvol>
@@ -1410,10 +1410,10 @@ EOF
 if ($pdsconfig == 0) {  #4-pi PDS converage
 
 #for placing the Arapucas over the cathode
-  $FrameCenter_y=-0.5*$Argon_y + $yLArBuffer + 0.5*$widthCathode;#-1.5*$FrameLenght_x+(4-$nCRM_x/2)/2*$FrameLenght_x;
+  $FrameCenter_y=-0.5*$Argon_y + $yLArBuffer + 0.5*$widthCathode;#-1.5*$FrameLenght_x+(4-$nCRM_y/2)/2*$FrameLenght_x;
   $FrameCenter_x=$CathodePosX;
   $FrameCenter_z=-0.5*$Argon_z + $zLArBuffer + 0.5*$lengthCathode;#-9.5*$FrameLenght_z+(20-$nCRM_z/2)/2*$FrameLenght_z;
-for($i=0;$i<$nCRM_x/2;$i++){
+for($i=0;$i<$nCRM_y/2;$i++){
 for($j=0;$j<$nCRM_z/2;$j++){
   place_OpDetsCathode($FrameCenter_x, $FrameCenter_y, $FrameCenter_z, $i, $j);
   $FrameCenter_z+=$lengthCathode;
@@ -1425,7 +1425,7 @@ for($j=0;$j<$nCRM_z/2;$j++){
 
 if ($pdsconfig == 0) {  #4-pi PDS converage
 #for placing the Arapucas on laterals
-  if ($nCRM_x==8) {
+  if ($nCRM_y==8) {
     $FrameCenter_x=0.5*($driftTPCActive + $ReadoutPlane) - 0.5*$padWidth; #anode position
     $FrameCenter_z=-19*$lengthCathode/2+(40-$nCRM_z)/2*$lengthCathode/2;
     for($j=0;$j<$nCRM_z/2;$j++){#nCRM will give the collumn number (1 collumn per frame)
@@ -1442,7 +1442,7 @@ if ($pdsconfig == 0) {  #4-pi PDS converage
 
     #8 arapucas por cathode, in a similar way as place_OpDetsLateral.
     #$FrameCenter_x=-0.5*$widthTPCActive+0.5*$widthCathode;
-    #for($j=0;$j<$nCRM_x/2;$j++)
+    #for($j=0;$j<$nCRM_y/2;$j++)
     #{
     #  $FrameCenter_y=$posZplane[0];
     #  $FrameCenter_z=-19*$lengthCathode/2+(40-$nCRM_z)/2*$lengthCathode/2;
@@ -1454,7 +1454,7 @@ if ($pdsconfig == 0) {  #4-pi PDS converage
 } else {  #membrane only PDS converage
 
 if($pdsconfig == 1){
-if ($nCRM_x==8) {
+if ($nCRM_y==8) {
   $FrameCenter_x=$posZplane[0]; #anode position
   $FrameCenter_z=-19*$lengthCathode/2+(40-$nCRM_z)/2*$lengthCathode/2;
 for($j=0;$j<$nCRM_z/2;$j++){#nCRM will give the collumn number (1 collumn per frame)
@@ -1517,7 +1517,7 @@ sub place_OpDetsCathode()
 	if ($Frame_x==0 and $ara==0) {
 	    $Ara_Y=$FrameCenter_y+$list_posx_bot[1];
 	}
-	if ($Frame_x==$nCRM_x/2-1 and $ara==3) {
+	if ($Frame_x==$nCRM_y/2-1 and $ara==3) {
 	    $Ara_Y=$FrameCenter_y+$list_posx_bot[2];
 	}
 
@@ -1544,7 +1544,7 @@ sub place_OpDetsLateral()
     $FrameCenter_z = $_[1];
     $Lat_z = $_[2];
 
-#Placing Arapucas on the laterals if nCRM_x=8 -- Single Sided
+#Placing Arapucas on the laterals if nCRM_y=8 -- Single Sided
 for ($ara = 0; $ara<8; $ara++)
 {
              # Arapucas on laterals
@@ -1586,7 +1586,7 @@ sub place_OpDetsShortLateral()
   $FrameCenter_y = $_[1];
   $FrameCenter_z = $_[2];
 
-  #Placing Arapucas on the laterals if nCRM_x=8 -- Single Sided
+  #Placing Arapucas on the laterals if nCRM_y=8 -- Single Sided
   for ($ara = 0; $ara<8; $ara++)
   {
              # Arapucas on the short laterals (along X).
@@ -1638,7 +1638,7 @@ sub place_OpDetsMembOnly()
     $FrameCenter_z = $_[1];
     $Lat_z = $_[2];
 
-#Placing Arapucas on the laterals if nCRM_x=8 -- Single Sided
+#Placing Arapucas on the laterals if nCRM_y=8 -- Single Sided
 for ($ara = 0; $ara<18; $ara++)
 {
              # Arapucas on laterals

--- a/dunecore/Geometry/gdml/generate_dunevd10kt_3view_30deg_v6_refactored.pl
+++ b/dunecore/Geometry/gdml/generate_dunevd10kt_3view_30deg_v6_refactored.pl
@@ -229,8 +229,8 @@ $anodePlateWidth   = $padWidth/2.;
 ############## Cathode Parameters ###############
 $heightCathode=4.0; #cm
 $CathodeBorder=4.0; #cm
-$widthCathode=2*$widthCRM;
-$lengthCathode=2*$lengthCRM;
+$widthCathode=2*$widthCRM + 2*$borderCRP; # need to add the border of the CRP in order to cover the whole TPC active area
+$lengthCathode=2*$lengthCRM + 2*$borderCRP;
 $widthCathodeVoid=76.35;
 $lengthCathodeVoid=67.0;
 
@@ -1341,7 +1341,8 @@ EOF
 
 if ($tpc_on==1) # place TPC inside croysotat offsetting each pair of CRMs by borderCRP
 {
-  $posX =  $Argon_x/2 - $HeightGaseousAr - 0.5*($driftTPCActive + $ReadoutPlane);
+  my $posX =  $Argon_x/2 - $HeightGaseousAr - 0.5*($driftTPCActive + $ReadoutPlane);
+  my $posXbottom = -$Argon_x/2 + $xLArBuffer + 0.5*($driftTPCActive + $ReadoutPlane);
   $idx = 0;
   my $posZ = -0.5*$Argon_z + $zLArBuffer + 0.5*$lengthCRM;
   for(my $ii=0;$ii<$nCRM_z;$ii++)
@@ -1378,7 +1379,7 @@ EOF
 	    <physvol>
 		<volumeref ref="volTPC"/>
 		<position name="posTPC\-$idx" unit="cm"
-		    x="@{[-$Argon_x/2 + $xLArBuffer + 0.5*($driftTPCActive + $ReadoutPlane)]}" y="$posY" z="$posZ"/>
+		    x="$posXbottom" y="$posY" z="$posZ"/>
 		<rotationref ref="rPlus180AboutY"/>
             </physvol>
 EOF

--- a/dunecore/Geometry/gdml/generate_dunevd10kt_3view_30deg_v6_refactored.pl
+++ b/dunecore/Geometry/gdml/generate_dunevd10kt_3view_30deg_v6_refactored.pl
@@ -398,10 +398,10 @@ $VerticalPDdist = 75.0; #distance of arapucas (center to center) in the y direct
 $FirstFrameVertDist = 40.0; #Vertical distance from top/bottom anode (=204.55+85.3 cm above/below cathode)
 
 #Positions of the 4 arapucas with respect to the Frame center --> arapucas over the cathode
-$list_posy_bot[0]=-2*$widthCathodeVoid - 2.0*$CathodeBorder + $GapPD + 0.5*$ArapucaOut_x;
-$list_posz_bot[0]= 0.5*$lengthCathodeVoid + $CathodeBorder;
-$list_posy_bot[1]= - $CathodeBorder - $GapPD - 0.5*$ArapucaOut_x;
-$list_posz_bot[1]=-1.5*$lengthCathodeVoid - 2.0*$CathodeBorder;
+$list_posy_bot[0]= -2*$widthCathodeVoid - 2.0*$CathodeBorder + $GapPD + 0.5*$ArapucaOut_x;
+$list_posz_bot[0]= -(0.5*$lengthCathodeVoid + $CathodeBorder);
+$list_posy_bot[1]=  ($CathodeBorder + $GapPD + 0.5*$ArapucaOut_x);
+$list_posz_bot[1]= -(1.5*$lengthCathodeVoid + 2.0*$CathodeBorder);
 $list_posy_bot[2]=-$list_posy_bot[1];
 $list_posz_bot[2]=-$list_posz_bot[1];
 $list_posy_bot[3]=-$list_posy_bot[0];
@@ -1638,16 +1638,16 @@ sub place_OpDetsCathode()
 
         #If an arapuca is at a wall, move it inward. This also takes care of corner cases.
         if ($Frame_z==0 and $ara==1) {
-            $Ara_Z=$FrameCenter_z+$list_posz_bot[3];
-        }
-        if ($Frame_z==$nCRM_z/2-1 and $ara==2){
             $Ara_Z=$FrameCenter_z+$list_posz_bot[0];
         }
+        if ($Frame_z==$nCRM_z/2-1 and $ara==2){
+            $Ara_Z=$FrameCenter_z+$list_posz_bot[3];
+        }
         if ($Frame_x==0 and $ara==0) {
-            $Ara_Y=$FrameCenter_y+$list_posy_bot[1];
+            $Ara_Y=$FrameCenter_y+$list_posy_bot[2];
         }
         if ($Frame_x==$nCRM_y/2-1 and $ara==3) {
-            $Ara_Y=$FrameCenter_y+$list_posy_bot[2];
+            $Ara_Y=$FrameCenter_y+$list_posy_bot[1];
         }
 
         print CRYO <<EOF;

--- a/dunecore/Geometry/gdml/generate_dunevd10kt_3view_30deg_v6_refactored.pl
+++ b/dunecore/Geometry/gdml/generate_dunevd10kt_3view_30deg_v6_refactored.pl
@@ -1391,45 +1391,15 @@ EOF
   }
 }
 
-#The +50 in the x positions must depend on some other parameter
-#
-# FIXME (vpec): don't depend on OriginXset. Placement of the fieldcage
-# within the cryostat must be independent of the position of
-# volDetEnclosure within the World volume. - DONE
   if ( $FieldCage_switch eq "on" ) {
-    for ( $i=0; $i<$NFieldShapers; $i=$i+1 ) {
-    $dist=$i*$FieldShaperSeparation;
-    $posX = $Argon_x/2 - $HeightGaseousAr - ($driftTPCActive + $ReadoutPlane) + ($i+0.5)*$FieldShaperSeparation;
-    # $posX = -$OriginXSet+50+($i-$NFieldShapers*0.5)*$FieldShaperSeparation;
-	if ($pdsconfig==0){
-		if ($dist>250){
-	print CRYO <<EOF;
-  <physvol>
-     <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper$i" unit="cm"  x="@{[$posX]}" y="@{[-0.5*$FieldShaperShortTubeLength-$FieldShaperTorRad]}" z="0" />
-     <rotationref ref="rPlus90AboutZ"/>
-  </physvol>
-EOF
-		}else{
-	print CRYO <<EOF;
-  <physvol>
-     <volumeref ref="volFieldShaper"/>
-     <position name="posFieldShaper$i" unit="cm"  x="@{[$posX]}" y="@{[-0.5*$FieldShaperShortTubeLength-$FieldShaperTorRad]}" z="0" />
-     <rotationref ref="rPlus90AboutZ"/>
-  </physvol>
-EOF
-		}
-	}else{
-	print CRYO <<EOF;
-  <physvol>
-     <volumeref ref="volFieldShaperSlim"/>
-     <position name="posFieldShaper$i" unit="cm"  x="@{[$posX]}" y="@{[-0.5*$FieldShaperShortTubeLength-$FieldShaperTorRad]}" z="0" />
-     <rotationref ref="rPlus90AboutZ"/>
-  </physvol>
-EOF
-	}
-    }
+      my $reversed = 0;
+      place_FieldShaper($reversed);
+      if ( $nCRM_x == 2 ) {
+        $reversed = 1;
+	place_FieldShaper($reversed);
+      }
   }
+
 
 # FIXME (vpec): Remove OrigineXSet. This is placement within cryostat,
 # must be independent of volDetEnclosure placement - DONE.
@@ -1549,6 +1519,65 @@ EOF
 
 close(CRYO);
 }
+
+
+#+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+#++++++++++++++++++++++++++++++++++++ place_FieldShaper +++++++++++++++++++++++++++++++++++++++
+#+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+sub place_FieldShaper()
+{
+    my $reversed = 0; # are these bottom field shapers, in reversed order?
+    if (scalar(@_) > 0) {
+	$reversed = @_[0]
+    }
+
+    #The +50 in the x positions must depend on some other parameter
+    #
+    # FIXME (vpec): don't depend on OriginXset. Placement of the fieldcage
+    # within the cryostat must be independent of the position of
+    # volDetEnclosure within the World volume. - DONE
+    my $posX;
+    my $posY;
+    my $posZ;
+
+    for ( $i=0; $i<$NFieldShapers; $i=$i+1 ) {
+	$dist=$i*$FieldShaperSeparation;
+	if ( !$reversed ) {
+	    $posX = $Argon_x/2 - $HeightGaseousAr - ($driftTPCActive + $ReadoutPlane) + ($i+0.5)*$FieldShaperSeparation;
+	} else  {
+	    $posX = $Argon_x/2 - $HeightGaseousAr - ($driftTPCActive + $ReadoutPlane + $heightCathode) - ($i+0.5)*$FieldShaperSeparation;
+	}
+	if ($pdsconfig==0){
+	    if ($dist>250){
+		print CRYO <<EOF;
+    <physvol>
+      <volumeref ref="volFieldShaperSlim"/>
+      <position name="posFieldShaper_$reversed_$i" unit="cm"  x="@{[$posX]}" y="@{[-0.5*$FieldShaperShortTubeLength-$FieldShaperTorRad]}" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+EOF
+	    }else{
+		print CRYO <<EOF;
+    <physvol>
+      <volumeref ref="volFieldShaper"/>
+      <position name="posFieldShaper_$reversed_$i" unit="cm"  x="@{[$posX]}" y="@{[-0.5*$FieldShaperShortTubeLength-$FieldShaperTorRad]}" z="0" />
+      <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+EOF
+	    }
+	}else{
+	    print CRYO <<EOF;
+    <physvol>
+    	<volumeref ref="volFieldShaperSlim"/>
+    	<position name="posFieldShaper_$reversed_$i" unit="cm"  x="@{[$posX]}" y="@{[-0.5*$FieldShaperShortTubeLength-$FieldShaperTorRad]}" z="0" />
+        <rotationref ref="rPlus90AboutZ"/>
+    </physvol>
+EOF
+	}
+    }
+}
+
 
 #+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 #++++++++++++++++++++++++++++++++++++ place_OpDets +++++++++++++++++++++++++++++++++++++++

--- a/dunecore/Geometry/gdml/generate_dunevd10kt_3view_30deg_v6_refactored.pl
+++ b/dunecore/Geometry/gdml/generate_dunevd10kt_3view_30deg_v6_refactored.pl
@@ -1,0 +1,2044 @@
+#!/usr/bin/perl
+
+#
+#
+#  First attempt to make a GDML fragment generator for the DUNE vertical drift
+#  10kt detector geometry with 3 views: +/- Xdeg for induction and 90 deg collection
+#  The lower chamber is not added yet.
+#  !!!NOTE!!!: the readout is on a positive Y plane (drift along horizontal X)
+#              due to current reco limitations)
+#  No photon detectors declared
+#  Simplified treatment of inter-module dead spaces
+#
+#  Created: Thu Oct  1 16:45:27 CEST 2020
+#           Vyacheslav Galymov <vgalymov@ipnl.in2p3.fr>
+#
+#  Modified:
+#           VG: Added defs to enable use in the refactored sim framework
+#           VG: 23.02.21 Adjust plane dimensions to fit a given number of ch per side
+#           VG: 23.02.21 Group CRUs in CRPs
+#           VG: 02.03.21 The length for the ROP is force to be the lenght
+#                        given by nch_collection x pitch_collection
+#    V2:    Laura Paulucci (lpaulucc@fnal.gov): Sept 2021 PDS added.
+#             Use option -pds=1 for backup design (membrane only coverage).
+#             Default (pds=0) is the reference design (~4-pi).
+#             This is linked with a larger geometry to account for photon propagation, generate it with -k=4.
+#             Field Cage is turned on with reference and backup designs to match PDS option.
+#	      For not including the pds, please use option -pds=-1
+#    V3:      Mar 2022: Cathode included
+#             Apr 2022: Pitch and number of channels changed.
+#                       Collection pitch = 5.1 mm (4.89 mm in v2)
+#                       Induction pitch = 7.65 mm (7.335 mm in v2)
+#                       Reference for changes: https://indico.fnal.gov/event/53111/timetable/
+#    V4:    May 2022: Inclusion of anode plate on top of the 3 wire planes as requested by the background TF.
+#           This is included together with the cathode switch on. In order to avoid overlaps, the gaseous argon
+#           was decreased and displaced by $anodePlateWidth = 0.01 cm. Currently the material of this plate is
+#           set to vm2000 so that no additional geometry (ReflAnode) is needed to obtain optical fast simulation.
+#    V5:    José Soto (jsoto@cern.ch) LAr buffer around the active volume in Y and Z has been adapted in the
+#           workspace geometries to fit the numbers of the full geometry.
+#           volCryostat tagged as SensDet, in order to simulate the energy deposit in the full LAr volume.
+#           PDS:
+#                Arapucas in the short laterals included in all 8-CRMs-width workspace geometries, with a slim
+#                field cage "window" in front of them.
+#                Distance Membrane to Arapuca is set to 10cm.
+#                Field Cage is set to Aluminum_Al, cathode is set to G10.
+#    v6:    Jun 2023: Viktor Pec (viktor.pec@fzu.cz) based on changes by Laura Pauluci and Abdulrahman Kauther:
+#               - outer cathode arapucas shifted inwards
+#
+#################################################################################
+
+# Each subroutine generates a fragment GDML file, and the last subroutine
+# creates an XML file that make_gdml.pl will use to appropriately arrange
+# the fragment GDML files to create the final desired DUNE GDML file,
+# to be named by make_gdml output command
+
+##################################################################################
+
+
+#use warnings;
+use gdmlMaterials;
+use Math::Trig;
+use Getopt::Long;
+use Math::BigFloat;
+Math::BigFloat->precision(-16);
+
+###
+GetOptions( "help|h" => \$help,
+	    "suffix|s:s" => \$suffix,
+	    "output|o:s" => \$output,
+	    "wires|w:s" => \$wires,
+            "workspace|k:s" => \$wkspc,
+            "pdsconfig|pds:s" => \$pdsconfig);
+
+my $FieldCage_switch="on";
+my $Cathode_switch="on";
+
+if ( defined $help )
+{
+    # If the user requested help, print the usage notes and exit.
+    usage();
+    exit;
+}
+
+if ( ! defined $suffix )
+{
+    # The user didn't supply a suffix, so append nothing to the file
+    # names.
+    $suffix = "";
+}
+else
+{
+    # Otherwise, stick a "-" before the suffix, so that a suffix of
+    # "test" applied to filename.gdml becomes "filename-test.gdml".
+    $suffix = "-" . $suffix;
+}
+
+
+$workspace = 0;
+if(defined $wkspc )
+{
+    $workspace = $wkspc;
+}
+elsif ( $workspace != 0 )
+{
+    print "\t\tCreating smaller workspace geometry.\n";
+}
+
+if ( ! defined $pdsconfig )
+{
+    $pdsconfig = 0;
+    print "\t\tCreating reference design: 4-pi PDS converage.\n";
+}
+elsif ( $pdsconfig == 1 )
+{
+    print "\t\tCreating backup design: membrane-only PDS coverage.\n";
+}
+
+# set wires on to be the default, unless given an input by the user
+$wires_on = 1; # 1=on, 0=off
+if (defined $wires)
+{
+    $wires_on = $wires;
+}
+
+$tpc_on = 1;
+$basename="dunevd10kt";
+
+
+##################################################################
+############## Parameters for One Readout Panel ##################
+
+%nChans = ('Ind1', 286, 'Ind1Bot', 96, 'Ind2', 286, 'Col', 292);
+$nViews = keys %nChans;
+
+# first induction view
+$wirePitchU      = 0.765;  # cm
+$wireAngleU      = 150.0;   # deg
+
+# second induction view
+$wirePitchV      = 0.765;  # cm
+$wireAngleV      = 30.0;    # deg
+
+# last collection view
+$wirePitchZ      = 0.51;   # cm
+
+# force length to be equal to collection nch x pitch
+$lengthPCBActive = $wirePitchZ * $nChans{'Col'};
+$widthPCBActive  = 167.7006;
+
+#
+$borderCRM       = 0.0;     # border space aroud each CRM
+
+$widthCRM_active  = $widthPCBActive;
+$lengthCRM_active = $lengthPCBActive;
+
+$widthCRM  = $widthPCBActive  + 2 * $borderCRM;
+$lengthCRM = $lengthPCBActive + 2 * $borderCRM;
+
+$borderCRP = 0.5; # cm
+
+# number of CRMs in y and z
+$nCRM_x   = 4 * 2;
+$nCRM_z   = 20 * 2;
+
+# create a smaller geometry
+if( $workspace == 1 )
+{
+    $nCRM_x = 1 * 2;
+    $nCRM_z = 1 * 2;
+}
+
+# create a smaller geometry
+if( $workspace == 2 )
+{
+    $nCRM_x = 2 * 2;
+    $nCRM_z = 2 * 2;
+}
+
+# create a smaller geometry (1x8x6)
+if( $workspace == 3 )
+{
+    $nCRM_x = 4 * 2;
+    $nCRM_z = 3 * 2;
+}
+
+# create pds geometry (1x8x14)
+if( $workspace == 4 )
+{
+    $nCRM_x = 4 * 2;
+    $nCRM_z = 7 * 2;
+}
+# create full geometry with only one drift volume
+if( $workspace == 5 )
+{
+    $nCRM_x = 4 * 2;
+    $nCRM_z = 20 * 2;
+}
+
+# calculate tpc area based on number of CRMs and their dimensions
+# each CRP should have a 2x2 CRMs
+$widthTPCActive  = $nCRM_x * $widthCRM + $nCRM_x * $borderCRP;  # around 1200 for full module
+$lengthTPCActive = $nCRM_z * $lengthCRM + $nCRM_z * $borderCRP; # around 6000 for full module
+
+# active volume dimensions
+$driftTPCActive  = 650.0;
+
+# model anode strips as wires of some diameter
+$padWidth          = 0.02;
+$ReadoutPlane      = $nViews * $padWidth; # 3 readout planes (no space b/w)!
+
+# anode plate definition
+$anodePlateWidth   = $padWidth/2.;
+
+##################################################################
+############## Parameters for TPC and inner volume ###############
+
+# inner volume dimensions of the cryostat
+$Argon_x = 1510;
+$Argon_y = 1510;
+$Argon_z = 6200;
+
+# width of gas argon layer on top
+$HeightGaseousAr = 100;
+
+if( $workspace != 0 )
+{
+    #active tpc + 1.0 m buffer on each side
+    $Argon_x = $driftTPCActive + $HeightGaseousAr + $ReadoutPlane + 100;
+    $Argon_y = $widthTPCActive + 162;
+    $Argon_z = $lengthTPCActive + 214.0;
+}
+
+
+# size of liquid argon buffer
+$xLArBuffer = $Argon_x - $driftTPCActive - $HeightGaseousAr - $ReadoutPlane;
+$yLArBuffer = 0.5 * ($Argon_y - $widthTPCActive);
+$zLArBuffer = 0.5 * ($Argon_z - $lengthTPCActive);
+
+# cryostat
+$SteelThickness = 0.12; # membrane
+
+$Cryostat_x = $Argon_x + 2*$SteelThickness;
+$Cryostat_y = $Argon_y + 2*$SteelThickness;
+$Cryostat_z = $Argon_z + 2*$SteelThickness;
+
+##################################################################
+############## DetEnc and World relevant parameters  #############
+
+$SteelSupport_x  =  100;
+$SteelSupport_y  =  100;
+$SteelSupport_z  =  100;
+$FoamPadding     =  80;
+$FracMassOfSteel =  0.5; #The steel support is not a solid block, but a mixture of air and steel
+$FracMassOfAir   =  1 - $FracMassOfSteel;
+
+
+$SpaceSteelSupportToWall    = 100;
+$SpaceSteelSupportToCeiling = 100;
+
+$DetEncX  =    $Cryostat_x
+                  + 2*($SteelSupport_x + $FoamPadding) + $SpaceSteelSupportToCeiling;
+
+$DetEncY  =    $Cryostat_y
+                  + 2*($SteelSupport_y + $FoamPadding) + 2*$SpaceSteelSupportToWall;
+
+$DetEncZ  =    $Cryostat_z
+                  + 2*($SteelSupport_z + $FoamPadding) + 2*$SpaceSteelSupportToWall;
+
+$posCryoInDetEnc_x = - $DetEncX/2 + $SteelSupport_x + $FoamPadding + $Cryostat_x/2;
+
+
+$RockThickness = 4000;
+
+  # We want the world origin to be vertically centered on active TPC
+  # This is to be added to the x and y position of every volume in volWorld
+
+$OriginXSet =  $DetEncX/2.0
+             - $SteelSupport_x
+             - $FoamPadding
+             - $SteelThickness
+             - $xLArBuffer
+             - $driftTPCActive/2.0;
+
+$OriginYSet =   $DetEncY/2.0
+              - $SpaceSteelSupportToWall
+              - $SteelSupport_y
+              - $FoamPadding
+              - $SteelThickness
+              - $yLArBuffer
+              - $widthTPCActive/2.0;
+
+  # We want the world origin to be at the very front of the fiducial volume.
+  # move it to the front of the enclosure, then back it up through the concrete/foam,
+  # then through the Cryostat shell, then through the upstream dead LAr (including the
+  # dead LAr on the edge of the TPC)
+  # This is to be added to the z position of every volume in volWorld
+
+$OriginZSet =   $DetEncZ/2.0
+              - $SpaceSteelSupportToWall
+              - $SteelSupport_z
+              - $FoamPadding
+              - $SteelThickness
+              - $zLArBuffer
+              - $borderCRM;
+
+##################################################################
+############## Field Cage Parameters ###############
+$FieldShaperLongTubeLength  =  $lengthTPCActive;
+$FieldShaperShortTubeLength =  $widthTPCActive;
+$FieldShaperInnerRadius = 0.5; #cm
+$FieldShaperOuterRadius = 2.285; #cm
+$FieldShaperOuterRadiusSlim = 0.75; #cm
+$FieldShaperTorRad = 2.3; #cm
+$FieldCageArapucaWindowLength = 670; #cm
+
+$FieldShaperLength = $FieldShaperLongTubeLength + 2*$FieldShaperOuterRadius+ 2*$FieldShaperTorRad;
+$FieldShaperWidth =  $FieldShaperShortTubeLength + 2*$FieldShaperOuterRadius+ 2*$FieldShaperTorRad;
+
+$FieldShaperSeparation = 6.0; #cm
+$NFieldShapers = ($driftTPCActive/$FieldShaperSeparation) - 1;
+
+$FieldCageSizeX = $FieldShaperSeparation*$NFieldShapers+2;
+$FieldCageSizeY = $FieldShaperWidth+2;
+$FieldCageSizeZ = $FieldShaperLength+2;
+
+
+##################################################################
+############## Cathode Parameters ###############
+$heightCathode=4.0; #cm
+$CathodeBorder=4.0; #cm
+$widthCathode=2*$widthCRM;
+$lengthCathode=2*$lengthCRM;
+$widthCathodeVoid=76.35;
+$lengthCathodeVoid=67.0;
+
+
+####################################################################
+######################## ARAPUCA Dimensions ########################
+## in cm
+
+$ArapucaOut_x = 65.0;
+$ArapucaOut_y = 2.5;
+$ArapucaOut_z = 65.0;
+$ArapucaIn_x = 60.0;
+$ArapucaIn_y = 2.0;
+$ArapucaIn_z = 60.0;
+$ArapucaAcceptanceWindow_x = 60.0;
+$ArapucaAcceptanceWindow_y = 1.0;
+$ArapucaAcceptanceWindow_z = 60.0;
+$GapPD = 0.5; #Arapuca distance from Cathode Frame
+$FrameToArapucaSpace       =    1.0; #Small vertical gap over laterals to avoid overlap
+$FrameToArapucaSpaceLat    =   10.0; #Arapucas 60 cm behind FC. At this moment, should cover the thickness of Frame + small gap to prevent overlap. VALUE NEEDS TO BE CHECKED!!!
+$VerticalPDdist = 75.0; #distance of arapucas (center to center) in the y direction
+$FirstFrameVertDist = 40.0; #Vertical distance from top/bottom anode (=204.55+85.3 cm above/below cathode)
+
+#Positions of the 4 arapucas with respect to the Frame center --> arapucas over the cathode
+$list_posx_bot[0]=-2*$widthCathodeVoid - 2.0*$CathodeBorder + $GapPD + 0.5*$ArapucaOut_x;
+$list_posz_bot[0]= 0.5*$lengthCathodeVoid + $CathodeBorder;
+$list_posx_bot[1]= - $CathodeBorder - $GapPD - 0.5*$ArapucaOut_x;
+$list_posz_bot[1]=-1.5*$lengthCathodeVoid - 2.0*$CathodeBorder;
+$list_posx_bot[2]=-$list_posx_bot[1];
+$list_posz_bot[2]=-$list_posz_bot[1];
+$list_posx_bot[3]=-$list_posx_bot[0];
+$list_posz_bot[3]=-$list_posz_bot[0];
+
+
+#+++++++++++++++++++++++++ End defining variables ++++++++++++++++++++++++++
+
+
+#+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+#+++++++++++++++++++++++++++++++++++++++++ usage +++++++++++++++++++++++++++++++++++++++++
+#+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+sub usage()
+{
+    print "Usage: $0 [-h|--help] [-o|--output <fragments-file>] [-s|--suffix <string>]\n";
+    print "       if -o is omitted, output goes to STDOUT; <fragments-file> is input to make_gdml.pl\n";
+    print "       -s <string> appends the string to the file names; useful for multiple detector versions\n";
+    print "       -h prints this message, then quits\n";
+}
+
+
+sub gen_Extend()
+{
+
+# Create the <define> fragment file name,
+# add file to list of fragments,
+# and open it
+    $DEF = $basename."_Ext" . $suffix . ".gdml";
+    push (@gdmlFiles, $DEF);
+    $DEF = ">" . $DEF;
+    open(DEF) or die("Could not open file $DEF for writing");
+
+print DEF <<EOF;
+<?xml version='1.0'?>
+<gdml>
+<extension>
+   <color name="magenta"     R="0.0"  G="1.0"  B="0.0"  A="1.0" />
+   <color name="green"       R="0.0"  G="1.0"  B="0.0"  A="1.0" />
+   <color name="red"         R="1.0"  G="0.0"  B="0.0"  A="1.0" />
+   <color name="blue"        R="0.0"  G="0.0"  B="1.0"  A="1.0" />
+   <color name="yellow"      R="1.0"  G="1.0"  B="0.0"  A="1.0" />
+</extension>
+</gdml>
+EOF
+    close (DEF);
+}
+
+#+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+#++++++++++++++++++++++++++++++++++++++ gen_Define +++++++++++++++++++++++++++++++++++++++
+#+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+sub gen_Define()
+{
+
+# Create the <define> fragment file name,
+# add file to list of fragments,
+# and open it
+    $DEF = $basename."_Def" . $suffix . ".gdml";
+    push (@gdmlFiles, $DEF);
+    $DEF = ">" . $DEF;
+    open(DEF) or die("Could not open file $DEF for writing");
+
+
+print DEF <<EOF;
+<?xml version='1.0'?>
+<gdml>
+<define>
+
+<!--
+
+
+
+-->
+
+   <position name="posCryoInDetEnc"     unit="cm" x="$posCryoInDetEnc_x" y="0" z="0"/>
+   <position name="posCenter"           unit="cm" x="0" y="0" z="0"/>
+   <rotation name="rUWireAboutX"        unit="deg" x="$wireAngleU" y="0" z="0"/>
+   <rotation name="rVWireAboutX"        unit="deg" x="$wireAngleV" y="0" z="0"/>
+   <rotation name="rPlus90AboutX"       unit="deg" x="90" y="0" z="0"/>
+   <rotation name="rPlus90AboutY"       unit="deg" x="0" y="90" z="0"/>
+   <rotation name="rPlus90AboutXPlus90AboutY" unit="deg" x="90" y="90" z="0"/>
+   <rotation name="rMinus90AboutX"      unit="deg" x="270" y="0" z="0"/>
+   <rotation name="rMinus90AboutY"      unit="deg" x="0" y="270" z="0"/>
+   <rotation name="rMinus90AboutYMinus90AboutX"       unit="deg" x="270" y="270" z="0"/>
+   <rotation name="rPlus180AboutX"	unit="deg" x="180" y="0"   z="0"/>
+   <rotation name="rPlus180AboutY"	unit="deg" x="0" y="180"   z="0"/>
+   <rotation name="rPlus180AboutXPlus180AboutY"	unit="deg" x="180" y="180"   z="0"/>
+   <rotation name="rIdentity"		unit="deg" x="0" y="0"   z="0"/>
+   <rotation name="rPlus90AboutXPlus90AboutZ" unit="deg" x="90" y="0" z="90"/>
+   <rotation name="rPlus90AboutXPlus180AboutY" unit="deg" x="90" y="180" z="0" />
+   <rotation name="rPlus90AboutXMinux90AboutY" unit="deg" x="90" y="270" z="0" />
+   <rotation name="rPlus90AboutZ" unit="deg" x="0" y="0" z="90" />
+</define>
+</gdml>
+EOF
+    close (DEF);
+}
+
+#+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+#+++++++++++++++++++++++++++++++++++++ gen_Materials +++++++++++++++++++++++++++++++++++++
+#+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+sub gen_Materials()
+{
+
+# Create the <materials> fragment file name,
+# add file to list of output GDML fragments,
+# and open it
+    $MAT = $basename."_Materials" . $suffix . ".gdml";
+    push (@gdmlFiles, $MAT);
+    $MAT = ">" . $MAT;
+
+    open(MAT) or die("Could not open file $MAT for writing");
+
+    # Add any materials special to this geometry by defining a mulitline string
+    # and passing it to the gdmlMaterials::gen_Materials() function.
+my $asmix = <<EOF;
+  <!-- preliminary values -->
+  <material name="AirSteelMixture" formula="AirSteelMixture">
+   <D value="@{[0.001205*(1-$FracMassOfSteel) + 7.9300*$FracMassOfSteel]}" unit="g/cm3"/>
+   <fraction n="$FracMassOfSteel" ref="STEEL_STAINLESS_Fe7Cr2Ni"/>
+   <fraction n="$FracMassOfAir"   ref="Air"/>
+  </material>
+  <material name="vm2000" formula="vm2000">
+    <D value="1.2" unit="g/cm3"/>
+    <composite n="2" ref="carbon"/>
+    <composite n="4" ref="hydrogen"/>
+  </material>
+EOF
+
+    # add the general materials used anywere
+    print MAT gdmlMaterials::gen_Materials( $asmix );
+
+    close(MAT);
+}
+
+
+#+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+#++++++++++++++++++++++++++++++++++++++++ gen_TPC ++++++++++++++++++++++++++++++++++++++++
+#+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+# line clip on the rectangle boundary
+sub lineClip {
+    my $x0  = $_[0];
+    my $y0  = $_[1];
+    my $nx  = $_[2];
+    my $ny  = $_[3];
+    my $rcl = $_[4];
+    my $rcw = $_[5];
+
+    my $tol = 1.0E-4;
+    my @endpts = ();
+    if( abs( nx ) < tol ){
+	push( @endpts, ($x0, 0) );
+	push( @endpts, ($x0, $rcw) );
+	return @endpts;
+    }
+    if( abs( ny ) < tol ){
+	push( @endpts, (0, $y0) );
+	push( @endpts, ($rcl, $y0) );
+	return @endpts;
+    }
+
+    # left border at x = 0
+    my $y = $y0 - $x0 * $ny/$nx;
+    if( $y >= 0 && $y <= $rcw ){
+	push( @endpts, (0, $y) );
+    }
+
+    # right border at x = l
+    $y = $y0 + ($rcl-$x0) * $ny/$nx;
+    if( $y >= 0 && $y <= $rcw ){
+	push( @endpts, ($rcl, $y) );
+	if( scalar(@endpts) == 4 ){
+	    return @endpts;
+	}
+    }
+
+    # bottom border at y = 0
+    my $x = $x0 - $y0 * $nx/$ny;
+    if( $x >= 0 && $x <= $rcl ){
+	push( @endpts, ($x, 0) );
+	if( scalar(@endpts) == 4 ){
+	    return @endpts;
+	}
+    }
+
+    # top border at y = w
+    $x = $x0 + ($rcw-$y0)* $nx/$ny;
+    if( $x >= 0 && $x <= $rcl ){
+	push( @endpts, ($x, $rcw) );
+    }
+
+    return @endpts;
+}
+
+sub gen_Wires
+{
+    my $length = $_[0];  #
+    my $width  = $_[1];  #
+    my $nch    = $_[2];  #
+    my $nchb   = $_[3];  # nch per bottom side
+    my $pitch  = $_[4];  #
+    my $theta  = $_[5];  # deg
+    my $dia    = $_[6];  #
+
+    $theta  = $theta * pi()/180.0;
+    my @dirw   = (cos($theta), sin($theta));
+    my @dirp   = (cos($theta - pi()/2), sin($theta - pi()/2));
+
+    # calculate
+    my $alpha = $theta;
+    if( $alpha > pi()/2 ){
+	$alpha = pi() - $alpha;
+    }
+    my $dX = $pitch / sin( $alpha );
+    my $dY = $pitch / sin( pi()/2 - $alpha );
+    if( $length <= 0 ){
+        $length = $dX * $nchb;
+    }
+    if( $width <= 0 ){
+	$width = $dY * ($nch - $nchb);
+    }
+
+    my @orig   = (0, 0);
+    if( $dirp[0] < 0 ){
+	$orig[0] = $length;
+    }
+    if( $dirp[1] < 0 ){
+	$orig[1] = $width;
+    }
+
+    #print "origin    : @orig\n";
+    #print "pitch dir : @dirp\n";
+    #print "wire dir  : @dirw\n";
+    #print "$length x $width cm2\n";
+
+    # gen wires
+    my @winfo  = ();
+    my $offset = $pitch/2;
+    foreach my $ch (0..$nch-1){
+	#print "Processing $ch\n";
+
+	# calculate reference point for this strip
+	my @wcn = (0, 0);
+	$wcn[0] = $orig[0] + $offset * $dirp[0];
+	$wcn[1] = $orig[1] + $offset * $dirp[1];
+
+	# line clip on the rectangle boundary
+	@endpts = lineClip( $wcn[0], $wcn[1], $dirw[0], $dirw[1], $length, $width );
+
+	if( scalar(@endpts) != 4 ){
+	    print "Could not find end points for wire $ch : @endpts\n";
+	    $offset = $offset + $pitch;
+	    next;
+	}
+
+	# re-center on the mid-point
+	$endpts[0] -= $length/2;
+	$endpts[2] -= $length/2;
+	$endpts[1] -= $width/2;
+	$endpts[3] -= $width/2;
+
+	# calculate the strip center in the rectangle of CRU
+	$wcn[0] = ($endpts[0] + $endpts[2])/2;
+	$wcn[1] = ($endpts[1] + $endpts[3])/2;
+
+	# calculate the length
+	my $dx = $endpts[0] - $endpts[2];
+	my $dy = $endpts[1] - $endpts[3];
+	my $wlen = sqrt($dx**2 + $dy**2);
+
+	# put all info together
+	my @wire = ($ch, $wcn[0], $wcn[1], $wlen);
+	push( @wire, @endpts );
+	push( @winfo, \@wire);
+	$offset = $offset + $pitch;
+	#last;
+    }
+    return @winfo;
+}
+
+#
+
+sub gen_TPC()
+{
+    # CRM active volume
+    my $TPCActive_x = $driftTPCActive;
+    my $TPCActive_y = $widthCRM_active;
+    my $TPCActive_z = $lengthCRM_active;
+
+    # CRM total volume
+    my $TPC_x = $TPCActive_x + $ReadoutPlane;
+    my $TPC_y = $widthCRM;
+    my $TPC_z = $lengthCRM;
+
+    print " TPC dimensions     : $TPC_x x $TPC_y x $TPC_z\n";
+
+    $TPC = $basename."_TPC" . $suffix . ".gdml";
+    push (@gdmlFiles, $TPC);
+    $TPC = ">" . $TPC;
+    open(TPC) or die("Could not open file $TPC for writing");
+
+    # The standard XML prefix and starting the gdml
+print TPC <<EOF;
+    <?xml version='1.0'?>
+	<gdml>
+EOF
+
+    # compute wires for 1st induction
+    my @winfoU = ();
+    my @winfoV = ();
+    if( $wires_on == 1 ){
+	@winfoU = gen_Wires( $TPCActive_z, 0, # force length
+			     $nChans{'Ind1'}, $nChans{'Ind1Bot'},
+			     $wirePitchU, $wireAngleU, $padWidth );
+	@winfoV = gen_Wires( $TPCActive_z, 0, # force length
+			     $nChans{'Ind2'}, $nChans{'Ind1Bot'},
+			     $wirePitchV, $wireAngleV, $padWidth );
+
+    }
+
+    # All the TPC solids save the wires.
+print TPC <<EOF;
+    <solids>
+EOF
+
+print TPC <<EOF;
+   <box name="CRM"
+      x="$TPC_x"
+      y="$TPC_y"
+      z="$TPC_z"
+      lunit="cm"/>
+   <box name="CRMUPlane"
+      x="$padWidth"
+      y="$TPCActive_y"
+      z="$TPCActive_z"
+      lunit="cm"/>
+   <box name="CRMVPlane"
+      x="$padWidth"
+      y="$TPCActive_y"
+      z="$TPCActive_z"
+      lunit="cm"/>
+   <box name="CRMZPlane"
+      x="$padWidth"
+      y="$TPCActive_y"
+      z="$TPCActive_z"
+      lunit="cm"/>
+   <box name="CRMActive"
+      x="$TPCActive_x"
+      y="$TPCActive_y"
+      z="$TPCActive_z"
+      lunit="cm"/>
+EOF
+
+#++++++++++++++++++++++++++++ Wire Solids ++++++++++++++++++++++++++++++
+if($wires_on==1){
+
+    foreach my $wire (@winfoU) {
+	my $wid = $wire->[0];
+	my $wln = $wire->[3];
+print TPC <<EOF;
+   <tube name="CRMWireU$wid"
+      rmax="0.5*$padWidth"
+      z="$wln"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+EOF
+    }
+
+    foreach my $wire (@winfoV) {
+	my $wid = $wire->[0];
+	my $wln = $wire->[3];
+print TPC <<EOF;
+   <tube name="CRMWireV$wid"
+      rmax="0.5*$padWidth"
+      z="$wln"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+EOF
+    }
+
+
+print TPC <<EOF;
+   <tube name="CRMWireZ"
+      rmax="0.5*$padWidth"
+      z="$TPCActive_y"
+      deltaphi="360"
+      aunit="deg" lunit="cm"/>
+EOF
+}
+print TPC <<EOF;
+</solids>
+EOF
+
+
+# Begin structure and create wire logical volumes
+print TPC <<EOF;
+<structure>
+    <volume name="volTPCActive">
+      <materialref ref="LAr"/>
+      <solidref ref="CRMActive"/>
+      <auxiliary auxtype="SensDet" auxvalue="SimEnergyDeposit"/>
+      <auxiliary auxtype="StepLimit" auxunit="cm" auxvalue="0.5208*cm"/>
+      <auxiliary auxtype="Efield" auxunit="V/cm" auxvalue="500*V/cm"/>
+      <colorref ref="blue"/>
+    </volume>
+EOF
+
+if($wires_on==1)
+{
+    foreach my $wire (@winfoU)
+    {
+	my $wid = $wire->[0];
+print TPC <<EOF;
+    <volume name="volTPCWireU$wid">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireU$wid"/>
+    </volume>
+EOF
+    }
+
+    foreach my $wire (@winfoV)
+    {
+	my $wid = $wire->[0];
+print TPC <<EOF;
+    <volume name="volTPCWireV$wid">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireV$wid"/>
+    </volume>
+EOF
+    }
+
+print TPC <<EOF;
+    <volume name="volTPCWireZ">
+      <materialref ref="Copper_Beryllium_alloy25"/>
+      <solidref ref="CRMWireZ"/>
+    </volume>
+EOF
+}
+    # 1st induction plane
+print TPC <<EOF;
+   <volume name="volTPCPlaneU">
+     <materialref ref="LAr"/>
+     <solidref ref="CRMUPlane"/>
+EOF
+if ($wires_on==1) # add wires to U plane
+{
+    # the coordinates were computed with a corner at (0,0)
+    # so we need to move to plane coordinates
+    my $offsetZ = 0; #-0.5 * $TPCActive_z;
+    my $offsetY = 0; #-0.5 * $TPCActive_y;
+
+    foreach my $wire (@winfoU) {
+	my $wid  = $wire->[0];
+	my $zpos = $wire->[1] + $offsetZ;
+	my $ypos = $wire->[2] + $offsetY;
+print TPC <<EOF;
+     <physvol>
+       <volumeref ref="volTPCWireU$wid"/>
+       <position name="posWireU$wid" unit="cm" x="0" y="$ypos" z="$zpos"/>
+       <rotationref ref="rUWireAboutX"/>
+     </physvol>
+EOF
+    }
+}
+print TPC <<EOF;
+   </volume>
+EOF
+
+# 2nd induction plane
+print TPC <<EOF;
+  <volume name="volTPCPlaneV">
+    <materialref ref="LAr"/>
+    <solidref ref="CRMVPlane"/>
+EOF
+
+if ($wires_on==1) # add wires to V plane (plane with wires reading y position)
+  {
+          # the coordinates were computed with a corner at (0,0)
+    # so we need to move to plane coordinates
+    my $offsetZ = 0; #-0.5 * $TPCActive_z;
+    my $offsetY = 0; #-0.5 * $TPCActive_y;
+
+    foreach my $wire (@winfoV) {
+	my $wid  = $wire->[0];
+	my $zpos = $wire->[1] + $offsetZ;
+	my $ypos = $wire->[2] + $offsetY;
+print TPC <<EOF;
+     <physvol>
+       <volumeref ref="volTPCWireV$wid"/>
+       <position name="posWireV$wid" unit="cm" x="0" y="$ypos" z="$zpos"/>
+       <rotationref ref="rVWireAboutX"/>
+     </physvol>
+EOF
+    }
+}
+print TPC <<EOF;
+  </volume>
+EOF
+
+# collection plane
+print TPC <<EOF;
+  <volume name="volTPCPlaneZ">
+    <materialref ref="LAr"/>
+    <solidref ref="CRMZPlane"/>
+EOF
+if ($wires_on==1) # add wires to Z plane (plane with wires reading z position)
+   {
+       for($i=0;$i<$nChans{'Col'};++$i)
+       {
+	  #my $zpos = -0.5 * $TPCActive_z + ($i+0.5)*$wirePitchZ + 0.5*$padWidth;
+	   my $zpos = ($i + 0.5 - $nChans{'Col'}/2)*$wirePitchZ;
+	   if( (0.5 * $TPCActive_z - abs($zpos)) < 0 ){
+	       die "Cannot place wire $i in view Z, as plane is too small\n";
+	   }
+print TPC <<EOF;
+       <physvol>
+         <volumeref ref="volTPCWireZ"/>
+         <position name="posWireZ$i" unit="cm" x="0" y="0" z="$zpos"/>
+         <rotationref ref="rPlus90AboutX"/>
+       </physvol>
+EOF
+       }
+}
+print TPC <<EOF;
+  </volume>
+EOF
+
+$posUplane[0] = 0.5*$TPC_x - 2.5*$padWidth;
+$posUplane[1] = 0;
+$posUplane[2] = 0;
+
+$posVplane[0] = 0.5*$TPC_x - 1.5*$padWidth;
+$posVplane[1] = 0;
+$posVplane[2] = 0;
+
+$posZplane[0] = 0.5*$TPC_x - 0.5*$padWidth;
+$posZplane[1] = 0;
+$posZplane[2] = 0;
+
+$posTPCActive[0] = -$ReadoutPlane/2;
+$posTPCActive[1] = 0;
+$posTPCActive[2] = 0;
+
+#wrap up the TPC file
+print TPC <<EOF;
+   <volume name="volTPC">
+     <materialref ref="LAr"/>
+       <solidref ref="CRM"/>
+       <physvol>
+       <volumeref ref="volTPCPlaneU"/>
+       <position name="posPlaneU" unit="cm"
+         x="$posUplane[0]" y="$posUplane[1]" z="$posUplane[2]"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCPlaneV"/>
+       <position name="posPlaneY" unit="cm"
+         x="$posVplane[0]" y="$posVplane[1]" z="$posVplane[2]"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCPlaneZ"/>
+       <position name="posPlaneZ" unit="cm"
+         x="$posZplane[0]" y="$posZplane[1]" z="$posZplane[2]"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+     <physvol>
+       <volumeref ref="volTPCActive"/>
+       <position name="posActive" unit="cm"
+        x="$posTPCActive[0]" y="$posTPCAtive[1]" z="$posTPCActive[2]"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+   </volume>
+EOF
+print TPC <<EOF;
+ </structure>
+ </gdml>
+EOF
+
+    close(TPC);
+}
+
+
+#+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+#++++++++++++++++++++++++++++++++++++++ gen_FieldCage ++++++++++++++++++++++++++++++++++++
+#+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+sub gen_FieldCage {
+
+    $FieldCage = $basename."_FieldCage" . $suffix . ".gdml";
+    push (@gdmlFiles, $FieldCage);
+    $FieldCage = ">" . $FieldCage;
+    open(FieldCage) or die("Could not open file $FieldCage for writing");
+
+# The standard XML prefix and starting the gdml
+print FieldCage <<EOF;
+   <?xml version='1.0'?>
+   <gdml>
+EOF
+# The printing solids used in the Field Cage
+#print "lengthTPCActive      : $lengthTPCActive \n";
+#print "widthTPCActive       : $widthTPCActive \n";
+
+
+print FieldCage <<EOF;
+<solids>
+     <torus name="FieldShaperCorner" rmin="$FieldShaperInnerRadius" rmax="$FieldShaperOuterRadius" rtor="$FieldShaperTorRad" deltaphi="90" startphi="0" aunit="deg" lunit="cm"/>
+     <tube name="FieldShaperLongtube" rmin="$FieldShaperInnerRadius" rmax="$FieldShaperOuterRadius" z="$FieldShaperLongTubeLength" deltaphi="360" startphi="0" aunit="deg" lunit="cm"/>
+     <tube name="FieldShaperLongtubeSlim" rmin="$FieldShaperInnerRadius" rmax="$FieldShaperOuterRadiusSlim" z="$FieldShaperLongTubeLength" deltaphi="360" startphi="0" aunit="deg" lunit="cm"/>
+     <tube name="FieldShaperShorttube" rmin="$FieldShaperInnerRadius" rmax="$FieldShaperOuterRadius" z="$FieldShaperShortTubeLength" deltaphi="360" startphi="0" aunit="deg" lunit="cm"/>
+EOF
+
+if ($nCRM_x==8){
+
+#Create "windows" for the XArapucas in the short walls.
+print FieldCage <<EOF;
+     <tube name="FieldShaperShorttubeWindowSlim" rmin="$FieldShaperInnerRadius" rmax="$FieldShaperOuterRadiusSlim" z="@{[$FieldCageArapucaWindowLength]}" deltaphi="360" startphi="0" aunit="deg" lunit="cm"/>
+     <tube name="FieldShaperShorttubeWindowNotSlim" rmin="$FieldShaperInnerRadius" rmax="$FieldShaperOuterRadius" z="@{[0.5*($FieldShaperShortTubeLength - $FieldCageArapucaWindowLength)]}" deltaphi="360" startphi="0" aunit="deg" lunit="cm"/>
+
+
+    <union name="FSunionWindow1">
+      <first ref="FieldShaperShorttubeWindowSlim"/>
+      <second ref="FieldShaperShorttubeWindowNotSlim"/>
+      <position name="posFieldShaperShortTube_shift1" unit="cm" x="0" y="0" z="@{[+0.25*($FieldCageArapucaWindowLength+$FieldShaperShortTubeLength)]}"/>
+    </union>
+
+    <union name="FieldShaperShorttubeSlim">
+      <first ref="FSunionWindow1"/>
+      <second ref="FieldShaperShorttubeWindowNotSlim"/>
+      <position name="posFieldShaperShortTube_shift2" unit="cm" x="0" y="0" z="@{[-0.25*($FieldCageArapucaWindowLength+$FieldShaperShortTubeLength)]}"/>
+    </union>
+
+EOF
+} else {
+#Thick FieldShaperShorttube for the option withouth XArapucas in the short walls.
+
+print FieldCage <<EOF;
+     <tube name="FieldShaperShorttubeSlim" rmin="$FieldShaperInnerRadius" rmax="$FieldShaperOuterRadius" z="$FieldShaperShortTubeLength" deltaphi="360" startphi="0" aunit="deg" lunit="cm"/>
+
+EOF
+}
+
+print FieldCage <<EOF;
+
+
+
+    <union name="FSunion1">
+      <first ref="FieldShaperLongtube"/>
+      <second ref="FieldShaperCorner"/>
+                <position name="esquinapos1" unit="cm" x="@{[-$FieldShaperTorRad]}" y="0" z="@{[0.5*$FieldShaperLongTubeLength]}"/>
+                <rotationref ref="rPlus90AboutX"/>
+    </union>
+
+    <union name="FSunion2">
+      <first ref="FSunion1"/>
+      <second ref="FieldShaperShorttube"/>
+   		<position name="esquinapos2" unit="cm" x="@{[-0.5*$FieldShaperShortTubeLength-$FieldShaperTorRad]}" y="0" z="@{[+0.5*$FieldShaperLongTubeLength+$FieldShaperTorRad]}"/>
+   		<rotationref ref="rPlus90AboutY"/>
+    </union>
+
+    <union name="FSunion3">
+      <first ref="FSunion2"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos3" unit="cm" x="@{[-$FieldShaperShortTubeLength-$FieldShaperTorRad]}" y="0" z="@{[0.5*$FieldShaperLongTubeLength]}"/>
+		<rotationref ref="rPlus90AboutXMinux90AboutY"/>
+    </union>
+
+    <union name="FSunion4">
+      <first ref="FSunion3"/>
+      <second ref="FieldShaperLongtube"/>
+   		<position name="esquinapos4" unit="cm" x="@{[-$FieldShaperShortTubeLength-2*$FieldShaperTorRad]}" y="0" z="0"/>
+    </union>
+
+    <union name="FSunion5">
+      <first ref="FSunion4"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos5" unit="cm" x="@{[-$FieldShaperShortTubeLength-$FieldShaperTorRad]}" y="0" z="@{[-0.5*$FieldShaperLongTubeLength]}"/>
+		<rotationref ref="rPlus90AboutXPlus180AboutY"/>
+    </union>
+
+    <union name="FSunion6">
+      <first ref="FSunion5"/>
+      <second ref="FieldShaperShorttube"/>
+   		<position name="esquinapos6" unit="cm" x="@{[-0.5*$FieldShaperShortTubeLength-$FieldShaperTorRad]}" y="0" z="@{[-0.5*$FieldShaperLongTubeLength-$FieldShaperTorRad]}"/>
+		<rotationref ref="rPlus90AboutY"/>
+    </union>
+
+    <union name="FieldShaperSolid">
+      <first ref="FSunion6"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos7" unit="cm" x="@{[-$FieldShaperTorRad]}" y="0" z="@{[-0.5*$FieldShaperLongTubeLength]}"/>
+		<rotationref ref="rPlus90AboutXPlus90AboutY"/>
+    </union>
+
+    <union name="FSunionSlim1">
+      <first ref="FieldShaperLongtubeSlim"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos8" unit="cm" x="@{[-$FieldShaperTorRad]}" y="0" z="@{[0.5*$FieldShaperLongTubeLength]}"/>
+		<rotationref ref="rPlus90AboutX"/>
+    </union>
+
+    <union name="FSunionSlim2">
+      <first ref="FSunionSlim1"/>
+      <second ref="FieldShaperShorttubeSlim"/>
+   		<position name="esquinapos9" unit="cm" x="@{[-0.5*$FieldShaperShortTubeLength-$FieldShaperTorRad]}" y="0" z="@{[+0.5*$FieldShaperLongTubeLength+$FieldShaperTorRad]}"/>
+   		<rotationref ref="rPlus90AboutY"/>
+    </union>
+
+    <union name="FSunionSlim3">
+      <first ref="FSunionSlim2"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos10" unit="cm" x="@{[-$FieldShaperShortTubeLength-$FieldShaperTorRad]}" y="0" z="@{[0.5*$FieldShaperLongTubeLength]}"/>
+		<rotationref ref="rPlus90AboutXMinux90AboutY"/>
+    </union>
+
+    <union name="FSunionSlim4">
+      <first ref="FSunionSlim3"/>
+      <second ref="FieldShaperLongtubeSlim"/>
+   		<position name="esquinapos4" unit="cm" x="@{[-$FieldShaperShortTubeLength-2*$FieldShaperTorRad]}" y="0" z="0"/>
+    </union>
+
+    <union name="FSunionSlim5">
+      <first ref="FSunionSlim4"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos11" unit="cm" x="@{[-$FieldShaperShortTubeLength-$FieldShaperTorRad]}" y="0" z="@{[-0.5*$FieldShaperLongTubeLength]}"/>
+		<rotationref ref="rPlus90AboutXPlus180AboutY"/>
+    </union>
+
+    <union name="FSunionSlim6">
+      <first ref="FSunionSlim5"/>
+      <second ref="FieldShaperShorttubeSlim"/>
+   		<position name="esquinapos12" unit="cm" x="@{[-0.5*$FieldShaperShortTubeLength-$FieldShaperTorRad]}" y="0" z="@{[-0.5*$FieldShaperLongTubeLength-$FieldShaperTorRad]}"/>
+		<rotationref ref="rPlus90AboutY"/>
+    </union>
+
+    <union name="FieldShaperSolidSlim">
+      <first ref="FSunionSlim6"/>
+      <second ref="FieldShaperCorner"/>
+   		<position name="esquinapos13" unit="cm" x="@{[-$FieldShaperTorRad]}" y="0" z="@{[-0.5*$FieldShaperLongTubeLength]}"/>
+		<rotationref ref="rPlus90AboutXPlus90AboutY"/>
+    </union>
+
+</solids>
+
+EOF
+
+print FieldCage <<EOF;
+
+<structure>
+<volume name="volFieldShaper">
+  <materialref ref="ALUMINUM_Al"/>
+  <solidref ref="FieldShaperSolid"/>
+</volume>
+<volume name="volFieldShaperSlim">
+  <materialref ref="ALUMINUM_Al"/>
+  <solidref ref="FieldShaperSolidSlim"/>
+</volume>
+
+</structure>
+
+EOF
+
+print FieldCage <<EOF;
+
+</gdml>
+EOF
+close(FieldCage);
+}
+
+
+
+#+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+#++++++++++++++++++++++++++++++++++++++ gen_Cryostat +++++++++++++++++++++++++++++++++++++
+#+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+sub gen_Cryostat()
+{
+
+# Create the cryostat fragment file name,
+# add file to list of output GDML fragments,
+# and open it
+    $CRYO = $basename."_Cryostat" . $suffix . ".gdml";
+    push (@gdmlFiles, $CRYO);
+    $CRYO = ">" . $CRYO;
+    open(CRYO) or die("Could not open file $CRYO for writing");
+
+
+# The standard XML prefix and starting the gdml
+    print CRYO <<EOF;
+<?xml version='1.0'?>
+<gdml>
+EOF
+
+# All the cryostat solids.
+# External active are two side volumes for generating light outside the field cage (no top or bottom buffers included)
+print CRYO <<EOF;
+<solids>
+    <box name="Cryostat" lunit="cm"
+      x="$Cryostat_x"
+      y="$Cryostat_y"
+      z="$Cryostat_z"/>
+
+    <box name="ArgonInterior" lunit="cm"
+      x="$Argon_x"
+      y="$Argon_y"
+      z="$Argon_z"/>
+
+    <box name="GaseousArgon" lunit="cm"
+      x="@{[$HeightGaseousAr - $anodePlateWidth]}"
+      y="$Argon_y"
+      z="$Argon_z"/>
+
+    <subtraction name="SteelShell">
+      <first ref="Cryostat"/>
+      <second ref="ArgonInterior"/>
+    </subtraction>
+
+</solids>
+EOF
+
+#PDS
+#Double sided detectors should only be included when both top and bottom volumes become available
+#Optical sensitive volumes cannot be rotated because Larsoft cannot pick up the rotation when obtinaing the lengths needed for the semi-analytic model --> two acceptance windows for single sided lateral and cathode
+print CRYO <<EOF;
+<solids>
+    <box name="ArapucaOut" lunit="cm"
+      x="@{[$ArapucaOut_x]}"
+      y="@{[$ArapucaOut_y]}"
+      z="@{[$ArapucaOut_z]}"/>
+
+    <box name="ArapucaIn" lunit="cm"
+      x="@{[$ArapucaIn_x]}"
+      y="@{[$ArapucaOut_y]}"
+      z="@{[$ArapucaIn_z]}"/>
+
+     <subtraction name="ArapucaWalls">
+      <first  ref="ArapucaOut"/>
+      <second ref="ArapucaIn"/>
+      <position name="posArapucaSub" x="0" y="@{[$ArapucaOut_y/2.0]}" z="0." unit="cm"/>
+      </subtraction>
+
+    <box name="ArapucaAcceptanceWindow" lunit="cm"
+      x="@{[$ArapucaAcceptanceWindow_x]}"
+      y="@{[$ArapucaAcceptanceWindow_y]}"
+      z="@{[$ArapucaAcceptanceWindow_z]}"/>
+
+    <box name="ArapucaDoubleIn" lunit="cm"
+      x="@{[$ArapucaIn_x]}"
+      y="@{[$ArapucaOut_y+1.0]}"
+      z="@{[$ArapucaIn_z]}"/>
+
+     <subtraction name="ArapucaDoubleWalls">
+      <first  ref="ArapucaOut"/>
+      <second ref="ArapucaDoubleIn"/>
+      <position name="posArapucaDoubleSub" x="0" y="0" z="0" unit="cm"/>
+      </subtraction>
+
+    <box name="ArapucaDoubleAcceptanceWindow" lunit="cm"
+      x="@{[$ArapucaOut_y-0.02]}"
+      y="@{[$ArapucaAcceptanceWindow_x]}"
+      z="@{[$ArapucaAcceptanceWindow_z]}"/>
+
+    <box name="ArapucaCathodeAcceptanceWindow" lunit="cm"
+      x="@{[$ArapucaAcceptanceWindow_y]}"
+      y="@{[$ArapucaAcceptanceWindow_x]}"
+      z="@{[$ArapucaAcceptanceWindow_z]}"/>
+
+</solids>
+EOF
+
+# Cryostat structure
+print CRYO <<EOF;
+<structure>
+    <volume name="volSteelShell">
+      <materialref ref="STEEL_STAINLESS_Fe7Cr2Ni" />
+      <solidref ref="SteelShell" />
+    </volume>
+    <volume name="volCathodeGrid">
+      <materialref ref="G10" />
+      <solidref ref="CathodeGrid" />
+    </volume>
+    <volume name="volAnodePlate">
+     <materialref ref="vm2000"/>
+     <solidref ref="AnodePlate"/>
+    </volume>
+    <volume name="volGaseousArgon">
+      <materialref ref="ArGas"/>
+      <solidref ref="GaseousArgon"/>
+    </volume>
+
+    <volume name="volOpDetSensitive">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaAcceptanceWindow"/>
+    </volume>
+
+    <volume name="Arapuca">
+      <materialref ref="G10" />
+      <solidref ref="ArapucaWalls" />
+    </volume>
+
+    <volume name="volArapuca">
+      <materialref ref="LAr"/>
+      <solidref ref="ArapucaOut"/>
+      <physvol>
+        <volumeref ref="Arapuca"/>
+        <positionref ref="posCenter"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volOpDetSensitive"/>
+        <position name="opdetshift" unit="cm" x="0" y="@{[$ArapucaAcceptanceWindow_y/2.0]}" z="0"/>
+      </physvol>
+    </volume>
+
+EOF
+#including single sided arapucas over the cathode while there is only the top volume
+#if double sided, use
+#    <volume name="volArapucaDouble_$i\-$j\-$p">
+#      <materialref ref="G10" />
+#      <solidref ref="ArapucaDoubleWalls" />
+#    </volume>
+#    <volume name="volOpDetSensitive_ArapucaDouble_$i\-$j\-$p">
+#      <materialref ref="LAr"/>
+#      <solidref ref="ArapucaDoubleAcceptanceWindow"/>
+#    </volume>
+
+      print CRYO <<EOF;
+
+    <volume name="volCryostat">
+      <materialref ref="LAr" />
+      <solidref ref="Cryostat" />
+      <auxiliary auxtype="SensDet" auxvalue="SimEnergyDeposit"/>
+      <auxiliary auxtype="StepLimit" auxunit="cm" auxvalue="0.5208*cm"/>
+      <auxiliary auxtype="Efield" auxunit="V/cm" auxvalue="0*V/cm"/>
+
+      <physvol>
+        <volumeref ref="volGaseousArgon"/>
+        <position name="posGaseousArgon" unit="cm" x="@{[$Argon_x/2-$HeightGaseousAr/2+$anodePlateWidth/2]}" y="0" z="0"/>
+      </physvol>
+      <physvol>
+        <volumeref ref="volSteelShell"/>
+        <position name="posSteelShell" unit="cm" x="0" y="0" z="0"/>
+      </physvol>
+EOF
+
+if ($tpc_on==1) # place TPC inside croysotat offsetting each pair of CRMs by borderCRP
+{
+  $posX =  $Argon_x/2 - $HeightGaseousAr - 0.5*($driftTPCActive + $ReadoutPlane);
+  $idx = 0;
+  my $posZ = -0.5*$Argon_z + $zLArBuffer + 0.5*$lengthCRM;
+  for(my $ii=0;$ii<$nCRM_z;$ii++)
+  {
+    if( $ii % 2 == 0 ){
+	$posZ += $borderCRP;
+	if( $ii>0 ){
+	    $posZ += $borderCRP;
+	}
+    }
+    my $posY = -0.5*$Argon_y + $yLArBuffer + 0.5*$widthCRM;
+    for(my $jj=0;$jj<$nCRM_x;$jj++)
+    {
+	if( $jj % 2 == 0 ){
+	    $posY += $borderCRP;
+	    if( $jj>0 ){
+		$posY += $borderCRP;
+	    }
+	}
+	print CRYO <<EOF;
+      <physvol>
+        <volumeref ref="volTPC"/>
+	<position name="posTPC\-$idx" unit="cm"
+           x="$posX" y="$posY" z="$posZ"/>
+      </physvol>
+EOF
+       $idx++;
+       $posY += $widthCRM;
+    }
+
+    $posZ += $lengthCRM;
+  }
+}
+
+#The +50 in the x positions must depend on some other parameter
+  if ( $FieldCage_switch eq "on" ) {
+    for ( $i=0; $i<$NFieldShapers; $i=$i+1 ) {
+    $dist=$i*$FieldShaperSeparation;
+$posX = -$OriginXSet+50+($i-$NFieldShapers*0.5)*$FieldShaperSeparation;
+	if ($pdsconfig==0){
+		if ($dist>250){
+	print CRYO <<EOF;
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper$i" unit="cm"  x="@{[$posX]}" y="@{[-0.5*$FieldShaperShortTubeLength-$FieldShaperTorRad]}" z="0" />
+     <rotationref ref="rPlus90AboutZ"/>
+  </physvol>
+EOF
+		}else{
+	print CRYO <<EOF;
+  <physvol>
+     <volumeref ref="volFieldShaper"/>
+     <position name="posFieldShaper$i" unit="cm"  x="@{[$posX]}" y="@{[-0.5*$FieldShaperShortTubeLength-$FieldShaperTorRad]}" z="0" />
+     <rotationref ref="rPlus90AboutZ"/>
+  </physvol>
+EOF
+		}
+	}else{
+	print CRYO <<EOF;
+  <physvol>
+     <volumeref ref="volFieldShaperSlim"/>
+     <position name="posFieldShaper$i" unit="cm"  x="@{[$posX]}" y="@{[-0.5*$FieldShaperShortTubeLength-$FieldShaperTorRad]}" z="0" />
+     <rotationref ref="rPlus90AboutZ"/>
+  </physvol>
+EOF
+	}
+    }
+  }
+
+
+$CathodePosX =-$OriginXSet+50+(-1-$NFieldShapers*0.5)*$FieldShaperSeparation + $tpc_x_disp;
+$CathodePosY = -0.5*$Argon_y + $yLArBuffer + 0.5*$widthCathode;
+$CathodePosZ = -0.5*$Argon_z + $zLArBuffer + 0.5*$lengthCathode;
+$posAnodePlate = 0.5*($driftTPCActive + $nViews*$padWidth) + $anodePlateWidth/2;#right above TPC vol
+
+$idx = 0;
+  if ( $Cathode_switch eq "on" )
+  {
+  for(my $ii=0;$ii<$nCRM_z/2;$ii++)
+  {
+    for(my $jj=0;$jj<$nCRM_x/2;$jj++)
+    {
+	print CRYO <<EOF;
+      <physvol>
+   <volumeref ref="volCathodeGrid"/>
+   <position name="posCathodeGrid\-$idx" unit="cm" x="$CathodePosX" y="@{[$CathodePosY]}" z="@{[$CathodePosZ]}"/>
+      </physvol>
+      <physvol>
+       <volumeref ref="volAnodePlate"/>
+       <position name="posAnodePlate\-$idx" unit="cm" x="$posAnodePlate" y="@{[$CathodePosY]}" z="@{[$CathodePosZ]}"/>
+       <rotationref ref="rIdentity"/>
+     </physvol>
+EOF
+       $idx++;
+       $CathodePosY += $widthCathode;
+    }
+       $CathodePosZ += $lengthCathode;
+       $CathodePosY = -0.5*$Argon_y + $yLArBuffer + 0.5*$widthCathode;
+  }
+  }
+
+if ($pdsconfig == 0) {  #4-pi PDS converage
+
+#for placing the Arapucas over the cathode
+  $FrameCenter_y=-0.5*$Argon_y + $yLArBuffer + 0.5*$widthCathode;#-1.5*$FrameLenght_x+(4-$nCRM_x/2)/2*$FrameLenght_x;
+  $FrameCenter_x=$CathodePosX;
+  $FrameCenter_z=-0.5*$Argon_z + $zLArBuffer + 0.5*$lengthCathode;#-9.5*$FrameLenght_z+(20-$nCRM_z/2)/2*$FrameLenght_z;
+for($i=0;$i<$nCRM_x/2;$i++){
+for($j=0;$j<$nCRM_z/2;$j++){
+  place_OpDetsCathode($FrameCenter_x, $FrameCenter_y, $FrameCenter_z, $i, $j);
+  $FrameCenter_z+=$lengthCathode;
+}
+  $FrameCenter_y+=$widthCathode;
+  $FrameCenter_z=-0.5*$Argon_z + $zLArBuffer + 0.5*$lengthCathode;
+}
+}
+
+if ($pdsconfig == 0) {  #4-pi PDS converage
+#for placing the Arapucas on laterals
+  if ($nCRM_x==8) {
+    $FrameCenter_x=0.5*($driftTPCActive + $ReadoutPlane) - 0.5*$padWidth; #anode position
+    $FrameCenter_z=-19*$lengthCathode/2+(40-$nCRM_z)/2*$lengthCathode/2;
+    for($j=0;$j<$nCRM_z/2;$j++){#nCRM will give the collumn number (1 collumn per frame)
+      place_OpDetsLateral($FrameCenter_x, $FrameCenter_z, $j);
+      $FrameCenter_z+=$lengthCathode;
+    }
+
+    #16 arapucas, 8 at y=-2.2m and 8 at y=2.2m.
+
+    $FrameCenter_x=0.5*($driftTPCActive + $ReadoutPlane) - 0.5*$padWidth; #anode position
+    $FrameCenter_z=-19*$lengthCathode/2+(40-$nCRM_z)/2*$lengthCathode/2;
+    place_OpDetsShortLateral($FrameCenter_x,-220, $FrameCenter_z);
+    place_OpDetsShortLateral($FrameCenter_x,220, $FrameCenter_z);
+
+    #8 arapucas por cathode, in a similar way as place_OpDetsLateral.
+    #$FrameCenter_x=-0.5*$widthTPCActive+0.5*$widthCathode;
+    #for($j=0;$j<$nCRM_x/2;$j++)
+    #{
+    #  $FrameCenter_y=$posZplane[0];
+    #  $FrameCenter_z=-19*$lengthCathode/2+(40-$nCRM_z)/2*$lengthCathode/2;
+    #  place_OpDetsShortLateral(220,$FrameCenter_y, $FrameCenter_z);
+    #  $FrameCenter_x+=$widthCathode;
+    #}
+  }
+
+} else {  #membrane only PDS converage
+
+if($pdsconfig == 1){
+if ($nCRM_x==8) {
+  $FrameCenter_x=$posZplane[0]; #anode position
+  $FrameCenter_z=-19*$lengthCathode/2+(40-$nCRM_z)/2*$lengthCathode/2;
+for($j=0;$j<$nCRM_z/2;$j++){#nCRM will give the collumn number (1 collumn per frame)
+  place_OpDetsMembOnly($FrameCenter_x, $FrameCenter_z, $j);
+  $FrameCenter_z+=$lengthCathode;
+}
+}
+}
+
+}
+
+ print CRYO <<EOF;
+    </volume>
+</structure>
+</gdml>
+EOF
+
+close(CRYO);
+}
+
+#+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+#++++++++++++++++++++++++++++++++++++ place_OpDets +++++++++++++++++++++++++++++++++++++++
+#+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+sub place_OpDetsCathode()
+{
+
+    $FrameCenter_x = $_[0];
+    $FrameCenter_y = $_[1];
+    $FrameCenter_z = $_[2];
+    $Frame_x = $_[3];
+    $Frame_z = $_[4];
+
+#Placing Arapucas over the Cathode
+#If there are both top and bottom volumes --> use double-sided:
+#     <physvol>
+#       <volumeref ref="volOpDetSensitive_ArapucaDouble_$Frame_x\-$Frame_z\-$ara"/>
+#       <position name="posOpArapucaDouble$ara-Frame\-$Frame_x\-$Frame_z" unit="cm"
+#         x="@{[$Ara_X]}"
+#	 y="@{[$Ara_Y]}"
+#	 z="@{[$Ara_Z]}"/>
+#     </physvol>
+#else
+for ($ara = 0; $ara<4; $ara++)
+{
+             # All Arapuca centers will have the same Y coordinate
+             # X and Z coordinates are defined with respect to the center of the current Frame
+
+ 	     $Ara_Y = $FrameCenter_y+$list_posx_bot[$ara]; #GEOMETRY IS ROTATED: X--> Y AND Y--> X
+             $Ara_X = $FrameCenter_x;
+ 	     $Ara_Z = $FrameCenter_z+$list_posz_bot[$ara];
+
+		 #If an arapuca is at a wall, move it inward. This also takes care of corner cases.
+		 if ($Frame_z==0 and $ara==1) {
+			 $Ara_Z=$FrameCenter_z+$list_posz_bot[3];
+		 }
+		 if ($Frame_z==$nCRM_z/2 and $ara==2){
+			 $Ara_Z==$FrameCenter_z+$list_posz_bot[0];
+		 }
+		 if ($Frame_x==0 and $ara==0) {
+			 $Ara_Y=$FrameCenter_y+$list_posx_bot[1];
+		 }
+		 if ($Frame_x==$nCRM_x/2 and $ara==3) {
+			 $Ara_Y=$FrameCenter_y+$list_posx_bot[2];
+		 }
+
+
+
+	print CRYO <<EOF;
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapucaDouble$ara-Frame\-$Frame_x\-$Frame_z" unit="cm"
+         x="@{[$Ara_X]}"
+	 y="@{[$Ara_Y]}"
+	 z="@{[$Ara_Z]}"/>
+       <rotationref ref="rPlus90AboutXPlus90AboutZ"/>
+     </physvol>
+EOF
+
+}#end Ara for-loop
+
+}
+
+
+sub place_OpDetsLateral()
+{
+
+    $FrameCenter_x = $_[0];
+    $FrameCenter_z = $_[1];
+    $Lat_z = $_[2];
+
+#Placing Arapucas on the laterals if nCRM_x=8 -- Single Sided
+for ($ara = 0; $ara<8; $ara++)
+{
+             # Arapucas on laterals
+             # All Arapuca centers on a given collumn will have the same Z coordinate
+             # X coordinates are on the left and right laterals
+             # Y coordinates are defined with respect to the cathode position
+             # There are two collumns per frame on each side.
+
+             if ($ara<4) {$Ara_Y = -0.5*$Argon_y + $FrameToArapucaSpaceLat;
+                         $Ara_YSens = ($Ara_Y+0.5*$ArapucaOut_y-0.5*$ArapucaAcceptanceWindow_y-0.01);
+                         $rot= "rIdentity"; }
+             else {$Ara_Y = 0.5*$Argon_y - $FrameToArapucaSpaceLat;
+                         $Ara_YSens = ($Ara_Y-0.5*$ArapucaOut_y+0.5*$ArapucaAcceptanceWindow_y+0.01);
+                         $rot = "rPlus180AboutX";} #GEOMETRY IS ROTATED: X--> Y AND Y--> X
+             if($ara==0||$ara==4) {$Ara_X = $FrameCenter_x-$FirstFrameVertDist;} #first tile's center 40 cm bellow anode
+             else{$Ara_X-=$VerticalPDdist;} #other tiles separated by VerticalPDdist
+             $Ara_Z = $FrameCenter_z;
+
+    #print " ArapucaPos Lateral $ara :    x=@{[$Ara_X]} y= @{[$Ara_Y]}  z= @{[$Ara_Z]}\n";
+
+	print CRYO <<EOF;
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca$ara-Lat\-$Lat_z" unit="cm"
+         x="@{[$Ara_X]}"
+	 y="@{[$Ara_Y]}"
+	 z="@{[$Ara_Z]}"/>
+       <rotationref ref="$rot"/>
+     </physvol>
+EOF
+
+}#end Ara for-loop
+
+}
+
+sub place_OpDetsShortLateral()
+{
+  $FrameCenter_x = $_[0];
+  $FrameCenter_y = $_[1];
+  $FrameCenter_z = $_[2];
+
+  #Placing Arapucas on the laterals if nCRM_x=8 -- Single Sided
+  for ($ara = 0; $ara<8; $ara++)
+  {
+             # Arapucas on the short laterals (along X).
+             # All Arapuca centers on a given collumn will have the same X coordinate
+             # Y coordinates are defined with respect to the cathode position
+             # There are two collumns per frame on each side.
+
+    if ($ara<4) {
+      $Ara_Z = -0.5*$Argon_z + $FrameToArapucaSpaceLat;
+      $Ara_ZSens = ($Ara_Z+0.5*$ArapucaOut_y-0.5*$ArapucaAcceptanceWindow_y-0.01);
+      $rot= "rMinus90AboutX";
+    }
+    else {
+      $Ara_Z = 0.5*$Argon_z - $FrameToArapucaSpaceLat;
+      $Ara_ZSens = ($Ara_Z-0.5*$ArapucaOut_y+0.5*$ArapucaAcceptanceWindow_y+0.01);
+      $rot = "rPlus90AboutX";
+    }
+    #GEOMETRY IS ROTATED: X--> Y AND Y--> X
+    if ($ara==0||$ara==4) {
+      $Ara_X = $FrameCenter_x-$FirstFrameVertDist;;
+    } #first tile's center 40 cm bellow anode
+    else {
+      $Ara_X-=$VerticalPDdist; #drift direction
+    } #other tiles separated by VerticalPDdist
+    $Ara_Y = $FrameCenter_y;
+
+    #print " ArapucaPos ShortLAteral $ara :    x=@{[$Ara_X]} y= @{[$Ara_Y]}  z= @{[$Ara_Z]}\n";
+    print CRYO <<EOF;
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca$ara-ShortLat$FrameCenter_y" unit="cm"
+         x="@{[$Ara_X]}"
+	 y="@{[$Ara_Y]}"
+	 z="@{[$Ara_Z]}"/>
+       <rotationref ref="$rot"/>
+     </physvol>
+EOF
+
+}#end Ara for-loop
+
+}
+
+
+
+sub place_OpDetsMembOnly()
+{
+
+    $FrameCenter_x = $_[0];
+    $FrameCenter_z = $_[1];
+    $Lat_z = $_[2];
+
+#Placing Arapucas on the laterals if nCRM_x=8 -- Single Sided
+for ($ara = 0; $ara<18; $ara++)
+{
+             # Arapucas on laterals
+             # All Arapuca centers on a given collumn will have the same Z coordinate
+             # X coordinates are on the left and right laterals
+             # Y coordinates are defined with respect to the cathode position
+             # There are two collumns per frame on each side.
+
+             if($ara<9) {$Ara_Y = -0.5*$Argon_y + $FrameToArapucaSpaceLat;
+                         $Ara_YSens = ($Ara_Y+0.5*$ArapucaOut_y-0.5*$ArapucaAcceptanceWindow_y-0.01);
+                         $rot= "rIdentity"; }
+             else {$Ara_Y = 0.5*$Argon_y - $FrameToArapucaSpaceLat;
+                         $Ara_YSens = ($Ara_Y-0.5*$ArapucaOut_y+0.5*$ArapucaAcceptanceWindow_y+0.01);
+                         $rot = "rPlus180AboutX";} #GEOMETRY IS ROTATED: X--> Y AND Y--> X
+             if($ara==0||$ara==9) {$Ara_X = $FrameCenter_x-$ArapucaOut_x/2;} #first tile's center right below anode
+             else {$Ara_X-=$ArapucaOut_x - $FrameToArapucaSpace;} #other tiles separated by minimal distance + buffer
+             $Ara_Z = $FrameCenter_z;
+
+#        print "lateral arapucas: $Ara_X, $Ara_Y, $Ara_Z \n";
+
+	print CRYO <<EOF;
+     <physvol>
+       <volumeref ref="volArapuca"/>
+       <position name="posArapuca$ara-Lat\-$Lat_z" unit="cm"
+         x="@{[$Ara_X]}"
+	 y="@{[$Ara_Y]}"
+	 z="@{[$Ara_Z]}"/>
+       <rotationref ref="$rot"/>
+     </physvol>
+EOF
+
+}#end Ara for-loop
+
+
+
+}
+
+
+#+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+#+++++++++++++++++++++++++++++++++++++ gen_Enclosure +++++++++++++++++++++++++++++++++++++
+#+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+sub gen_Enclosure()
+{
+
+# Create the detector enclosure fragment file name,
+# add file to list of output GDML fragments,
+# and open it
+    $ENCL = $basename."_DetEnclosure" . $suffix . ".gdml";
+    push (@gdmlFiles, $ENCL);
+    $ENCL = ">" . $ENCL;
+    open(ENCL) or die("Could not open file $ENCL for writing");
+
+
+# The standard XML prefix and starting the gdml
+    print ENCL <<EOF;
+<?xml version='1.0'?>
+<gdml>
+EOF
+
+
+# All the detector enclosure solids.
+print ENCL <<EOF;
+<solids>
+
+    <box name="CathodeBlock" lunit="cm"
+      x="@{[$heightCathode]}"
+      y="@{[$widthCathode]}"
+      z="@{[$lengthCathode]}" />
+
+    <box name="CathodeVoid" lunit="cm"
+      x="@{[$heightCathode+1.0]}"
+      y="@{[$widthCathodeVoid]}"
+      z="@{[$lengthCathodeVoid]}" />
+
+    <subtraction name="Cathode1">
+      <first ref="CathodeBlock"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub1" x="0" y="@{[-1.5*$widthCathodeVoid-2.0*$CathodeBorder]}" z="@{[-1.5*$lengthCathodeVoid-2.0*$CathodeBorder]}" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode2">
+      <first ref="Cathode1"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub2" x="0" y="@{[-1.5*$widthCathodeVoid-2.0*$CathodeBorder]}" z="@{[-0.5*$lengthCathodeVoid-1.0*$CathodeBorder]}" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode3">
+      <first ref="Cathode2"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub3" x="0" y="@{[-1.5*$widthCathodeVoid-2.0*$CathodeBorder]}" z="@{[0.5*$lengthCathodeVoid+1.0*$CathodeBorder]}" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode4">
+      <first ref="Cathode3"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub4" x="0" y="@{[-1.5*$widthCathodeVoid-2.0*$CathodeBorder]}" z="@{[1.5*$lengthCathodeVoid+2.0*$CathodeBorder]}" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode5">
+      <first ref="Cathode4"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub5" x="0" y="@{[-0.5*$widthCathodeVoid-1.0*$CathodeBorder]}" z="@{[-1.5*$lengthCathodeVoid-2.0*$CathodeBorder]}" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode6">
+      <first ref="Cathode5"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub6" x="0" y="@{[-0.5*$widthCathodeVoid-1.0*$CathodeBorder]}" z="@{[-0.5*$lengthCathodeVoid-1.0*$CathodeBorder]}" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode7">
+      <first ref="Cathode6"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub7" x="0" y="@{[-0.5*$widthCathodeVoid-1.0*$CathodeBorder]}" z="@{[0.5*$lengthCathodeVoid+1.0*$CathodeBorder]}" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode8">
+      <first ref="Cathode7"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub8" x="0" y="@{[-0.5*$widthCathodeVoid-1.0*$CathodeBorder]}" z="@{[1.5*$lengthCathodeVoid+2.0*$CathodeBorder]}" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode9">
+      <first ref="Cathode8"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub9" x="0" y="@{[0.5*$widthCathodeVoid+1.0*$CathodeBorder]}" z="@{[-1.5*$lengthCathodeVoid-2.0*$CathodeBorder]}" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode10">
+      <first ref="Cathode9"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub10" x="0" y="@{[0.5*$widthCathodeVoid+1.0*$CathodeBorder]}" z="@{[-0.5*$lengthCathodeVoid-1.0*$CathodeBorder]}" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode11">
+      <first ref="Cathode10"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub11" x="0" y="@{[0.5*$widthCathodeVoid+1.0*$CathodeBorder]}" z="@{[0.5*$lengthCathodeVoid+1.0*$CathodeBorder]}" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode12">
+      <first ref="Cathode11"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub12" x="0" y="@{[0.5*$widthCathodeVoid+1.0*$CathodeBorder]}" z="@{[1.5*$lengthCathodeVoid+2.0*$CathodeBorder]}" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode13">
+      <first ref="Cathode12"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub13" x="0" y="@{[1.5*$widthCathodeVoid+2.0*$CathodeBorder]}" z="@{[-1.5*$lengthCathodeVoid-2.0*$CathodeBorder]}" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode14">
+      <first ref="Cathode13"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub14" x="0" y="@{[1.5*$widthCathodeVoid+2.0*$CathodeBorder]}" z="@{[-0.5*$lengthCathodeVoid-1.0*$CathodeBorder]}" unit="cm"/>
+    </subtraction>
+    <subtraction name="Cathode15">
+      <first ref="Cathode14"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub15" x="0" y="@{[1.5*$widthCathodeVoid+2.0*$CathodeBorder]}" z="@{[0.5*$lengthCathodeVoid+1.0*$CathodeBorder]}" unit="cm"/>
+    </subtraction>
+    <subtraction name="CathodeGrid">
+      <first ref="Cathode15"/>
+      <second ref="CathodeVoid"/>
+      <position name="posCathodeSub16" x="0" y="@{[1.5*$widthCathodeVoid+2.0*$CathodeBorder]}" z="@{[1.5*$lengthCathodeVoid+2.0*$CathodeBorder]}" unit="cm"/>
+    </subtraction>
+
+   <box name="AnodePlate"
+      x="$anodePlateWidth"
+      y="$widthCathode"
+      z="$lengthCathode"
+      lunit="cm"/>
+
+    <box name="FoamPadBlock" lunit="cm"
+      x="@{[$Cryostat_x + 2*$FoamPadding]}"
+      y="@{[$Cryostat_y + 2*$FoamPadding]}"
+      z="@{[$Cryostat_z + 2*$FoamPadding]}" />
+
+    <subtraction name="FoamPadding">
+      <first ref="FoamPadBlock"/>
+      <second ref="Cryostat"/>
+      <positionref ref="posCenter"/>
+    </subtraction>
+
+    <box name="SteelSupportBlock" lunit="cm"
+      x="@{[$Cryostat_x + 2*$FoamPadding + 2*$SteelSupport_x]}"
+      y="@{[$Cryostat_y + 2*$FoamPadding + 2*$SteelSupport_y]}"
+      z="@{[$Cryostat_z + 2*$FoamPadding + 2*$SteelSupport_z]}" />
+
+    <subtraction name="SteelSupport">
+      <first ref="SteelSupportBlock"/>
+      <second ref="FoamPadBlock"/>
+      <positionref ref="posCenter"/>
+    </subtraction>
+
+    <box name="DetEnclosure" lunit="cm"
+      x="$DetEncX"
+      y="$DetEncY"
+      z="$DetEncZ"/>
+
+</solids>
+EOF
+
+
+# Detector enclosure structure
+    print ENCL <<EOF;
+<structure>
+    <volume name="volFoamPadding">
+      <materialref ref="fibrous_glass"/>
+      <solidref ref="FoamPadding"/>
+    </volume>
+
+    <volume name="volSteelSupport">
+      <materialref ref="AirSteelMixture"/>
+      <solidref ref="SteelSupport"/>
+    </volume>
+
+    <volume name="volDetEnclosure">
+      <materialref ref="Air"/>
+      <solidref ref="DetEnclosure"/>
+
+       <physvol>
+           <volumeref ref="volFoamPadding"/>
+           <positionref ref="posCryoInDetEnc"/>
+       </physvol>
+       <physvol>
+           <volumeref ref="volSteelSupport"/>
+           <positionref ref="posCryoInDetEnc"/>
+       </physvol>
+       <physvol>
+           <volumeref ref="volCryostat"/>
+           <positionref ref="posCryoInDetEnc"/>
+       </physvol>
+EOF
+
+
+print ENCL <<EOF;
+    </volume>
+EOF
+
+print ENCL <<EOF;
+</structure>
+</gdml>
+EOF
+
+close(ENCL);
+}
+
+
+
+#+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+#+++++++++++++++++++++++++++++++++++++++ gen_World +++++++++++++++++++++++++++++++++++++++
+#+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+sub gen_World()
+{
+
+# Create the WORLD fragment file name,
+# add file to list of output GDML fragments,
+# and open it
+    $WORLD = $basename."_World" . $suffix . ".gdml";
+    push (@gdmlFiles, $WORLD);
+    $WORLD = ">" . $WORLD;
+    open(WORLD) or die("Could not open file $WORLD for writing");
+
+
+# The standard XML prefix and starting the gdml
+    print WORLD <<EOF;
+<?xml version='1.0'?>
+<gdml>
+EOF
+
+
+# All the World solids.
+print WORLD <<EOF;
+<solids>
+    <box name="World" lunit="cm"
+      x="@{[$DetEncX+2*$RockThickness]}"
+      y="@{[$DetEncY+2*$RockThickness]}"
+      z="@{[$DetEncZ+2*$RockThickness]}"/>
+</solids>
+EOF
+
+# World structure
+print WORLD <<EOF;
+<structure>
+    <volume name="volWorld" >
+      <materialref ref="DUSEL_Rock"/>
+      <solidref ref="World"/>
+
+      <physvol>
+        <volumeref ref="volDetEnclosure"/>
+	<position name="posDetEnclosure" unit="cm" x="$OriginXSet" y="$OriginYSet" z="$OriginZSet"/>
+      </physvol>
+
+    </volume>
+</structure>
+</gdml>
+EOF
+
+# make_gdml.pl will take care of <setup/>
+
+close(WORLD);
+}
+
+
+
+#+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+#++++++++++++++++++++++++++++++++++++ write_fragments ++++++++++++++++++++++++++++++++++++
+#+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+sub write_fragments()
+{
+   # This subroutine creates an XML file that summarizes the the subfiles output
+   # by the other sub routines - it is the input file for make_gdml.pl which will
+   # give the final desired GDML file. Specify its name with the output option.
+   # (you can change the name when running make_gdml)
+
+   # This code is taken straigh from the similar MicroBooNE generate script, Thank you.
+
+    if ( ! defined $output )
+    {
+	$output = "-"; # write to STDOUT
+    }
+
+    # Set up the output file.
+    $OUTPUT = ">" . $output;
+    open(OUTPUT) or die("Could not open file $OUTPUT");
+
+    print OUTPUT <<EOF;
+<?xml version='1.0'?>
+
+<!-- Input to Geometry/gdml/make_gdml.pl; define the GDML fragments
+     that will be zipped together to create a detector description.
+     -->
+
+<config>
+
+   <constantfiles>
+
+      <!-- These files contain GDML <constant></constant>
+           blocks. They are read in separately, so they can be
+           interpreted into the remaining GDML. See make_gdml.pl for
+           more information.
+	   -->
+
+EOF
+
+    foreach $filename (@defFiles)
+    {
+	print OUTPUT <<EOF;
+      <filename> $filename </filename>
+EOF
+    }
+
+    print OUTPUT <<EOF;
+
+   </constantfiles>
+
+   <gdmlfiles>
+
+      <!-- The GDML file fragments to be zipped together. -->
+
+EOF
+
+    foreach $filename (@gdmlFiles)
+    {
+	print OUTPUT <<EOF;
+      <filename> $filename </filename>
+EOF
+    }
+
+    print OUTPUT <<EOF;
+
+   </gdmlfiles>
+
+</config>
+EOF
+
+    close(OUTPUT);
+}
+
+
+print "Some of the principal parameters for this TPC geometry (unit cm unless noted otherwise)\n";
+print " CRM active area       : $widthCRM_active x $lengthCRM_active\n";
+print " CRM total area        : $widthCRM x $lengthCRM\n";
+print " Wire pitch in U, V, Z : $wirePitchU, $wirePitchV, $wirePitchZ\n";
+print " TPC active volume  : $driftTPCActive x $widthTPCActive x $lengthTPCActive\n";
+print " Argon volume       : ($Argon_x, $Argon_y, $Argon_z) \n";
+print " Argon buffer       : ($xLArBuffer, $yLArBuffer, $zLArBuffer) \n";
+print " Detector enclosure : $DetEncX x $DetEncY x $DetEncZ\n";
+print " TPC Origin         : ($OriginXSet, $OriginYSet, $OriginZSet) \n";
+print " Field Cage         : $FieldCage_switch \n";
+print " Cathode            : $Cathode_switch \n";
+print " Workspace          : $workspace \n";
+print " Wires              : $wires \n";
+
+# run the sub routines that generate the fragments
+if ( $FieldCage_switch eq "on" ) {  gen_FieldCage();	}
+#if ( $Cathode_switch eq "on" ) {  gen_Cathode();	} #Cathode for now has the same geometry as the Ground Grid
+
+gen_Extend();    # generates the GDML color extension for the refactored geometry
+gen_Define(); 	 # generates definitions at beginning of GDML
+gen_Materials(); # generates materials to be used
+gen_TPC();       # generate TPC for a given unit CRM
+gen_Cryostat();  #
+gen_Enclosure(); #
+gen_World();	 # places the enclosure among DUSEL Rock
+write_fragments(); # writes the XML input for make_gdml.pl
+		   # which zips together the final GDML
+print "--- done\n\n\n";
+exit;

--- a/dunecore/Geometry/gdml/generate_dunevd10kt_3view_30deg_v6_refactored.pl
+++ b/dunecore/Geometry/gdml/generate_dunevd10kt_3view_30deg_v6_refactored.pl
@@ -398,13 +398,13 @@ $VerticalPDdist = 75.0; #distance of arapucas (center to center) in the y direct
 $FirstFrameVertDist = 40.0; #Vertical distance from top/bottom anode (=204.55+85.3 cm above/below cathode)
 
 #Positions of the 4 arapucas with respect to the Frame center --> arapucas over the cathode
-$list_posx_bot[0]=-2*$widthCathodeVoid - 2.0*$CathodeBorder + $GapPD + 0.5*$ArapucaOut_x;
+$list_posy_bot[0]=-2*$widthCathodeVoid - 2.0*$CathodeBorder + $GapPD + 0.5*$ArapucaOut_x;
 $list_posz_bot[0]= 0.5*$lengthCathodeVoid + $CathodeBorder;
-$list_posx_bot[1]= - $CathodeBorder - $GapPD - 0.5*$ArapucaOut_x;
+$list_posy_bot[1]= - $CathodeBorder - $GapPD - 0.5*$ArapucaOut_x;
 $list_posz_bot[1]=-1.5*$lengthCathodeVoid - 2.0*$CathodeBorder;
-$list_posx_bot[2]=-$list_posx_bot[1];
+$list_posy_bot[2]=-$list_posy_bot[1];
 $list_posz_bot[2]=-$list_posz_bot[1];
-$list_posx_bot[3]=-$list_posx_bot[0];
+$list_posy_bot[3]=-$list_posy_bot[0];
 $list_posz_bot[3]=-$list_posz_bot[0];
 
 
@@ -1632,7 +1632,7 @@ sub place_OpDetsCathode()
         # All Arapuca centers will have the same Y coordinate
         # X and Z coordinates are defined with respect to the center of the current Frame
 
-        $Ara_Y = $FrameCenter_y+$list_posx_bot[$ara]; #GEOMETRY IS ROTATED: X--> Y AND Y--> X
+        $Ara_Y = $FrameCenter_y+$list_posy_bot[$ara]; #GEOMETRY IS ROTATED: X--> Y AND Y--> X
         $Ara_X = $FrameCenter_x;
         $Ara_Z = $FrameCenter_z+$list_posz_bot[$ara];
 
@@ -1644,10 +1644,10 @@ sub place_OpDetsCathode()
             $Ara_Z=$FrameCenter_z+$list_posz_bot[0];
         }
         if ($Frame_x==0 and $ara==0) {
-            $Ara_Y=$FrameCenter_y+$list_posx_bot[1];
+            $Ara_Y=$FrameCenter_y+$list_posy_bot[1];
         }
         if ($Frame_x==$nCRM_y/2-1 and $ara==3) {
-            $Ara_Y=$FrameCenter_y+$list_posx_bot[2];
+            $Ara_Y=$FrameCenter_y+$list_posy_bot[2];
         }
 
         print CRYO <<EOF;

--- a/dunecore/Geometry/gdml/generate_dunevd10kt_3view_30deg_v6_refactored.pl
+++ b/dunecore/Geometry/gdml/generate_dunevd10kt_3view_30deg_v6_refactored.pl
@@ -1619,26 +1619,40 @@ sub place_OpDetsLateral()
     $FrameCenter_z = $_[1];
     $Lat_z = $_[2];
 
-#Placing Arapucas on the laterals if nCRM_y=8 -- Single Sided
-for ($ara = 0; $ara<8; $ara++)
-{
-             # Arapucas on laterals
-             # All Arapuca centers on a given collumn will have the same Z coordinate
-             # X coordinates are on the left and right laterals
-             # Y coordinates are defined with respect to the cathode position
-             # There are two collumns per frame on each side.
+    #Placing Arapucas on the laterals if nCRM_y=8 -- Single Sided
+    for ($ara = 0; $ara<8*$nCRM_x; $ara++)
+    {
+	# Arapucas on laterals
+	# All Arapuca centers on a given collumn will have the same Z coordinate
+	# X coordinates are on the left and right laterals
+	# Y coordinates are defined with respect to the cathode position
+	# There are two collumns per frame on each side.
 
-             if ($ara<4) {$Ara_Y = -0.5*$Argon_y + $FrameToArapucaSpaceLat;
-                         $Ara_YSens = ($Ara_Y+0.5*$ArapucaOut_y-0.5*$ArapucaAcceptanceWindow_y-0.01);
-                         $rot= "rIdentity"; }
-             else {$Ara_Y = 0.5*$Argon_y - $FrameToArapucaSpaceLat;
-                         $Ara_YSens = ($Ara_Y-0.5*$ArapucaOut_y+0.5*$ArapucaAcceptanceWindow_y+0.01);
-                         $rot = "rPlus180AboutX";} #GEOMETRY IS ROTATED: X--> Y AND Y--> X
-             if($ara==0||$ara==4) {$Ara_X = $FrameCenter_x-$FirstFrameVertDist;} #first tile's center 40 cm bellow anode
-             else{$Ara_X-=$VerticalPDdist;} #other tiles separated by VerticalPDdist
-             $Ara_Z = $FrameCenter_z;
+	if ($ara%8 < 4) {
+	    $Ara_Y = -0.5*$Argon_y + $FrameToArapucaSpaceLat;
+	    $Ara_YSens = ($Ara_Y+0.5*$ArapucaOut_y-0.5*$ArapucaAcceptanceWindow_y-0.01);
+	    $rot= "rIdentity";
+	} else {
+	    $Ara_Y = 0.5*$Argon_y - $FrameToArapucaSpaceLat;
+	    $Ara_YSens = ($Ara_Y-0.5*$ArapucaOut_y+0.5*$ArapucaAcceptanceWindow_y+0.01);
+	    $rot = "rPlus180AboutX";
+	}
+	if($ara%4==0) { #first tile's center 40 cm bellow anode
+	    if ($ara < 8) {
+		$Ara_X = $FrameCenter_x-$FirstFrameVertDist;
+	    } else { # bottom TPC arapucas
+		$Ara_X = -$FrameCenter_x - $HeightGaseousAr + $xLArBuffer + $FirstFrameVertDist;
+	    }
+	} else { #other tiles separated by VerticalPDdist
+	    if ($ara < 8) {
+		$Ara_X-=$VerticalPDdist;
+	    } else {
+		$Ara_X+=$VerticalPDdist;
+	    }
+	}
+	$Ara_Z = $FrameCenter_z;
 
-    #print " ArapucaPos Lateral $ara :    x=@{[$Ara_X]} y= @{[$Ara_Y]}  z= @{[$Ara_Z]}\n";
+	#print " ArapucaPos Lateral $ara :    x=@{[$Ara_X]} y= @{[$Ara_Y]}  z= @{[$Ara_Z]}\n";
 
 	print CRYO <<EOF;
      <physvol>
@@ -1662,14 +1676,14 @@ sub place_OpDetsShortLateral()
   $FrameCenter_z = $_[2];
 
   #Placing Arapucas on the laterals if nCRM_y=8 -- Single Sided
-  for ($ara = 0; $ara<8; $ara++)
+  for ($ara = 0; $ara<8*$nCRM_x; $ara++)
   {
              # Arapucas on the short laterals (along X).
              # All Arapuca centers on a given collumn will have the same X coordinate
              # Y coordinates are defined with respect to the cathode position
              # There are two collumns per frame on each side.
 
-    if ($ara<4) {
+    if ($ara%8<4) {
       $Ara_Z = -0.5*$Argon_z + $FrameToArapucaSpaceLat;
       $Ara_ZSens = ($Ara_Z+0.5*$ArapucaOut_y-0.5*$ArapucaAcceptanceWindow_y-0.01);
       $rot= "rMinus90AboutX";
@@ -1679,13 +1693,20 @@ sub place_OpDetsShortLateral()
       $Ara_ZSens = ($Ara_Z-0.5*$ArapucaOut_y+0.5*$ArapucaAcceptanceWindow_y+0.01);
       $rot = "rPlus90AboutX";
     }
-    #GEOMETRY IS ROTATED: X--> Y AND Y--> X
-    if ($ara==0||$ara==4) {
-      $Ara_X = $FrameCenter_x-$FirstFrameVertDist;;
-    } #first tile's center 40 cm bellow anode
-    else {
-      $Ara_X-=$VerticalPDdist; #drift direction
-    } #other tiles separated by VerticalPDdist
+
+    if($ara%4==0) { #first tile's center 40 cm bellow anode
+	if ($ara < 8) {
+	    $Ara_X = $FrameCenter_x-$FirstFrameVertDist;
+	} else { # bottom TPC arapucas
+	    $Ara_X = -$FrameCenter_x - $HeightGaseousAr + $xLArBuffer + $FirstFrameVertDist;
+	}
+    } else { #other tiles separated by VerticalPDdist
+	if ($ara < 8) {
+	    $Ara_X-=$VerticalPDdist;
+	} else {
+	    $Ara_X+=$VerticalPDdist;
+	}
+    }
     $Ara_Y = $FrameCenter_y;
 
     #print " ArapucaPos ShortLAteral $ara :    x=@{[$Ara_X]} y= @{[$Ara_Y]}  z= @{[$Ara_Z]}\n";

--- a/dunecore/Geometry/gdml/generate_dunevd10kt_3view_30deg_v6_refactored.pl
+++ b/dunecore/Geometry/gdml/generate_dunevd10kt_3view_30deg_v6_refactored.pl
@@ -1488,40 +1488,38 @@ sub place_OpDetsCathode()
     $Frame_x = $_[3];
     $Frame_z = $_[4];
 
-#Placing Arapucas over the Cathode
-#If there are both top and bottom volumes --> use double-sided:
-#     <physvol>
-#       <volumeref ref="volOpDetSensitive_ArapucaDouble_$Frame_x\-$Frame_z\-$ara"/>
-#       <position name="posOpArapucaDouble$ara-Frame\-$Frame_x\-$Frame_z" unit="cm"
-#         x="@{[$Ara_X]}"
-#	 y="@{[$Ara_Y]}"
-#	 z="@{[$Ara_Z]}"/>
-#     </physvol>
-#else
-for ($ara = 0; $ara<4; $ara++)
-{
-             # All Arapuca centers will have the same Y coordinate
-             # X and Z coordinates are defined with respect to the center of the current Frame
+    #Placing Arapucas over the Cathode
+    #If there are both top and bottom volumes --> use double-sided:
+    #     <physvol>
+    #       <volumeref ref="volOpDetSensitive_ArapucaDouble_$Frame_x\-$Frame_z\-$ara"/>
+    #       <position name="posOpArapucaDouble$ara-Frame\-$Frame_x\-$Frame_z" unit="cm"
+    #         x="@{[$Ara_X]}"
+    #	 y="@{[$Ara_Y]}"
+    #	 z="@{[$Ara_Z]}"/>
+    #     </physvol>
+    #else
+    for ($ara = 0; $ara<4; $ara++)
+    {
+	# All Arapuca centers will have the same Y coordinate
+	# X and Z coordinates are defined with respect to the center of the current Frame
 
- 	     $Ara_Y = $FrameCenter_y+$list_posx_bot[$ara]; #GEOMETRY IS ROTATED: X--> Y AND Y--> X
-             $Ara_X = $FrameCenter_x;
- 	     $Ara_Z = $FrameCenter_z+$list_posz_bot[$ara];
+	$Ara_Y = $FrameCenter_y+$list_posx_bot[$ara]; #GEOMETRY IS ROTATED: X--> Y AND Y--> X
+	$Ara_X = $FrameCenter_x;
+	$Ara_Z = $FrameCenter_z+$list_posz_bot[$ara];
 
-		 #If an arapuca is at a wall, move it inward. This also takes care of corner cases.
-		 if ($Frame_z==0 and $ara==1) {
-			 $Ara_Z=$FrameCenter_z+$list_posz_bot[3];
-		 }
-		 if ($Frame_z==$nCRM_z/2 and $ara==2){
-			 $Ara_Z==$FrameCenter_z+$list_posz_bot[0];
-		 }
-		 if ($Frame_x==0 and $ara==0) {
-			 $Ara_Y=$FrameCenter_y+$list_posx_bot[1];
-		 }
-		 if ($Frame_x==$nCRM_x/2 and $ara==3) {
-			 $Ara_Y=$FrameCenter_y+$list_posx_bot[2];
-		 }
-
-
+	#If an arapuca is at a wall, move it inward. This also takes care of corner cases.
+	if ($Frame_z==0 and $ara==1) {
+	    $Ara_Z=$FrameCenter_z+$list_posz_bot[3];
+	}
+	if ($Frame_z==$nCRM_z/2-1 and $ara==2){
+	    $Ara_Z=$FrameCenter_z+$list_posz_bot[0];
+	}
+	if ($Frame_x==0 and $ara==0) {
+	    $Ara_Y=$FrameCenter_y+$list_posx_bot[1];
+	}
+	if ($Frame_x==$nCRM_x/2-1 and $ara==3) {
+	    $Ara_Y=$FrameCenter_y+$list_posx_bot[2];
+	}
 
 	print CRYO <<EOF;
      <physvol>
@@ -1534,7 +1532,7 @@ for ($ara = 0; $ara<4; $ara++)
      </physvol>
 EOF
 
-}#end Ara for-loop
+    }#end Ara for-loop
 
 }
 

--- a/dunecore/Geometry/gdml/generate_dunevd10kt_3view_30deg_v6_refactored.pl
+++ b/dunecore/Geometry/gdml/generate_dunevd10kt_3view_30deg_v6_refactored.pl
@@ -44,6 +44,8 @@
 #                Field Cage is set to Aluminum_Al, cathode is set to G10.
 #    v6:    Jun 2023: Viktor Pec (viktor.pec@fzu.cz) based on changes by Laura Pauluci and Abdulrahman Kauther:
 #               - outer cathode arapucas shifted inwards
+#               - implemented bottom drift volume, together with double-sided arapucas on the cathode
+#               - arapucas on the outer sides of the cathode shifted inwards
 #
 #################################################################################
 
@@ -207,6 +209,13 @@ if( $workspace == 6 )
 {
     $nCRM_y = 4 * 2;
     $nCRM_z = 3 * 2;
+    $nCRM_x = 2;
+}
+# create a smaller geometry with both drift volumes (2x8x14)
+if( $workspace == 7 )
+{
+    $nCRM_y = 4 * 2;
+    $nCRM_z = 7 * 2;
     $nCRM_x = 2;
 }
 


### PR DESCRIPTION
Adding v6 VD geometry generator and corresponding gdml files for the 1x8x6 workspace.
This adds the bottom drift volume. One can now choose from multiple workspaces with either single drift or both drift volumes. Cathode arapucas are made double-sided.

Outer most cathode arapucas are shifted inwards, as requested by the PDS group. Layout of the 4 arapucas inside a single cathode frame has been mirrored as this seem to agree with the system specification.