### PR TITLE
Re-enable writing methods in HDF5RawDataFile that I had previously removed

### DIFF
--- a/dunecore/HDF5Utils/CMakeLists.txt
+++ b/dunecore/HDF5Utils/CMakeLists.txt
@@ -28,6 +28,14 @@ simple_plugin(HDF5RawInput2 "source"
   dunecore::HDF5Utils_HDF5RawFile2Service_service
 )
 
+simple_plugin(HDF5TPStreamInput2 "source"
+  dunepdlegacy_Overlays
+  HDF5Utils
+  dunecore::dunedaqhdf5utils2
+  art::Framework_Services_Registry
+  dunecore::HDF5Utils_HDF5RawFile2Service_service
+)
+
 simple_plugin(HDF5RawFile2Service "service"
               ${ART_PERSISTENCY_ROOTDB}
               art::Framework_Services_Registry

--- a/dunecore/HDF5Utils/HDF5TPStreamInput2.fcl
+++ b/dunecore/HDF5Utils/HDF5TPStreamInput2.fcl
@@ -1,0 +1,13 @@
+BEGIN_PROLOG
+
+# HDF5TPStreamInput2 source configuration parameters
+# for the HDF5 file format released by DUNE-DAQ in November 2022
+
+hdf5tpstreaminput2: {
+  raw_data_label:        "daq"                # module label for products put in the event
+  module_type:           HDF5TPStreamInput2   # source plug-in name
+  ClockFrequencyMHz:     62.5                 # clock frequency for converting timestamps
+  LogLevel: 0                                 # debug printout
+}
+
+END_PROLOG

--- a/dunecore/HDF5Utils/HDF5TPStreamInput2.h
+++ b/dunecore/HDF5Utils/HDF5TPStreamInput2.h
@@ -1,0 +1,56 @@
+// Input source for the second HDF5 file format version from the DAQ people
+// using the DUNE-DAQ HDF5RawInputFile class
+
+#ifndef HDF5TPStreamInput2_h
+#define HDF5TPStreamInput2_h
+#include "art/Framework/Core/InputSourceMacros.h" 
+#include "art/Framework/IO/Sources/Source.h" 
+#include "art/Framework/IO/Sources/SourceTraits.h"
+#include "art/Framework/Core/fwd.h"
+#include "art/Framework/Core/FileBlock.h"
+#include "art/Framework/Core/ProductRegistryHelper.h"
+#include "art/Framework/IO/Sources/SourceHelper.h"
+#include "art/Framework/IO/Sources/put_product_in_principal.h"
+#include "art/Framework/Principal/EventPrincipal.h"
+#include "art/Framework/Principal/RunPrincipal.h"
+#include "art/Framework/Principal/SubRunPrincipal.h"
+#include "art/Framework/Services/Registry/ServiceHandle.h"
+#include "canvas/Persistency/Provenance/FileFormatVersion.h"
+#include "messagefacility/MessageLogger/MessageLogger.h"
+#include "fhiclcpp/ParameterSet.h"
+#include "art/Framework/Services/Registry/ServiceHandle.h"
+#include "dunecore/HDF5Utils/HDF5RawFile2Service.h"
+#include "dunecore/HDF5Utils/HDF5Utils.h"
+
+namespace dune {
+//Forward declare the class
+class HDF5TPStreamInput2Detail;
+}
+
+class dune::HDF5TPStreamInput2Detail {
+ public:
+  HDF5TPStreamInput2Detail(fhicl::ParameterSet const & ps,
+                              art::ProductRegistryHelper & rh,
+                              art::SourceHelper const & sh);
+
+  void readFile(std::string const & filename, art::FileBlock*& fb);
+
+  bool readNext(art::RunPrincipal const* const inR,
+                art::SubRunPrincipal const* const inSR,
+                art::RunPrincipal*& outR,
+                art::SubRunPrincipal*& outSR,
+                art::EventPrincipal*& outE);
+
+  void closeCurrentFile() {
+    art::ServiceHandle<dune::HDF5RawFile2Service> rawFileService;
+    rawFileService->Close();
+  };
+
+ private:
+  dunedaq::hdf5libs::HDF5RawDataFile::record_id_set fUnprocessedTimeSliceIDs;
+  std::string pretend_module_name;
+  int fLogLevel;
+  double fClockFreqMHz;               // clock frequency in MHz -- used to unpack trigger timestamps for the event
+  art::SourceHelper const& pmaker;
+ };
+#endif

--- a/dunecore/HDF5Utils/HDF5TPStreamInput2_source.cc
+++ b/dunecore/HDF5Utils/HDF5TPStreamInput2_source.cc
@@ -1,0 +1,156 @@
+#include "art/Framework/Core/InputSourceMacros.h"
+#include "art/Framework/IO/Sources/Source.h"
+#include "art/Framework/IO/Sources/SourceTraits.h"
+#include "dunecore/HDF5Utils/HDF5TPStreamInput2.h"
+#include "dunecore/DuneObj/DUNEHDF5FileInfo2.h"
+#include "lardataobj/RawData/RDTimeStamp.h"
+
+dune::HDF5TPStreamInput2Detail::HDF5TPStreamInput2Detail(
+                                               fhicl::ParameterSet const & ps,
+                                               art::ProductRegistryHelper & rh,
+                                               art::SourceHelper const & sh) 
+  : pretend_module_name(ps.get<std::string>("raw_data_label", "daq")),
+    fLogLevel(ps.get<int>("LogLevel", 0)),
+    fClockFreqMHz(ps.get<double>("ClockFrequencyMHz", 50.0)),
+    pmaker(sh) {
+      rh.reconstitutes<raw::DUNEHDF5FileInfo2, art::InEvent>(pretend_module_name);
+      rh.reconstitutes<raw::RDTimeStamp, art::InEvent>(pretend_module_name, "timeslice");  // does "trigger" work better?
+    }
+
+void dune::HDF5TPStreamInput2Detail::readFile(
+                                         std::string const & filename, art::FileBlock*& fb) {
+
+  // open the input file with the dunedaq class and hand the ownership off to the rawFileServie
+
+  art::ServiceHandle<dune::HDF5RawFile2Service> rawFileService;
+  auto hdf_file = std::make_unique<dunedaq::hdf5libs::HDF5RawDataFile>(filename);
+  rawFileService->SetPtr(std::move(hdf_file));
+
+  // for convenience, get a non-owning pointer
+  auto rf = rawFileService->GetPtr();
+
+  fUnprocessedTimeSliceIDs = rf->get_all_timeslice_ids();
+
+  uint32_t run_number = rf->get_attribute<uint32_t>("run_number");
+  MF_LOG_INFO("HDF5")
+    << "HDF5 opened HDF file with run number " <<
+    run_number  << " and " <<
+    fUnprocessedTimeSliceIDs.size() << " TimeSlices";
+  if (fLogLevel > 0)
+    {
+       for (const auto & e : fUnprocessedTimeSliceIDs) MF_LOG_INFO("HDF5") << e.first << " " << e.second;
+    }
+
+  fb = new art::FileBlock(art::FileFormatVersion(1, "RawTimeSlice2011"),
+                          filename); 
+}
+
+bool dune::HDF5TPStreamInput2Detail::readNext(art::RunPrincipal const* const inR,
+                                         art::SubRunPrincipal const* const inSR,
+                                         art::RunPrincipal*& outR,
+                                         art::SubRunPrincipal*& outSR,
+                                         art::EventPrincipal*& outE) 
+{
+  using namespace dune::HDF5Utils;
+  
+  art::ServiceHandle<dune::HDF5RawFile2Service> rawFileService;
+  auto rf = rawFileService->GetPtr();
+
+  // Establish default 'results'
+  outR = 0;
+  outSR = 0;
+  outE = 0;
+
+  if (fUnprocessedTimeSliceIDs.empty()) {return false;}
+
+  // take the first unprocessed event off the set
+
+  auto nextTimeSliceRecordID_i = fUnprocessedTimeSliceIDs.cbegin();
+  auto nextTimeSliceRecordID = *nextTimeSliceRecordID_i;
+  fUnprocessedTimeSliceIDs.erase(nextTimeSliceRecordID_i);
+
+  uint32_t run_id = rf->get_attribute<uint32_t>("run_number");
+
+  // get TimeSlice record header pointer
+
+  auto tsh = rf->get_tsh_ptr(nextTimeSliceRecordID);
+
+  //check that the run number in the trigger record header agrees with that in the file attribute
+
+  auto run_id2 = tsh->run_number;
+  if (run_id != run_id2)
+    {
+      throw cet::exception("HDF5TPStreamInput2_source.cc") << " Inconsistent run IDs in file attribute and TimeSlice record header " << run_id << " " << run_id2;
+    }
+
+  // check that the TimeSlice record number in the header agrees with what we are expecting
+
+  auto trhtn = tsh->timeslice_number;
+  if (nextTimeSliceRecordID.first != trhtn)
+    {
+      throw cet::exception("HDF5TPStreamInput2_source.cc") << " Inconsistent timeslice numbers: " << nextTimeSliceRecordID.first << " " << trhtn;
+    }
+  
+  // TimeSliceTimeStamp is NOT time but Clock-tick since the epoch.
+
+  uint64_t TimeSliceTimeStamp = 0;  // TODO -- find a timestamp.  From the first fragment perhaps?
+  if (fLogLevel > 0)
+    {
+      std::cout << "HDF5TPStreamInput2_source: TimeSlice Time Stamp: " << TimeSliceTimeStamp << std::endl;
+    }
+    
+  uint64_t getTrigTime = formatTrigTimeStampWithFrequency(TimeSliceTimeStamp, fClockFreqMHz);
+  if (fLogLevel > 0)
+    {
+      std::cout << "HDF5TPStreamInput2_source: getTrigTime: " << getTrigTime << std::endl;
+    }
+
+  art::Timestamp artTrigStamp (getTrigTime);
+  if (fLogLevel > 0)
+    {
+      std::cout << "HDF5TPStreamInput2_source: artTrigStamp: " <<   artTrigStamp.value()<< std::endl;
+    }
+
+  std::unique_ptr<raw::RDTimeStamp> rd_timestamp(new raw::RDTimeStamp(TimeSliceTimeStamp));
+
+  // make new run if inR is 0 or if the run has changed
+  if (inR == 0 || inR->run() != run_id) {
+    outR = pmaker.makeRunPrincipal(run_id,artTrigStamp);
+  }
+
+  // make new subrun if inSR is 0 or if the subrun has changed
+  art::SubRunID subrun_check(run_id, 1);
+  if (inSR == 0 || subrun_check != inSR->subRunID()) {
+    outSR = pmaker.makeSubRunPrincipal(run_id, 1, artTrigStamp);
+  }
+
+  // this is the TimeSlice record ID:
+
+  int event = nextTimeSliceRecordID.first;
+
+  outE = pmaker.makeEventPrincipal(run_id, 1, event, artTrigStamp);
+  if (fLogLevel > 0)
+    {
+      std::cout << "HDF5TPStreamInput2_source: Event Time Stamp :" << outE->time().value() << std::endl;
+    }
+
+ 
+  std::unique_ptr<raw::DUNEHDF5FileInfo2> the_info(
+                                                   new raw::DUNEHDF5FileInfo2(rf->get_file_name(), run_id, nextTimeSliceRecordID.first,
+                                                                              nextTimeSliceRecordID.second));
+
+  put_product_in_principal(std::move(the_info), *outE, pretend_module_name,
+                           "");
+  put_product_in_principal(std::move(rd_timestamp), *outE, pretend_module_name,
+                           "timeslice");
+
+  return true;
+}
+
+//typedef for shorthand
+namespace dune {
+  using HDF5TPStreamInput2Source = art::Source<HDF5TPStreamInput2Detail>;
+}
+
+
+DEFINE_ART_INPUT_SOURCE(dune::HDF5TPStreamInput2Source)

--- a/dunecore/HDF5Utils/dunedaqhdf5utils2/HDF5RawDataFile.cpp
+++ b/dunecore/HDF5Utils/dunedaqhdf5utils2/HDF5RawDataFile.cpp
@@ -22,6 +22,7 @@
 #include <utility>
 #include <vector>
 #include <chrono>
+#include <cstdio>
 
 namespace dunedaq {
 namespace hdf5libs {
@@ -98,7 +99,9 @@ HDF5RawDataFile::~HDF5RawDataFile()
     m_file_ptr->flush();
 
     // rename file to the bare name
-    std::filesystem::rename(m_file_ptr->getName(), m_bare_file_name);
+    // seems to break under the c7 compiler use cstdio version instead
+    //std::filesystem::rename(m_file_ptr->getName(), m_bare_file_name);
+    rename(m_file_ptr->getName().c_str(), m_bare_file_name.c_str());
   }
 
   // explicit destruction; not really needed, but nice to be clear...

--- a/dunecore/HDF5Utils/dunedaqhdf5utils2/HDF5RawDataFile.cpp
+++ b/dunecore/HDF5Utils/dunedaqhdf5utils2/HDF5RawDataFile.cpp
@@ -5,6 +5,8 @@
  *
  * Modified November 2022 by Tom Junk -- remove writing functionality (depended on an arbitrary
  * choice of channel maps), and change logging and exception classes.
+ * Modified September 5, 2023 by Tom Junk -- add back the writing functionality, as the channel map
+ * interface is now no longer an input and we can support writing again.
  */
 
 #include "dunecore/HDF5Utils/dunedaqhdf5utils2/HDF5RawDataFile.hpp"
@@ -19,20 +21,285 @@
 #include <string>
 #include <utility>
 #include <vector>
+#include <chrono>
 
 namespace dunedaq {
 namespace hdf5libs {
 
 constexpr uint32_t MAX_FILELAYOUT_VERSION = 4294967295; // NOLINT(build/unsigned)
 
+/**
+ * @brief Constructor for writing a new file
+ */
+HDF5RawDataFile::HDF5RawDataFile(std::string file_name,
+                                 daqdataformats::run_number_t run_number,
+                                 size_t file_index,
+                                 std::string application_name,
+                                 const hdf5filelayout::FileLayoutParams& fl_params,
+                                 hdf5rawdatafile::SrcIDGeoIDMap srcid_geoid_map,
+                                 std::string inprogress_filename_suffix,
+                                 unsigned open_flags)
+  : m_bare_file_name(file_name)
+  , m_open_flags(open_flags)
+{
+
+  // check and make sure that the file isn't ReadOnly
+  if (m_open_flags == HighFive::File::ReadOnly) {
+    throw cet::exception("HDF5RawDataFile") << " Incompatible Open Flags " << file_name << " " << m_open_flags;
+  }
+
+  auto filename_to_open = m_bare_file_name + inprogress_filename_suffix;
+
+  // do the file open
+  try {
+    m_file_ptr.reset(new HighFive::File(filename_to_open, m_open_flags));
+  } catch (std::exception const& excpt) {
+    throw cet::exception("HDF5RawDataFile") << " File Open Failed " << filename_to_open << " " << excpt.what();
+  }
+
+  m_recorded_size = 0;
+
+  int64_t timestamp =
+    std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
+  std::string file_creation_timestamp = std::to_string(timestamp);
+
+  MF_LOG_DEBUG("HDF5RawDataFile.cpp") << "Created HDF5 file (" << file_name << ") at time " << file_creation_timestamp << " .";
+
+  // write some file attributes
+  write_attribute("run_number", run_number);
+  write_attribute("file_index", file_index);
+  write_attribute("creation_timestamp", file_creation_timestamp);
+  write_attribute("application_name", application_name);
+
+  // set the file layout contents
+  m_file_layout_ptr.reset(new HDF5FileLayout(fl_params));
+  write_file_layout();
+
+  // write the SourceID-related attributes
+  HDF5SourceIDHandler::populate_source_id_geo_id_map(srcid_geoid_map, m_file_level_source_id_geo_id_map);
+  HDF5SourceIDHandler::store_file_level_geo_id_info(*m_file_ptr, m_file_level_source_id_geo_id_map);
+
+  // write the record type
+  m_record_type = fl_params.record_name_prefix;
+  write_attribute("record_type", m_record_type);
+}
+
+
 HDF5RawDataFile::~HDF5RawDataFile()
 {
+  if (m_file_ptr.get() != nullptr && m_open_flags != HighFive::File::ReadOnly) {
+    write_attribute("recorded_size", m_recorded_size);
+
+    int64_t timestamp =
+      std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
+    std::string file_closing_timestamp = std::to_string(timestamp);
+    write_attribute("closing_timestamp", file_closing_timestamp);
+
+    m_file_ptr->flush();
+
+    // rename file to the bare name
+    std::filesystem::rename(m_file_ptr->getName(), m_bare_file_name);
+  }
 
   // explicit destruction; not really needed, but nice to be clear...
   m_file_ptr.reset();
   m_file_layout_ptr.reset();
 }
 
+/**
+ * @brief Write a TriggerRecord to the file.
+ */
+void
+HDF5RawDataFile::write(const daqdataformats::TriggerRecord& tr)
+{
+  // the source_id_path map that we will build up as we write the TR header
+  // and fragments (and then write the map into the HDF5 TR_record Group)
+  HDF5SourceIDHandler::source_id_path_map_t source_id_path_map;
+
+  // the map of fragment types to SourceIDS
+  HDF5SourceIDHandler::fragment_type_source_id_map_t fragment_type_source_id_map;
+
+  // the map of subdetectors to SourceIDS
+  HDF5SourceIDHandler::subdetector_source_id_map_t subdetector_source_id_map;
+
+  // write the record header into the HDF5 file/group
+  HighFive::Group record_level_group = write(tr.get_header_ref(), source_id_path_map);
+
+  // store the SourceID of the record header in the HDF5 file/group
+  // (since there should only be one entry in the map at this point, we'll take advantage of that...)
+  for (auto const& source_id_path : source_id_path_map) {
+    HDF5SourceIDHandler::store_record_header_source_id(record_level_group, source_id_path.first);
+  }
+
+  // write all of the fragments into the HDF5 file/group
+  for (auto const& frag_ptr : tr.get_fragments_ref()) {
+    write(*frag_ptr, source_id_path_map);
+    HDF5SourceIDHandler::add_fragment_type_source_id_to_map(
+      fragment_type_source_id_map, frag_ptr->get_fragment_type(), frag_ptr->get_element_id());
+    HDF5SourceIDHandler::add_subdetector_source_id_to_map(
+      subdetector_source_id_map,
+      static_cast<detdataformats::DetID::Subdetector>(frag_ptr->get_detector_id()),
+      frag_ptr->get_element_id());
+  }
+
+  // store all of the record-level maps in the HDF5 file/group
+  HDF5SourceIDHandler::store_record_level_path_info(record_level_group, source_id_path_map);
+  HDF5SourceIDHandler::store_record_level_fragment_type_map(record_level_group, fragment_type_source_id_map);
+  HDF5SourceIDHandler::store_record_level_subdetector_map(record_level_group, subdetector_source_id_map);
+}
+
+/**
+ * @brief Write a TimeSlice to the file.
+ */
+void
+HDF5RawDataFile::write(const daqdataformats::TimeSlice& ts)
+{
+  // the source_id_path map that we will build up as we write the TR header
+  // and fragments (and then write the map into the HDF5 TR_record Group)
+  HDF5SourceIDHandler::source_id_path_map_t source_id_path_map;
+
+  // the map of fragment types to SourceIDS
+  HDF5SourceIDHandler::fragment_type_source_id_map_t fragment_type_source_id_map;
+
+  // the map of subdetectors to SourceIDS
+  HDF5SourceIDHandler::subdetector_source_id_map_t subdetector_source_id_map;
+
+  // write the record header into the HDF5 file/group
+  HighFive::Group record_level_group = write(ts.get_header(), source_id_path_map);
+
+  // store the SourceID of the record header in the HDF5 file/group
+  // (since there should only be one entry in the map at this point, we'll take advantage of that...)
+  for (auto const& source_id_path : source_id_path_map) {
+    HDF5SourceIDHandler::store_record_header_source_id(record_level_group, source_id_path.first);
+  }
+
+  // write all of the fragments into the HDF5 file/group
+  for (auto const& frag_ptr : ts.get_fragments_ref()) {
+    write(*frag_ptr, source_id_path_map);
+    HDF5SourceIDHandler::add_fragment_type_source_id_to_map(
+      fragment_type_source_id_map, frag_ptr->get_fragment_type(), frag_ptr->get_element_id());
+    HDF5SourceIDHandler::add_subdetector_source_id_to_map(
+      subdetector_source_id_map,
+      static_cast<detdataformats::DetID::Subdetector>(frag_ptr->get_detector_id()),
+      frag_ptr->get_element_id());
+  }
+
+  // store all of the record-level maps in the HDF5 file/group
+  HDF5SourceIDHandler::store_record_level_path_info(record_level_group, source_id_path_map);
+  HDF5SourceIDHandler::store_record_level_fragment_type_map(record_level_group, fragment_type_source_id_map);
+  HDF5SourceIDHandler::store_record_level_subdetector_map(record_level_group, subdetector_source_id_map);
+}
+
+/**
+ * @brief Write a TriggerRecordHeader to the file.
+ */
+HighFive::Group
+HDF5RawDataFile::write(const daqdataformats::TriggerRecordHeader& trh,
+                       HDF5SourceIDHandler::source_id_path_map_t& path_map)
+{
+  std::tuple<size_t, std::string, HighFive::Group> write_results =
+    do_write(m_file_layout_ptr->get_path_elements(trh),
+             static_cast<const char*>(trh.get_storage_location()),
+             trh.get_total_size_bytes());
+  m_recorded_size += std::get<0>(write_results);
+  HDF5SourceIDHandler::add_source_id_path_to_map(path_map, trh.get_header().element_id, std::get<1>(write_results));
+  return std::get<2>(write_results);
+}
+
+/**
+ * @brief Write a TimeSliceHeader to the file.
+ */
+HighFive::Group
+HDF5RawDataFile::write(const daqdataformats::TimeSliceHeader& tsh, HDF5SourceIDHandler::source_id_path_map_t& path_map)
+{
+  std::tuple<size_t, std::string, HighFive::Group> write_results =
+    do_write(m_file_layout_ptr->get_path_elements(tsh), (const char*)(&tsh), sizeof(daqdataformats::TimeSliceHeader));
+  m_recorded_size += std::get<0>(write_results);
+  HDF5SourceIDHandler::add_source_id_path_to_map(path_map, tsh.element_id, std::get<1>(write_results));
+  return std::get<2>(write_results);
+}
+
+/**
+ * @brief Write a Fragment to the file.
+ */
+void
+HDF5RawDataFile::write(const daqdataformats::Fragment& frag, HDF5SourceIDHandler::source_id_path_map_t& path_map)
+{
+  std::tuple<size_t, std::string, HighFive::Group> write_results =
+    do_write(m_file_layout_ptr->get_path_elements(frag.get_header()),
+             static_cast<const char*>(frag.get_storage_location()),
+             frag.get_size());
+  m_recorded_size += std::get<0>(write_results);
+
+  daqdataformats::SourceID source_id = frag.get_element_id();
+  HDF5SourceIDHandler::add_source_id_path_to_map(path_map, source_id, std::get<1>(write_results));
+}
+
+/**
+ * @brief write the file layout
+ */
+void
+HDF5RawDataFile::write_file_layout()
+{
+  hdf5filelayout::data_t fl_json;
+  hdf5filelayout::to_json(fl_json, m_file_layout_ptr->get_file_layout_params());
+  write_attribute("filelayout_params", fl_json.dump());
+  write_attribute("filelayout_version", m_file_layout_ptr->get_version());
+}
+
+/**
+ * @brief write bytes to a dataset in the file, at the appropriate path
+ */
+std::tuple<size_t, std::string, HighFive::Group>
+HDF5RawDataFile::do_write(std::vector<std::string> const& group_and_dataset_path_elements,
+                          const char* raw_data_ptr,
+                          size_t raw_data_size_bytes)
+{
+  const std::string dataset_name = group_and_dataset_path_elements.back();
+
+  // create top level group if needed
+  std::string const& top_level_group_name = group_and_dataset_path_elements.at(0);
+  if (!m_file_ptr->exist(top_level_group_name))
+    m_file_ptr->createGroup(top_level_group_name);
+
+  // setup sub_group to work with
+  HighFive::Group sub_group = m_file_ptr->getGroup(top_level_group_name);
+  if (!sub_group.isValid()) {
+    throw cet::exception("HDF5RawDataFile") << " Invalid HDF5 Group: " << top_level_group_name;
+  }
+  HighFive::Group top_level_group = sub_group;
+
+  // Create the remaining subgroups
+  for (size_t idx = 1; idx < group_and_dataset_path_elements.size() - 1; ++idx) {
+    // group_dataset.size()-1 because the last element is the dataset
+    std::string const& child_group_name = group_and_dataset_path_elements[idx];
+    if (child_group_name.empty()) {
+      throw cet::exception("HDF5RawDataFile") << " Invalid HDF5 Group: " << child_group_name;
+    }
+    if (!sub_group.exist(child_group_name)) {
+      sub_group.createGroup(child_group_name);
+    }
+    HighFive::Group child_group = sub_group.getGroup(child_group_name);
+    if (!child_group.isValid()) {
+      throw cet::exception("HDF5RawDataFile") << " Invalid HDF5 Group: " << child_group_name;
+    }
+    sub_group = child_group;
+  }
+
+  // Create dataset
+  HighFive::DataSpace data_space = HighFive::DataSpace({ raw_data_size_bytes, 1 });
+  HighFive::DataSetCreateProps data_set_create_props;
+  HighFive::DataSetAccessProps data_set_access_props;
+
+  auto data_set = sub_group.createDataSet<char>(dataset_name, data_space, data_set_create_props, data_set_access_props);
+  if (data_set.isValid()) {
+    data_set.write_raw(raw_data_ptr);
+    m_file_ptr->flush();
+    return std::make_tuple(raw_data_size_bytes, data_set.getPath(), top_level_group);
+  } else {
+    throw cet::exception("HDF5RawDataFile") << " Invalid HDF5 Dataset: " << dataset_name << " " <<  m_file_ptr->getName();
+  }
+}
 
 /**
  * @brief Constructor for reading a file

--- a/dunecore/HDF5Utils/dunedaqhdf5utils2/HDF5SourceIDHandler.cpp
+++ b/dunecore/HDF5Utils/dunedaqhdf5utils2/HDF5SourceIDHandler.cpp
@@ -4,6 +4,7 @@
  * received with this code.
  *
  * modified by Tom Junk, Nov. 2021.  Remove ers, detchannelmaps dependencies.
+ * Sep. 5, 2023: put back populate_source_id_geo_id_map as it no longer depends on detchannelmaps
  */
 
 #include "dunecore/HDF5Utils/dunedaqhdf5utils2/HDF5SourceIDHandler.hpp"
@@ -12,6 +13,19 @@
 namespace dunedaq {
 namespace hdf5libs {
 
+void 
+HDF5SourceIDHandler::populate_source_id_geo_id_map(dunedaq::hdf5libs::hdf5rawdatafile::SrcIDGeoIDMap  src_id_geo_id_mp_struct,
+                                  source_id_geo_id_map_t& source_id_geo_id_map)
+{
+
+  for( auto const& entry : src_id_geo_id_mp_struct ) {
+    daqdataformats::SourceID source_id(daqdataformats::SourceID::Subsystem::kDetectorReadout, entry.src_id);
+    // FIXME: replace with a proper coder/decoder
+    uint64_t geoid = (static_cast<uint64_t>(entry.geo_id.stream_id) << 48) | (static_cast<uint64_t>(entry.geo_id.slot_id) << 32) | (static_cast<uint64_t>(entry.geo_id.crate_id) << 16) | entry.geo_id.det_id;
+    add_source_id_geo_id_to_map(source_id_geo_id_map, source_id, geoid);
+  }
+}
+  
 void
 HDF5SourceIDHandler::store_file_level_geo_id_info(HighFive::File& h5_file, const source_id_geo_id_map_t& the_map)
 {

--- a/dunecore/HDF5Utils/dunedaqhdf5utils2/HDF5SourceIDHandler.hpp
+++ b/dunecore/HDF5Utils/dunedaqhdf5utils2/HDF5SourceIDHandler.hpp
@@ -14,6 +14,7 @@
 
 #include "daqdataformats/v3_4_1/Fragment.hpp"
 #include "daqdataformats/v3_4_1/SourceID.hpp"
+#include "dunecore/HDF5Utils/dunedaqhdf5utils2/hdf5rawdatafile/Structs.hpp"
 #include "detdataformats/DetID.hpp"
 
 #include <highfive/H5File.hpp>
@@ -45,6 +46,12 @@ public:
   typedef std::map<daqdataformats::FragmentType, std::set<daqdataformats::SourceID>> fragment_type_source_id_map_t;
   typedef std::map<detdataformats::DetID::Subdetector, std::set<daqdataformats::SourceID>> subdetector_source_id_map_t;
 
+  /**
+   * Populates the specified source_id_geo_id map with information contained in the
+   * specified Hardware Map.
+   */
+  static void populate_source_id_geo_id_map(dunedaq::hdf5libs::hdf5rawdatafile::SrcIDGeoIDMap  src_id_geo_id_mp_struct,
+                                            source_id_geo_id_map_t& the_map);
   /**
    * Stores the map from SourceID to GeoID in the specified HighFive::File.
    */

--- a/dunecore/HDF5Utils/dunedaqhdf5utils2/hdf5rawdatafile/Nljs.hpp
+++ b/dunecore/HDF5Utils/dunedaqhdf5utils2/hdf5rawdatafile/Nljs.hpp
@@ -1,0 +1,52 @@
+/*
+ * This file is 100% generated.  Any manual edits will likely be lost.
+ *
+ * This contains functions struct and other type definitions for shema in 
+ * namespace dunedaq::hdf5libs::hdf5rawdatafile to be serialized via nlohmann::json.
+ */
+#ifndef DUNEDAQ_HDF5LIBS_HDF5RAWDATAFILE_NLJS_HPP
+#define DUNEDAQ_HDF5LIBS_HDF5RAWDATAFILE_NLJS_HPP
+
+// My structs
+#include "hdf5libs/hdf5rawdatafile/Structs.hpp"
+
+
+#include <nlohmann/json.hpp>
+
+namespace dunedaq::hdf5libs::hdf5rawdatafile {
+
+    using data_t = nlohmann::json;
+    
+    inline void to_json(data_t& j, const GeoID& obj) {
+        j["det_id"] = obj.det_id;
+        j["crate_id"] = obj.crate_id;
+        j["slot_id"] = obj.slot_id;
+        j["stream_id"] = obj.stream_id;
+    }
+    
+    inline void from_json(const data_t& j, GeoID& obj) {
+        if (j.contains("det_id"))
+            j.at("det_id").get_to(obj.det_id);    
+        if (j.contains("crate_id"))
+            j.at("crate_id").get_to(obj.crate_id);    
+        if (j.contains("slot_id"))
+            j.at("slot_id").get_to(obj.slot_id);    
+        if (j.contains("stream_id"))
+            j.at("stream_id").get_to(obj.stream_id);    
+    }
+    
+    inline void to_json(data_t& j, const SrcIDGeoIDEntry& obj) {
+        j["src_id"] = obj.src_id;
+        j["geo_id"] = obj.geo_id;
+    }
+    
+    inline void from_json(const data_t& j, SrcIDGeoIDEntry& obj) {
+        if (j.contains("src_id"))
+            j.at("src_id").get_to(obj.src_id);    
+        if (j.contains("geo_id"))
+            j.at("geo_id").get_to(obj.geo_id);    
+    }
+    
+} // namespace dunedaq::hdf5libs::hdf5rawdatafile
+
+#endif // DUNEDAQ_HDF5LIBS_HDF5RAWDATAFILE_NLJS_HPP

--- a/dunecore/HDF5Utils/dunedaqhdf5utils2/hdf5rawdatafile/Structs.hpp
+++ b/dunecore/HDF5Utils/dunedaqhdf5utils2/hdf5rawdatafile/Structs.hpp
@@ -1,0 +1,60 @@
+/*
+ * This file is 100% generated.  Any manual edits will likely be lost.
+ *
+ * This contains struct and other type definitions for shema in 
+ * namespace dunedaq::hdf5libs::hdf5rawdatafile.
+ */
+#ifndef DUNEDAQ_HDF5LIBS_HDF5RAWDATAFILE_STRUCTS_HPP
+#define DUNEDAQ_HDF5LIBS_HDF5RAWDATAFILE_STRUCTS_HPP
+
+#include <cstdint>
+
+#include <vector>
+
+namespace dunedaq::hdf5libs::hdf5rawdatafile {
+
+    // @brief A count of not too many things
+    using Count = int32_t;
+
+
+    // @brief Parameter that can be used to enable or disable functionality
+    using Flag = bool;
+
+    // @brief Geographic ID structure
+    struct GeoID 
+    {
+
+        // @brief Detector ID
+        Count det_id = 0;
+
+        // @brief Crate ID
+        Count crate_id = 0;
+
+        // @brief Slot ID
+        Count slot_id = 0;
+
+        // @brief Stream ID
+        Count stream_id = 0;
+    };
+
+    // @brief A count of very many things
+    using Size = uint64_t; // NOLINT
+
+
+    // @brief SourceID GeoID Map entry
+    struct SrcIDGeoIDEntry 
+    {
+
+        // @brief Source ID
+        Size src_id = 0;
+
+        // @brief Geo ID
+        GeoID geo_id = {0, 0, 0, 0};
+    };
+
+    // @brief SourceID to GeoID map
+    using SrcIDGeoIDMap = std::vector<dunedaq::hdf5libs::hdf5rawdatafile::SrcIDGeoIDEntry>;
+
+} // namespace dunedaq::hdf5libs::hdf5rawdatafile
+
+#endif // DUNEDAQ_HDF5LIBS_HDF5RAWDATAFILE_STRUCTS_HPP


### PR DESCRIPTION
Last November, I took out the methods that wrote to the output HDF5 file when I copied code from dune-daq/hdf5libs into dunecore, because it required an argument from detchannelmaps.  We didn't know which channel map to use offline, since we support so many detectors.  Now the DUNE-DAQ people have removed that argument, saying it was unnecessary and problematic, so I was able to re-instate the methods.  I made some changes -- changing ERS warnings to MF_LOG_WARNING, and ERS exceptions to cet::exceptions, and I also had to use the cstdio rename method instead of the one in the C++ filesystem library because the linker complained with clang (though not gcc).