### PR TITLE
added name for v5 1x2x2 geometry to make things consistent

### DIFF
--- a/dunecore/Geometry/geometry_dune.fcl
+++ b/dunecore/Geometry/geometry_dune.fcl
@@ -165,6 +165,7 @@ dune10kt_1x2x2_v4_refactored_geo.GDML: "dune10kt_v4_refactored_1x2x2.gdml"
 dune10kt_1x2x2_v4_refactored_geo.ROOT: "dune10kt_v4_refactored_1x2x2.gdml"
 
 dune10kt_1x2x2_v5_refactored_geo:      @local::dune10kt_geo
+dune10kt_1x2x2_v5_refactored_geo.Name: "dune10kt_v5_1x2x2"
 dune10kt_1x2x2_v5_refactored_geo.GDML: "dune10kt_v5_refactored_1x2x2.gdml"
 dune10kt_1x2x2_v5_refactored_geo.ROOT: "dune10kt_v5_refactored_1x2x2.gdml"
 


### PR DESCRIPTION
dune10kt_v5_refactored_1x2x2.gdml did not have a name in the geometry_dune.fcl file so it would default to dune10kt_v1.  Explicityly added name to fix this.