### PR TITLE
Update to dunedetdataformats v4_1_0 and dunedaqdataformats v4_0_0

### DIFF
--- a/dunecore/DAQTriggerSim/FDHDDAQWriter/FDHDDAQWriter_module.cc
+++ b/dunecore/DAQTriggerSim/FDHDDAQWriter/FDHDDAQWriter_module.cc
@@ -173,7 +173,7 @@ void FDHDDAQWriter::analyze(art::Event const& e)
 	      uint32_t sloc = slot & 0x7;  // but use this for channel map lookup
 	      uint32_t daqlink = ilink % 2;
 
-              std::vector<dunedaq::detdataformats::wib2::WIB2Frame> frames(nSamples);
+              std::vector<dunedaq::fddetdataformats::WIB2Frame> frames(nSamples);
 	      for (size_t isample=0; isample<nSamples; ++isample)
 		{
 		  frames.at(isample).header.version = 2;
@@ -219,7 +219,7 @@ void FDHDDAQWriter::analyze(art::Event const& e)
 		    }
 		}
 
-              dunedaq::daqdataformats::Fragment frag(&frames[0],frames.size()*sizeof(dunedaq::detdataformats::wib2::WIB2Frame));
+              dunedaq::daqdataformats::Fragment frag(&frames[0],frames.size()*sizeof(dunedaq::fddetdataformats::WIB2Frame));
 	      frag.set_run_number(runno);
 	      frag.set_trigger_number(evtno);
 	      frag.set_trigger_timestamp(0);

--- a/dunecore/DuneObj/classes_def.xml
+++ b/dunecore/DuneObj/classes_def.xml
@@ -134,16 +134,21 @@
   </class>
   <class name="art::Wrapper<raw::DUNEHDF5FileInfo2>"/>
 
-  <class name="dunedaq::daqdataformats::SourceID"/>
-  <class name="art::Wrapper<map<dunedaq::daqdataformats::SourceID,std::vector<dunedaq::trgdataformats::TriggerCandidateDa\
-ta> > >"/>
-  <class name="art::Wrapper<map<dunedaq::daqdataformats::SourceID,std::vector<dunedaq::trgdataformats::TriggerPrimitive> \
-> >"/>
-  <class name="art::Wrapper<map<dunedaq::daqdataformats::SourceID,std::vector<dunedaq::trgdataformats::TriggerActivityDat\
-a> > >"/>
-  <class name="dunedaq::trgdataformats::TriggerCandidateData"/>
-  <class name="dunedaq::trgdataformats::TriggerPrimitive"/>
-  <class name="dunedaq::trgdataformats::TriggerActivityData"/>
+  <class name="dunedaq::daqdataformats::SourceID" ClassVersion="10">
+   <version ClassVersion="10" checksum="3885252001"/>
+  </class>
+  <class name="art::Wrapper<map<dunedaq::daqdataformats::SourceID,std::vector<dunedaq::trgdataformats::TriggerCandidateData> > >"/>
+  <class name="art::Wrapper<map<dunedaq::daqdataformats::SourceID,std::vector<dunedaq::trgdataformats::TriggerPrimitive> > >"/>
+  <class name="art::Wrapper<map<dunedaq::daqdataformats::SourceID,std::vector<dunedaq::trgdataformats::TriggerActivityData> > >"/>
+  <class name="dunedaq::trgdataformats::TriggerCandidateData" ClassVersion="10">
+   <version ClassVersion="10" checksum="2442584095"/>
+  </class>
+  <class name="dunedaq::trgdataformats::TriggerPrimitive" ClassVersion="10">
+   <version ClassVersion="10" checksum="356762401"/>
+  </class>
+  <class name="dunedaq::trgdataformats::TriggerActivityData" ClassVersion="10">
+   <version ClassVersion="10" checksum="3029379803"/>
+  </class>
   <class name="std::map<dunedaq::daqdataformats::SourceID,std::vector<dunedaq::trgdataformats::TriggerCandidateData> >"/>
   <class name="std::map<dunedaq::daqdataformats::SourceID,std::vector<dunedaq::trgdataformats::TriggerPrimitive> >"/>
   <class name="std::map<dunedaq::daqdataformats::SourceID,std::vector<dunedaq::trgdataformats::TriggerActivityData> >"/>

--- a/dunecore/DuneObj/classes_def.xml
+++ b/dunecore/DuneObj/classes_def.xml
@@ -135,21 +135,21 @@
   <class name="art::Wrapper<raw::DUNEHDF5FileInfo2>"/>
 
   <class name="dunedaq::daqdataformats::SourceID"/>
-  <class name="art::Wrapper<map<dunedaq::daqdataformats::SourceID,std::vector<dunedaq::detdataformats::trigger::TriggerCandidateDa\
+  <class name="art::Wrapper<map<dunedaq::daqdataformats::SourceID,std::vector<dunedaq::trgdataformats::TriggerCandidateDa\
 ta> > >"/>
-  <class name="art::Wrapper<map<dunedaq::daqdataformats::SourceID,std::vector<dunedaq::detdataformats::trigger::TriggerPrimitive> \
+  <class name="art::Wrapper<map<dunedaq::daqdataformats::SourceID,std::vector<dunedaq::trgdataformats::TriggerPrimitive> \
 > >"/>
-  <class name="art::Wrapper<map<dunedaq::daqdataformats::SourceID,std::vector<dunedaq::detdataformats::trigger::TriggerActivityDat\
+  <class name="art::Wrapper<map<dunedaq::daqdataformats::SourceID,std::vector<dunedaq::trgdataformats::TriggerActivityDat\
 a> > >"/>
-  <class name="dunedaq::detdataformats::trigger::TriggerCandidateData"/>
-  <class name="dunedaq::detdataformats::trigger::TriggerPrimitive"/>
-  <class name="dunedaq::detdataformats::trigger::TriggerActivityData"/>
-  <class name="std::map<dunedaq::daqdataformats::SourceID,std::vector<dunedaq::detdataformats::trigger::TriggerCandidateData> >"/>
-  <class name="std::map<dunedaq::daqdataformats::SourceID,std::vector<dunedaq::detdataformats::trigger::TriggerPrimitive> >"/>
-  <class name="std::map<dunedaq::daqdataformats::SourceID,std::vector<dunedaq::detdataformats::trigger::TriggerActivityData> >"/>
-  <class name="std::vector<dunedaq::detdataformats::trigger::TriggerCandidateData>"/>
-  <class name="std::vector<dunedaq::detdataformats::trigger::TriggerPrimitive>"/>
-  <class name="std::vector<dunedaq::detdataformats::trigger::TriggerActivityData>"/>
+  <class name="dunedaq::trgdataformats::TriggerCandidateData"/>
+  <class name="dunedaq::trgdataformats::TriggerPrimitive"/>
+  <class name="dunedaq::trgdataformats::TriggerActivityData"/>
+  <class name="std::map<dunedaq::daqdataformats::SourceID,std::vector<dunedaq::trgdataformats::TriggerCandidateData> >"/>
+  <class name="std::map<dunedaq::daqdataformats::SourceID,std::vector<dunedaq::trgdataformats::TriggerPrimitive> >"/>
+  <class name="std::map<dunedaq::daqdataformats::SourceID,std::vector<dunedaq::trgdataformats::TriggerActivityData> >"/>
+  <class name="std::vector<dunedaq::trgdataformats::TriggerCandidateData>"/>
+  <class name="std::vector<dunedaq::trgdataformats::TriggerPrimitive>"/>
+  <class name="std::vector<dunedaq::trgdataformats::TriggerActivityData>"/>
 
 
 </lcgdict>

--- a/dunecore/RawDecoding/FDHDDataInterface_tool.cc
+++ b/dunecore/RawDecoding/FDHDDataInterface_tool.cc
@@ -101,7 +101,7 @@ int FDHDDataInterface::retrieveDataAPAListWithLabels( art::Event &evt,
 void FDHDDataInterface::getFragmentsForEvent(hid_t the_group, RawDigits& raw_digits, RDTimeStamps &timestamps, int apano)
 {
   using namespace dune::HDF5Utils;
-  using dunedaq::detdataformats::wib2::WIB2Frame;
+  using dunedaq::fddetdataformats::WIB2Frame;
 
   art::ServiceHandle<dune::FDHDChannelMapService> channelMap;
 

--- a/ups/product_deps
+++ b/ups/product_deps
@@ -29,8 +29,8 @@ product             version
 dunepdlegacy        v1_00_03
 duneutil            v09_77_00d00
 dune_pardata        v01_84_00
-dunedetdataformats  v3_6_1
-dunedaqdataformats  v3_4_1
+dunedetdataformats  v4_1_0
+dunedaqdataformats  v4_0_0
 nusystematics       v01_03_10
 larsoft             v09_77_00
 cetbuildtools       v8_20_00    -       only_for_build


### PR DESCRIPTION
Update to dunedetdataformats v4_1_0 and dunedaqdataformats v4_0_0

Some DAQ-supplied classes are updated, and most of the changes that are exposed to us have to do with their new namespaces.  The namespaces are part of the TBranch names for the trigger primitive, trigger activity and trigger candidate classes as these are directly used in the output ROOT files.

I also added some missing version lines in dunecore/DuneObj/classes_def.xml and now TTree:Draw works.

There is a corresponding PR in duneprototypes.

