### PR TITLE
add missing CMakeLists.txt file to install headers in hdf5rawdatafile

### DIFF
--- a/dunecore/HDF5Utils/dunedaqhdf5utils2/CMakeLists.txt
+++ b/dunecore/HDF5Utils/dunedaqhdf5utils2/CMakeLists.txt
@@ -14,4 +14,5 @@ install_source()
 
 add_subdirectory(hdf5filelayout)
 add_subdirectory(hdf5sourceidmaps)
+add_subdirectory(hdf5rawdatafile)
 

--- a/dunecore/HDF5Utils/dunedaqhdf5utils2/hdf5rawdatafile/CMakeLists.txt
+++ b/dunecore/HDF5Utils/dunedaqhdf5utils2/hdf5rawdatafile/CMakeLists.txt
@@ -1,0 +1,1 @@
+install_headers()


### PR DESCRIPTION
Amazingly, the build of the dunesw stack succeeds when you build the whole thing, which is what the CI system does.  But if you build just duneprototypes, then it notices some headers in dunecore were not installed.  This PR adjusts CMakeLists.txt files to install them.

A minor annoyance -- nlohmann_json autogenerates header files called Nljs.hpp and Structs.hpp.  We have several of these, with different contents, in the dune-daq repository and copied here in dunecore.  While not a problem -- the source files that #include them always get the right ones because their pathnames are all spelled out, it might be an annoyance for debugging, where you can set a breakpoint based on a filename and a line number.  I guess we won't be setting breakpoints in Nljs.hpp.