### PR TITLE
Remove version for larg4 detector and let geometry_dune handle it

### DIFF
--- a/dunecore/Utilities/services_dunefd_horizdrift_1x2x6.fcl
+++ b/dunecore/Utilities/services_dunefd_horizdrift_1x2x6.fcl
@@ -44,7 +44,7 @@ dunefd_1x2x6_services: {
 dunefd_1x2x6_simulation_services: {
     @table::dunefd_simulation_services
     Geometry: @local::dune10kt_1x2x6_refactored_geo
-    LArG4Detector:      @local::dune10kt_1x2x6_v4_larg4detector
+    LArG4Detector:      @local::dune10kt_1x2x6_larg4detector
 }
 
 dunefd_1x2x6_reco_services: {


### PR DESCRIPTION
LArG4 detector for the 1x2x6 hardcodes the version number into the fcl param name and the value.  Remove the specified versions and let geometry_dune.fcl handle which version to point to.

Needs https://github.com/DUNE/dunesim/pull/41