### PR TITLE
Regenerated FD HD 1x2x6 gdmls

### DIFF
--- a/dunecore/Geometry/gdml/dune10kt_v5_refactored_1x2x6.gdml
+++ b/dunecore/Geometry/gdml/dune10kt_v5_refactored_1x2x6.gdml
@@ -215,6 +215,11 @@
    <fraction n="0.53" ref="fibrous_glass"/>
   </material>
 
+  <material name="FR4SussexAPA">
+   <D value="1.75" unit="g/cm3"/>
+   <fraction n="1" ref="FR4"/>
+  </material>
+
   <material name="STEEL_STAINLESS_Fe7Cr2Ni" formula="STEEL_STAINLESS_Fe7Cr2Ni">
    <D value="7.9300" unit="g/cm3"/>
    <fraction n="0.0010" ref="carbon"/>
@@ -391,7 +396,7 @@
 <solids>
     <box name="Inner" lunit="cm"
       x="360.843"
-      y="607.82875"
+      y="608.46375"
       z="232.39"/>
     <box name="InnerUPlane" lunit="cm"
       x="0.015"
@@ -407,7 +412,7 @@
       z="229.456"/>
     <box name="InnerActive" lunit="cm"
       x="359.415"
-      y="600.01875"
+      y="600.65375"
       z="232.39"/>
 
     <tube name="InnerWireVert"
@@ -10831,7 +10836,7 @@
 
     <box name="Outer" lunit="cm"
       x="16.443"
-      y="607.82875"
+      y="608.46375"
       z="232.39"/>
     <box name="OuterUPlane" lunit="cm"
       x="0.015"
@@ -10847,7 +10852,7 @@
       z="229.456"/>
     <box name="OuterActive" lunit="cm"
       x="15.015"
-      y="600.01875"
+      y="600.65375"
       z="232.39"/>
 
     <tube name="OuterWireVert"
@@ -21276,27 +21281,27 @@
       aunit="deg"
       lunit="cm"/>
     <box name="Cryostat" lunit="cm"
-      x="759.3241"
-      y="1357.6975"
+      x="759.8921"
+      y="1358.9675"
       z="1746.48"/>
     <box name="ArgonInterior" lunit="cm"
-      x="756.7841"
-      y="1355.1575"
+      x="757.3521"
+      y="1356.4275"
       z="1743.94"/>
     <box name="FieldCageOut" lunit="cm"
-      x="726.7841"
-      y="1216.1655"
-      z="1394.848"/>
+      x="727.3521"
+      y="1219.4355"
+      z="1396.848"/>
     <box name="FieldCageIn" lunit="cm"
-      x="727.7841"
-      y="1215.6575"
-      z="1394.34"/>
+      x="728.3521"
+      y="1218.9275"
+      z="1396.34"/>
     <subtraction name="FieldCage">
       <first ref="FieldCageOut"/>
       <second ref="FieldCageIn"/>
     </subtraction>
     <box name="GaseousArgon" lunit="cm"
-      x="756.7841"
+      x="757.3521"
       y="50"
       z="1743.94"/>
     <subtraction name="SteelShell">
@@ -21304,8 +21309,8 @@
       <second ref="ArgonInterior"/>
     </subtraction>
     <box name="Cathode" lunit="cm"
-      x="0.016"
-      y="602.36275"
+      x="0.3"
+      y="602.99775"
       z="226.524"/>
 
     <box name="ArapucaOut" lunit="cm"
@@ -21362,11 +21367,11 @@
      <box name="APAFrameZSideHollow" lunit="cm"
       x="4.4565"
       y="9.5504"
-      z="230.0025"/>
+      z="229.3675"/>
      <box name="APAFrameZSideShell" lunit="cm"
       x="5.0661"
       y="10.16"
-      z="230.0025"/>
+      z="229.3675"/>
      <subtraction name="APAFrameZSide">
       <first  ref="APAFrameZSideShell"/>
       <second ref="APAFrameZSideHollow"/>
@@ -21383,23 +21388,29 @@
      <box name="G10BoardYSideCenterSeg" lunit="cm"
       x="5.0661"
       y="606"
-      z="0.3175"/>
+      z="0.47625"/>
 
      <box name="G10BoardZSideCenterSeg" lunit="cm"
       x="5.0661"
-      y="0.3175"
-      z="230.0025"/>
+      y="0.47625"
+      z="229.3675"/>
+
+      <!-- Approximate stack of FR-4 readout boards at APA head -->
+     <box name="G10HeadBoards" lunit="cm"
+      x="3.81"
+      y="16.5"
+      z="229.3675"/>
 
 
 
     <box name="FoamPadBlock" lunit="cm"
-      x="919.3241"
-      y="1517.6975"
+      x="919.8921"
+      y="1518.9675"
       z="1906.48" />
 
     <box name="FoamPadInner" lunit="cm"
-      x="759.3341"
-      y="1357.7075"
+      x="759.9021"
+      y="1358.9775"
       z="1746.49" />
 
     <subtraction name="FoamPadding">
@@ -21409,13 +21420,13 @@
     </subtraction>
 
     <box name="SteelSupportBlock" lunit="cm"
-      x="1119.3241"
-      y="1617.6975"
+      x="1119.8921"
+      y="1618.9675"
       z="2106.48" />
 
     <box name="SteelSupportInner" lunit="cm"
-      x="919.3341"
-      y="1517.7075"
+      x="919.9021"
+      y="1518.9775"
       z="1906.49" />
 
     <subtraction name="SteelSupport">
@@ -21425,14 +21436,14 @@
     </subtraction>
 
     <box name="DetEnclosure" lunit="cm"
-      x="1219.3241"
-      y="1817.6975"
+      x="1219.8921"
+      y="1818.9675"
       z="2306.48"/>
 
 
     <box name="World" lunit="cm"
-      x="7219.3241"
-      y="7817.6975"
+      x="7219.8921"
+      y="7818.9675"
       z="8306.48"/>
 </solids>
 <structure>
@@ -41768,19 +41779,19 @@
      <physvol>
        <volumeref ref="volTPCPlaneZInner"/>
        <position name="posInnerPlaneZ" unit="cm"
-         x="-179.953" y="-3.09062500000005" z="0"/>
+         x="-179.953" y="-2.77312500000005" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volTPCPlaneVInner"/>
        <position name="posInnerPlaneV" unit="cm"
-         x="-179.477" y="-3.24937500000004" z="0"/>
+         x="-179.477" y="-3.01125000000002" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volTPCPlaneUInner"/>
        <position name="posInnerPlaneU" unit="cm"
-         x="-179.001" y="-3.40812500000004" z="0"/>
+         x="-179.001" y="-3.24937500000004" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
@@ -62123,19 +62134,19 @@
      <physvol>
        <volumeref ref="volTPCPlaneZOuter"/>
        <position name="posOuterPlaneZ" unit="cm"
-         x="-7.753" y="-3.09062500000005" z="0"/>
+         x="-7.753" y="-2.77312500000005" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volTPCPlaneVOuter"/>
        <position name="posOuterPlaneV" unit="cm"
-         x="-7.277" y="-3.24937500000004" z="0"/>
+         x="-7.277" y="-3.01125000000002" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volTPCPlaneUOuter"/>
        <position name="posOuterPlaneU" unit="cm"
-         x="-6.801" y="-3.40812500000004" z="0"/>
+         x="-6.801" y="-3.24937500000004" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
@@ -62163,7 +62174,7 @@
       <solidref ref="GaseousArgon"/>
     </volume>
     <volume name="volCathode">
-      <materialref ref="STEEL_STAINLESS_Fe7Cr2Ni" />
+      <materialref ref="FR4SussexAPA" />
       <solidref ref="Cathode" />
     </volume>
    <volume name="volOpDetSensitive_0-0-0">
@@ -64087,483 +64098,483 @@
      <solidref ref="ArapucaAcceptanceWindow"/>
    </volume>
    <volume name="volArapuca_0-0">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_0-1">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_0-2">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_0-3">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_0-4">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_0-5">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_0-6">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_0-7">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_0-8">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_0-9">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_1-0">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_1-1">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_1-2">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_1-3">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_1-4">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_1-5">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_1-6">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_1-7">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_1-8">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_1-9">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_2-0">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_2-1">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_2-2">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_2-3">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_2-4">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_2-5">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_2-6">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_2-7">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_2-8">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_2-9">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_3-0">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_3-1">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_3-2">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_3-3">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_3-4">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_3-5">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_3-6">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_3-7">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_3-8">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_3-9">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_4-0">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_4-1">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_4-2">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_4-3">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_4-4">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_4-5">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_4-6">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_4-7">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_4-8">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_4-9">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_5-0">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_5-1">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_5-2">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_5-3">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_5-4">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_5-5">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_5-6">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_5-7">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_5-8">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_5-9">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_6-0">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_6-1">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_6-2">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_6-3">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_6-4">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_6-5">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_6-6">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_6-7">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_6-8">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_6-9">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_7-0">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_7-1">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_7-2">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_7-3">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_7-4">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_7-5">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_7-6">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_7-7">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_7-8">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_7-9">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_8-0">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_8-1">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_8-2">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_8-3">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_8-4">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_8-5">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_8-6">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_8-7">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_8-8">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_8-9">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_9-0">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_9-1">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_9-2">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_9-3">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_9-4">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_9-5">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_9-6">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_9-7">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_9-8">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_9-9">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_10-0">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_10-1">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_10-2">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_10-3">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_10-4">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_10-5">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_10-6">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_10-7">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_10-8">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_10-9">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_11-0">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_11-1">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_11-2">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_11-3">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_11-4">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_11-5">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_11-6">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_11-7">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_11-8">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_11-9">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
 
@@ -64583,13 +64594,18 @@
     </volume>
 
     <volume name="volG10BoardYSideCenterSeg">
-      <materialref ref="G10"/>
+      <materialref ref="FR4SussexAPA"/>
       <solidref ref="G10BoardYSideCenterSeg"/>
     </volume>
 
     <volume name="volG10BoardZSideCenterSeg">
-      <materialref ref="G10"/>
+      <materialref ref="FR4SussexAPA"/>
       <solidref ref="G10BoardZSideCenterSeg"/>
+    </volume>
+
+    <volume name="volG10HeadBoards">
+      <materialref ref="FR4SussexAPA"/>
+      <solidref ref="G10HeadBoards"/>
     </volume>
 
     <volume name="volCryostat">
@@ -64597,14 +64613,14 @@
       <solidref ref="Cryostat" />
       <physvol>
         <volumeref ref="volGaseousArgon"/>
-        <position name="posGaseousArgon" unit="cm" x="0" y="652.57875" z="0"/>
+        <position name="posGaseousArgon" unit="cm" x="0" y="653.21375" z="0"/>
       </physvol>
       <physvol>
         <volumeref ref="volSourceModerator"/>
         <position name="posSourceModerator" unit="cm"
           x="220"
 	        y="280"
-	        z="-607.424"/>
+	        z="-608.424"/>
         <rotationref ref="rPlus90AboutX"/>
       </physvol>
       <physvol>
@@ -64622,23 +64638,23 @@
         <volumeref ref="volAPAFrameYSide"/>
         <position name="posAPAFrameYSideNeg-0" unit="cm"
       x="0"
-      y="-325.37875"
-      z="-564.89625"/>
+      y="-326.01375"
+      z="-564.57875"/>
         <rotationref ref="rIdentity"/>
       </physvol>
       <physvol>
         <volumeref ref="volAPAFrameYSide"/>
         <position name="posAPAFrameYSidePos-0" unit="cm"
       x="0"
-      y="-325.37875"
-      z="-345.05375"/>
+      y="-326.01375"
+      z="-345.37125"/>
         <rotationref ref="rIdentity"/>
       </physvol>
       <physvol>
         <volumeref ref="volAPAFrameZSide"/>
         <position name="posAPAFrameZSidePos-0" unit="cm"
       x="0"
-      y="-27.45875"
+      y="-28.0937500000001"
       z="-454.975"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -64646,7 +64662,7 @@
         <volumeref ref="volAPAFrameZSide"/>
         <position name="posAPAFrameZSideNeg-0" unit="cm"
       x="0"
-      y="-623.29875"
+      y="-623.93375"
       z="-454.975"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -64657,22 +64673,33 @@
       - There are two boards on each the up and downstream end,
           one each to wrap the U and V views around the APA frame
       - There are 4 on the bottom which anchor the U V and Z wires and the grid plane
-      - The rest of the parts of the G10 boards must be placed directly in volTPC   -->
+      FIXME: This is not true -> - The rest of the parts of the G10 boards must be placed directly in volTPC   -->
+
+      <!-- Position readout boards -->
+      <physvol>
+        <volumeref ref="volG10HeadBoards"/>
+        <position name="posG10HeadBoards-0" unit="cm"
+	  x="0"
+	  y="-639.51775"
+      	  z="-454.975"/>
+        <rotationref ref="rIdentity"/>
+      </physvol>
 
       <physvol>
         <volumeref ref="volG10BoardYSideCenterSeg"/>
         <position name="posG10BoardYSideCenterSeg-Vup-0" unit="cm"
-      x="0"
-      y="-325.37875"
-      z="-570.135"/>
-        <rotationref ref="rIdentity"/>
+         x="0"
+         y="-326.01375"
+         z="-569.896875"/>
+         <rotationref ref="rIdentity"/>
       </physvol>
+
       <physvol>
         <volumeref ref="volG10BoardYSideCenterSeg"/>
         <position name="posG10BoardYSideCenterSeg-Uup-0" unit="cm"
       x="0"
-      y="-325.37875"
-      z="-570.4525"/>
+      y="-326.01375"
+      z="-570.373125"/>
         <rotationref ref="rIdentity"/>
       </physvol>
 
@@ -64680,16 +64707,16 @@
         <volumeref ref="volG10BoardYSideCenterSeg"/>
         <position name="posG10BoardYSideCenterSeg-Vdown-0" unit="cm"
       x="0"
-      y="-325.37875"
-      z="-339.815"/>
+      y="-326.01375"
+      z="-340.053125"/>
         <rotationref ref="rIdentity"/>
       </physvol>
       <physvol>
         <volumeref ref="volG10BoardYSideCenterSeg"/>
         <position name="posG10BoardYSideCenterSeg-Udown-0" unit="cm"
       x="0"
-      y="-325.37875"
-      z="-339.4975"/>
+      y="-326.01375"
+      z="-339.576875"/>
         <rotationref ref="rIdentity"/>
       </physvol>
 
@@ -64697,7 +64724,7 @@
         <volumeref ref="volG10BoardZSideCenterSeg"/>
         <position name="posG10BoardZSideCenterSeg-Z-0" unit="cm"
       x="0"
-      y="-22.22"
+      y="-22.775625"
       z="-454.975"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -64705,7 +64732,7 @@
         <volumeref ref="volG10BoardZSideCenterSeg"/>
         <position name="posG10BoardZSideCenterSeg-V-0" unit="cm"
       x="0"
-      y="-21.9025"
+      y="-22.2993750000001"
       z="-454.975"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -64713,7 +64740,7 @@
         <volumeref ref="volG10BoardZSideCenterSeg"/>
         <position name="posG10BoardZSideCenterSeg-U-0" unit="cm"
       x="0"
-      y="-21.585"
+      y="-21.8231250000001"
       z="-454.975"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -64721,7 +64748,7 @@
         <volumeref ref="volG10BoardZSideCenterSeg"/>
         <position name="posG10BoardZSideCenterSeg-Grid-0" unit="cm"
       x="0"
-      y="-21.2675"
+      y="-21.3468750000001"
       z="-454.975"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -64730,7 +64757,7 @@
 <volumeref ref="volArapuca_0-0"/>
 <position name="posArapuca0-0-TPC-12-0-0" unit="cm"
 x="0"
-y="-612.31875"
+y="-612.95375"
 z="-454.975"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -64738,7 +64765,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_0-0-0"/>
        <position name="posOpArapuca0-0-0-TPC-12-0-0" unit="cm"
          x="-0.0500000000000002"
-       y="-612.31875"
+       y="-612.95375"
          z="-535.175"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -64746,7 +64773,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_0-0-1"/>
        <position name="posOpArapuca0-0-1-TPC-12-0-0" unit="cm"
          x="-0.0500000000000002"
-       y="-612.31875"
+       y="-612.95375"
          z="-486.375"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -64754,7 +64781,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_0-0-2"/>
        <position name="posOpArapuca0-0-2-TPC-12-0-0" unit="cm"
          x="-0.0500000000000002"
-       y="-612.31875"
+       y="-612.95375"
          z="-423.575"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -64762,7 +64789,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_0-0-3"/>
        <position name="posOpArapuca0-0-3-TPC-12-0-0" unit="cm"
          x="-0.0500000000000002"
-       y="-612.31875"
+       y="-612.95375"
          z="-374.775"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -64770,7 +64797,7 @@ z="-454.975"/>
 <volumeref ref="volArapuca_0-1"/>
 <position name="posArapuca0-1-TPC-12-0-0" unit="cm"
 x="0"
-y="-550.048355263158"
+y="-550.616513157895"
 z="-454.975"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -64778,7 +64805,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_0-1-0"/>
        <position name="posOpArapuca0-1-0-TPC-12-0-0" unit="cm"
          x="-0.0500000000000002"
-       y="-550.048355263158"
+       y="-550.616513157895"
          z="-535.175"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -64786,7 +64813,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_0-1-1"/>
        <position name="posOpArapuca0-1-1-TPC-12-0-0" unit="cm"
          x="-0.0500000000000002"
-       y="-550.048355263158"
+       y="-550.616513157895"
          z="-486.375"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -64794,7 +64821,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_0-1-2"/>
        <position name="posOpArapuca0-1-2-TPC-12-0-0" unit="cm"
          x="-0.0500000000000002"
-       y="-550.048355263158"
+       y="-550.616513157895"
          z="-423.575"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -64802,7 +64829,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_0-1-3"/>
        <position name="posOpArapuca0-1-3-TPC-12-0-0" unit="cm"
          x="-0.0500000000000002"
-       y="-550.048355263158"
+       y="-550.616513157895"
          z="-374.775"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -64810,7 +64837,7 @@ z="-454.975"/>
 <volumeref ref="volArapuca_0-2"/>
 <position name="posArapuca0-2-TPC-12-0-0" unit="cm"
 x="0"
-y="-487.777960526316"
+y="-488.27927631579"
 z="-454.975"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -64818,7 +64845,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_0-2-0"/>
        <position name="posOpArapuca0-2-0-TPC-12-0-0" unit="cm"
          x="-0.0500000000000002"
-       y="-487.777960526316"
+       y="-488.27927631579"
          z="-535.175"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -64826,7 +64853,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_0-2-1"/>
        <position name="posOpArapuca0-2-1-TPC-12-0-0" unit="cm"
          x="-0.0500000000000002"
-       y="-487.777960526316"
+       y="-488.27927631579"
          z="-486.375"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -64834,7 +64861,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_0-2-2"/>
        <position name="posOpArapuca0-2-2-TPC-12-0-0" unit="cm"
          x="-0.0500000000000002"
-       y="-487.777960526316"
+       y="-488.27927631579"
          z="-423.575"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -64842,7 +64869,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_0-2-3"/>
        <position name="posOpArapuca0-2-3-TPC-12-0-0" unit="cm"
          x="-0.0500000000000002"
-       y="-487.777960526316"
+       y="-488.27927631579"
          z="-374.775"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -64850,7 +64877,7 @@ z="-454.975"/>
 <volumeref ref="volArapuca_0-3"/>
 <position name="posArapuca0-3-TPC-12-0-0" unit="cm"
 x="0"
-y="-425.507565789474"
+y="-425.942039473684"
 z="-454.975"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -64858,7 +64885,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_0-3-0"/>
        <position name="posOpArapuca0-3-0-TPC-12-0-0" unit="cm"
          x="-0.0500000000000002"
-       y="-425.507565789474"
+       y="-425.942039473684"
          z="-535.175"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -64866,7 +64893,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_0-3-1"/>
        <position name="posOpArapuca0-3-1-TPC-12-0-0" unit="cm"
          x="-0.0500000000000002"
-       y="-425.507565789474"
+       y="-425.942039473684"
          z="-486.375"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -64874,7 +64901,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_0-3-2"/>
        <position name="posOpArapuca0-3-2-TPC-12-0-0" unit="cm"
          x="-0.0500000000000002"
-       y="-425.507565789474"
+       y="-425.942039473684"
          z="-423.575"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -64882,7 +64909,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_0-3-3"/>
        <position name="posOpArapuca0-3-3-TPC-12-0-0" unit="cm"
          x="-0.0500000000000002"
-       y="-425.507565789474"
+       y="-425.942039473684"
          z="-374.775"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -64890,7 +64917,7 @@ z="-454.975"/>
 <volumeref ref="volArapuca_0-4"/>
 <position name="posArapuca0-4-TPC-12-0-0" unit="cm"
 x="0"
-y="-363.237171052632"
+y="-363.604802631579"
 z="-454.975"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -64898,7 +64925,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_0-4-0"/>
        <position name="posOpArapuca0-4-0-TPC-12-0-0" unit="cm"
          x="-0.0500000000000002"
-       y="-363.237171052632"
+       y="-363.604802631579"
          z="-535.175"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -64906,7 +64933,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_0-4-1"/>
        <position name="posOpArapuca0-4-1-TPC-12-0-0" unit="cm"
          x="-0.0500000000000002"
-       y="-363.237171052632"
+       y="-363.604802631579"
          z="-486.375"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -64914,7 +64941,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_0-4-2"/>
        <position name="posOpArapuca0-4-2-TPC-12-0-0" unit="cm"
          x="-0.0500000000000002"
-       y="-363.237171052632"
+       y="-363.604802631579"
          z="-423.575"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -64922,7 +64949,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_0-4-3"/>
        <position name="posOpArapuca0-4-3-TPC-12-0-0" unit="cm"
          x="-0.0500000000000002"
-       y="-363.237171052632"
+       y="-363.604802631579"
          z="-374.775"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -64930,7 +64957,7 @@ z="-454.975"/>
 <volumeref ref="volArapuca_0-5"/>
 <position name="posArapuca0-5-TPC-12-0-0" unit="cm"
 x="0"
-y="-300.96677631579"
+y="-301.267565789474"
 z="-454.975"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -64938,7 +64965,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_0-5-0"/>
        <position name="posOpArapuca0-5-0-TPC-12-0-0" unit="cm"
          x="-0.0500000000000002"
-       y="-300.96677631579"
+       y="-301.267565789474"
          z="-535.175"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -64946,7 +64973,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_0-5-1"/>
        <position name="posOpArapuca0-5-1-TPC-12-0-0" unit="cm"
          x="-0.0500000000000002"
-       y="-300.96677631579"
+       y="-301.267565789474"
          z="-486.375"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -64954,7 +64981,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_0-5-2"/>
        <position name="posOpArapuca0-5-2-TPC-12-0-0" unit="cm"
          x="-0.0500000000000002"
-       y="-300.96677631579"
+       y="-301.267565789474"
          z="-423.575"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -64962,7 +64989,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_0-5-3"/>
        <position name="posOpArapuca0-5-3-TPC-12-0-0" unit="cm"
          x="-0.0500000000000002"
-       y="-300.96677631579"
+       y="-301.267565789474"
          z="-374.775"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -64970,7 +64997,7 @@ z="-454.975"/>
 <volumeref ref="volArapuca_0-6"/>
 <position name="posArapuca0-6-TPC-12-0-0" unit="cm"
 x="0"
-y="-238.696381578947"
+y="-238.930328947368"
 z="-454.975"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -64978,7 +65005,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_0-6-0"/>
        <position name="posOpArapuca0-6-0-TPC-12-0-0" unit="cm"
          x="-0.0500000000000002"
-       y="-238.696381578947"
+       y="-238.930328947368"
          z="-535.175"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -64986,7 +65013,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_0-6-1"/>
        <position name="posOpArapuca0-6-1-TPC-12-0-0" unit="cm"
          x="-0.0500000000000002"
-       y="-238.696381578947"
+       y="-238.930328947368"
          z="-486.375"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -64994,7 +65021,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_0-6-2"/>
        <position name="posOpArapuca0-6-2-TPC-12-0-0" unit="cm"
          x="-0.0500000000000002"
-       y="-238.696381578947"
+       y="-238.930328947368"
          z="-423.575"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -65002,7 +65029,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_0-6-3"/>
        <position name="posOpArapuca0-6-3-TPC-12-0-0" unit="cm"
          x="-0.0500000000000002"
-       y="-238.696381578947"
+       y="-238.930328947368"
          z="-374.775"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -65010,7 +65037,7 @@ z="-454.975"/>
 <volumeref ref="volArapuca_0-7"/>
 <position name="posArapuca0-7-TPC-12-0-0" unit="cm"
 x="0"
-y="-176.425986842105"
+y="-176.593092105263"
 z="-454.975"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -65018,7 +65045,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_0-7-0"/>
        <position name="posOpArapuca0-7-0-TPC-12-0-0" unit="cm"
          x="-0.0500000000000002"
-       y="-176.425986842105"
+       y="-176.593092105263"
          z="-535.175"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -65026,7 +65053,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_0-7-1"/>
        <position name="posOpArapuca0-7-1-TPC-12-0-0" unit="cm"
          x="-0.0500000000000002"
-       y="-176.425986842105"
+       y="-176.593092105263"
          z="-486.375"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -65034,7 +65061,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_0-7-2"/>
        <position name="posOpArapuca0-7-2-TPC-12-0-0" unit="cm"
          x="-0.0500000000000002"
-       y="-176.425986842105"
+       y="-176.593092105263"
          z="-423.575"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -65042,7 +65069,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_0-7-3"/>
        <position name="posOpArapuca0-7-3-TPC-12-0-0" unit="cm"
          x="-0.0500000000000002"
-       y="-176.425986842105"
+       y="-176.593092105263"
          z="-374.775"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -65050,7 +65077,7 @@ z="-454.975"/>
 <volumeref ref="volArapuca_0-8"/>
 <position name="posArapuca0-8-TPC-12-0-0" unit="cm"
 x="0"
-y="-114.155592105263"
+y="-114.255855263158"
 z="-454.975"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -65058,7 +65085,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_0-8-0"/>
        <position name="posOpArapuca0-8-0-TPC-12-0-0" unit="cm"
          x="-0.0500000000000002"
-       y="-114.155592105263"
+       y="-114.255855263158"
          z="-535.175"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -65066,7 +65093,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_0-8-1"/>
        <position name="posOpArapuca0-8-1-TPC-12-0-0" unit="cm"
          x="-0.0500000000000002"
-       y="-114.155592105263"
+       y="-114.255855263158"
          z="-486.375"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -65074,7 +65101,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_0-8-2"/>
        <position name="posOpArapuca0-8-2-TPC-12-0-0" unit="cm"
          x="-0.0500000000000002"
-       y="-114.155592105263"
+       y="-114.255855263158"
          z="-423.575"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -65082,7 +65109,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_0-8-3"/>
        <position name="posOpArapuca0-8-3-TPC-12-0-0" unit="cm"
          x="-0.0500000000000002"
-       y="-114.155592105263"
+       y="-114.255855263158"
          z="-374.775"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -65090,7 +65117,7 @@ z="-454.975"/>
 <volumeref ref="volArapuca_0-9"/>
 <position name="posArapuca0-9-TPC-12-0-0" unit="cm"
 x="0"
-y="-51.885197368421"
+y="-51.9186184210527"
 z="-454.975"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -65098,7 +65125,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_0-9-0"/>
        <position name="posOpArapuca0-9-0-TPC-12-0-0" unit="cm"
          x="-0.0500000000000002"
-       y="-51.885197368421"
+       y="-51.9186184210527"
          z="-535.175"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -65106,7 +65133,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_0-9-1"/>
        <position name="posOpArapuca0-9-1-TPC-12-0-0" unit="cm"
          x="-0.0500000000000002"
-       y="-51.885197368421"
+       y="-51.9186184210527"
          z="-486.375"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -65114,7 +65141,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_0-9-2"/>
        <position name="posOpArapuca0-9-2-TPC-12-0-0" unit="cm"
          x="-0.0500000000000002"
-       y="-51.885197368421"
+       y="-51.9186184210527"
          z="-423.575"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -65122,7 +65149,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_0-9-3"/>
        <position name="posOpArapuca0-9-3-TPC-12-0-0" unit="cm"
          x="-0.0500000000000002"
-       y="-51.885197368421"
+       y="-51.9186184210527"
          z="-374.775"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -65131,7 +65158,7 @@ z="-454.975"/>
         <volumeref ref="volTPCInner"/>
         <position name="posTPC-0" unit="cm"
         x="-182.95455"
-        y="-324.664375"
+        y="-324.981875"
         z="-454.975"/>
         <rotationref ref="rPlus180AboutXPlus180AboutY"/>
       </physvol>
@@ -65139,7 +65166,7 @@ z="-454.975"/>
         <volumeref ref="volTPCInner"/>
         <position name="posTPC-1" unit="cm"
         x="182.95455"
-        y="-324.664375"
+        y="-324.981875"
         z="-454.975"/>
         <rotationref ref="rPlus180AboutX"/>
       </physvol>
@@ -65147,16 +65174,16 @@ z="-454.975"/>
       <physvol>
         <volumeref ref="volCathode"/>
         <position name="posCathode-1-0" unit="cm"
-      x="-363.38405"
-      y="-324.664375"
+      x="-363.52605"
+      y="-324.981875"
       z="-454.975"/>
         <rotationref ref="rIdentity"/>
       </physvol>
       <physvol>
         <volumeref ref="volCathode"/>
         <position name="posCathode-1-1" unit="cm"
-      x="363.38405"
-      y="-324.664375"
+      x="363.52605"
+      y="-324.981875"
       z="-454.975"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -65165,23 +65192,23 @@ z="-454.975"/>
         <volumeref ref="volAPAFrameYSide"/>
         <position name="posAPAFrameYSideNeg-1" unit="cm"
       x="0"
-      y="283.87875"
-      z="-564.89625"/>
+      y="284.51375"
+      z="-564.57875"/>
         <rotationref ref="rIdentity"/>
       </physvol>
       <physvol>
         <volumeref ref="volAPAFrameYSide"/>
         <position name="posAPAFrameYSidePos-1" unit="cm"
       x="0"
-      y="283.87875"
-      z="-345.05375"/>
+      y="284.51375"
+      z="-345.37125"/>
         <rotationref ref="rIdentity"/>
       </physvol>
       <physvol>
         <volumeref ref="volAPAFrameZSide"/>
         <position name="posAPAFrameZSidePos-1" unit="cm"
       x="0"
-      y="581.79875"
+      y="582.43375"
       z="-454.975"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -65189,7 +65216,7 @@ z="-454.975"/>
         <volumeref ref="volAPAFrameZSide"/>
         <position name="posAPAFrameZSideNeg-1" unit="cm"
       x="0"
-      y="-14.0412500000001"
+      y="-13.40625"
       z="-454.975"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -65200,22 +65227,33 @@ z="-454.975"/>
       - There are two boards on each the up and downstream end,
           one each to wrap the U and V views around the APA frame
       - There are 4 on the bottom which anchor the U V and Z wires and the grid plane
-      - The rest of the parts of the G10 boards must be placed directly in volTPC   -->
+      FIXME: This is not true -> - The rest of the parts of the G10 boards must be placed directly in volTPC   -->
+
+      <!-- Position readout boards -->
+      <physvol>
+        <volumeref ref="volG10HeadBoards"/>
+        <position name="posG10HeadBoards-1" unit="cm"
+	  x="0"
+	  y="598.01775"
+      	  z="-454.975"/>
+        <rotationref ref="rIdentity"/>
+      </physvol>
 
       <physvol>
         <volumeref ref="volG10BoardYSideCenterSeg"/>
         <position name="posG10BoardYSideCenterSeg-Vup-1" unit="cm"
-      x="0"
-      y="283.87875"
-      z="-570.135"/>
-        <rotationref ref="rIdentity"/>
+         x="0"
+         y="284.51375"
+         z="-569.896875"/>
+         <rotationref ref="rIdentity"/>
       </physvol>
+
       <physvol>
         <volumeref ref="volG10BoardYSideCenterSeg"/>
         <position name="posG10BoardYSideCenterSeg-Uup-1" unit="cm"
       x="0"
-      y="283.87875"
-      z="-570.4525"/>
+      y="284.51375"
+      z="-570.373125"/>
         <rotationref ref="rIdentity"/>
       </physvol>
 
@@ -65223,16 +65261,16 @@ z="-454.975"/>
         <volumeref ref="volG10BoardYSideCenterSeg"/>
         <position name="posG10BoardYSideCenterSeg-Vdown-1" unit="cm"
       x="0"
-      y="283.87875"
-      z="-339.815"/>
+      y="284.51375"
+      z="-340.053125"/>
         <rotationref ref="rIdentity"/>
       </physvol>
       <physvol>
         <volumeref ref="volG10BoardYSideCenterSeg"/>
         <position name="posG10BoardYSideCenterSeg-Udown-1" unit="cm"
       x="0"
-      y="283.87875"
-      z="-339.4975"/>
+      y="284.51375"
+      z="-339.576875"/>
         <rotationref ref="rIdentity"/>
       </physvol>
 
@@ -65240,7 +65278,7 @@ z="-454.975"/>
         <volumeref ref="volG10BoardZSideCenterSeg"/>
         <position name="posG10BoardZSideCenterSeg-Z-1" unit="cm"
       x="0"
-      y="-19.2800000000001"
+      y="-18.7243750000001"
       z="-454.975"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -65248,7 +65286,7 @@ z="-454.975"/>
         <volumeref ref="volG10BoardZSideCenterSeg"/>
         <position name="posG10BoardZSideCenterSeg-V-1" unit="cm"
       x="0"
-      y="-19.5975000000001"
+      y="-19.2006250000001"
       z="-454.975"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -65256,7 +65294,7 @@ z="-454.975"/>
         <volumeref ref="volG10BoardZSideCenterSeg"/>
         <position name="posG10BoardZSideCenterSeg-U-1" unit="cm"
       x="0"
-      y="-19.9150000000001"
+      y="-19.6768750000001"
       z="-454.975"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -65264,7 +65302,7 @@ z="-454.975"/>
         <volumeref ref="volG10BoardZSideCenterSeg"/>
         <position name="posG10BoardZSideCenterSeg-Grid-1" unit="cm"
       x="0"
-      y="-20.2325000000001"
+      y="-20.153125"
       z="-454.975"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -65273,7 +65311,7 @@ z="-454.975"/>
 <volumeref ref="volArapuca_1-0"/>
 <position name="posArapuca1-0-TPC-12-1-0" unit="cm"
 x="0"
-y="10.385197368421"
+y="10.4186184210526"
 z="-454.975"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -65281,7 +65319,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_1-0-0"/>
        <position name="posOpArapuca1-0-0-TPC-12-1-0" unit="cm"
          x="0.0500000000000002"
-       y="10.385197368421"
+       y="10.4186184210526"
          z="-535.175"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -65289,7 +65327,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_1-0-1"/>
        <position name="posOpArapuca1-0-1-TPC-12-1-0" unit="cm"
          x="0.0500000000000002"
-       y="10.385197368421"
+       y="10.4186184210526"
          z="-486.375"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -65297,7 +65335,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_1-0-2"/>
        <position name="posOpArapuca1-0-2-TPC-12-1-0" unit="cm"
          x="0.0500000000000002"
-       y="10.385197368421"
+       y="10.4186184210526"
          z="-423.575"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -65305,7 +65343,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_1-0-3"/>
        <position name="posOpArapuca1-0-3-TPC-12-1-0" unit="cm"
          x="0.0500000000000002"
-       y="10.385197368421"
+       y="10.4186184210526"
          z="-374.775"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -65313,7 +65351,7 @@ z="-454.975"/>
 <volumeref ref="volArapuca_1-1"/>
 <position name="posArapuca1-1-TPC-12-1-0" unit="cm"
 x="0"
-y="72.6555921052631"
+y="72.7558552631579"
 z="-454.975"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -65321,7 +65359,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_1-1-0"/>
        <position name="posOpArapuca1-1-0-TPC-12-1-0" unit="cm"
          x="0.0500000000000002"
-       y="72.6555921052631"
+       y="72.7558552631579"
          z="-535.175"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -65329,7 +65367,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_1-1-1"/>
        <position name="posOpArapuca1-1-1-TPC-12-1-0" unit="cm"
          x="0.0500000000000002"
-       y="72.6555921052631"
+       y="72.7558552631579"
          z="-486.375"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -65337,7 +65375,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_1-1-2"/>
        <position name="posOpArapuca1-1-2-TPC-12-1-0" unit="cm"
          x="0.0500000000000002"
-       y="72.6555921052631"
+       y="72.7558552631579"
          z="-423.575"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -65345,7 +65383,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_1-1-3"/>
        <position name="posOpArapuca1-1-3-TPC-12-1-0" unit="cm"
          x="0.0500000000000002"
-       y="72.6555921052631"
+       y="72.7558552631579"
          z="-374.775"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -65353,7 +65391,7 @@ z="-454.975"/>
 <volumeref ref="volArapuca_1-2"/>
 <position name="posArapuca1-2-TPC-12-1-0" unit="cm"
 x="0"
-y="134.925986842105"
+y="135.093092105263"
 z="-454.975"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -65361,7 +65399,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_1-2-0"/>
        <position name="posOpArapuca1-2-0-TPC-12-1-0" unit="cm"
          x="0.0500000000000002"
-       y="134.925986842105"
+       y="135.093092105263"
          z="-535.175"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -65369,7 +65407,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_1-2-1"/>
        <position name="posOpArapuca1-2-1-TPC-12-1-0" unit="cm"
          x="0.0500000000000002"
-       y="134.925986842105"
+       y="135.093092105263"
          z="-486.375"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -65377,7 +65415,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_1-2-2"/>
        <position name="posOpArapuca1-2-2-TPC-12-1-0" unit="cm"
          x="0.0500000000000002"
-       y="134.925986842105"
+       y="135.093092105263"
          z="-423.575"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -65385,7 +65423,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_1-2-3"/>
        <position name="posOpArapuca1-2-3-TPC-12-1-0" unit="cm"
          x="0.0500000000000002"
-       y="134.925986842105"
+       y="135.093092105263"
          z="-374.775"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -65393,7 +65431,7 @@ z="-454.975"/>
 <volumeref ref="volArapuca_1-3"/>
 <position name="posArapuca1-3-TPC-12-1-0" unit="cm"
 x="0"
-y="197.196381578947"
+y="197.430328947368"
 z="-454.975"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -65401,7 +65439,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_1-3-0"/>
        <position name="posOpArapuca1-3-0-TPC-12-1-0" unit="cm"
          x="0.0500000000000002"
-       y="197.196381578947"
+       y="197.430328947368"
          z="-535.175"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -65409,7 +65447,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_1-3-1"/>
        <position name="posOpArapuca1-3-1-TPC-12-1-0" unit="cm"
          x="0.0500000000000002"
-       y="197.196381578947"
+       y="197.430328947368"
          z="-486.375"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -65417,7 +65455,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_1-3-2"/>
        <position name="posOpArapuca1-3-2-TPC-12-1-0" unit="cm"
          x="0.0500000000000002"
-       y="197.196381578947"
+       y="197.430328947368"
          z="-423.575"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -65425,7 +65463,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_1-3-3"/>
        <position name="posOpArapuca1-3-3-TPC-12-1-0" unit="cm"
          x="0.0500000000000002"
-       y="197.196381578947"
+       y="197.430328947368"
          z="-374.775"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -65433,7 +65471,7 @@ z="-454.975"/>
 <volumeref ref="volArapuca_1-4"/>
 <position name="posArapuca1-4-TPC-12-1-0" unit="cm"
 x="0"
-y="259.46677631579"
+y="259.767565789474"
 z="-454.975"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -65441,7 +65479,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_1-4-0"/>
        <position name="posOpArapuca1-4-0-TPC-12-1-0" unit="cm"
          x="0.0500000000000002"
-       y="259.46677631579"
+       y="259.767565789474"
          z="-535.175"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -65449,7 +65487,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_1-4-1"/>
        <position name="posOpArapuca1-4-1-TPC-12-1-0" unit="cm"
          x="0.0500000000000002"
-       y="259.46677631579"
+       y="259.767565789474"
          z="-486.375"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -65457,7 +65495,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_1-4-2"/>
        <position name="posOpArapuca1-4-2-TPC-12-1-0" unit="cm"
          x="0.0500000000000002"
-       y="259.46677631579"
+       y="259.767565789474"
          z="-423.575"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -65465,7 +65503,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_1-4-3"/>
        <position name="posOpArapuca1-4-3-TPC-12-1-0" unit="cm"
          x="0.0500000000000002"
-       y="259.46677631579"
+       y="259.767565789474"
          z="-374.775"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -65473,7 +65511,7 @@ z="-454.975"/>
 <volumeref ref="volArapuca_1-5"/>
 <position name="posArapuca1-5-TPC-12-1-0" unit="cm"
 x="0"
-y="321.737171052632"
+y="322.104802631579"
 z="-454.975"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -65481,7 +65519,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_1-5-0"/>
        <position name="posOpArapuca1-5-0-TPC-12-1-0" unit="cm"
          x="0.0500000000000002"
-       y="321.737171052632"
+       y="322.104802631579"
          z="-535.175"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -65489,7 +65527,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_1-5-1"/>
        <position name="posOpArapuca1-5-1-TPC-12-1-0" unit="cm"
          x="0.0500000000000002"
-       y="321.737171052632"
+       y="322.104802631579"
          z="-486.375"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -65497,7 +65535,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_1-5-2"/>
        <position name="posOpArapuca1-5-2-TPC-12-1-0" unit="cm"
          x="0.0500000000000002"
-       y="321.737171052632"
+       y="322.104802631579"
          z="-423.575"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -65505,7 +65543,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_1-5-3"/>
        <position name="posOpArapuca1-5-3-TPC-12-1-0" unit="cm"
          x="0.0500000000000002"
-       y="321.737171052632"
+       y="322.104802631579"
          z="-374.775"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -65513,7 +65551,7 @@ z="-454.975"/>
 <volumeref ref="volArapuca_1-6"/>
 <position name="posArapuca1-6-TPC-12-1-0" unit="cm"
 x="0"
-y="384.007565789474"
+y="384.442039473684"
 z="-454.975"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -65521,7 +65559,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_1-6-0"/>
        <position name="posOpArapuca1-6-0-TPC-12-1-0" unit="cm"
          x="0.0500000000000002"
-       y="384.007565789474"
+       y="384.442039473684"
          z="-535.175"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -65529,7 +65567,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_1-6-1"/>
        <position name="posOpArapuca1-6-1-TPC-12-1-0" unit="cm"
          x="0.0500000000000002"
-       y="384.007565789474"
+       y="384.442039473684"
          z="-486.375"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -65537,7 +65575,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_1-6-2"/>
        <position name="posOpArapuca1-6-2-TPC-12-1-0" unit="cm"
          x="0.0500000000000002"
-       y="384.007565789474"
+       y="384.442039473684"
          z="-423.575"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -65545,7 +65583,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_1-6-3"/>
        <position name="posOpArapuca1-6-3-TPC-12-1-0" unit="cm"
          x="0.0500000000000002"
-       y="384.007565789474"
+       y="384.442039473684"
          z="-374.775"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -65553,7 +65591,7 @@ z="-454.975"/>
 <volumeref ref="volArapuca_1-7"/>
 <position name="posArapuca1-7-TPC-12-1-0" unit="cm"
 x="0"
-y="446.277960526316"
+y="446.77927631579"
 z="-454.975"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -65561,7 +65599,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_1-7-0"/>
        <position name="posOpArapuca1-7-0-TPC-12-1-0" unit="cm"
          x="0.0500000000000002"
-       y="446.277960526316"
+       y="446.77927631579"
          z="-535.175"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -65569,7 +65607,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_1-7-1"/>
        <position name="posOpArapuca1-7-1-TPC-12-1-0" unit="cm"
          x="0.0500000000000002"
-       y="446.277960526316"
+       y="446.77927631579"
          z="-486.375"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -65577,7 +65615,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_1-7-2"/>
        <position name="posOpArapuca1-7-2-TPC-12-1-0" unit="cm"
          x="0.0500000000000002"
-       y="446.277960526316"
+       y="446.77927631579"
          z="-423.575"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -65585,7 +65623,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_1-7-3"/>
        <position name="posOpArapuca1-7-3-TPC-12-1-0" unit="cm"
          x="0.0500000000000002"
-       y="446.277960526316"
+       y="446.77927631579"
          z="-374.775"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -65593,7 +65631,7 @@ z="-454.975"/>
 <volumeref ref="volArapuca_1-8"/>
 <position name="posArapuca1-8-TPC-12-1-0" unit="cm"
 x="0"
-y="508.548355263158"
+y="509.116513157895"
 z="-454.975"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -65601,7 +65639,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_1-8-0"/>
        <position name="posOpArapuca1-8-0-TPC-12-1-0" unit="cm"
          x="0.0500000000000002"
-       y="508.548355263158"
+       y="509.116513157895"
          z="-535.175"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -65609,7 +65647,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_1-8-1"/>
        <position name="posOpArapuca1-8-1-TPC-12-1-0" unit="cm"
          x="0.0500000000000002"
-       y="508.548355263158"
+       y="509.116513157895"
          z="-486.375"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -65617,7 +65655,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_1-8-2"/>
        <position name="posOpArapuca1-8-2-TPC-12-1-0" unit="cm"
          x="0.0500000000000002"
-       y="508.548355263158"
+       y="509.116513157895"
          z="-423.575"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -65625,7 +65663,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_1-8-3"/>
        <position name="posOpArapuca1-8-3-TPC-12-1-0" unit="cm"
          x="0.0500000000000002"
-       y="508.548355263158"
+       y="509.116513157895"
          z="-374.775"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -65633,7 +65671,7 @@ z="-454.975"/>
 <volumeref ref="volArapuca_1-9"/>
 <position name="posArapuca1-9-TPC-12-1-0" unit="cm"
 x="0"
-y="570.81875"
+y="571.45375"
 z="-454.975"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -65641,7 +65679,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_1-9-0"/>
        <position name="posOpArapuca1-9-0-TPC-12-1-0" unit="cm"
          x="0.0500000000000002"
-       y="570.81875"
+       y="571.45375"
          z="-535.175"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -65649,7 +65687,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_1-9-1"/>
        <position name="posOpArapuca1-9-1-TPC-12-1-0" unit="cm"
          x="0.0500000000000002"
-       y="570.81875"
+       y="571.45375"
          z="-486.375"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -65657,7 +65695,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_1-9-2"/>
        <position name="posOpArapuca1-9-2-TPC-12-1-0" unit="cm"
          x="0.0500000000000002"
-       y="570.81875"
+       y="571.45375"
          z="-423.575"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -65665,7 +65703,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_1-9-3"/>
        <position name="posOpArapuca1-9-3-TPC-12-1-0" unit="cm"
          x="0.0500000000000002"
-       y="570.81875"
+       y="571.45375"
          z="-374.775"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -65674,7 +65712,7 @@ z="-454.975"/>
         <volumeref ref="volTPCInner"/>
         <position name="posTPC-2" unit="cm"
         x="-182.95455"
-        y="283.164375"
+        y="283.481875"
         z="-454.975"/>
         <rotationref ref="rPlus180AboutY"/>
       </physvol>
@@ -65682,7 +65720,7 @@ z="-454.975"/>
         <volumeref ref="volTPCInner"/>
         <position name="posTPC-3" unit="cm"
         x="182.95455"
-        y="283.164375"
+        y="283.481875"
         z="-454.975"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -65690,16 +65728,16 @@ z="-454.975"/>
       <physvol>
         <volumeref ref="volCathode"/>
         <position name="posCathode-2-0" unit="cm"
-      x="-363.38405"
-      y="283.164375"
+      x="-363.52605"
+      y="283.481875"
       z="-454.975"/>
         <rotationref ref="rIdentity"/>
       </physvol>
       <physvol>
         <volumeref ref="volCathode"/>
         <position name="posCathode-2-1" unit="cm"
-      x="363.38405"
-      y="283.164375"
+      x="363.52605"
+      y="283.481875"
       z="-454.975"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -65708,23 +65746,23 @@ z="-454.975"/>
         <volumeref ref="volAPAFrameYSide"/>
         <position name="posAPAFrameYSideNeg-2" unit="cm"
       x="0"
-      y="-325.37875"
-      z="-332.50625"/>
+      y="-326.01375"
+      z="-332.18875"/>
         <rotationref ref="rIdentity"/>
       </physvol>
       <physvol>
         <volumeref ref="volAPAFrameYSide"/>
         <position name="posAPAFrameYSidePos-2" unit="cm"
       x="0"
-      y="-325.37875"
-      z="-112.66375"/>
+      y="-326.01375"
+      z="-112.98125"/>
         <rotationref ref="rIdentity"/>
       </physvol>
       <physvol>
         <volumeref ref="volAPAFrameZSide"/>
         <position name="posAPAFrameZSidePos-2" unit="cm"
       x="0"
-      y="-27.45875"
+      y="-28.0937500000001"
       z="-222.585"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -65732,7 +65770,7 @@ z="-454.975"/>
         <volumeref ref="volAPAFrameZSide"/>
         <position name="posAPAFrameZSideNeg-2" unit="cm"
       x="0"
-      y="-623.29875"
+      y="-623.93375"
       z="-222.585"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -65743,22 +65781,33 @@ z="-454.975"/>
       - There are two boards on each the up and downstream end,
           one each to wrap the U and V views around the APA frame
       - There are 4 on the bottom which anchor the U V and Z wires and the grid plane
-      - The rest of the parts of the G10 boards must be placed directly in volTPC   -->
+      FIXME: This is not true -> - The rest of the parts of the G10 boards must be placed directly in volTPC   -->
+
+      <!-- Position readout boards -->
+      <physvol>
+        <volumeref ref="volG10HeadBoards"/>
+        <position name="posG10HeadBoards-2" unit="cm"
+	  x="0"
+	  y="-639.51775"
+      	  z="-222.585"/>
+        <rotationref ref="rIdentity"/>
+      </physvol>
 
       <physvol>
         <volumeref ref="volG10BoardYSideCenterSeg"/>
         <position name="posG10BoardYSideCenterSeg-Vup-2" unit="cm"
-      x="0"
-      y="-325.37875"
-      z="-337.745"/>
-        <rotationref ref="rIdentity"/>
+         x="0"
+         y="-326.01375"
+         z="-337.506875"/>
+         <rotationref ref="rIdentity"/>
       </physvol>
+
       <physvol>
         <volumeref ref="volG10BoardYSideCenterSeg"/>
         <position name="posG10BoardYSideCenterSeg-Uup-2" unit="cm"
       x="0"
-      y="-325.37875"
-      z="-338.0625"/>
+      y="-326.01375"
+      z="-337.983125"/>
         <rotationref ref="rIdentity"/>
       </physvol>
 
@@ -65766,16 +65815,16 @@ z="-454.975"/>
         <volumeref ref="volG10BoardYSideCenterSeg"/>
         <position name="posG10BoardYSideCenterSeg-Vdown-2" unit="cm"
       x="0"
-      y="-325.37875"
-      z="-107.425"/>
+      y="-326.01375"
+      z="-107.663125"/>
         <rotationref ref="rIdentity"/>
       </physvol>
       <physvol>
         <volumeref ref="volG10BoardYSideCenterSeg"/>
         <position name="posG10BoardYSideCenterSeg-Udown-2" unit="cm"
       x="0"
-      y="-325.37875"
-      z="-107.1075"/>
+      y="-326.01375"
+      z="-107.186875"/>
         <rotationref ref="rIdentity"/>
       </physvol>
 
@@ -65783,7 +65832,7 @@ z="-454.975"/>
         <volumeref ref="volG10BoardZSideCenterSeg"/>
         <position name="posG10BoardZSideCenterSeg-Z-2" unit="cm"
       x="0"
-      y="-22.22"
+      y="-22.775625"
       z="-222.585"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -65791,7 +65840,7 @@ z="-454.975"/>
         <volumeref ref="volG10BoardZSideCenterSeg"/>
         <position name="posG10BoardZSideCenterSeg-V-2" unit="cm"
       x="0"
-      y="-21.9025"
+      y="-22.2993750000001"
       z="-222.585"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -65799,7 +65848,7 @@ z="-454.975"/>
         <volumeref ref="volG10BoardZSideCenterSeg"/>
         <position name="posG10BoardZSideCenterSeg-U-2" unit="cm"
       x="0"
-      y="-21.585"
+      y="-21.8231250000001"
       z="-222.585"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -65807,7 +65856,7 @@ z="-454.975"/>
         <volumeref ref="volG10BoardZSideCenterSeg"/>
         <position name="posG10BoardZSideCenterSeg-Grid-2" unit="cm"
       x="0"
-      y="-21.2675"
+      y="-21.3468750000001"
       z="-222.585"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -65816,7 +65865,7 @@ z="-454.975"/>
 <volumeref ref="volArapuca_2-0"/>
 <position name="posArapuca2-0-TPC-12-0-1" unit="cm"
 x="0"
-y="-612.31875"
+y="-612.95375"
 z="-222.585"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -65824,7 +65873,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_2-0-0"/>
        <position name="posOpArapuca2-0-0-TPC-12-0-1" unit="cm"
          x="-0.0500000000000002"
-       y="-612.31875"
+       y="-612.95375"
          z="-302.785"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -65832,7 +65881,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_2-0-1"/>
        <position name="posOpArapuca2-0-1-TPC-12-0-1" unit="cm"
          x="-0.0500000000000002"
-       y="-612.31875"
+       y="-612.95375"
          z="-253.985"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -65840,7 +65889,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_2-0-2"/>
        <position name="posOpArapuca2-0-2-TPC-12-0-1" unit="cm"
          x="-0.0500000000000002"
-       y="-612.31875"
+       y="-612.95375"
          z="-191.185"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -65848,7 +65897,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_2-0-3"/>
        <position name="posOpArapuca2-0-3-TPC-12-0-1" unit="cm"
          x="-0.0500000000000002"
-       y="-612.31875"
+       y="-612.95375"
          z="-142.385"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -65856,7 +65905,7 @@ z="-222.585"/>
 <volumeref ref="volArapuca_2-1"/>
 <position name="posArapuca2-1-TPC-12-0-1" unit="cm"
 x="0"
-y="-550.048355263158"
+y="-550.616513157895"
 z="-222.585"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -65864,7 +65913,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_2-1-0"/>
        <position name="posOpArapuca2-1-0-TPC-12-0-1" unit="cm"
          x="-0.0500000000000002"
-       y="-550.048355263158"
+       y="-550.616513157895"
          z="-302.785"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -65872,7 +65921,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_2-1-1"/>
        <position name="posOpArapuca2-1-1-TPC-12-0-1" unit="cm"
          x="-0.0500000000000002"
-       y="-550.048355263158"
+       y="-550.616513157895"
          z="-253.985"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -65880,7 +65929,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_2-1-2"/>
        <position name="posOpArapuca2-1-2-TPC-12-0-1" unit="cm"
          x="-0.0500000000000002"
-       y="-550.048355263158"
+       y="-550.616513157895"
          z="-191.185"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -65888,7 +65937,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_2-1-3"/>
        <position name="posOpArapuca2-1-3-TPC-12-0-1" unit="cm"
          x="-0.0500000000000002"
-       y="-550.048355263158"
+       y="-550.616513157895"
          z="-142.385"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -65896,7 +65945,7 @@ z="-222.585"/>
 <volumeref ref="volArapuca_2-2"/>
 <position name="posArapuca2-2-TPC-12-0-1" unit="cm"
 x="0"
-y="-487.777960526316"
+y="-488.27927631579"
 z="-222.585"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -65904,7 +65953,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_2-2-0"/>
        <position name="posOpArapuca2-2-0-TPC-12-0-1" unit="cm"
          x="-0.0500000000000002"
-       y="-487.777960526316"
+       y="-488.27927631579"
          z="-302.785"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -65912,7 +65961,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_2-2-1"/>
        <position name="posOpArapuca2-2-1-TPC-12-0-1" unit="cm"
          x="-0.0500000000000002"
-       y="-487.777960526316"
+       y="-488.27927631579"
          z="-253.985"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -65920,7 +65969,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_2-2-2"/>
        <position name="posOpArapuca2-2-2-TPC-12-0-1" unit="cm"
          x="-0.0500000000000002"
-       y="-487.777960526316"
+       y="-488.27927631579"
          z="-191.185"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -65928,7 +65977,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_2-2-3"/>
        <position name="posOpArapuca2-2-3-TPC-12-0-1" unit="cm"
          x="-0.0500000000000002"
-       y="-487.777960526316"
+       y="-488.27927631579"
          z="-142.385"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -65936,7 +65985,7 @@ z="-222.585"/>
 <volumeref ref="volArapuca_2-3"/>
 <position name="posArapuca2-3-TPC-12-0-1" unit="cm"
 x="0"
-y="-425.507565789474"
+y="-425.942039473684"
 z="-222.585"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -65944,7 +65993,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_2-3-0"/>
        <position name="posOpArapuca2-3-0-TPC-12-0-1" unit="cm"
          x="-0.0500000000000002"
-       y="-425.507565789474"
+       y="-425.942039473684"
          z="-302.785"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -65952,7 +66001,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_2-3-1"/>
        <position name="posOpArapuca2-3-1-TPC-12-0-1" unit="cm"
          x="-0.0500000000000002"
-       y="-425.507565789474"
+       y="-425.942039473684"
          z="-253.985"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -65960,7 +66009,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_2-3-2"/>
        <position name="posOpArapuca2-3-2-TPC-12-0-1" unit="cm"
          x="-0.0500000000000002"
-       y="-425.507565789474"
+       y="-425.942039473684"
          z="-191.185"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -65968,7 +66017,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_2-3-3"/>
        <position name="posOpArapuca2-3-3-TPC-12-0-1" unit="cm"
          x="-0.0500000000000002"
-       y="-425.507565789474"
+       y="-425.942039473684"
          z="-142.385"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -65976,7 +66025,7 @@ z="-222.585"/>
 <volumeref ref="volArapuca_2-4"/>
 <position name="posArapuca2-4-TPC-12-0-1" unit="cm"
 x="0"
-y="-363.237171052632"
+y="-363.604802631579"
 z="-222.585"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -65984,7 +66033,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_2-4-0"/>
        <position name="posOpArapuca2-4-0-TPC-12-0-1" unit="cm"
          x="-0.0500000000000002"
-       y="-363.237171052632"
+       y="-363.604802631579"
          z="-302.785"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -65992,7 +66041,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_2-4-1"/>
        <position name="posOpArapuca2-4-1-TPC-12-0-1" unit="cm"
          x="-0.0500000000000002"
-       y="-363.237171052632"
+       y="-363.604802631579"
          z="-253.985"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -66000,7 +66049,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_2-4-2"/>
        <position name="posOpArapuca2-4-2-TPC-12-0-1" unit="cm"
          x="-0.0500000000000002"
-       y="-363.237171052632"
+       y="-363.604802631579"
          z="-191.185"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -66008,7 +66057,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_2-4-3"/>
        <position name="posOpArapuca2-4-3-TPC-12-0-1" unit="cm"
          x="-0.0500000000000002"
-       y="-363.237171052632"
+       y="-363.604802631579"
          z="-142.385"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -66016,7 +66065,7 @@ z="-222.585"/>
 <volumeref ref="volArapuca_2-5"/>
 <position name="posArapuca2-5-TPC-12-0-1" unit="cm"
 x="0"
-y="-300.96677631579"
+y="-301.267565789474"
 z="-222.585"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -66024,7 +66073,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_2-5-0"/>
        <position name="posOpArapuca2-5-0-TPC-12-0-1" unit="cm"
          x="-0.0500000000000002"
-       y="-300.96677631579"
+       y="-301.267565789474"
          z="-302.785"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -66032,7 +66081,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_2-5-1"/>
        <position name="posOpArapuca2-5-1-TPC-12-0-1" unit="cm"
          x="-0.0500000000000002"
-       y="-300.96677631579"
+       y="-301.267565789474"
          z="-253.985"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -66040,7 +66089,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_2-5-2"/>
        <position name="posOpArapuca2-5-2-TPC-12-0-1" unit="cm"
          x="-0.0500000000000002"
-       y="-300.96677631579"
+       y="-301.267565789474"
          z="-191.185"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -66048,7 +66097,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_2-5-3"/>
        <position name="posOpArapuca2-5-3-TPC-12-0-1" unit="cm"
          x="-0.0500000000000002"
-       y="-300.96677631579"
+       y="-301.267565789474"
          z="-142.385"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -66056,7 +66105,7 @@ z="-222.585"/>
 <volumeref ref="volArapuca_2-6"/>
 <position name="posArapuca2-6-TPC-12-0-1" unit="cm"
 x="0"
-y="-238.696381578947"
+y="-238.930328947368"
 z="-222.585"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -66064,7 +66113,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_2-6-0"/>
        <position name="posOpArapuca2-6-0-TPC-12-0-1" unit="cm"
          x="-0.0500000000000002"
-       y="-238.696381578947"
+       y="-238.930328947368"
          z="-302.785"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -66072,7 +66121,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_2-6-1"/>
        <position name="posOpArapuca2-6-1-TPC-12-0-1" unit="cm"
          x="-0.0500000000000002"
-       y="-238.696381578947"
+       y="-238.930328947368"
          z="-253.985"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -66080,7 +66129,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_2-6-2"/>
        <position name="posOpArapuca2-6-2-TPC-12-0-1" unit="cm"
          x="-0.0500000000000002"
-       y="-238.696381578947"
+       y="-238.930328947368"
          z="-191.185"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -66088,7 +66137,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_2-6-3"/>
        <position name="posOpArapuca2-6-3-TPC-12-0-1" unit="cm"
          x="-0.0500000000000002"
-       y="-238.696381578947"
+       y="-238.930328947368"
          z="-142.385"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -66096,7 +66145,7 @@ z="-222.585"/>
 <volumeref ref="volArapuca_2-7"/>
 <position name="posArapuca2-7-TPC-12-0-1" unit="cm"
 x="0"
-y="-176.425986842105"
+y="-176.593092105263"
 z="-222.585"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -66104,7 +66153,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_2-7-0"/>
        <position name="posOpArapuca2-7-0-TPC-12-0-1" unit="cm"
          x="-0.0500000000000002"
-       y="-176.425986842105"
+       y="-176.593092105263"
          z="-302.785"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -66112,7 +66161,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_2-7-1"/>
        <position name="posOpArapuca2-7-1-TPC-12-0-1" unit="cm"
          x="-0.0500000000000002"
-       y="-176.425986842105"
+       y="-176.593092105263"
          z="-253.985"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -66120,7 +66169,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_2-7-2"/>
        <position name="posOpArapuca2-7-2-TPC-12-0-1" unit="cm"
          x="-0.0500000000000002"
-       y="-176.425986842105"
+       y="-176.593092105263"
          z="-191.185"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -66128,7 +66177,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_2-7-3"/>
        <position name="posOpArapuca2-7-3-TPC-12-0-1" unit="cm"
          x="-0.0500000000000002"
-       y="-176.425986842105"
+       y="-176.593092105263"
          z="-142.385"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -66136,7 +66185,7 @@ z="-222.585"/>
 <volumeref ref="volArapuca_2-8"/>
 <position name="posArapuca2-8-TPC-12-0-1" unit="cm"
 x="0"
-y="-114.155592105263"
+y="-114.255855263158"
 z="-222.585"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -66144,7 +66193,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_2-8-0"/>
        <position name="posOpArapuca2-8-0-TPC-12-0-1" unit="cm"
          x="-0.0500000000000002"
-       y="-114.155592105263"
+       y="-114.255855263158"
          z="-302.785"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -66152,7 +66201,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_2-8-1"/>
        <position name="posOpArapuca2-8-1-TPC-12-0-1" unit="cm"
          x="-0.0500000000000002"
-       y="-114.155592105263"
+       y="-114.255855263158"
          z="-253.985"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -66160,7 +66209,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_2-8-2"/>
        <position name="posOpArapuca2-8-2-TPC-12-0-1" unit="cm"
          x="-0.0500000000000002"
-       y="-114.155592105263"
+       y="-114.255855263158"
          z="-191.185"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -66168,7 +66217,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_2-8-3"/>
        <position name="posOpArapuca2-8-3-TPC-12-0-1" unit="cm"
          x="-0.0500000000000002"
-       y="-114.155592105263"
+       y="-114.255855263158"
          z="-142.385"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -66176,7 +66225,7 @@ z="-222.585"/>
 <volumeref ref="volArapuca_2-9"/>
 <position name="posArapuca2-9-TPC-12-0-1" unit="cm"
 x="0"
-y="-51.885197368421"
+y="-51.9186184210527"
 z="-222.585"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -66184,7 +66233,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_2-9-0"/>
        <position name="posOpArapuca2-9-0-TPC-12-0-1" unit="cm"
          x="-0.0500000000000002"
-       y="-51.885197368421"
+       y="-51.9186184210527"
          z="-302.785"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -66192,7 +66241,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_2-9-1"/>
        <position name="posOpArapuca2-9-1-TPC-12-0-1" unit="cm"
          x="-0.0500000000000002"
-       y="-51.885197368421"
+       y="-51.9186184210527"
          z="-253.985"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -66200,7 +66249,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_2-9-2"/>
        <position name="posOpArapuca2-9-2-TPC-12-0-1" unit="cm"
          x="-0.0500000000000002"
-       y="-51.885197368421"
+       y="-51.9186184210527"
          z="-191.185"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -66208,7 +66257,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_2-9-3"/>
        <position name="posOpArapuca2-9-3-TPC-12-0-1" unit="cm"
          x="-0.0500000000000002"
-       y="-51.885197368421"
+       y="-51.9186184210527"
          z="-142.385"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -66217,7 +66266,7 @@ z="-222.585"/>
         <volumeref ref="volTPCInner"/>
         <position name="posTPC-4" unit="cm"
         x="-182.95455"
-        y="-324.664375"
+        y="-324.981875"
         z="-222.585"/>
         <rotationref ref="rPlus180AboutXPlus180AboutY"/>
       </physvol>
@@ -66225,7 +66274,7 @@ z="-222.585"/>
         <volumeref ref="volTPCInner"/>
         <position name="posTPC-5" unit="cm"
         x="182.95455"
-        y="-324.664375"
+        y="-324.981875"
         z="-222.585"/>
         <rotationref ref="rPlus180AboutX"/>
       </physvol>
@@ -66233,16 +66282,16 @@ z="-222.585"/>
       <physvol>
         <volumeref ref="volCathode"/>
         <position name="posCathode-3-0" unit="cm"
-      x="-363.38405"
-      y="-324.664375"
+      x="-363.52605"
+      y="-324.981875"
       z="-222.585"/>
         <rotationref ref="rIdentity"/>
       </physvol>
       <physvol>
         <volumeref ref="volCathode"/>
         <position name="posCathode-3-1" unit="cm"
-      x="363.38405"
-      y="-324.664375"
+      x="363.52605"
+      y="-324.981875"
       z="-222.585"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -66251,23 +66300,23 @@ z="-222.585"/>
         <volumeref ref="volAPAFrameYSide"/>
         <position name="posAPAFrameYSideNeg-3" unit="cm"
       x="0"
-      y="283.87875"
-      z="-332.50625"/>
+      y="284.51375"
+      z="-332.18875"/>
         <rotationref ref="rIdentity"/>
       </physvol>
       <physvol>
         <volumeref ref="volAPAFrameYSide"/>
         <position name="posAPAFrameYSidePos-3" unit="cm"
       x="0"
-      y="283.87875"
-      z="-112.66375"/>
+      y="284.51375"
+      z="-112.98125"/>
         <rotationref ref="rIdentity"/>
       </physvol>
       <physvol>
         <volumeref ref="volAPAFrameZSide"/>
         <position name="posAPAFrameZSidePos-3" unit="cm"
       x="0"
-      y="581.79875"
+      y="582.43375"
       z="-222.585"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -66275,7 +66324,7 @@ z="-222.585"/>
         <volumeref ref="volAPAFrameZSide"/>
         <position name="posAPAFrameZSideNeg-3" unit="cm"
       x="0"
-      y="-14.0412500000001"
+      y="-13.40625"
       z="-222.585"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -66286,22 +66335,33 @@ z="-222.585"/>
       - There are two boards on each the up and downstream end,
           one each to wrap the U and V views around the APA frame
       - There are 4 on the bottom which anchor the U V and Z wires and the grid plane
-      - The rest of the parts of the G10 boards must be placed directly in volTPC   -->
+      FIXME: This is not true -> - The rest of the parts of the G10 boards must be placed directly in volTPC   -->
+
+      <!-- Position readout boards -->
+      <physvol>
+        <volumeref ref="volG10HeadBoards"/>
+        <position name="posG10HeadBoards-3" unit="cm"
+	  x="0"
+	  y="598.01775"
+      	  z="-222.585"/>
+        <rotationref ref="rIdentity"/>
+      </physvol>
 
       <physvol>
         <volumeref ref="volG10BoardYSideCenterSeg"/>
         <position name="posG10BoardYSideCenterSeg-Vup-3" unit="cm"
-      x="0"
-      y="283.87875"
-      z="-337.745"/>
-        <rotationref ref="rIdentity"/>
+         x="0"
+         y="284.51375"
+         z="-337.506875"/>
+         <rotationref ref="rIdentity"/>
       </physvol>
+
       <physvol>
         <volumeref ref="volG10BoardYSideCenterSeg"/>
         <position name="posG10BoardYSideCenterSeg-Uup-3" unit="cm"
       x="0"
-      y="283.87875"
-      z="-338.0625"/>
+      y="284.51375"
+      z="-337.983125"/>
         <rotationref ref="rIdentity"/>
       </physvol>
 
@@ -66309,16 +66369,16 @@ z="-222.585"/>
         <volumeref ref="volG10BoardYSideCenterSeg"/>
         <position name="posG10BoardYSideCenterSeg-Vdown-3" unit="cm"
       x="0"
-      y="283.87875"
-      z="-107.425"/>
+      y="284.51375"
+      z="-107.663125"/>
         <rotationref ref="rIdentity"/>
       </physvol>
       <physvol>
         <volumeref ref="volG10BoardYSideCenterSeg"/>
         <position name="posG10BoardYSideCenterSeg-Udown-3" unit="cm"
       x="0"
-      y="283.87875"
-      z="-107.1075"/>
+      y="284.51375"
+      z="-107.186875"/>
         <rotationref ref="rIdentity"/>
       </physvol>
 
@@ -66326,7 +66386,7 @@ z="-222.585"/>
         <volumeref ref="volG10BoardZSideCenterSeg"/>
         <position name="posG10BoardZSideCenterSeg-Z-3" unit="cm"
       x="0"
-      y="-19.2800000000001"
+      y="-18.7243750000001"
       z="-222.585"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -66334,7 +66394,7 @@ z="-222.585"/>
         <volumeref ref="volG10BoardZSideCenterSeg"/>
         <position name="posG10BoardZSideCenterSeg-V-3" unit="cm"
       x="0"
-      y="-19.5975000000001"
+      y="-19.2006250000001"
       z="-222.585"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -66342,7 +66402,7 @@ z="-222.585"/>
         <volumeref ref="volG10BoardZSideCenterSeg"/>
         <position name="posG10BoardZSideCenterSeg-U-3" unit="cm"
       x="0"
-      y="-19.9150000000001"
+      y="-19.6768750000001"
       z="-222.585"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -66350,7 +66410,7 @@ z="-222.585"/>
         <volumeref ref="volG10BoardZSideCenterSeg"/>
         <position name="posG10BoardZSideCenterSeg-Grid-3" unit="cm"
       x="0"
-      y="-20.2325000000001"
+      y="-20.153125"
       z="-222.585"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -66359,7 +66419,7 @@ z="-222.585"/>
 <volumeref ref="volArapuca_3-0"/>
 <position name="posArapuca3-0-TPC-12-1-1" unit="cm"
 x="0"
-y="10.385197368421"
+y="10.4186184210526"
 z="-222.585"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -66367,7 +66427,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_3-0-0"/>
        <position name="posOpArapuca3-0-0-TPC-12-1-1" unit="cm"
          x="0.0500000000000002"
-       y="10.385197368421"
+       y="10.4186184210526"
          z="-302.785"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -66375,7 +66435,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_3-0-1"/>
        <position name="posOpArapuca3-0-1-TPC-12-1-1" unit="cm"
          x="0.0500000000000002"
-       y="10.385197368421"
+       y="10.4186184210526"
          z="-253.985"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -66383,7 +66443,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_3-0-2"/>
        <position name="posOpArapuca3-0-2-TPC-12-1-1" unit="cm"
          x="0.0500000000000002"
-       y="10.385197368421"
+       y="10.4186184210526"
          z="-191.185"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -66391,7 +66451,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_3-0-3"/>
        <position name="posOpArapuca3-0-3-TPC-12-1-1" unit="cm"
          x="0.0500000000000002"
-       y="10.385197368421"
+       y="10.4186184210526"
          z="-142.385"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -66399,7 +66459,7 @@ z="-222.585"/>
 <volumeref ref="volArapuca_3-1"/>
 <position name="posArapuca3-1-TPC-12-1-1" unit="cm"
 x="0"
-y="72.6555921052631"
+y="72.7558552631579"
 z="-222.585"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -66407,7 +66467,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_3-1-0"/>
        <position name="posOpArapuca3-1-0-TPC-12-1-1" unit="cm"
          x="0.0500000000000002"
-       y="72.6555921052631"
+       y="72.7558552631579"
          z="-302.785"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -66415,7 +66475,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_3-1-1"/>
        <position name="posOpArapuca3-1-1-TPC-12-1-1" unit="cm"
          x="0.0500000000000002"
-       y="72.6555921052631"
+       y="72.7558552631579"
          z="-253.985"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -66423,7 +66483,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_3-1-2"/>
        <position name="posOpArapuca3-1-2-TPC-12-1-1" unit="cm"
          x="0.0500000000000002"
-       y="72.6555921052631"
+       y="72.7558552631579"
          z="-191.185"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -66431,7 +66491,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_3-1-3"/>
        <position name="posOpArapuca3-1-3-TPC-12-1-1" unit="cm"
          x="0.0500000000000002"
-       y="72.6555921052631"
+       y="72.7558552631579"
          z="-142.385"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -66439,7 +66499,7 @@ z="-222.585"/>
 <volumeref ref="volArapuca_3-2"/>
 <position name="posArapuca3-2-TPC-12-1-1" unit="cm"
 x="0"
-y="134.925986842105"
+y="135.093092105263"
 z="-222.585"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -66447,7 +66507,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_3-2-0"/>
        <position name="posOpArapuca3-2-0-TPC-12-1-1" unit="cm"
          x="0.0500000000000002"
-       y="134.925986842105"
+       y="135.093092105263"
          z="-302.785"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -66455,7 +66515,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_3-2-1"/>
        <position name="posOpArapuca3-2-1-TPC-12-1-1" unit="cm"
          x="0.0500000000000002"
-       y="134.925986842105"
+       y="135.093092105263"
          z="-253.985"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -66463,7 +66523,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_3-2-2"/>
        <position name="posOpArapuca3-2-2-TPC-12-1-1" unit="cm"
          x="0.0500000000000002"
-       y="134.925986842105"
+       y="135.093092105263"
          z="-191.185"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -66471,7 +66531,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_3-2-3"/>
        <position name="posOpArapuca3-2-3-TPC-12-1-1" unit="cm"
          x="0.0500000000000002"
-       y="134.925986842105"
+       y="135.093092105263"
          z="-142.385"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -66479,7 +66539,7 @@ z="-222.585"/>
 <volumeref ref="volArapuca_3-3"/>
 <position name="posArapuca3-3-TPC-12-1-1" unit="cm"
 x="0"
-y="197.196381578947"
+y="197.430328947368"
 z="-222.585"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -66487,7 +66547,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_3-3-0"/>
        <position name="posOpArapuca3-3-0-TPC-12-1-1" unit="cm"
          x="0.0500000000000002"
-       y="197.196381578947"
+       y="197.430328947368"
          z="-302.785"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -66495,7 +66555,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_3-3-1"/>
        <position name="posOpArapuca3-3-1-TPC-12-1-1" unit="cm"
          x="0.0500000000000002"
-       y="197.196381578947"
+       y="197.430328947368"
          z="-253.985"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -66503,7 +66563,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_3-3-2"/>
        <position name="posOpArapuca3-3-2-TPC-12-1-1" unit="cm"
          x="0.0500000000000002"
-       y="197.196381578947"
+       y="197.430328947368"
          z="-191.185"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -66511,7 +66571,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_3-3-3"/>
        <position name="posOpArapuca3-3-3-TPC-12-1-1" unit="cm"
          x="0.0500000000000002"
-       y="197.196381578947"
+       y="197.430328947368"
          z="-142.385"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -66519,7 +66579,7 @@ z="-222.585"/>
 <volumeref ref="volArapuca_3-4"/>
 <position name="posArapuca3-4-TPC-12-1-1" unit="cm"
 x="0"
-y="259.46677631579"
+y="259.767565789474"
 z="-222.585"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -66527,7 +66587,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_3-4-0"/>
        <position name="posOpArapuca3-4-0-TPC-12-1-1" unit="cm"
          x="0.0500000000000002"
-       y="259.46677631579"
+       y="259.767565789474"
          z="-302.785"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -66535,7 +66595,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_3-4-1"/>
        <position name="posOpArapuca3-4-1-TPC-12-1-1" unit="cm"
          x="0.0500000000000002"
-       y="259.46677631579"
+       y="259.767565789474"
          z="-253.985"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -66543,7 +66603,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_3-4-2"/>
        <position name="posOpArapuca3-4-2-TPC-12-1-1" unit="cm"
          x="0.0500000000000002"
-       y="259.46677631579"
+       y="259.767565789474"
          z="-191.185"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -66551,7 +66611,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_3-4-3"/>
        <position name="posOpArapuca3-4-3-TPC-12-1-1" unit="cm"
          x="0.0500000000000002"
-       y="259.46677631579"
+       y="259.767565789474"
          z="-142.385"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -66559,7 +66619,7 @@ z="-222.585"/>
 <volumeref ref="volArapuca_3-5"/>
 <position name="posArapuca3-5-TPC-12-1-1" unit="cm"
 x="0"
-y="321.737171052632"
+y="322.104802631579"
 z="-222.585"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -66567,7 +66627,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_3-5-0"/>
        <position name="posOpArapuca3-5-0-TPC-12-1-1" unit="cm"
          x="0.0500000000000002"
-       y="321.737171052632"
+       y="322.104802631579"
          z="-302.785"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -66575,7 +66635,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_3-5-1"/>
        <position name="posOpArapuca3-5-1-TPC-12-1-1" unit="cm"
          x="0.0500000000000002"
-       y="321.737171052632"
+       y="322.104802631579"
          z="-253.985"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -66583,7 +66643,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_3-5-2"/>
        <position name="posOpArapuca3-5-2-TPC-12-1-1" unit="cm"
          x="0.0500000000000002"
-       y="321.737171052632"
+       y="322.104802631579"
          z="-191.185"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -66591,7 +66651,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_3-5-3"/>
        <position name="posOpArapuca3-5-3-TPC-12-1-1" unit="cm"
          x="0.0500000000000002"
-       y="321.737171052632"
+       y="322.104802631579"
          z="-142.385"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -66599,7 +66659,7 @@ z="-222.585"/>
 <volumeref ref="volArapuca_3-6"/>
 <position name="posArapuca3-6-TPC-12-1-1" unit="cm"
 x="0"
-y="384.007565789474"
+y="384.442039473684"
 z="-222.585"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -66607,7 +66667,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_3-6-0"/>
        <position name="posOpArapuca3-6-0-TPC-12-1-1" unit="cm"
          x="0.0500000000000002"
-       y="384.007565789474"
+       y="384.442039473684"
          z="-302.785"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -66615,7 +66675,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_3-6-1"/>
        <position name="posOpArapuca3-6-1-TPC-12-1-1" unit="cm"
          x="0.0500000000000002"
-       y="384.007565789474"
+       y="384.442039473684"
          z="-253.985"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -66623,7 +66683,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_3-6-2"/>
        <position name="posOpArapuca3-6-2-TPC-12-1-1" unit="cm"
          x="0.0500000000000002"
-       y="384.007565789474"
+       y="384.442039473684"
          z="-191.185"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -66631,7 +66691,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_3-6-3"/>
        <position name="posOpArapuca3-6-3-TPC-12-1-1" unit="cm"
          x="0.0500000000000002"
-       y="384.007565789474"
+       y="384.442039473684"
          z="-142.385"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -66639,7 +66699,7 @@ z="-222.585"/>
 <volumeref ref="volArapuca_3-7"/>
 <position name="posArapuca3-7-TPC-12-1-1" unit="cm"
 x="0"
-y="446.277960526316"
+y="446.77927631579"
 z="-222.585"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -66647,7 +66707,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_3-7-0"/>
        <position name="posOpArapuca3-7-0-TPC-12-1-1" unit="cm"
          x="0.0500000000000002"
-       y="446.277960526316"
+       y="446.77927631579"
          z="-302.785"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -66655,7 +66715,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_3-7-1"/>
        <position name="posOpArapuca3-7-1-TPC-12-1-1" unit="cm"
          x="0.0500000000000002"
-       y="446.277960526316"
+       y="446.77927631579"
          z="-253.985"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -66663,7 +66723,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_3-7-2"/>
        <position name="posOpArapuca3-7-2-TPC-12-1-1" unit="cm"
          x="0.0500000000000002"
-       y="446.277960526316"
+       y="446.77927631579"
          z="-191.185"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -66671,7 +66731,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_3-7-3"/>
        <position name="posOpArapuca3-7-3-TPC-12-1-1" unit="cm"
          x="0.0500000000000002"
-       y="446.277960526316"
+       y="446.77927631579"
          z="-142.385"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -66679,7 +66739,7 @@ z="-222.585"/>
 <volumeref ref="volArapuca_3-8"/>
 <position name="posArapuca3-8-TPC-12-1-1" unit="cm"
 x="0"
-y="508.548355263158"
+y="509.116513157895"
 z="-222.585"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -66687,7 +66747,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_3-8-0"/>
        <position name="posOpArapuca3-8-0-TPC-12-1-1" unit="cm"
          x="0.0500000000000002"
-       y="508.548355263158"
+       y="509.116513157895"
          z="-302.785"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -66695,7 +66755,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_3-8-1"/>
        <position name="posOpArapuca3-8-1-TPC-12-1-1" unit="cm"
          x="0.0500000000000002"
-       y="508.548355263158"
+       y="509.116513157895"
          z="-253.985"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -66703,7 +66763,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_3-8-2"/>
        <position name="posOpArapuca3-8-2-TPC-12-1-1" unit="cm"
          x="0.0500000000000002"
-       y="508.548355263158"
+       y="509.116513157895"
          z="-191.185"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -66711,7 +66771,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_3-8-3"/>
        <position name="posOpArapuca3-8-3-TPC-12-1-1" unit="cm"
          x="0.0500000000000002"
-       y="508.548355263158"
+       y="509.116513157895"
          z="-142.385"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -66719,7 +66779,7 @@ z="-222.585"/>
 <volumeref ref="volArapuca_3-9"/>
 <position name="posArapuca3-9-TPC-12-1-1" unit="cm"
 x="0"
-y="570.81875"
+y="571.45375"
 z="-222.585"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -66727,7 +66787,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_3-9-0"/>
        <position name="posOpArapuca3-9-0-TPC-12-1-1" unit="cm"
          x="0.0500000000000002"
-       y="570.81875"
+       y="571.45375"
          z="-302.785"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -66735,7 +66795,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_3-9-1"/>
        <position name="posOpArapuca3-9-1-TPC-12-1-1" unit="cm"
          x="0.0500000000000002"
-       y="570.81875"
+       y="571.45375"
          z="-253.985"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -66743,7 +66803,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_3-9-2"/>
        <position name="posOpArapuca3-9-2-TPC-12-1-1" unit="cm"
          x="0.0500000000000002"
-       y="570.81875"
+       y="571.45375"
          z="-191.185"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -66751,7 +66811,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_3-9-3"/>
        <position name="posOpArapuca3-9-3-TPC-12-1-1" unit="cm"
          x="0.0500000000000002"
-       y="570.81875"
+       y="571.45375"
          z="-142.385"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -66760,7 +66820,7 @@ z="-222.585"/>
         <volumeref ref="volTPCInner"/>
         <position name="posTPC-6" unit="cm"
         x="-182.95455"
-        y="283.164375"
+        y="283.481875"
         z="-222.585"/>
         <rotationref ref="rPlus180AboutY"/>
       </physvol>
@@ -66768,7 +66828,7 @@ z="-222.585"/>
         <volumeref ref="volTPCInner"/>
         <position name="posTPC-7" unit="cm"
         x="182.95455"
-        y="283.164375"
+        y="283.481875"
         z="-222.585"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -66776,16 +66836,16 @@ z="-222.585"/>
       <physvol>
         <volumeref ref="volCathode"/>
         <position name="posCathode-4-0" unit="cm"
-      x="-363.38405"
-      y="283.164375"
+      x="-363.52605"
+      y="283.481875"
       z="-222.585"/>
         <rotationref ref="rIdentity"/>
       </physvol>
       <physvol>
         <volumeref ref="volCathode"/>
         <position name="posCathode-4-1" unit="cm"
-      x="363.38405"
-      y="283.164375"
+      x="363.52605"
+      y="283.481875"
       z="-222.585"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -66794,23 +66854,23 @@ z="-222.585"/>
         <volumeref ref="volAPAFrameYSide"/>
         <position name="posAPAFrameYSideNeg-4" unit="cm"
       x="0"
-      y="-325.37875"
-      z="-100.11625"/>
+      y="-326.01375"
+      z="-99.7987499999999"/>
         <rotationref ref="rIdentity"/>
       </physvol>
       <physvol>
         <volumeref ref="volAPAFrameYSide"/>
         <position name="posAPAFrameYSidePos-4" unit="cm"
       x="0"
-      y="-325.37875"
-      z="119.72625"/>
+      y="-326.01375"
+      z="119.40875"/>
         <rotationref ref="rIdentity"/>
       </physvol>
       <physvol>
         <volumeref ref="volAPAFrameZSide"/>
         <position name="posAPAFrameZSidePos-4" unit="cm"
       x="0"
-      y="-27.45875"
+      y="-28.0937500000001"
       z="9.80500000000006"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -66818,7 +66878,7 @@ z="-222.585"/>
         <volumeref ref="volAPAFrameZSide"/>
         <position name="posAPAFrameZSideNeg-4" unit="cm"
       x="0"
-      y="-623.29875"
+      y="-623.93375"
       z="9.80500000000006"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -66829,22 +66889,33 @@ z="-222.585"/>
       - There are two boards on each the up and downstream end,
           one each to wrap the U and V views around the APA frame
       - There are 4 on the bottom which anchor the U V and Z wires and the grid plane
-      - The rest of the parts of the G10 boards must be placed directly in volTPC   -->
+      FIXME: This is not true -> - The rest of the parts of the G10 boards must be placed directly in volTPC   -->
+
+      <!-- Position readout boards -->
+      <physvol>
+        <volumeref ref="volG10HeadBoards"/>
+        <position name="posG10HeadBoards-4" unit="cm"
+	  x="0"
+	  y="-639.51775"
+      	  z="9.80500000000006"/>
+        <rotationref ref="rIdentity"/>
+      </physvol>
 
       <physvol>
         <volumeref ref="volG10BoardYSideCenterSeg"/>
         <position name="posG10BoardYSideCenterSeg-Vup-4" unit="cm"
-      x="0"
-      y="-325.37875"
-      z="-105.355"/>
-        <rotationref ref="rIdentity"/>
+         x="0"
+         y="-326.01375"
+         z="-105.116875"/>
+         <rotationref ref="rIdentity"/>
       </physvol>
+
       <physvol>
         <volumeref ref="volG10BoardYSideCenterSeg"/>
         <position name="posG10BoardYSideCenterSeg-Uup-4" unit="cm"
       x="0"
-      y="-325.37875"
-      z="-105.6725"/>
+      y="-326.01375"
+      z="-105.593125"/>
         <rotationref ref="rIdentity"/>
       </physvol>
 
@@ -66852,16 +66923,16 @@ z="-222.585"/>
         <volumeref ref="volG10BoardYSideCenterSeg"/>
         <position name="posG10BoardYSideCenterSeg-Vdown-4" unit="cm"
       x="0"
-      y="-325.37875"
-      z="124.965"/>
+      y="-326.01375"
+      z="124.726875"/>
         <rotationref ref="rIdentity"/>
       </physvol>
       <physvol>
         <volumeref ref="volG10BoardYSideCenterSeg"/>
         <position name="posG10BoardYSideCenterSeg-Udown-4" unit="cm"
       x="0"
-      y="-325.37875"
-      z="125.2825"/>
+      y="-326.01375"
+      z="125.203125"/>
         <rotationref ref="rIdentity"/>
       </physvol>
 
@@ -66869,7 +66940,7 @@ z="-222.585"/>
         <volumeref ref="volG10BoardZSideCenterSeg"/>
         <position name="posG10BoardZSideCenterSeg-Z-4" unit="cm"
       x="0"
-      y="-22.22"
+      y="-22.775625"
       z="9.80500000000006"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -66877,7 +66948,7 @@ z="-222.585"/>
         <volumeref ref="volG10BoardZSideCenterSeg"/>
         <position name="posG10BoardZSideCenterSeg-V-4" unit="cm"
       x="0"
-      y="-21.9025"
+      y="-22.2993750000001"
       z="9.80500000000006"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -66885,7 +66956,7 @@ z="-222.585"/>
         <volumeref ref="volG10BoardZSideCenterSeg"/>
         <position name="posG10BoardZSideCenterSeg-U-4" unit="cm"
       x="0"
-      y="-21.585"
+      y="-21.8231250000001"
       z="9.80500000000006"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -66893,7 +66964,7 @@ z="-222.585"/>
         <volumeref ref="volG10BoardZSideCenterSeg"/>
         <position name="posG10BoardZSideCenterSeg-Grid-4" unit="cm"
       x="0"
-      y="-21.2675"
+      y="-21.3468750000001"
       z="9.80500000000006"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -66902,7 +66973,7 @@ z="-222.585"/>
 <volumeref ref="volArapuca_4-0"/>
 <position name="posArapuca4-0-TPC-12-0-2" unit="cm"
 x="0"
-y="-612.31875"
+y="-612.95375"
 z="9.80500000000006"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -66910,7 +66981,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_4-0-0"/>
        <position name="posOpArapuca4-0-0-TPC-12-0-2" unit="cm"
          x="-0.0500000000000002"
-       y="-612.31875"
+       y="-612.95375"
          z="-70.3949999999999"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -66918,7 +66989,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_4-0-1"/>
        <position name="posOpArapuca4-0-1-TPC-12-0-2" unit="cm"
          x="-0.0500000000000002"
-       y="-612.31875"
+       y="-612.95375"
          z="-21.5949999999999"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -66926,7 +66997,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_4-0-2"/>
        <position name="posOpArapuca4-0-2-TPC-12-0-2" unit="cm"
          x="-0.0500000000000002"
-       y="-612.31875"
+       y="-612.95375"
          z="41.2050000000001"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -66934,7 +67005,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_4-0-3"/>
        <position name="posOpArapuca4-0-3-TPC-12-0-2" unit="cm"
          x="-0.0500000000000002"
-       y="-612.31875"
+       y="-612.95375"
          z="90.0050000000001"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -66942,7 +67013,7 @@ z="9.80500000000006"/>
 <volumeref ref="volArapuca_4-1"/>
 <position name="posArapuca4-1-TPC-12-0-2" unit="cm"
 x="0"
-y="-550.048355263158"
+y="-550.616513157895"
 z="9.80500000000006"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -66950,7 +67021,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_4-1-0"/>
        <position name="posOpArapuca4-1-0-TPC-12-0-2" unit="cm"
          x="-0.0500000000000002"
-       y="-550.048355263158"
+       y="-550.616513157895"
          z="-70.3949999999999"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -66958,7 +67029,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_4-1-1"/>
        <position name="posOpArapuca4-1-1-TPC-12-0-2" unit="cm"
          x="-0.0500000000000002"
-       y="-550.048355263158"
+       y="-550.616513157895"
          z="-21.5949999999999"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -66966,7 +67037,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_4-1-2"/>
        <position name="posOpArapuca4-1-2-TPC-12-0-2" unit="cm"
          x="-0.0500000000000002"
-       y="-550.048355263158"
+       y="-550.616513157895"
          z="41.2050000000001"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -66974,7 +67045,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_4-1-3"/>
        <position name="posOpArapuca4-1-3-TPC-12-0-2" unit="cm"
          x="-0.0500000000000002"
-       y="-550.048355263158"
+       y="-550.616513157895"
          z="90.0050000000001"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -66982,7 +67053,7 @@ z="9.80500000000006"/>
 <volumeref ref="volArapuca_4-2"/>
 <position name="posArapuca4-2-TPC-12-0-2" unit="cm"
 x="0"
-y="-487.777960526316"
+y="-488.27927631579"
 z="9.80500000000006"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -66990,7 +67061,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_4-2-0"/>
        <position name="posOpArapuca4-2-0-TPC-12-0-2" unit="cm"
          x="-0.0500000000000002"
-       y="-487.777960526316"
+       y="-488.27927631579"
          z="-70.3949999999999"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -66998,7 +67069,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_4-2-1"/>
        <position name="posOpArapuca4-2-1-TPC-12-0-2" unit="cm"
          x="-0.0500000000000002"
-       y="-487.777960526316"
+       y="-488.27927631579"
          z="-21.5949999999999"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -67006,7 +67077,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_4-2-2"/>
        <position name="posOpArapuca4-2-2-TPC-12-0-2" unit="cm"
          x="-0.0500000000000002"
-       y="-487.777960526316"
+       y="-488.27927631579"
          z="41.2050000000001"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -67014,7 +67085,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_4-2-3"/>
        <position name="posOpArapuca4-2-3-TPC-12-0-2" unit="cm"
          x="-0.0500000000000002"
-       y="-487.777960526316"
+       y="-488.27927631579"
          z="90.0050000000001"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -67022,7 +67093,7 @@ z="9.80500000000006"/>
 <volumeref ref="volArapuca_4-3"/>
 <position name="posArapuca4-3-TPC-12-0-2" unit="cm"
 x="0"
-y="-425.507565789474"
+y="-425.942039473684"
 z="9.80500000000006"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -67030,7 +67101,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_4-3-0"/>
        <position name="posOpArapuca4-3-0-TPC-12-0-2" unit="cm"
          x="-0.0500000000000002"
-       y="-425.507565789474"
+       y="-425.942039473684"
          z="-70.3949999999999"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -67038,7 +67109,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_4-3-1"/>
        <position name="posOpArapuca4-3-1-TPC-12-0-2" unit="cm"
          x="-0.0500000000000002"
-       y="-425.507565789474"
+       y="-425.942039473684"
          z="-21.5949999999999"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -67046,7 +67117,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_4-3-2"/>
        <position name="posOpArapuca4-3-2-TPC-12-0-2" unit="cm"
          x="-0.0500000000000002"
-       y="-425.507565789474"
+       y="-425.942039473684"
          z="41.2050000000001"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -67054,7 +67125,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_4-3-3"/>
        <position name="posOpArapuca4-3-3-TPC-12-0-2" unit="cm"
          x="-0.0500000000000002"
-       y="-425.507565789474"
+       y="-425.942039473684"
          z="90.0050000000001"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -67062,7 +67133,7 @@ z="9.80500000000006"/>
 <volumeref ref="volArapuca_4-4"/>
 <position name="posArapuca4-4-TPC-12-0-2" unit="cm"
 x="0"
-y="-363.237171052632"
+y="-363.604802631579"
 z="9.80500000000006"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -67070,7 +67141,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_4-4-0"/>
        <position name="posOpArapuca4-4-0-TPC-12-0-2" unit="cm"
          x="-0.0500000000000002"
-       y="-363.237171052632"
+       y="-363.604802631579"
          z="-70.3949999999999"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -67078,7 +67149,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_4-4-1"/>
        <position name="posOpArapuca4-4-1-TPC-12-0-2" unit="cm"
          x="-0.0500000000000002"
-       y="-363.237171052632"
+       y="-363.604802631579"
          z="-21.5949999999999"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -67086,7 +67157,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_4-4-2"/>
        <position name="posOpArapuca4-4-2-TPC-12-0-2" unit="cm"
          x="-0.0500000000000002"
-       y="-363.237171052632"
+       y="-363.604802631579"
          z="41.2050000000001"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -67094,7 +67165,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_4-4-3"/>
        <position name="posOpArapuca4-4-3-TPC-12-0-2" unit="cm"
          x="-0.0500000000000002"
-       y="-363.237171052632"
+       y="-363.604802631579"
          z="90.0050000000001"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -67102,7 +67173,7 @@ z="9.80500000000006"/>
 <volumeref ref="volArapuca_4-5"/>
 <position name="posArapuca4-5-TPC-12-0-2" unit="cm"
 x="0"
-y="-300.96677631579"
+y="-301.267565789474"
 z="9.80500000000006"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -67110,7 +67181,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_4-5-0"/>
        <position name="posOpArapuca4-5-0-TPC-12-0-2" unit="cm"
          x="-0.0500000000000002"
-       y="-300.96677631579"
+       y="-301.267565789474"
          z="-70.3949999999999"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -67118,7 +67189,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_4-5-1"/>
        <position name="posOpArapuca4-5-1-TPC-12-0-2" unit="cm"
          x="-0.0500000000000002"
-       y="-300.96677631579"
+       y="-301.267565789474"
          z="-21.5949999999999"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -67126,7 +67197,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_4-5-2"/>
        <position name="posOpArapuca4-5-2-TPC-12-0-2" unit="cm"
          x="-0.0500000000000002"
-       y="-300.96677631579"
+       y="-301.267565789474"
          z="41.2050000000001"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -67134,7 +67205,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_4-5-3"/>
        <position name="posOpArapuca4-5-3-TPC-12-0-2" unit="cm"
          x="-0.0500000000000002"
-       y="-300.96677631579"
+       y="-301.267565789474"
          z="90.0050000000001"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -67142,7 +67213,7 @@ z="9.80500000000006"/>
 <volumeref ref="volArapuca_4-6"/>
 <position name="posArapuca4-6-TPC-12-0-2" unit="cm"
 x="0"
-y="-238.696381578947"
+y="-238.930328947368"
 z="9.80500000000006"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -67150,7 +67221,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_4-6-0"/>
        <position name="posOpArapuca4-6-0-TPC-12-0-2" unit="cm"
          x="-0.0500000000000002"
-       y="-238.696381578947"
+       y="-238.930328947368"
          z="-70.3949999999999"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -67158,7 +67229,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_4-6-1"/>
        <position name="posOpArapuca4-6-1-TPC-12-0-2" unit="cm"
          x="-0.0500000000000002"
-       y="-238.696381578947"
+       y="-238.930328947368"
          z="-21.5949999999999"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -67166,7 +67237,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_4-6-2"/>
        <position name="posOpArapuca4-6-2-TPC-12-0-2" unit="cm"
          x="-0.0500000000000002"
-       y="-238.696381578947"
+       y="-238.930328947368"
          z="41.2050000000001"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -67174,7 +67245,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_4-6-3"/>
        <position name="posOpArapuca4-6-3-TPC-12-0-2" unit="cm"
          x="-0.0500000000000002"
-       y="-238.696381578947"
+       y="-238.930328947368"
          z="90.0050000000001"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -67182,7 +67253,7 @@ z="9.80500000000006"/>
 <volumeref ref="volArapuca_4-7"/>
 <position name="posArapuca4-7-TPC-12-0-2" unit="cm"
 x="0"
-y="-176.425986842105"
+y="-176.593092105263"
 z="9.80500000000006"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -67190,7 +67261,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_4-7-0"/>
        <position name="posOpArapuca4-7-0-TPC-12-0-2" unit="cm"
          x="-0.0500000000000002"
-       y="-176.425986842105"
+       y="-176.593092105263"
          z="-70.3949999999999"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -67198,7 +67269,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_4-7-1"/>
        <position name="posOpArapuca4-7-1-TPC-12-0-2" unit="cm"
          x="-0.0500000000000002"
-       y="-176.425986842105"
+       y="-176.593092105263"
          z="-21.5949999999999"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -67206,7 +67277,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_4-7-2"/>
        <position name="posOpArapuca4-7-2-TPC-12-0-2" unit="cm"
          x="-0.0500000000000002"
-       y="-176.425986842105"
+       y="-176.593092105263"
          z="41.2050000000001"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -67214,7 +67285,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_4-7-3"/>
        <position name="posOpArapuca4-7-3-TPC-12-0-2" unit="cm"
          x="-0.0500000000000002"
-       y="-176.425986842105"
+       y="-176.593092105263"
          z="90.0050000000001"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -67222,7 +67293,7 @@ z="9.80500000000006"/>
 <volumeref ref="volArapuca_4-8"/>
 <position name="posArapuca4-8-TPC-12-0-2" unit="cm"
 x="0"
-y="-114.155592105263"
+y="-114.255855263158"
 z="9.80500000000006"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -67230,7 +67301,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_4-8-0"/>
        <position name="posOpArapuca4-8-0-TPC-12-0-2" unit="cm"
          x="-0.0500000000000002"
-       y="-114.155592105263"
+       y="-114.255855263158"
          z="-70.3949999999999"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -67238,7 +67309,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_4-8-1"/>
        <position name="posOpArapuca4-8-1-TPC-12-0-2" unit="cm"
          x="-0.0500000000000002"
-       y="-114.155592105263"
+       y="-114.255855263158"
          z="-21.5949999999999"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -67246,7 +67317,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_4-8-2"/>
        <position name="posOpArapuca4-8-2-TPC-12-0-2" unit="cm"
          x="-0.0500000000000002"
-       y="-114.155592105263"
+       y="-114.255855263158"
          z="41.2050000000001"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -67254,7 +67325,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_4-8-3"/>
        <position name="posOpArapuca4-8-3-TPC-12-0-2" unit="cm"
          x="-0.0500000000000002"
-       y="-114.155592105263"
+       y="-114.255855263158"
          z="90.0050000000001"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -67262,7 +67333,7 @@ z="9.80500000000006"/>
 <volumeref ref="volArapuca_4-9"/>
 <position name="posArapuca4-9-TPC-12-0-2" unit="cm"
 x="0"
-y="-51.885197368421"
+y="-51.9186184210527"
 z="9.80500000000006"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -67270,7 +67341,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_4-9-0"/>
        <position name="posOpArapuca4-9-0-TPC-12-0-2" unit="cm"
          x="-0.0500000000000002"
-       y="-51.885197368421"
+       y="-51.9186184210527"
          z="-70.3949999999999"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -67278,7 +67349,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_4-9-1"/>
        <position name="posOpArapuca4-9-1-TPC-12-0-2" unit="cm"
          x="-0.0500000000000002"
-       y="-51.885197368421"
+       y="-51.9186184210527"
          z="-21.5949999999999"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -67286,7 +67357,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_4-9-2"/>
        <position name="posOpArapuca4-9-2-TPC-12-0-2" unit="cm"
          x="-0.0500000000000002"
-       y="-51.885197368421"
+       y="-51.9186184210527"
          z="41.2050000000001"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -67294,7 +67365,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_4-9-3"/>
        <position name="posOpArapuca4-9-3-TPC-12-0-2" unit="cm"
          x="-0.0500000000000002"
-       y="-51.885197368421"
+       y="-51.9186184210527"
          z="90.0050000000001"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -67303,7 +67374,7 @@ z="9.80500000000006"/>
         <volumeref ref="volTPCInner"/>
         <position name="posTPC-8" unit="cm"
         x="-182.95455"
-        y="-324.664375"
+        y="-324.981875"
         z="9.80500000000006"/>
         <rotationref ref="rPlus180AboutXPlus180AboutY"/>
       </physvol>
@@ -67311,7 +67382,7 @@ z="9.80500000000006"/>
         <volumeref ref="volTPCInner"/>
         <position name="posTPC-9" unit="cm"
         x="182.95455"
-        y="-324.664375"
+        y="-324.981875"
         z="9.80500000000006"/>
         <rotationref ref="rPlus180AboutX"/>
       </physvol>
@@ -67319,16 +67390,16 @@ z="9.80500000000006"/>
       <physvol>
         <volumeref ref="volCathode"/>
         <position name="posCathode-5-0" unit="cm"
-      x="-363.38405"
-      y="-324.664375"
+      x="-363.52605"
+      y="-324.981875"
       z="9.80500000000006"/>
         <rotationref ref="rIdentity"/>
       </physvol>
       <physvol>
         <volumeref ref="volCathode"/>
         <position name="posCathode-5-1" unit="cm"
-      x="363.38405"
-      y="-324.664375"
+      x="363.52605"
+      y="-324.981875"
       z="9.80500000000006"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -67337,23 +67408,23 @@ z="9.80500000000006"/>
         <volumeref ref="volAPAFrameYSide"/>
         <position name="posAPAFrameYSideNeg-5" unit="cm"
       x="0"
-      y="283.87875"
-      z="-100.11625"/>
+      y="284.51375"
+      z="-99.7987499999999"/>
         <rotationref ref="rIdentity"/>
       </physvol>
       <physvol>
         <volumeref ref="volAPAFrameYSide"/>
         <position name="posAPAFrameYSidePos-5" unit="cm"
       x="0"
-      y="283.87875"
-      z="119.72625"/>
+      y="284.51375"
+      z="119.40875"/>
         <rotationref ref="rIdentity"/>
       </physvol>
       <physvol>
         <volumeref ref="volAPAFrameZSide"/>
         <position name="posAPAFrameZSidePos-5" unit="cm"
       x="0"
-      y="581.79875"
+      y="582.43375"
       z="9.80500000000006"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -67361,7 +67432,7 @@ z="9.80500000000006"/>
         <volumeref ref="volAPAFrameZSide"/>
         <position name="posAPAFrameZSideNeg-5" unit="cm"
       x="0"
-      y="-14.0412500000001"
+      y="-13.40625"
       z="9.80500000000006"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -67372,22 +67443,33 @@ z="9.80500000000006"/>
       - There are two boards on each the up and downstream end,
           one each to wrap the U and V views around the APA frame
       - There are 4 on the bottom which anchor the U V and Z wires and the grid plane
-      - The rest of the parts of the G10 boards must be placed directly in volTPC   -->
+      FIXME: This is not true -> - The rest of the parts of the G10 boards must be placed directly in volTPC   -->
+
+      <!-- Position readout boards -->
+      <physvol>
+        <volumeref ref="volG10HeadBoards"/>
+        <position name="posG10HeadBoards-5" unit="cm"
+	  x="0"
+	  y="598.01775"
+      	  z="9.80500000000006"/>
+        <rotationref ref="rIdentity"/>
+      </physvol>
 
       <physvol>
         <volumeref ref="volG10BoardYSideCenterSeg"/>
         <position name="posG10BoardYSideCenterSeg-Vup-5" unit="cm"
-      x="0"
-      y="283.87875"
-      z="-105.355"/>
-        <rotationref ref="rIdentity"/>
+         x="0"
+         y="284.51375"
+         z="-105.116875"/>
+         <rotationref ref="rIdentity"/>
       </physvol>
+
       <physvol>
         <volumeref ref="volG10BoardYSideCenterSeg"/>
         <position name="posG10BoardYSideCenterSeg-Uup-5" unit="cm"
       x="0"
-      y="283.87875"
-      z="-105.6725"/>
+      y="284.51375"
+      z="-105.593125"/>
         <rotationref ref="rIdentity"/>
       </physvol>
 
@@ -67395,16 +67477,16 @@ z="9.80500000000006"/>
         <volumeref ref="volG10BoardYSideCenterSeg"/>
         <position name="posG10BoardYSideCenterSeg-Vdown-5" unit="cm"
       x="0"
-      y="283.87875"
-      z="124.965"/>
+      y="284.51375"
+      z="124.726875"/>
         <rotationref ref="rIdentity"/>
       </physvol>
       <physvol>
         <volumeref ref="volG10BoardYSideCenterSeg"/>
         <position name="posG10BoardYSideCenterSeg-Udown-5" unit="cm"
       x="0"
-      y="283.87875"
-      z="125.2825"/>
+      y="284.51375"
+      z="125.203125"/>
         <rotationref ref="rIdentity"/>
       </physvol>
 
@@ -67412,7 +67494,7 @@ z="9.80500000000006"/>
         <volumeref ref="volG10BoardZSideCenterSeg"/>
         <position name="posG10BoardZSideCenterSeg-Z-5" unit="cm"
       x="0"
-      y="-19.2800000000001"
+      y="-18.7243750000001"
       z="9.80500000000006"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -67420,7 +67502,7 @@ z="9.80500000000006"/>
         <volumeref ref="volG10BoardZSideCenterSeg"/>
         <position name="posG10BoardZSideCenterSeg-V-5" unit="cm"
       x="0"
-      y="-19.5975000000001"
+      y="-19.2006250000001"
       z="9.80500000000006"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -67428,7 +67510,7 @@ z="9.80500000000006"/>
         <volumeref ref="volG10BoardZSideCenterSeg"/>
         <position name="posG10BoardZSideCenterSeg-U-5" unit="cm"
       x="0"
-      y="-19.9150000000001"
+      y="-19.6768750000001"
       z="9.80500000000006"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -67436,7 +67518,7 @@ z="9.80500000000006"/>
         <volumeref ref="volG10BoardZSideCenterSeg"/>
         <position name="posG10BoardZSideCenterSeg-Grid-5" unit="cm"
       x="0"
-      y="-20.2325000000001"
+      y="-20.153125"
       z="9.80500000000006"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -67445,7 +67527,7 @@ z="9.80500000000006"/>
 <volumeref ref="volArapuca_5-0"/>
 <position name="posArapuca5-0-TPC-12-1-2" unit="cm"
 x="0"
-y="10.385197368421"
+y="10.4186184210526"
 z="9.80500000000006"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -67453,7 +67535,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_5-0-0"/>
        <position name="posOpArapuca5-0-0-TPC-12-1-2" unit="cm"
          x="0.0500000000000002"
-       y="10.385197368421"
+       y="10.4186184210526"
          z="-70.3949999999999"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -67461,7 +67543,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_5-0-1"/>
        <position name="posOpArapuca5-0-1-TPC-12-1-2" unit="cm"
          x="0.0500000000000002"
-       y="10.385197368421"
+       y="10.4186184210526"
          z="-21.5949999999999"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -67469,7 +67551,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_5-0-2"/>
        <position name="posOpArapuca5-0-2-TPC-12-1-2" unit="cm"
          x="0.0500000000000002"
-       y="10.385197368421"
+       y="10.4186184210526"
          z="41.2050000000001"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -67477,7 +67559,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_5-0-3"/>
        <position name="posOpArapuca5-0-3-TPC-12-1-2" unit="cm"
          x="0.0500000000000002"
-       y="10.385197368421"
+       y="10.4186184210526"
          z="90.0050000000001"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -67485,7 +67567,7 @@ z="9.80500000000006"/>
 <volumeref ref="volArapuca_5-1"/>
 <position name="posArapuca5-1-TPC-12-1-2" unit="cm"
 x="0"
-y="72.6555921052631"
+y="72.7558552631579"
 z="9.80500000000006"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -67493,7 +67575,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_5-1-0"/>
        <position name="posOpArapuca5-1-0-TPC-12-1-2" unit="cm"
          x="0.0500000000000002"
-       y="72.6555921052631"
+       y="72.7558552631579"
          z="-70.3949999999999"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -67501,7 +67583,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_5-1-1"/>
        <position name="posOpArapuca5-1-1-TPC-12-1-2" unit="cm"
          x="0.0500000000000002"
-       y="72.6555921052631"
+       y="72.7558552631579"
          z="-21.5949999999999"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -67509,7 +67591,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_5-1-2"/>
        <position name="posOpArapuca5-1-2-TPC-12-1-2" unit="cm"
          x="0.0500000000000002"
-       y="72.6555921052631"
+       y="72.7558552631579"
          z="41.2050000000001"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -67517,7 +67599,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_5-1-3"/>
        <position name="posOpArapuca5-1-3-TPC-12-1-2" unit="cm"
          x="0.0500000000000002"
-       y="72.6555921052631"
+       y="72.7558552631579"
          z="90.0050000000001"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -67525,7 +67607,7 @@ z="9.80500000000006"/>
 <volumeref ref="volArapuca_5-2"/>
 <position name="posArapuca5-2-TPC-12-1-2" unit="cm"
 x="0"
-y="134.925986842105"
+y="135.093092105263"
 z="9.80500000000006"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -67533,7 +67615,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_5-2-0"/>
        <position name="posOpArapuca5-2-0-TPC-12-1-2" unit="cm"
          x="0.0500000000000002"
-       y="134.925986842105"
+       y="135.093092105263"
          z="-70.3949999999999"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -67541,7 +67623,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_5-2-1"/>
        <position name="posOpArapuca5-2-1-TPC-12-1-2" unit="cm"
          x="0.0500000000000002"
-       y="134.925986842105"
+       y="135.093092105263"
          z="-21.5949999999999"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -67549,7 +67631,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_5-2-2"/>
        <position name="posOpArapuca5-2-2-TPC-12-1-2" unit="cm"
          x="0.0500000000000002"
-       y="134.925986842105"
+       y="135.093092105263"
          z="41.2050000000001"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -67557,7 +67639,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_5-2-3"/>
        <position name="posOpArapuca5-2-3-TPC-12-1-2" unit="cm"
          x="0.0500000000000002"
-       y="134.925986842105"
+       y="135.093092105263"
          z="90.0050000000001"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -67565,7 +67647,7 @@ z="9.80500000000006"/>
 <volumeref ref="volArapuca_5-3"/>
 <position name="posArapuca5-3-TPC-12-1-2" unit="cm"
 x="0"
-y="197.196381578947"
+y="197.430328947368"
 z="9.80500000000006"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -67573,7 +67655,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_5-3-0"/>
        <position name="posOpArapuca5-3-0-TPC-12-1-2" unit="cm"
          x="0.0500000000000002"
-       y="197.196381578947"
+       y="197.430328947368"
          z="-70.3949999999999"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -67581,7 +67663,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_5-3-1"/>
        <position name="posOpArapuca5-3-1-TPC-12-1-2" unit="cm"
          x="0.0500000000000002"
-       y="197.196381578947"
+       y="197.430328947368"
          z="-21.5949999999999"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -67589,7 +67671,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_5-3-2"/>
        <position name="posOpArapuca5-3-2-TPC-12-1-2" unit="cm"
          x="0.0500000000000002"
-       y="197.196381578947"
+       y="197.430328947368"
          z="41.2050000000001"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -67597,7 +67679,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_5-3-3"/>
        <position name="posOpArapuca5-3-3-TPC-12-1-2" unit="cm"
          x="0.0500000000000002"
-       y="197.196381578947"
+       y="197.430328947368"
          z="90.0050000000001"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -67605,7 +67687,7 @@ z="9.80500000000006"/>
 <volumeref ref="volArapuca_5-4"/>
 <position name="posArapuca5-4-TPC-12-1-2" unit="cm"
 x="0"
-y="259.46677631579"
+y="259.767565789474"
 z="9.80500000000006"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -67613,7 +67695,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_5-4-0"/>
        <position name="posOpArapuca5-4-0-TPC-12-1-2" unit="cm"
          x="0.0500000000000002"
-       y="259.46677631579"
+       y="259.767565789474"
          z="-70.3949999999999"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -67621,7 +67703,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_5-4-1"/>
        <position name="posOpArapuca5-4-1-TPC-12-1-2" unit="cm"
          x="0.0500000000000002"
-       y="259.46677631579"
+       y="259.767565789474"
          z="-21.5949999999999"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -67629,7 +67711,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_5-4-2"/>
        <position name="posOpArapuca5-4-2-TPC-12-1-2" unit="cm"
          x="0.0500000000000002"
-       y="259.46677631579"
+       y="259.767565789474"
          z="41.2050000000001"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -67637,7 +67719,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_5-4-3"/>
        <position name="posOpArapuca5-4-3-TPC-12-1-2" unit="cm"
          x="0.0500000000000002"
-       y="259.46677631579"
+       y="259.767565789474"
          z="90.0050000000001"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -67645,7 +67727,7 @@ z="9.80500000000006"/>
 <volumeref ref="volArapuca_5-5"/>
 <position name="posArapuca5-5-TPC-12-1-2" unit="cm"
 x="0"
-y="321.737171052632"
+y="322.104802631579"
 z="9.80500000000006"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -67653,7 +67735,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_5-5-0"/>
        <position name="posOpArapuca5-5-0-TPC-12-1-2" unit="cm"
          x="0.0500000000000002"
-       y="321.737171052632"
+       y="322.104802631579"
          z="-70.3949999999999"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -67661,7 +67743,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_5-5-1"/>
        <position name="posOpArapuca5-5-1-TPC-12-1-2" unit="cm"
          x="0.0500000000000002"
-       y="321.737171052632"
+       y="322.104802631579"
          z="-21.5949999999999"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -67669,7 +67751,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_5-5-2"/>
        <position name="posOpArapuca5-5-2-TPC-12-1-2" unit="cm"
          x="0.0500000000000002"
-       y="321.737171052632"
+       y="322.104802631579"
          z="41.2050000000001"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -67677,7 +67759,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_5-5-3"/>
        <position name="posOpArapuca5-5-3-TPC-12-1-2" unit="cm"
          x="0.0500000000000002"
-       y="321.737171052632"
+       y="322.104802631579"
          z="90.0050000000001"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -67685,7 +67767,7 @@ z="9.80500000000006"/>
 <volumeref ref="volArapuca_5-6"/>
 <position name="posArapuca5-6-TPC-12-1-2" unit="cm"
 x="0"
-y="384.007565789474"
+y="384.442039473684"
 z="9.80500000000006"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -67693,7 +67775,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_5-6-0"/>
        <position name="posOpArapuca5-6-0-TPC-12-1-2" unit="cm"
          x="0.0500000000000002"
-       y="384.007565789474"
+       y="384.442039473684"
          z="-70.3949999999999"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -67701,7 +67783,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_5-6-1"/>
        <position name="posOpArapuca5-6-1-TPC-12-1-2" unit="cm"
          x="0.0500000000000002"
-       y="384.007565789474"
+       y="384.442039473684"
          z="-21.5949999999999"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -67709,7 +67791,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_5-6-2"/>
        <position name="posOpArapuca5-6-2-TPC-12-1-2" unit="cm"
          x="0.0500000000000002"
-       y="384.007565789474"
+       y="384.442039473684"
          z="41.2050000000001"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -67717,7 +67799,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_5-6-3"/>
        <position name="posOpArapuca5-6-3-TPC-12-1-2" unit="cm"
          x="0.0500000000000002"
-       y="384.007565789474"
+       y="384.442039473684"
          z="90.0050000000001"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -67725,7 +67807,7 @@ z="9.80500000000006"/>
 <volumeref ref="volArapuca_5-7"/>
 <position name="posArapuca5-7-TPC-12-1-2" unit="cm"
 x="0"
-y="446.277960526316"
+y="446.77927631579"
 z="9.80500000000006"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -67733,7 +67815,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_5-7-0"/>
        <position name="posOpArapuca5-7-0-TPC-12-1-2" unit="cm"
          x="0.0500000000000002"
-       y="446.277960526316"
+       y="446.77927631579"
          z="-70.3949999999999"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -67741,7 +67823,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_5-7-1"/>
        <position name="posOpArapuca5-7-1-TPC-12-1-2" unit="cm"
          x="0.0500000000000002"
-       y="446.277960526316"
+       y="446.77927631579"
          z="-21.5949999999999"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -67749,7 +67831,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_5-7-2"/>
        <position name="posOpArapuca5-7-2-TPC-12-1-2" unit="cm"
          x="0.0500000000000002"
-       y="446.277960526316"
+       y="446.77927631579"
          z="41.2050000000001"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -67757,7 +67839,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_5-7-3"/>
        <position name="posOpArapuca5-7-3-TPC-12-1-2" unit="cm"
          x="0.0500000000000002"
-       y="446.277960526316"
+       y="446.77927631579"
          z="90.0050000000001"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -67765,7 +67847,7 @@ z="9.80500000000006"/>
 <volumeref ref="volArapuca_5-8"/>
 <position name="posArapuca5-8-TPC-12-1-2" unit="cm"
 x="0"
-y="508.548355263158"
+y="509.116513157895"
 z="9.80500000000006"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -67773,7 +67855,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_5-8-0"/>
        <position name="posOpArapuca5-8-0-TPC-12-1-2" unit="cm"
          x="0.0500000000000002"
-       y="508.548355263158"
+       y="509.116513157895"
          z="-70.3949999999999"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -67781,7 +67863,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_5-8-1"/>
        <position name="posOpArapuca5-8-1-TPC-12-1-2" unit="cm"
          x="0.0500000000000002"
-       y="508.548355263158"
+       y="509.116513157895"
          z="-21.5949999999999"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -67789,7 +67871,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_5-8-2"/>
        <position name="posOpArapuca5-8-2-TPC-12-1-2" unit="cm"
          x="0.0500000000000002"
-       y="508.548355263158"
+       y="509.116513157895"
          z="41.2050000000001"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -67797,7 +67879,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_5-8-3"/>
        <position name="posOpArapuca5-8-3-TPC-12-1-2" unit="cm"
          x="0.0500000000000002"
-       y="508.548355263158"
+       y="509.116513157895"
          z="90.0050000000001"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -67805,7 +67887,7 @@ z="9.80500000000006"/>
 <volumeref ref="volArapuca_5-9"/>
 <position name="posArapuca5-9-TPC-12-1-2" unit="cm"
 x="0"
-y="570.81875"
+y="571.45375"
 z="9.80500000000006"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -67813,7 +67895,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_5-9-0"/>
        <position name="posOpArapuca5-9-0-TPC-12-1-2" unit="cm"
          x="0.0500000000000002"
-       y="570.81875"
+       y="571.45375"
          z="-70.3949999999999"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -67821,7 +67903,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_5-9-1"/>
        <position name="posOpArapuca5-9-1-TPC-12-1-2" unit="cm"
          x="0.0500000000000002"
-       y="570.81875"
+       y="571.45375"
          z="-21.5949999999999"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -67829,7 +67911,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_5-9-2"/>
        <position name="posOpArapuca5-9-2-TPC-12-1-2" unit="cm"
          x="0.0500000000000002"
-       y="570.81875"
+       y="571.45375"
          z="41.2050000000001"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -67837,7 +67919,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_5-9-3"/>
        <position name="posOpArapuca5-9-3-TPC-12-1-2" unit="cm"
          x="0.0500000000000002"
-       y="570.81875"
+       y="571.45375"
          z="90.0050000000001"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -67846,7 +67928,7 @@ z="9.80500000000006"/>
         <volumeref ref="volTPCInner"/>
         <position name="posTPC-10" unit="cm"
         x="-182.95455"
-        y="283.164375"
+        y="283.481875"
         z="9.80500000000006"/>
         <rotationref ref="rPlus180AboutY"/>
       </physvol>
@@ -67854,7 +67936,7 @@ z="9.80500000000006"/>
         <volumeref ref="volTPCInner"/>
         <position name="posTPC-11" unit="cm"
         x="182.95455"
-        y="283.164375"
+        y="283.481875"
         z="9.80500000000006"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -67862,16 +67944,16 @@ z="9.80500000000006"/>
       <physvol>
         <volumeref ref="volCathode"/>
         <position name="posCathode-6-0" unit="cm"
-      x="-363.38405"
-      y="283.164375"
+      x="-363.52605"
+      y="283.481875"
       z="9.80500000000006"/>
         <rotationref ref="rIdentity"/>
       </physvol>
       <physvol>
         <volumeref ref="volCathode"/>
         <position name="posCathode-6-1" unit="cm"
-      x="363.38405"
-      y="283.164375"
+      x="363.52605"
+      y="283.481875"
       z="9.80500000000006"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -67880,23 +67962,23 @@ z="9.80500000000006"/>
         <volumeref ref="volAPAFrameYSide"/>
         <position name="posAPAFrameYSideNeg-6" unit="cm"
       x="0"
-      y="-325.37875"
-      z="132.27375"/>
+      y="-326.01375"
+      z="132.59125"/>
         <rotationref ref="rIdentity"/>
       </physvol>
       <physvol>
         <volumeref ref="volAPAFrameYSide"/>
         <position name="posAPAFrameYSidePos-6" unit="cm"
       x="0"
-      y="-325.37875"
-      z="352.11625"/>
+      y="-326.01375"
+      z="351.79875"/>
         <rotationref ref="rIdentity"/>
       </physvol>
       <physvol>
         <volumeref ref="volAPAFrameZSide"/>
         <position name="posAPAFrameZSidePos-6" unit="cm"
       x="0"
-      y="-27.45875"
+      y="-28.0937500000001"
       z="242.195"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -67904,7 +67986,7 @@ z="9.80500000000006"/>
         <volumeref ref="volAPAFrameZSide"/>
         <position name="posAPAFrameZSideNeg-6" unit="cm"
       x="0"
-      y="-623.29875"
+      y="-623.93375"
       z="242.195"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -67915,22 +67997,33 @@ z="9.80500000000006"/>
       - There are two boards on each the up and downstream end,
           one each to wrap the U and V views around the APA frame
       - There are 4 on the bottom which anchor the U V and Z wires and the grid plane
-      - The rest of the parts of the G10 boards must be placed directly in volTPC   -->
+      FIXME: This is not true -> - The rest of the parts of the G10 boards must be placed directly in volTPC   -->
+
+      <!-- Position readout boards -->
+      <physvol>
+        <volumeref ref="volG10HeadBoards"/>
+        <position name="posG10HeadBoards-6" unit="cm"
+	  x="0"
+	  y="-639.51775"
+      	  z="242.195"/>
+        <rotationref ref="rIdentity"/>
+      </physvol>
 
       <physvol>
         <volumeref ref="volG10BoardYSideCenterSeg"/>
         <position name="posG10BoardYSideCenterSeg-Vup-6" unit="cm"
-      x="0"
-      y="-325.37875"
-      z="127.035"/>
-        <rotationref ref="rIdentity"/>
+         x="0"
+         y="-326.01375"
+         z="127.273125"/>
+         <rotationref ref="rIdentity"/>
       </physvol>
+
       <physvol>
         <volumeref ref="volG10BoardYSideCenterSeg"/>
         <position name="posG10BoardYSideCenterSeg-Uup-6" unit="cm"
       x="0"
-      y="-325.37875"
-      z="126.7175"/>
+      y="-326.01375"
+      z="126.796875"/>
         <rotationref ref="rIdentity"/>
       </physvol>
 
@@ -67938,16 +68031,16 @@ z="9.80500000000006"/>
         <volumeref ref="volG10BoardYSideCenterSeg"/>
         <position name="posG10BoardYSideCenterSeg-Vdown-6" unit="cm"
       x="0"
-      y="-325.37875"
-      z="357.355"/>
+      y="-326.01375"
+      z="357.116875"/>
         <rotationref ref="rIdentity"/>
       </physvol>
       <physvol>
         <volumeref ref="volG10BoardYSideCenterSeg"/>
         <position name="posG10BoardYSideCenterSeg-Udown-6" unit="cm"
       x="0"
-      y="-325.37875"
-      z="357.6725"/>
+      y="-326.01375"
+      z="357.593125"/>
         <rotationref ref="rIdentity"/>
       </physvol>
 
@@ -67955,7 +68048,7 @@ z="9.80500000000006"/>
         <volumeref ref="volG10BoardZSideCenterSeg"/>
         <position name="posG10BoardZSideCenterSeg-Z-6" unit="cm"
       x="0"
-      y="-22.22"
+      y="-22.775625"
       z="242.195"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -67963,7 +68056,7 @@ z="9.80500000000006"/>
         <volumeref ref="volG10BoardZSideCenterSeg"/>
         <position name="posG10BoardZSideCenterSeg-V-6" unit="cm"
       x="0"
-      y="-21.9025"
+      y="-22.2993750000001"
       z="242.195"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -67971,7 +68064,7 @@ z="9.80500000000006"/>
         <volumeref ref="volG10BoardZSideCenterSeg"/>
         <position name="posG10BoardZSideCenterSeg-U-6" unit="cm"
       x="0"
-      y="-21.585"
+      y="-21.8231250000001"
       z="242.195"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -67979,7 +68072,7 @@ z="9.80500000000006"/>
         <volumeref ref="volG10BoardZSideCenterSeg"/>
         <position name="posG10BoardZSideCenterSeg-Grid-6" unit="cm"
       x="0"
-      y="-21.2675"
+      y="-21.3468750000001"
       z="242.195"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -67988,7 +68081,7 @@ z="9.80500000000006"/>
 <volumeref ref="volArapuca_6-0"/>
 <position name="posArapuca6-0-TPC-12-0-3" unit="cm"
 x="0"
-y="-612.31875"
+y="-612.95375"
 z="242.195"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -67996,7 +68089,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_6-0-0"/>
        <position name="posOpArapuca6-0-0-TPC-12-0-3" unit="cm"
          x="-0.0500000000000002"
-       y="-612.31875"
+       y="-612.95375"
          z="161.995"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -68004,7 +68097,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_6-0-1"/>
        <position name="posOpArapuca6-0-1-TPC-12-0-3" unit="cm"
          x="-0.0500000000000002"
-       y="-612.31875"
+       y="-612.95375"
          z="210.795"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -68012,7 +68105,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_6-0-2"/>
        <position name="posOpArapuca6-0-2-TPC-12-0-3" unit="cm"
          x="-0.0500000000000002"
-       y="-612.31875"
+       y="-612.95375"
          z="273.595"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -68020,7 +68113,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_6-0-3"/>
        <position name="posOpArapuca6-0-3-TPC-12-0-3" unit="cm"
          x="-0.0500000000000002"
-       y="-612.31875"
+       y="-612.95375"
          z="322.395"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -68028,7 +68121,7 @@ z="242.195"/>
 <volumeref ref="volArapuca_6-1"/>
 <position name="posArapuca6-1-TPC-12-0-3" unit="cm"
 x="0"
-y="-550.048355263158"
+y="-550.616513157895"
 z="242.195"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -68036,7 +68129,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_6-1-0"/>
        <position name="posOpArapuca6-1-0-TPC-12-0-3" unit="cm"
          x="-0.0500000000000002"
-       y="-550.048355263158"
+       y="-550.616513157895"
          z="161.995"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -68044,7 +68137,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_6-1-1"/>
        <position name="posOpArapuca6-1-1-TPC-12-0-3" unit="cm"
          x="-0.0500000000000002"
-       y="-550.048355263158"
+       y="-550.616513157895"
          z="210.795"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -68052,7 +68145,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_6-1-2"/>
        <position name="posOpArapuca6-1-2-TPC-12-0-3" unit="cm"
          x="-0.0500000000000002"
-       y="-550.048355263158"
+       y="-550.616513157895"
          z="273.595"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -68060,7 +68153,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_6-1-3"/>
        <position name="posOpArapuca6-1-3-TPC-12-0-3" unit="cm"
          x="-0.0500000000000002"
-       y="-550.048355263158"
+       y="-550.616513157895"
          z="322.395"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -68068,7 +68161,7 @@ z="242.195"/>
 <volumeref ref="volArapuca_6-2"/>
 <position name="posArapuca6-2-TPC-12-0-3" unit="cm"
 x="0"
-y="-487.777960526316"
+y="-488.27927631579"
 z="242.195"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -68076,7 +68169,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_6-2-0"/>
        <position name="posOpArapuca6-2-0-TPC-12-0-3" unit="cm"
          x="-0.0500000000000002"
-       y="-487.777960526316"
+       y="-488.27927631579"
          z="161.995"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -68084,7 +68177,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_6-2-1"/>
        <position name="posOpArapuca6-2-1-TPC-12-0-3" unit="cm"
          x="-0.0500000000000002"
-       y="-487.777960526316"
+       y="-488.27927631579"
          z="210.795"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -68092,7 +68185,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_6-2-2"/>
        <position name="posOpArapuca6-2-2-TPC-12-0-3" unit="cm"
          x="-0.0500000000000002"
-       y="-487.777960526316"
+       y="-488.27927631579"
          z="273.595"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -68100,7 +68193,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_6-2-3"/>
        <position name="posOpArapuca6-2-3-TPC-12-0-3" unit="cm"
          x="-0.0500000000000002"
-       y="-487.777960526316"
+       y="-488.27927631579"
          z="322.395"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -68108,7 +68201,7 @@ z="242.195"/>
 <volumeref ref="volArapuca_6-3"/>
 <position name="posArapuca6-3-TPC-12-0-3" unit="cm"
 x="0"
-y="-425.507565789474"
+y="-425.942039473684"
 z="242.195"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -68116,7 +68209,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_6-3-0"/>
        <position name="posOpArapuca6-3-0-TPC-12-0-3" unit="cm"
          x="-0.0500000000000002"
-       y="-425.507565789474"
+       y="-425.942039473684"
          z="161.995"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -68124,7 +68217,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_6-3-1"/>
        <position name="posOpArapuca6-3-1-TPC-12-0-3" unit="cm"
          x="-0.0500000000000002"
-       y="-425.507565789474"
+       y="-425.942039473684"
          z="210.795"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -68132,7 +68225,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_6-3-2"/>
        <position name="posOpArapuca6-3-2-TPC-12-0-3" unit="cm"
          x="-0.0500000000000002"
-       y="-425.507565789474"
+       y="-425.942039473684"
          z="273.595"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -68140,7 +68233,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_6-3-3"/>
        <position name="posOpArapuca6-3-3-TPC-12-0-3" unit="cm"
          x="-0.0500000000000002"
-       y="-425.507565789474"
+       y="-425.942039473684"
          z="322.395"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -68148,7 +68241,7 @@ z="242.195"/>
 <volumeref ref="volArapuca_6-4"/>
 <position name="posArapuca6-4-TPC-12-0-3" unit="cm"
 x="0"
-y="-363.237171052632"
+y="-363.604802631579"
 z="242.195"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -68156,7 +68249,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_6-4-0"/>
        <position name="posOpArapuca6-4-0-TPC-12-0-3" unit="cm"
          x="-0.0500000000000002"
-       y="-363.237171052632"
+       y="-363.604802631579"
          z="161.995"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -68164,7 +68257,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_6-4-1"/>
        <position name="posOpArapuca6-4-1-TPC-12-0-3" unit="cm"
          x="-0.0500000000000002"
-       y="-363.237171052632"
+       y="-363.604802631579"
          z="210.795"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -68172,7 +68265,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_6-4-2"/>
        <position name="posOpArapuca6-4-2-TPC-12-0-3" unit="cm"
          x="-0.0500000000000002"
-       y="-363.237171052632"
+       y="-363.604802631579"
          z="273.595"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -68180,7 +68273,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_6-4-3"/>
        <position name="posOpArapuca6-4-3-TPC-12-0-3" unit="cm"
          x="-0.0500000000000002"
-       y="-363.237171052632"
+       y="-363.604802631579"
          z="322.395"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -68188,7 +68281,7 @@ z="242.195"/>
 <volumeref ref="volArapuca_6-5"/>
 <position name="posArapuca6-5-TPC-12-0-3" unit="cm"
 x="0"
-y="-300.96677631579"
+y="-301.267565789474"
 z="242.195"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -68196,7 +68289,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_6-5-0"/>
        <position name="posOpArapuca6-5-0-TPC-12-0-3" unit="cm"
          x="-0.0500000000000002"
-       y="-300.96677631579"
+       y="-301.267565789474"
          z="161.995"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -68204,7 +68297,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_6-5-1"/>
        <position name="posOpArapuca6-5-1-TPC-12-0-3" unit="cm"
          x="-0.0500000000000002"
-       y="-300.96677631579"
+       y="-301.267565789474"
          z="210.795"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -68212,7 +68305,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_6-5-2"/>
        <position name="posOpArapuca6-5-2-TPC-12-0-3" unit="cm"
          x="-0.0500000000000002"
-       y="-300.96677631579"
+       y="-301.267565789474"
          z="273.595"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -68220,7 +68313,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_6-5-3"/>
        <position name="posOpArapuca6-5-3-TPC-12-0-3" unit="cm"
          x="-0.0500000000000002"
-       y="-300.96677631579"
+       y="-301.267565789474"
          z="322.395"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -68228,7 +68321,7 @@ z="242.195"/>
 <volumeref ref="volArapuca_6-6"/>
 <position name="posArapuca6-6-TPC-12-0-3" unit="cm"
 x="0"
-y="-238.696381578947"
+y="-238.930328947368"
 z="242.195"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -68236,7 +68329,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_6-6-0"/>
        <position name="posOpArapuca6-6-0-TPC-12-0-3" unit="cm"
          x="-0.0500000000000002"
-       y="-238.696381578947"
+       y="-238.930328947368"
          z="161.995"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -68244,7 +68337,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_6-6-1"/>
        <position name="posOpArapuca6-6-1-TPC-12-0-3" unit="cm"
          x="-0.0500000000000002"
-       y="-238.696381578947"
+       y="-238.930328947368"
          z="210.795"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -68252,7 +68345,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_6-6-2"/>
        <position name="posOpArapuca6-6-2-TPC-12-0-3" unit="cm"
          x="-0.0500000000000002"
-       y="-238.696381578947"
+       y="-238.930328947368"
          z="273.595"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -68260,7 +68353,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_6-6-3"/>
        <position name="posOpArapuca6-6-3-TPC-12-0-3" unit="cm"
          x="-0.0500000000000002"
-       y="-238.696381578947"
+       y="-238.930328947368"
          z="322.395"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -68268,7 +68361,7 @@ z="242.195"/>
 <volumeref ref="volArapuca_6-7"/>
 <position name="posArapuca6-7-TPC-12-0-3" unit="cm"
 x="0"
-y="-176.425986842105"
+y="-176.593092105263"
 z="242.195"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -68276,7 +68369,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_6-7-0"/>
        <position name="posOpArapuca6-7-0-TPC-12-0-3" unit="cm"
          x="-0.0500000000000002"
-       y="-176.425986842105"
+       y="-176.593092105263"
          z="161.995"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -68284,7 +68377,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_6-7-1"/>
        <position name="posOpArapuca6-7-1-TPC-12-0-3" unit="cm"
          x="-0.0500000000000002"
-       y="-176.425986842105"
+       y="-176.593092105263"
          z="210.795"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -68292,7 +68385,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_6-7-2"/>
        <position name="posOpArapuca6-7-2-TPC-12-0-3" unit="cm"
          x="-0.0500000000000002"
-       y="-176.425986842105"
+       y="-176.593092105263"
          z="273.595"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -68300,7 +68393,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_6-7-3"/>
        <position name="posOpArapuca6-7-3-TPC-12-0-3" unit="cm"
          x="-0.0500000000000002"
-       y="-176.425986842105"
+       y="-176.593092105263"
          z="322.395"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -68308,7 +68401,7 @@ z="242.195"/>
 <volumeref ref="volArapuca_6-8"/>
 <position name="posArapuca6-8-TPC-12-0-3" unit="cm"
 x="0"
-y="-114.155592105263"
+y="-114.255855263158"
 z="242.195"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -68316,7 +68409,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_6-8-0"/>
        <position name="posOpArapuca6-8-0-TPC-12-0-3" unit="cm"
          x="-0.0500000000000002"
-       y="-114.155592105263"
+       y="-114.255855263158"
          z="161.995"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -68324,7 +68417,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_6-8-1"/>
        <position name="posOpArapuca6-8-1-TPC-12-0-3" unit="cm"
          x="-0.0500000000000002"
-       y="-114.155592105263"
+       y="-114.255855263158"
          z="210.795"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -68332,7 +68425,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_6-8-2"/>
        <position name="posOpArapuca6-8-2-TPC-12-0-3" unit="cm"
          x="-0.0500000000000002"
-       y="-114.155592105263"
+       y="-114.255855263158"
          z="273.595"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -68340,7 +68433,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_6-8-3"/>
        <position name="posOpArapuca6-8-3-TPC-12-0-3" unit="cm"
          x="-0.0500000000000002"
-       y="-114.155592105263"
+       y="-114.255855263158"
          z="322.395"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -68348,7 +68441,7 @@ z="242.195"/>
 <volumeref ref="volArapuca_6-9"/>
 <position name="posArapuca6-9-TPC-12-0-3" unit="cm"
 x="0"
-y="-51.885197368421"
+y="-51.9186184210527"
 z="242.195"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -68356,7 +68449,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_6-9-0"/>
        <position name="posOpArapuca6-9-0-TPC-12-0-3" unit="cm"
          x="-0.0500000000000002"
-       y="-51.885197368421"
+       y="-51.9186184210527"
          z="161.995"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -68364,7 +68457,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_6-9-1"/>
        <position name="posOpArapuca6-9-1-TPC-12-0-3" unit="cm"
          x="-0.0500000000000002"
-       y="-51.885197368421"
+       y="-51.9186184210527"
          z="210.795"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -68372,7 +68465,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_6-9-2"/>
        <position name="posOpArapuca6-9-2-TPC-12-0-3" unit="cm"
          x="-0.0500000000000002"
-       y="-51.885197368421"
+       y="-51.9186184210527"
          z="273.595"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -68380,7 +68473,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_6-9-3"/>
        <position name="posOpArapuca6-9-3-TPC-12-0-3" unit="cm"
          x="-0.0500000000000002"
-       y="-51.885197368421"
+       y="-51.9186184210527"
          z="322.395"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -68389,7 +68482,7 @@ z="242.195"/>
         <volumeref ref="volTPCInner"/>
         <position name="posTPC-12" unit="cm"
         x="-182.95455"
-        y="-324.664375"
+        y="-324.981875"
         z="242.195"/>
         <rotationref ref="rPlus180AboutXPlus180AboutY"/>
       </physvol>
@@ -68397,7 +68490,7 @@ z="242.195"/>
         <volumeref ref="volTPCInner"/>
         <position name="posTPC-13" unit="cm"
         x="182.95455"
-        y="-324.664375"
+        y="-324.981875"
         z="242.195"/>
         <rotationref ref="rPlus180AboutX"/>
       </physvol>
@@ -68405,16 +68498,16 @@ z="242.195"/>
       <physvol>
         <volumeref ref="volCathode"/>
         <position name="posCathode-7-0" unit="cm"
-      x="-363.38405"
-      y="-324.664375"
+      x="-363.52605"
+      y="-324.981875"
       z="242.195"/>
         <rotationref ref="rIdentity"/>
       </physvol>
       <physvol>
         <volumeref ref="volCathode"/>
         <position name="posCathode-7-1" unit="cm"
-      x="363.38405"
-      y="-324.664375"
+      x="363.52605"
+      y="-324.981875"
       z="242.195"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -68423,23 +68516,23 @@ z="242.195"/>
         <volumeref ref="volAPAFrameYSide"/>
         <position name="posAPAFrameYSideNeg-7" unit="cm"
       x="0"
-      y="283.87875"
-      z="132.27375"/>
+      y="284.51375"
+      z="132.59125"/>
         <rotationref ref="rIdentity"/>
       </physvol>
       <physvol>
         <volumeref ref="volAPAFrameYSide"/>
         <position name="posAPAFrameYSidePos-7" unit="cm"
       x="0"
-      y="283.87875"
-      z="352.11625"/>
+      y="284.51375"
+      z="351.79875"/>
         <rotationref ref="rIdentity"/>
       </physvol>
       <physvol>
         <volumeref ref="volAPAFrameZSide"/>
         <position name="posAPAFrameZSidePos-7" unit="cm"
       x="0"
-      y="581.79875"
+      y="582.43375"
       z="242.195"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -68447,7 +68540,7 @@ z="242.195"/>
         <volumeref ref="volAPAFrameZSide"/>
         <position name="posAPAFrameZSideNeg-7" unit="cm"
       x="0"
-      y="-14.0412500000001"
+      y="-13.40625"
       z="242.195"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -68458,22 +68551,33 @@ z="242.195"/>
       - There are two boards on each the up and downstream end,
           one each to wrap the U and V views around the APA frame
       - There are 4 on the bottom which anchor the U V and Z wires and the grid plane
-      - The rest of the parts of the G10 boards must be placed directly in volTPC   -->
+      FIXME: This is not true -> - The rest of the parts of the G10 boards must be placed directly in volTPC   -->
+
+      <!-- Position readout boards -->
+      <physvol>
+        <volumeref ref="volG10HeadBoards"/>
+        <position name="posG10HeadBoards-7" unit="cm"
+	  x="0"
+	  y="598.01775"
+      	  z="242.195"/>
+        <rotationref ref="rIdentity"/>
+      </physvol>
 
       <physvol>
         <volumeref ref="volG10BoardYSideCenterSeg"/>
         <position name="posG10BoardYSideCenterSeg-Vup-7" unit="cm"
-      x="0"
-      y="283.87875"
-      z="127.035"/>
-        <rotationref ref="rIdentity"/>
+         x="0"
+         y="284.51375"
+         z="127.273125"/>
+         <rotationref ref="rIdentity"/>
       </physvol>
+
       <physvol>
         <volumeref ref="volG10BoardYSideCenterSeg"/>
         <position name="posG10BoardYSideCenterSeg-Uup-7" unit="cm"
       x="0"
-      y="283.87875"
-      z="126.7175"/>
+      y="284.51375"
+      z="126.796875"/>
         <rotationref ref="rIdentity"/>
       </physvol>
 
@@ -68481,16 +68585,16 @@ z="242.195"/>
         <volumeref ref="volG10BoardYSideCenterSeg"/>
         <position name="posG10BoardYSideCenterSeg-Vdown-7" unit="cm"
       x="0"
-      y="283.87875"
-      z="357.355"/>
+      y="284.51375"
+      z="357.116875"/>
         <rotationref ref="rIdentity"/>
       </physvol>
       <physvol>
         <volumeref ref="volG10BoardYSideCenterSeg"/>
         <position name="posG10BoardYSideCenterSeg-Udown-7" unit="cm"
       x="0"
-      y="283.87875"
-      z="357.6725"/>
+      y="284.51375"
+      z="357.593125"/>
         <rotationref ref="rIdentity"/>
       </physvol>
 
@@ -68498,7 +68602,7 @@ z="242.195"/>
         <volumeref ref="volG10BoardZSideCenterSeg"/>
         <position name="posG10BoardZSideCenterSeg-Z-7" unit="cm"
       x="0"
-      y="-19.2800000000001"
+      y="-18.7243750000001"
       z="242.195"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -68506,7 +68610,7 @@ z="242.195"/>
         <volumeref ref="volG10BoardZSideCenterSeg"/>
         <position name="posG10BoardZSideCenterSeg-V-7" unit="cm"
       x="0"
-      y="-19.5975000000001"
+      y="-19.2006250000001"
       z="242.195"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -68514,7 +68618,7 @@ z="242.195"/>
         <volumeref ref="volG10BoardZSideCenterSeg"/>
         <position name="posG10BoardZSideCenterSeg-U-7" unit="cm"
       x="0"
-      y="-19.9150000000001"
+      y="-19.6768750000001"
       z="242.195"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -68522,7 +68626,7 @@ z="242.195"/>
         <volumeref ref="volG10BoardZSideCenterSeg"/>
         <position name="posG10BoardZSideCenterSeg-Grid-7" unit="cm"
       x="0"
-      y="-20.2325000000001"
+      y="-20.153125"
       z="242.195"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -68531,7 +68635,7 @@ z="242.195"/>
 <volumeref ref="volArapuca_7-0"/>
 <position name="posArapuca7-0-TPC-12-1-3" unit="cm"
 x="0"
-y="10.385197368421"
+y="10.4186184210526"
 z="242.195"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -68539,7 +68643,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_7-0-0"/>
        <position name="posOpArapuca7-0-0-TPC-12-1-3" unit="cm"
          x="0.0500000000000002"
-       y="10.385197368421"
+       y="10.4186184210526"
          z="161.995"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -68547,7 +68651,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_7-0-1"/>
        <position name="posOpArapuca7-0-1-TPC-12-1-3" unit="cm"
          x="0.0500000000000002"
-       y="10.385197368421"
+       y="10.4186184210526"
          z="210.795"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -68555,7 +68659,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_7-0-2"/>
        <position name="posOpArapuca7-0-2-TPC-12-1-3" unit="cm"
          x="0.0500000000000002"
-       y="10.385197368421"
+       y="10.4186184210526"
          z="273.595"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -68563,7 +68667,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_7-0-3"/>
        <position name="posOpArapuca7-0-3-TPC-12-1-3" unit="cm"
          x="0.0500000000000002"
-       y="10.385197368421"
+       y="10.4186184210526"
          z="322.395"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -68571,7 +68675,7 @@ z="242.195"/>
 <volumeref ref="volArapuca_7-1"/>
 <position name="posArapuca7-1-TPC-12-1-3" unit="cm"
 x="0"
-y="72.6555921052631"
+y="72.7558552631579"
 z="242.195"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -68579,7 +68683,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_7-1-0"/>
        <position name="posOpArapuca7-1-0-TPC-12-1-3" unit="cm"
          x="0.0500000000000002"
-       y="72.6555921052631"
+       y="72.7558552631579"
          z="161.995"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -68587,7 +68691,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_7-1-1"/>
        <position name="posOpArapuca7-1-1-TPC-12-1-3" unit="cm"
          x="0.0500000000000002"
-       y="72.6555921052631"
+       y="72.7558552631579"
          z="210.795"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -68595,7 +68699,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_7-1-2"/>
        <position name="posOpArapuca7-1-2-TPC-12-1-3" unit="cm"
          x="0.0500000000000002"
-       y="72.6555921052631"
+       y="72.7558552631579"
          z="273.595"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -68603,7 +68707,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_7-1-3"/>
        <position name="posOpArapuca7-1-3-TPC-12-1-3" unit="cm"
          x="0.0500000000000002"
-       y="72.6555921052631"
+       y="72.7558552631579"
          z="322.395"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -68611,7 +68715,7 @@ z="242.195"/>
 <volumeref ref="volArapuca_7-2"/>
 <position name="posArapuca7-2-TPC-12-1-3" unit="cm"
 x="0"
-y="134.925986842105"
+y="135.093092105263"
 z="242.195"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -68619,7 +68723,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_7-2-0"/>
        <position name="posOpArapuca7-2-0-TPC-12-1-3" unit="cm"
          x="0.0500000000000002"
-       y="134.925986842105"
+       y="135.093092105263"
          z="161.995"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -68627,7 +68731,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_7-2-1"/>
        <position name="posOpArapuca7-2-1-TPC-12-1-3" unit="cm"
          x="0.0500000000000002"
-       y="134.925986842105"
+       y="135.093092105263"
          z="210.795"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -68635,7 +68739,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_7-2-2"/>
        <position name="posOpArapuca7-2-2-TPC-12-1-3" unit="cm"
          x="0.0500000000000002"
-       y="134.925986842105"
+       y="135.093092105263"
          z="273.595"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -68643,7 +68747,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_7-2-3"/>
        <position name="posOpArapuca7-2-3-TPC-12-1-3" unit="cm"
          x="0.0500000000000002"
-       y="134.925986842105"
+       y="135.093092105263"
          z="322.395"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -68651,7 +68755,7 @@ z="242.195"/>
 <volumeref ref="volArapuca_7-3"/>
 <position name="posArapuca7-3-TPC-12-1-3" unit="cm"
 x="0"
-y="197.196381578947"
+y="197.430328947368"
 z="242.195"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -68659,7 +68763,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_7-3-0"/>
        <position name="posOpArapuca7-3-0-TPC-12-1-3" unit="cm"
          x="0.0500000000000002"
-       y="197.196381578947"
+       y="197.430328947368"
          z="161.995"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -68667,7 +68771,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_7-3-1"/>
        <position name="posOpArapuca7-3-1-TPC-12-1-3" unit="cm"
          x="0.0500000000000002"
-       y="197.196381578947"
+       y="197.430328947368"
          z="210.795"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -68675,7 +68779,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_7-3-2"/>
        <position name="posOpArapuca7-3-2-TPC-12-1-3" unit="cm"
          x="0.0500000000000002"
-       y="197.196381578947"
+       y="197.430328947368"
          z="273.595"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -68683,7 +68787,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_7-3-3"/>
        <position name="posOpArapuca7-3-3-TPC-12-1-3" unit="cm"
          x="0.0500000000000002"
-       y="197.196381578947"
+       y="197.430328947368"
          z="322.395"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -68691,7 +68795,7 @@ z="242.195"/>
 <volumeref ref="volArapuca_7-4"/>
 <position name="posArapuca7-4-TPC-12-1-3" unit="cm"
 x="0"
-y="259.46677631579"
+y="259.767565789474"
 z="242.195"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -68699,7 +68803,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_7-4-0"/>
        <position name="posOpArapuca7-4-0-TPC-12-1-3" unit="cm"
          x="0.0500000000000002"
-       y="259.46677631579"
+       y="259.767565789474"
          z="161.995"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -68707,7 +68811,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_7-4-1"/>
        <position name="posOpArapuca7-4-1-TPC-12-1-3" unit="cm"
          x="0.0500000000000002"
-       y="259.46677631579"
+       y="259.767565789474"
          z="210.795"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -68715,7 +68819,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_7-4-2"/>
        <position name="posOpArapuca7-4-2-TPC-12-1-3" unit="cm"
          x="0.0500000000000002"
-       y="259.46677631579"
+       y="259.767565789474"
          z="273.595"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -68723,7 +68827,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_7-4-3"/>
        <position name="posOpArapuca7-4-3-TPC-12-1-3" unit="cm"
          x="0.0500000000000002"
-       y="259.46677631579"
+       y="259.767565789474"
          z="322.395"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -68731,7 +68835,7 @@ z="242.195"/>
 <volumeref ref="volArapuca_7-5"/>
 <position name="posArapuca7-5-TPC-12-1-3" unit="cm"
 x="0"
-y="321.737171052632"
+y="322.104802631579"
 z="242.195"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -68739,7 +68843,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_7-5-0"/>
        <position name="posOpArapuca7-5-0-TPC-12-1-3" unit="cm"
          x="0.0500000000000002"
-       y="321.737171052632"
+       y="322.104802631579"
          z="161.995"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -68747,7 +68851,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_7-5-1"/>
        <position name="posOpArapuca7-5-1-TPC-12-1-3" unit="cm"
          x="0.0500000000000002"
-       y="321.737171052632"
+       y="322.104802631579"
          z="210.795"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -68755,7 +68859,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_7-5-2"/>
        <position name="posOpArapuca7-5-2-TPC-12-1-3" unit="cm"
          x="0.0500000000000002"
-       y="321.737171052632"
+       y="322.104802631579"
          z="273.595"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -68763,7 +68867,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_7-5-3"/>
        <position name="posOpArapuca7-5-3-TPC-12-1-3" unit="cm"
          x="0.0500000000000002"
-       y="321.737171052632"
+       y="322.104802631579"
          z="322.395"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -68771,7 +68875,7 @@ z="242.195"/>
 <volumeref ref="volArapuca_7-6"/>
 <position name="posArapuca7-6-TPC-12-1-3" unit="cm"
 x="0"
-y="384.007565789474"
+y="384.442039473684"
 z="242.195"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -68779,7 +68883,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_7-6-0"/>
        <position name="posOpArapuca7-6-0-TPC-12-1-3" unit="cm"
          x="0.0500000000000002"
-       y="384.007565789474"
+       y="384.442039473684"
          z="161.995"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -68787,7 +68891,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_7-6-1"/>
        <position name="posOpArapuca7-6-1-TPC-12-1-3" unit="cm"
          x="0.0500000000000002"
-       y="384.007565789474"
+       y="384.442039473684"
          z="210.795"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -68795,7 +68899,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_7-6-2"/>
        <position name="posOpArapuca7-6-2-TPC-12-1-3" unit="cm"
          x="0.0500000000000002"
-       y="384.007565789474"
+       y="384.442039473684"
          z="273.595"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -68803,7 +68907,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_7-6-3"/>
        <position name="posOpArapuca7-6-3-TPC-12-1-3" unit="cm"
          x="0.0500000000000002"
-       y="384.007565789474"
+       y="384.442039473684"
          z="322.395"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -68811,7 +68915,7 @@ z="242.195"/>
 <volumeref ref="volArapuca_7-7"/>
 <position name="posArapuca7-7-TPC-12-1-3" unit="cm"
 x="0"
-y="446.277960526316"
+y="446.77927631579"
 z="242.195"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -68819,7 +68923,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_7-7-0"/>
        <position name="posOpArapuca7-7-0-TPC-12-1-3" unit="cm"
          x="0.0500000000000002"
-       y="446.277960526316"
+       y="446.77927631579"
          z="161.995"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -68827,7 +68931,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_7-7-1"/>
        <position name="posOpArapuca7-7-1-TPC-12-1-3" unit="cm"
          x="0.0500000000000002"
-       y="446.277960526316"
+       y="446.77927631579"
          z="210.795"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -68835,7 +68939,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_7-7-2"/>
        <position name="posOpArapuca7-7-2-TPC-12-1-3" unit="cm"
          x="0.0500000000000002"
-       y="446.277960526316"
+       y="446.77927631579"
          z="273.595"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -68843,7 +68947,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_7-7-3"/>
        <position name="posOpArapuca7-7-3-TPC-12-1-3" unit="cm"
          x="0.0500000000000002"
-       y="446.277960526316"
+       y="446.77927631579"
          z="322.395"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -68851,7 +68955,7 @@ z="242.195"/>
 <volumeref ref="volArapuca_7-8"/>
 <position name="posArapuca7-8-TPC-12-1-3" unit="cm"
 x="0"
-y="508.548355263158"
+y="509.116513157895"
 z="242.195"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -68859,7 +68963,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_7-8-0"/>
        <position name="posOpArapuca7-8-0-TPC-12-1-3" unit="cm"
          x="0.0500000000000002"
-       y="508.548355263158"
+       y="509.116513157895"
          z="161.995"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -68867,7 +68971,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_7-8-1"/>
        <position name="posOpArapuca7-8-1-TPC-12-1-3" unit="cm"
          x="0.0500000000000002"
-       y="508.548355263158"
+       y="509.116513157895"
          z="210.795"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -68875,7 +68979,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_7-8-2"/>
        <position name="posOpArapuca7-8-2-TPC-12-1-3" unit="cm"
          x="0.0500000000000002"
-       y="508.548355263158"
+       y="509.116513157895"
          z="273.595"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -68883,7 +68987,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_7-8-3"/>
        <position name="posOpArapuca7-8-3-TPC-12-1-3" unit="cm"
          x="0.0500000000000002"
-       y="508.548355263158"
+       y="509.116513157895"
          z="322.395"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -68891,7 +68995,7 @@ z="242.195"/>
 <volumeref ref="volArapuca_7-9"/>
 <position name="posArapuca7-9-TPC-12-1-3" unit="cm"
 x="0"
-y="570.81875"
+y="571.45375"
 z="242.195"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -68899,7 +69003,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_7-9-0"/>
        <position name="posOpArapuca7-9-0-TPC-12-1-3" unit="cm"
          x="0.0500000000000002"
-       y="570.81875"
+       y="571.45375"
          z="161.995"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -68907,7 +69011,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_7-9-1"/>
        <position name="posOpArapuca7-9-1-TPC-12-1-3" unit="cm"
          x="0.0500000000000002"
-       y="570.81875"
+       y="571.45375"
          z="210.795"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -68915,7 +69019,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_7-9-2"/>
        <position name="posOpArapuca7-9-2-TPC-12-1-3" unit="cm"
          x="0.0500000000000002"
-       y="570.81875"
+       y="571.45375"
          z="273.595"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -68923,7 +69027,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_7-9-3"/>
        <position name="posOpArapuca7-9-3-TPC-12-1-3" unit="cm"
          x="0.0500000000000002"
-       y="570.81875"
+       y="571.45375"
          z="322.395"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -68932,7 +69036,7 @@ z="242.195"/>
         <volumeref ref="volTPCInner"/>
         <position name="posTPC-14" unit="cm"
         x="-182.95455"
-        y="283.164375"
+        y="283.481875"
         z="242.195"/>
         <rotationref ref="rPlus180AboutY"/>
       </physvol>
@@ -68940,7 +69044,7 @@ z="242.195"/>
         <volumeref ref="volTPCInner"/>
         <position name="posTPC-15" unit="cm"
         x="182.95455"
-        y="283.164375"
+        y="283.481875"
         z="242.195"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -68948,16 +69052,16 @@ z="242.195"/>
       <physvol>
         <volumeref ref="volCathode"/>
         <position name="posCathode-8-0" unit="cm"
-      x="-363.38405"
-      y="283.164375"
+      x="-363.52605"
+      y="283.481875"
       z="242.195"/>
         <rotationref ref="rIdentity"/>
       </physvol>
       <physvol>
         <volumeref ref="volCathode"/>
         <position name="posCathode-8-1" unit="cm"
-      x="363.38405"
-      y="283.164375"
+      x="363.52605"
+      y="283.481875"
       z="242.195"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -68966,23 +69070,23 @@ z="242.195"/>
         <volumeref ref="volAPAFrameYSide"/>
         <position name="posAPAFrameYSideNeg-8" unit="cm"
       x="0"
-      y="-325.37875"
-      z="364.66375"/>
+      y="-326.01375"
+      z="364.98125"/>
         <rotationref ref="rIdentity"/>
       </physvol>
       <physvol>
         <volumeref ref="volAPAFrameYSide"/>
         <position name="posAPAFrameYSidePos-8" unit="cm"
       x="0"
-      y="-325.37875"
-      z="584.50625"/>
+      y="-326.01375"
+      z="584.18875"/>
         <rotationref ref="rIdentity"/>
       </physvol>
       <physvol>
         <volumeref ref="volAPAFrameZSide"/>
         <position name="posAPAFrameZSidePos-8" unit="cm"
       x="0"
-      y="-27.45875"
+      y="-28.0937500000001"
       z="474.585"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -68990,7 +69094,7 @@ z="242.195"/>
         <volumeref ref="volAPAFrameZSide"/>
         <position name="posAPAFrameZSideNeg-8" unit="cm"
       x="0"
-      y="-623.29875"
+      y="-623.93375"
       z="474.585"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -69001,22 +69105,33 @@ z="242.195"/>
       - There are two boards on each the up and downstream end,
           one each to wrap the U and V views around the APA frame
       - There are 4 on the bottom which anchor the U V and Z wires and the grid plane
-      - The rest of the parts of the G10 boards must be placed directly in volTPC   -->
+      FIXME: This is not true -> - The rest of the parts of the G10 boards must be placed directly in volTPC   -->
+
+      <!-- Position readout boards -->
+      <physvol>
+        <volumeref ref="volG10HeadBoards"/>
+        <position name="posG10HeadBoards-8" unit="cm"
+	  x="0"
+	  y="-639.51775"
+      	  z="474.585"/>
+        <rotationref ref="rIdentity"/>
+      </physvol>
 
       <physvol>
         <volumeref ref="volG10BoardYSideCenterSeg"/>
         <position name="posG10BoardYSideCenterSeg-Vup-8" unit="cm"
-      x="0"
-      y="-325.37875"
-      z="359.425"/>
-        <rotationref ref="rIdentity"/>
+         x="0"
+         y="-326.01375"
+         z="359.663125"/>
+         <rotationref ref="rIdentity"/>
       </physvol>
+
       <physvol>
         <volumeref ref="volG10BoardYSideCenterSeg"/>
         <position name="posG10BoardYSideCenterSeg-Uup-8" unit="cm"
       x="0"
-      y="-325.37875"
-      z="359.1075"/>
+      y="-326.01375"
+      z="359.186875"/>
         <rotationref ref="rIdentity"/>
       </physvol>
 
@@ -69024,16 +69139,16 @@ z="242.195"/>
         <volumeref ref="volG10BoardYSideCenterSeg"/>
         <position name="posG10BoardYSideCenterSeg-Vdown-8" unit="cm"
       x="0"
-      y="-325.37875"
-      z="589.745"/>
+      y="-326.01375"
+      z="589.506875"/>
         <rotationref ref="rIdentity"/>
       </physvol>
       <physvol>
         <volumeref ref="volG10BoardYSideCenterSeg"/>
         <position name="posG10BoardYSideCenterSeg-Udown-8" unit="cm"
       x="0"
-      y="-325.37875"
-      z="590.0625"/>
+      y="-326.01375"
+      z="589.983125"/>
         <rotationref ref="rIdentity"/>
       </physvol>
 
@@ -69041,7 +69156,7 @@ z="242.195"/>
         <volumeref ref="volG10BoardZSideCenterSeg"/>
         <position name="posG10BoardZSideCenterSeg-Z-8" unit="cm"
       x="0"
-      y="-22.22"
+      y="-22.775625"
       z="474.585"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -69049,7 +69164,7 @@ z="242.195"/>
         <volumeref ref="volG10BoardZSideCenterSeg"/>
         <position name="posG10BoardZSideCenterSeg-V-8" unit="cm"
       x="0"
-      y="-21.9025"
+      y="-22.2993750000001"
       z="474.585"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -69057,7 +69172,7 @@ z="242.195"/>
         <volumeref ref="volG10BoardZSideCenterSeg"/>
         <position name="posG10BoardZSideCenterSeg-U-8" unit="cm"
       x="0"
-      y="-21.585"
+      y="-21.8231250000001"
       z="474.585"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -69065,7 +69180,7 @@ z="242.195"/>
         <volumeref ref="volG10BoardZSideCenterSeg"/>
         <position name="posG10BoardZSideCenterSeg-Grid-8" unit="cm"
       x="0"
-      y="-21.2675"
+      y="-21.3468750000001"
       z="474.585"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -69074,7 +69189,7 @@ z="242.195"/>
 <volumeref ref="volArapuca_8-0"/>
 <position name="posArapuca8-0-TPC-12-0-4" unit="cm"
 x="0"
-y="-612.31875"
+y="-612.95375"
 z="474.585"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -69082,7 +69197,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_8-0-0"/>
        <position name="posOpArapuca8-0-0-TPC-12-0-4" unit="cm"
          x="-0.0500000000000002"
-       y="-612.31875"
+       y="-612.95375"
          z="394.385"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -69090,7 +69205,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_8-0-1"/>
        <position name="posOpArapuca8-0-1-TPC-12-0-4" unit="cm"
          x="-0.0500000000000002"
-       y="-612.31875"
+       y="-612.95375"
          z="443.185"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -69098,7 +69213,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_8-0-2"/>
        <position name="posOpArapuca8-0-2-TPC-12-0-4" unit="cm"
          x="-0.0500000000000002"
-       y="-612.31875"
+       y="-612.95375"
          z="505.985"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -69106,7 +69221,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_8-0-3"/>
        <position name="posOpArapuca8-0-3-TPC-12-0-4" unit="cm"
          x="-0.0500000000000002"
-       y="-612.31875"
+       y="-612.95375"
          z="554.785"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -69114,7 +69229,7 @@ z="474.585"/>
 <volumeref ref="volArapuca_8-1"/>
 <position name="posArapuca8-1-TPC-12-0-4" unit="cm"
 x="0"
-y="-550.048355263158"
+y="-550.616513157895"
 z="474.585"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -69122,7 +69237,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_8-1-0"/>
        <position name="posOpArapuca8-1-0-TPC-12-0-4" unit="cm"
          x="-0.0500000000000002"
-       y="-550.048355263158"
+       y="-550.616513157895"
          z="394.385"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -69130,7 +69245,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_8-1-1"/>
        <position name="posOpArapuca8-1-1-TPC-12-0-4" unit="cm"
          x="-0.0500000000000002"
-       y="-550.048355263158"
+       y="-550.616513157895"
          z="443.185"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -69138,7 +69253,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_8-1-2"/>
        <position name="posOpArapuca8-1-2-TPC-12-0-4" unit="cm"
          x="-0.0500000000000002"
-       y="-550.048355263158"
+       y="-550.616513157895"
          z="505.985"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -69146,7 +69261,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_8-1-3"/>
        <position name="posOpArapuca8-1-3-TPC-12-0-4" unit="cm"
          x="-0.0500000000000002"
-       y="-550.048355263158"
+       y="-550.616513157895"
          z="554.785"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -69154,7 +69269,7 @@ z="474.585"/>
 <volumeref ref="volArapuca_8-2"/>
 <position name="posArapuca8-2-TPC-12-0-4" unit="cm"
 x="0"
-y="-487.777960526316"
+y="-488.27927631579"
 z="474.585"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -69162,7 +69277,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_8-2-0"/>
        <position name="posOpArapuca8-2-0-TPC-12-0-4" unit="cm"
          x="-0.0500000000000002"
-       y="-487.777960526316"
+       y="-488.27927631579"
          z="394.385"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -69170,7 +69285,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_8-2-1"/>
        <position name="posOpArapuca8-2-1-TPC-12-0-4" unit="cm"
          x="-0.0500000000000002"
-       y="-487.777960526316"
+       y="-488.27927631579"
          z="443.185"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -69178,7 +69293,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_8-2-2"/>
        <position name="posOpArapuca8-2-2-TPC-12-0-4" unit="cm"
          x="-0.0500000000000002"
-       y="-487.777960526316"
+       y="-488.27927631579"
          z="505.985"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -69186,7 +69301,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_8-2-3"/>
        <position name="posOpArapuca8-2-3-TPC-12-0-4" unit="cm"
          x="-0.0500000000000002"
-       y="-487.777960526316"
+       y="-488.27927631579"
          z="554.785"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -69194,7 +69309,7 @@ z="474.585"/>
 <volumeref ref="volArapuca_8-3"/>
 <position name="posArapuca8-3-TPC-12-0-4" unit="cm"
 x="0"
-y="-425.507565789474"
+y="-425.942039473684"
 z="474.585"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -69202,7 +69317,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_8-3-0"/>
        <position name="posOpArapuca8-3-0-TPC-12-0-4" unit="cm"
          x="-0.0500000000000002"
-       y="-425.507565789474"
+       y="-425.942039473684"
          z="394.385"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -69210,7 +69325,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_8-3-1"/>
        <position name="posOpArapuca8-3-1-TPC-12-0-4" unit="cm"
          x="-0.0500000000000002"
-       y="-425.507565789474"
+       y="-425.942039473684"
          z="443.185"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -69218,7 +69333,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_8-3-2"/>
        <position name="posOpArapuca8-3-2-TPC-12-0-4" unit="cm"
          x="-0.0500000000000002"
-       y="-425.507565789474"
+       y="-425.942039473684"
          z="505.985"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -69226,7 +69341,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_8-3-3"/>
        <position name="posOpArapuca8-3-3-TPC-12-0-4" unit="cm"
          x="-0.0500000000000002"
-       y="-425.507565789474"
+       y="-425.942039473684"
          z="554.785"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -69234,7 +69349,7 @@ z="474.585"/>
 <volumeref ref="volArapuca_8-4"/>
 <position name="posArapuca8-4-TPC-12-0-4" unit="cm"
 x="0"
-y="-363.237171052632"
+y="-363.604802631579"
 z="474.585"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -69242,7 +69357,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_8-4-0"/>
        <position name="posOpArapuca8-4-0-TPC-12-0-4" unit="cm"
          x="-0.0500000000000002"
-       y="-363.237171052632"
+       y="-363.604802631579"
          z="394.385"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -69250,7 +69365,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_8-4-1"/>
        <position name="posOpArapuca8-4-1-TPC-12-0-4" unit="cm"
          x="-0.0500000000000002"
-       y="-363.237171052632"
+       y="-363.604802631579"
          z="443.185"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -69258,7 +69373,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_8-4-2"/>
        <position name="posOpArapuca8-4-2-TPC-12-0-4" unit="cm"
          x="-0.0500000000000002"
-       y="-363.237171052632"
+       y="-363.604802631579"
          z="505.985"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -69266,7 +69381,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_8-4-3"/>
        <position name="posOpArapuca8-4-3-TPC-12-0-4" unit="cm"
          x="-0.0500000000000002"
-       y="-363.237171052632"
+       y="-363.604802631579"
          z="554.785"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -69274,7 +69389,7 @@ z="474.585"/>
 <volumeref ref="volArapuca_8-5"/>
 <position name="posArapuca8-5-TPC-12-0-4" unit="cm"
 x="0"
-y="-300.96677631579"
+y="-301.267565789474"
 z="474.585"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -69282,7 +69397,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_8-5-0"/>
        <position name="posOpArapuca8-5-0-TPC-12-0-4" unit="cm"
          x="-0.0500000000000002"
-       y="-300.96677631579"
+       y="-301.267565789474"
          z="394.385"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -69290,7 +69405,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_8-5-1"/>
        <position name="posOpArapuca8-5-1-TPC-12-0-4" unit="cm"
          x="-0.0500000000000002"
-       y="-300.96677631579"
+       y="-301.267565789474"
          z="443.185"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -69298,7 +69413,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_8-5-2"/>
        <position name="posOpArapuca8-5-2-TPC-12-0-4" unit="cm"
          x="-0.0500000000000002"
-       y="-300.96677631579"
+       y="-301.267565789474"
          z="505.985"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -69306,7 +69421,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_8-5-3"/>
        <position name="posOpArapuca8-5-3-TPC-12-0-4" unit="cm"
          x="-0.0500000000000002"
-       y="-300.96677631579"
+       y="-301.267565789474"
          z="554.785"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -69314,7 +69429,7 @@ z="474.585"/>
 <volumeref ref="volArapuca_8-6"/>
 <position name="posArapuca8-6-TPC-12-0-4" unit="cm"
 x="0"
-y="-238.696381578947"
+y="-238.930328947368"
 z="474.585"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -69322,7 +69437,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_8-6-0"/>
        <position name="posOpArapuca8-6-0-TPC-12-0-4" unit="cm"
          x="-0.0500000000000002"
-       y="-238.696381578947"
+       y="-238.930328947368"
          z="394.385"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -69330,7 +69445,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_8-6-1"/>
        <position name="posOpArapuca8-6-1-TPC-12-0-4" unit="cm"
          x="-0.0500000000000002"
-       y="-238.696381578947"
+       y="-238.930328947368"
          z="443.185"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -69338,7 +69453,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_8-6-2"/>
        <position name="posOpArapuca8-6-2-TPC-12-0-4" unit="cm"
          x="-0.0500000000000002"
-       y="-238.696381578947"
+       y="-238.930328947368"
          z="505.985"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -69346,7 +69461,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_8-6-3"/>
        <position name="posOpArapuca8-6-3-TPC-12-0-4" unit="cm"
          x="-0.0500000000000002"
-       y="-238.696381578947"
+       y="-238.930328947368"
          z="554.785"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -69354,7 +69469,7 @@ z="474.585"/>
 <volumeref ref="volArapuca_8-7"/>
 <position name="posArapuca8-7-TPC-12-0-4" unit="cm"
 x="0"
-y="-176.425986842105"
+y="-176.593092105263"
 z="474.585"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -69362,7 +69477,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_8-7-0"/>
        <position name="posOpArapuca8-7-0-TPC-12-0-4" unit="cm"
          x="-0.0500000000000002"
-       y="-176.425986842105"
+       y="-176.593092105263"
          z="394.385"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -69370,7 +69485,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_8-7-1"/>
        <position name="posOpArapuca8-7-1-TPC-12-0-4" unit="cm"
          x="-0.0500000000000002"
-       y="-176.425986842105"
+       y="-176.593092105263"
          z="443.185"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -69378,7 +69493,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_8-7-2"/>
        <position name="posOpArapuca8-7-2-TPC-12-0-4" unit="cm"
          x="-0.0500000000000002"
-       y="-176.425986842105"
+       y="-176.593092105263"
          z="505.985"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -69386,7 +69501,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_8-7-3"/>
        <position name="posOpArapuca8-7-3-TPC-12-0-4" unit="cm"
          x="-0.0500000000000002"
-       y="-176.425986842105"
+       y="-176.593092105263"
          z="554.785"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -69394,7 +69509,7 @@ z="474.585"/>
 <volumeref ref="volArapuca_8-8"/>
 <position name="posArapuca8-8-TPC-12-0-4" unit="cm"
 x="0"
-y="-114.155592105263"
+y="-114.255855263158"
 z="474.585"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -69402,7 +69517,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_8-8-0"/>
        <position name="posOpArapuca8-8-0-TPC-12-0-4" unit="cm"
          x="-0.0500000000000002"
-       y="-114.155592105263"
+       y="-114.255855263158"
          z="394.385"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -69410,7 +69525,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_8-8-1"/>
        <position name="posOpArapuca8-8-1-TPC-12-0-4" unit="cm"
          x="-0.0500000000000002"
-       y="-114.155592105263"
+       y="-114.255855263158"
          z="443.185"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -69418,7 +69533,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_8-8-2"/>
        <position name="posOpArapuca8-8-2-TPC-12-0-4" unit="cm"
          x="-0.0500000000000002"
-       y="-114.155592105263"
+       y="-114.255855263158"
          z="505.985"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -69426,7 +69541,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_8-8-3"/>
        <position name="posOpArapuca8-8-3-TPC-12-0-4" unit="cm"
          x="-0.0500000000000002"
-       y="-114.155592105263"
+       y="-114.255855263158"
          z="554.785"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -69434,7 +69549,7 @@ z="474.585"/>
 <volumeref ref="volArapuca_8-9"/>
 <position name="posArapuca8-9-TPC-12-0-4" unit="cm"
 x="0"
-y="-51.885197368421"
+y="-51.9186184210527"
 z="474.585"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -69442,7 +69557,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_8-9-0"/>
        <position name="posOpArapuca8-9-0-TPC-12-0-4" unit="cm"
          x="-0.0500000000000002"
-       y="-51.885197368421"
+       y="-51.9186184210527"
          z="394.385"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -69450,7 +69565,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_8-9-1"/>
        <position name="posOpArapuca8-9-1-TPC-12-0-4" unit="cm"
          x="-0.0500000000000002"
-       y="-51.885197368421"
+       y="-51.9186184210527"
          z="443.185"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -69458,7 +69573,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_8-9-2"/>
        <position name="posOpArapuca8-9-2-TPC-12-0-4" unit="cm"
          x="-0.0500000000000002"
-       y="-51.885197368421"
+       y="-51.9186184210527"
          z="505.985"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -69466,7 +69581,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_8-9-3"/>
        <position name="posOpArapuca8-9-3-TPC-12-0-4" unit="cm"
          x="-0.0500000000000002"
-       y="-51.885197368421"
+       y="-51.9186184210527"
          z="554.785"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -69475,7 +69590,7 @@ z="474.585"/>
         <volumeref ref="volTPCInner"/>
         <position name="posTPC-16" unit="cm"
         x="-182.95455"
-        y="-324.664375"
+        y="-324.981875"
         z="474.585"/>
         <rotationref ref="rPlus180AboutXPlus180AboutY"/>
       </physvol>
@@ -69483,7 +69598,7 @@ z="474.585"/>
         <volumeref ref="volTPCInner"/>
         <position name="posTPC-17" unit="cm"
         x="182.95455"
-        y="-324.664375"
+        y="-324.981875"
         z="474.585"/>
         <rotationref ref="rPlus180AboutX"/>
       </physvol>
@@ -69491,16 +69606,16 @@ z="474.585"/>
       <physvol>
         <volumeref ref="volCathode"/>
         <position name="posCathode-9-0" unit="cm"
-      x="-363.38405"
-      y="-324.664375"
+      x="-363.52605"
+      y="-324.981875"
       z="474.585"/>
         <rotationref ref="rIdentity"/>
       </physvol>
       <physvol>
         <volumeref ref="volCathode"/>
         <position name="posCathode-9-1" unit="cm"
-      x="363.38405"
-      y="-324.664375"
+      x="363.52605"
+      y="-324.981875"
       z="474.585"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -69509,23 +69624,23 @@ z="474.585"/>
         <volumeref ref="volAPAFrameYSide"/>
         <position name="posAPAFrameYSideNeg-9" unit="cm"
       x="0"
-      y="283.87875"
-      z="364.66375"/>
+      y="284.51375"
+      z="364.98125"/>
         <rotationref ref="rIdentity"/>
       </physvol>
       <physvol>
         <volumeref ref="volAPAFrameYSide"/>
         <position name="posAPAFrameYSidePos-9" unit="cm"
       x="0"
-      y="283.87875"
-      z="584.50625"/>
+      y="284.51375"
+      z="584.18875"/>
         <rotationref ref="rIdentity"/>
       </physvol>
       <physvol>
         <volumeref ref="volAPAFrameZSide"/>
         <position name="posAPAFrameZSidePos-9" unit="cm"
       x="0"
-      y="581.79875"
+      y="582.43375"
       z="474.585"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -69533,7 +69648,7 @@ z="474.585"/>
         <volumeref ref="volAPAFrameZSide"/>
         <position name="posAPAFrameZSideNeg-9" unit="cm"
       x="0"
-      y="-14.0412500000001"
+      y="-13.40625"
       z="474.585"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -69544,22 +69659,33 @@ z="474.585"/>
       - There are two boards on each the up and downstream end,
           one each to wrap the U and V views around the APA frame
       - There are 4 on the bottom which anchor the U V and Z wires and the grid plane
-      - The rest of the parts of the G10 boards must be placed directly in volTPC   -->
+      FIXME: This is not true -> - The rest of the parts of the G10 boards must be placed directly in volTPC   -->
+
+      <!-- Position readout boards -->
+      <physvol>
+        <volumeref ref="volG10HeadBoards"/>
+        <position name="posG10HeadBoards-9" unit="cm"
+	  x="0"
+	  y="598.01775"
+      	  z="474.585"/>
+        <rotationref ref="rIdentity"/>
+      </physvol>
 
       <physvol>
         <volumeref ref="volG10BoardYSideCenterSeg"/>
         <position name="posG10BoardYSideCenterSeg-Vup-9" unit="cm"
-      x="0"
-      y="283.87875"
-      z="359.425"/>
-        <rotationref ref="rIdentity"/>
+         x="0"
+         y="284.51375"
+         z="359.663125"/>
+         <rotationref ref="rIdentity"/>
       </physvol>
+
       <physvol>
         <volumeref ref="volG10BoardYSideCenterSeg"/>
         <position name="posG10BoardYSideCenterSeg-Uup-9" unit="cm"
       x="0"
-      y="283.87875"
-      z="359.1075"/>
+      y="284.51375"
+      z="359.186875"/>
         <rotationref ref="rIdentity"/>
       </physvol>
 
@@ -69567,16 +69693,16 @@ z="474.585"/>
         <volumeref ref="volG10BoardYSideCenterSeg"/>
         <position name="posG10BoardYSideCenterSeg-Vdown-9" unit="cm"
       x="0"
-      y="283.87875"
-      z="589.745"/>
+      y="284.51375"
+      z="589.506875"/>
         <rotationref ref="rIdentity"/>
       </physvol>
       <physvol>
         <volumeref ref="volG10BoardYSideCenterSeg"/>
         <position name="posG10BoardYSideCenterSeg-Udown-9" unit="cm"
       x="0"
-      y="283.87875"
-      z="590.0625"/>
+      y="284.51375"
+      z="589.983125"/>
         <rotationref ref="rIdentity"/>
       </physvol>
 
@@ -69584,7 +69710,7 @@ z="474.585"/>
         <volumeref ref="volG10BoardZSideCenterSeg"/>
         <position name="posG10BoardZSideCenterSeg-Z-9" unit="cm"
       x="0"
-      y="-19.2800000000001"
+      y="-18.7243750000001"
       z="474.585"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -69592,7 +69718,7 @@ z="474.585"/>
         <volumeref ref="volG10BoardZSideCenterSeg"/>
         <position name="posG10BoardZSideCenterSeg-V-9" unit="cm"
       x="0"
-      y="-19.5975000000001"
+      y="-19.2006250000001"
       z="474.585"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -69600,7 +69726,7 @@ z="474.585"/>
         <volumeref ref="volG10BoardZSideCenterSeg"/>
         <position name="posG10BoardZSideCenterSeg-U-9" unit="cm"
       x="0"
-      y="-19.9150000000001"
+      y="-19.6768750000001"
       z="474.585"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -69608,7 +69734,7 @@ z="474.585"/>
         <volumeref ref="volG10BoardZSideCenterSeg"/>
         <position name="posG10BoardZSideCenterSeg-Grid-9" unit="cm"
       x="0"
-      y="-20.2325000000001"
+      y="-20.153125"
       z="474.585"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -69617,7 +69743,7 @@ z="474.585"/>
 <volumeref ref="volArapuca_9-0"/>
 <position name="posArapuca9-0-TPC-12-1-4" unit="cm"
 x="0"
-y="10.385197368421"
+y="10.4186184210526"
 z="474.585"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -69625,7 +69751,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_9-0-0"/>
        <position name="posOpArapuca9-0-0-TPC-12-1-4" unit="cm"
          x="0.0500000000000002"
-       y="10.385197368421"
+       y="10.4186184210526"
          z="394.385"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -69633,7 +69759,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_9-0-1"/>
        <position name="posOpArapuca9-0-1-TPC-12-1-4" unit="cm"
          x="0.0500000000000002"
-       y="10.385197368421"
+       y="10.4186184210526"
          z="443.185"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -69641,7 +69767,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_9-0-2"/>
        <position name="posOpArapuca9-0-2-TPC-12-1-4" unit="cm"
          x="0.0500000000000002"
-       y="10.385197368421"
+       y="10.4186184210526"
          z="505.985"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -69649,7 +69775,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_9-0-3"/>
        <position name="posOpArapuca9-0-3-TPC-12-1-4" unit="cm"
          x="0.0500000000000002"
-       y="10.385197368421"
+       y="10.4186184210526"
          z="554.785"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -69657,7 +69783,7 @@ z="474.585"/>
 <volumeref ref="volArapuca_9-1"/>
 <position name="posArapuca9-1-TPC-12-1-4" unit="cm"
 x="0"
-y="72.6555921052631"
+y="72.7558552631579"
 z="474.585"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -69665,7 +69791,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_9-1-0"/>
        <position name="posOpArapuca9-1-0-TPC-12-1-4" unit="cm"
          x="0.0500000000000002"
-       y="72.6555921052631"
+       y="72.7558552631579"
          z="394.385"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -69673,7 +69799,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_9-1-1"/>
        <position name="posOpArapuca9-1-1-TPC-12-1-4" unit="cm"
          x="0.0500000000000002"
-       y="72.6555921052631"
+       y="72.7558552631579"
          z="443.185"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -69681,7 +69807,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_9-1-2"/>
        <position name="posOpArapuca9-1-2-TPC-12-1-4" unit="cm"
          x="0.0500000000000002"
-       y="72.6555921052631"
+       y="72.7558552631579"
          z="505.985"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -69689,7 +69815,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_9-1-3"/>
        <position name="posOpArapuca9-1-3-TPC-12-1-4" unit="cm"
          x="0.0500000000000002"
-       y="72.6555921052631"
+       y="72.7558552631579"
          z="554.785"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -69697,7 +69823,7 @@ z="474.585"/>
 <volumeref ref="volArapuca_9-2"/>
 <position name="posArapuca9-2-TPC-12-1-4" unit="cm"
 x="0"
-y="134.925986842105"
+y="135.093092105263"
 z="474.585"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -69705,7 +69831,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_9-2-0"/>
        <position name="posOpArapuca9-2-0-TPC-12-1-4" unit="cm"
          x="0.0500000000000002"
-       y="134.925986842105"
+       y="135.093092105263"
          z="394.385"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -69713,7 +69839,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_9-2-1"/>
        <position name="posOpArapuca9-2-1-TPC-12-1-4" unit="cm"
          x="0.0500000000000002"
-       y="134.925986842105"
+       y="135.093092105263"
          z="443.185"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -69721,7 +69847,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_9-2-2"/>
        <position name="posOpArapuca9-2-2-TPC-12-1-4" unit="cm"
          x="0.0500000000000002"
-       y="134.925986842105"
+       y="135.093092105263"
          z="505.985"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -69729,7 +69855,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_9-2-3"/>
        <position name="posOpArapuca9-2-3-TPC-12-1-4" unit="cm"
          x="0.0500000000000002"
-       y="134.925986842105"
+       y="135.093092105263"
          z="554.785"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -69737,7 +69863,7 @@ z="474.585"/>
 <volumeref ref="volArapuca_9-3"/>
 <position name="posArapuca9-3-TPC-12-1-4" unit="cm"
 x="0"
-y="197.196381578947"
+y="197.430328947368"
 z="474.585"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -69745,7 +69871,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_9-3-0"/>
        <position name="posOpArapuca9-3-0-TPC-12-1-4" unit="cm"
          x="0.0500000000000002"
-       y="197.196381578947"
+       y="197.430328947368"
          z="394.385"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -69753,7 +69879,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_9-3-1"/>
        <position name="posOpArapuca9-3-1-TPC-12-1-4" unit="cm"
          x="0.0500000000000002"
-       y="197.196381578947"
+       y="197.430328947368"
          z="443.185"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -69761,7 +69887,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_9-3-2"/>
        <position name="posOpArapuca9-3-2-TPC-12-1-4" unit="cm"
          x="0.0500000000000002"
-       y="197.196381578947"
+       y="197.430328947368"
          z="505.985"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -69769,7 +69895,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_9-3-3"/>
        <position name="posOpArapuca9-3-3-TPC-12-1-4" unit="cm"
          x="0.0500000000000002"
-       y="197.196381578947"
+       y="197.430328947368"
          z="554.785"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -69777,7 +69903,7 @@ z="474.585"/>
 <volumeref ref="volArapuca_9-4"/>
 <position name="posArapuca9-4-TPC-12-1-4" unit="cm"
 x="0"
-y="259.46677631579"
+y="259.767565789474"
 z="474.585"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -69785,7 +69911,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_9-4-0"/>
        <position name="posOpArapuca9-4-0-TPC-12-1-4" unit="cm"
          x="0.0500000000000002"
-       y="259.46677631579"
+       y="259.767565789474"
          z="394.385"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -69793,7 +69919,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_9-4-1"/>
        <position name="posOpArapuca9-4-1-TPC-12-1-4" unit="cm"
          x="0.0500000000000002"
-       y="259.46677631579"
+       y="259.767565789474"
          z="443.185"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -69801,7 +69927,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_9-4-2"/>
        <position name="posOpArapuca9-4-2-TPC-12-1-4" unit="cm"
          x="0.0500000000000002"
-       y="259.46677631579"
+       y="259.767565789474"
          z="505.985"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -69809,7 +69935,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_9-4-3"/>
        <position name="posOpArapuca9-4-3-TPC-12-1-4" unit="cm"
          x="0.0500000000000002"
-       y="259.46677631579"
+       y="259.767565789474"
          z="554.785"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -69817,7 +69943,7 @@ z="474.585"/>
 <volumeref ref="volArapuca_9-5"/>
 <position name="posArapuca9-5-TPC-12-1-4" unit="cm"
 x="0"
-y="321.737171052632"
+y="322.104802631579"
 z="474.585"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -69825,7 +69951,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_9-5-0"/>
        <position name="posOpArapuca9-5-0-TPC-12-1-4" unit="cm"
          x="0.0500000000000002"
-       y="321.737171052632"
+       y="322.104802631579"
          z="394.385"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -69833,7 +69959,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_9-5-1"/>
        <position name="posOpArapuca9-5-1-TPC-12-1-4" unit="cm"
          x="0.0500000000000002"
-       y="321.737171052632"
+       y="322.104802631579"
          z="443.185"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -69841,7 +69967,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_9-5-2"/>
        <position name="posOpArapuca9-5-2-TPC-12-1-4" unit="cm"
          x="0.0500000000000002"
-       y="321.737171052632"
+       y="322.104802631579"
          z="505.985"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -69849,7 +69975,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_9-5-3"/>
        <position name="posOpArapuca9-5-3-TPC-12-1-4" unit="cm"
          x="0.0500000000000002"
-       y="321.737171052632"
+       y="322.104802631579"
          z="554.785"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -69857,7 +69983,7 @@ z="474.585"/>
 <volumeref ref="volArapuca_9-6"/>
 <position name="posArapuca9-6-TPC-12-1-4" unit="cm"
 x="0"
-y="384.007565789474"
+y="384.442039473684"
 z="474.585"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -69865,7 +69991,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_9-6-0"/>
        <position name="posOpArapuca9-6-0-TPC-12-1-4" unit="cm"
          x="0.0500000000000002"
-       y="384.007565789474"
+       y="384.442039473684"
          z="394.385"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -69873,7 +69999,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_9-6-1"/>
        <position name="posOpArapuca9-6-1-TPC-12-1-4" unit="cm"
          x="0.0500000000000002"
-       y="384.007565789474"
+       y="384.442039473684"
          z="443.185"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -69881,7 +70007,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_9-6-2"/>
        <position name="posOpArapuca9-6-2-TPC-12-1-4" unit="cm"
          x="0.0500000000000002"
-       y="384.007565789474"
+       y="384.442039473684"
          z="505.985"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -69889,7 +70015,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_9-6-3"/>
        <position name="posOpArapuca9-6-3-TPC-12-1-4" unit="cm"
          x="0.0500000000000002"
-       y="384.007565789474"
+       y="384.442039473684"
          z="554.785"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -69897,7 +70023,7 @@ z="474.585"/>
 <volumeref ref="volArapuca_9-7"/>
 <position name="posArapuca9-7-TPC-12-1-4" unit="cm"
 x="0"
-y="446.277960526316"
+y="446.77927631579"
 z="474.585"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -69905,7 +70031,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_9-7-0"/>
        <position name="posOpArapuca9-7-0-TPC-12-1-4" unit="cm"
          x="0.0500000000000002"
-       y="446.277960526316"
+       y="446.77927631579"
          z="394.385"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -69913,7 +70039,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_9-7-1"/>
        <position name="posOpArapuca9-7-1-TPC-12-1-4" unit="cm"
          x="0.0500000000000002"
-       y="446.277960526316"
+       y="446.77927631579"
          z="443.185"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -69921,7 +70047,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_9-7-2"/>
        <position name="posOpArapuca9-7-2-TPC-12-1-4" unit="cm"
          x="0.0500000000000002"
-       y="446.277960526316"
+       y="446.77927631579"
          z="505.985"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -69929,7 +70055,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_9-7-3"/>
        <position name="posOpArapuca9-7-3-TPC-12-1-4" unit="cm"
          x="0.0500000000000002"
-       y="446.277960526316"
+       y="446.77927631579"
          z="554.785"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -69937,7 +70063,7 @@ z="474.585"/>
 <volumeref ref="volArapuca_9-8"/>
 <position name="posArapuca9-8-TPC-12-1-4" unit="cm"
 x="0"
-y="508.548355263158"
+y="509.116513157895"
 z="474.585"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -69945,7 +70071,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_9-8-0"/>
        <position name="posOpArapuca9-8-0-TPC-12-1-4" unit="cm"
          x="0.0500000000000002"
-       y="508.548355263158"
+       y="509.116513157895"
          z="394.385"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -69953,7 +70079,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_9-8-1"/>
        <position name="posOpArapuca9-8-1-TPC-12-1-4" unit="cm"
          x="0.0500000000000002"
-       y="508.548355263158"
+       y="509.116513157895"
          z="443.185"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -69961,7 +70087,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_9-8-2"/>
        <position name="posOpArapuca9-8-2-TPC-12-1-4" unit="cm"
          x="0.0500000000000002"
-       y="508.548355263158"
+       y="509.116513157895"
          z="505.985"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -69969,7 +70095,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_9-8-3"/>
        <position name="posOpArapuca9-8-3-TPC-12-1-4" unit="cm"
          x="0.0500000000000002"
-       y="508.548355263158"
+       y="509.116513157895"
          z="554.785"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -69977,7 +70103,7 @@ z="474.585"/>
 <volumeref ref="volArapuca_9-9"/>
 <position name="posArapuca9-9-TPC-12-1-4" unit="cm"
 x="0"
-y="570.81875"
+y="571.45375"
 z="474.585"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -69985,7 +70111,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_9-9-0"/>
        <position name="posOpArapuca9-9-0-TPC-12-1-4" unit="cm"
          x="0.0500000000000002"
-       y="570.81875"
+       y="571.45375"
          z="394.385"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -69993,7 +70119,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_9-9-1"/>
        <position name="posOpArapuca9-9-1-TPC-12-1-4" unit="cm"
          x="0.0500000000000002"
-       y="570.81875"
+       y="571.45375"
          z="443.185"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -70001,7 +70127,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_9-9-2"/>
        <position name="posOpArapuca9-9-2-TPC-12-1-4" unit="cm"
          x="0.0500000000000002"
-       y="570.81875"
+       y="571.45375"
          z="505.985"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -70009,7 +70135,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_9-9-3"/>
        <position name="posOpArapuca9-9-3-TPC-12-1-4" unit="cm"
          x="0.0500000000000002"
-       y="570.81875"
+       y="571.45375"
          z="554.785"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -70018,7 +70144,7 @@ z="474.585"/>
         <volumeref ref="volTPCInner"/>
         <position name="posTPC-18" unit="cm"
         x="-182.95455"
-        y="283.164375"
+        y="283.481875"
         z="474.585"/>
         <rotationref ref="rPlus180AboutY"/>
       </physvol>
@@ -70026,7 +70152,7 @@ z="474.585"/>
         <volumeref ref="volTPCInner"/>
         <position name="posTPC-19" unit="cm"
         x="182.95455"
-        y="283.164375"
+        y="283.481875"
         z="474.585"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -70034,16 +70160,16 @@ z="474.585"/>
       <physvol>
         <volumeref ref="volCathode"/>
         <position name="posCathode-10-0" unit="cm"
-      x="-363.38405"
-      y="283.164375"
+      x="-363.52605"
+      y="283.481875"
       z="474.585"/>
         <rotationref ref="rIdentity"/>
       </physvol>
       <physvol>
         <volumeref ref="volCathode"/>
         <position name="posCathode-10-1" unit="cm"
-      x="363.38405"
-      y="283.164375"
+      x="363.52605"
+      y="283.481875"
       z="474.585"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -70052,23 +70178,23 @@ z="474.585"/>
         <volumeref ref="volAPAFrameYSide"/>
         <position name="posAPAFrameYSideNeg-10" unit="cm"
       x="0"
-      y="-325.37875"
-      z="597.05375"/>
+      y="-326.01375"
+      z="597.37125"/>
         <rotationref ref="rIdentity"/>
       </physvol>
       <physvol>
         <volumeref ref="volAPAFrameYSide"/>
         <position name="posAPAFrameYSidePos-10" unit="cm"
       x="0"
-      y="-325.37875"
-      z="816.89625"/>
+      y="-326.01375"
+      z="816.57875"/>
         <rotationref ref="rIdentity"/>
       </physvol>
       <physvol>
         <volumeref ref="volAPAFrameZSide"/>
         <position name="posAPAFrameZSidePos-10" unit="cm"
       x="0"
-      y="-27.45875"
+      y="-28.0937500000001"
       z="706.975"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -70076,7 +70202,7 @@ z="474.585"/>
         <volumeref ref="volAPAFrameZSide"/>
         <position name="posAPAFrameZSideNeg-10" unit="cm"
       x="0"
-      y="-623.29875"
+      y="-623.93375"
       z="706.975"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -70087,22 +70213,33 @@ z="474.585"/>
       - There are two boards on each the up and downstream end,
           one each to wrap the U and V views around the APA frame
       - There are 4 on the bottom which anchor the U V and Z wires and the grid plane
-      - The rest of the parts of the G10 boards must be placed directly in volTPC   -->
+      FIXME: This is not true -> - The rest of the parts of the G10 boards must be placed directly in volTPC   -->
+
+      <!-- Position readout boards -->
+      <physvol>
+        <volumeref ref="volG10HeadBoards"/>
+        <position name="posG10HeadBoards-10" unit="cm"
+	  x="0"
+	  y="-639.51775"
+      	  z="706.975"/>
+        <rotationref ref="rIdentity"/>
+      </physvol>
 
       <physvol>
         <volumeref ref="volG10BoardYSideCenterSeg"/>
         <position name="posG10BoardYSideCenterSeg-Vup-10" unit="cm"
-      x="0"
-      y="-325.37875"
-      z="591.815"/>
-        <rotationref ref="rIdentity"/>
+         x="0"
+         y="-326.01375"
+         z="592.053125"/>
+         <rotationref ref="rIdentity"/>
       </physvol>
+
       <physvol>
         <volumeref ref="volG10BoardYSideCenterSeg"/>
         <position name="posG10BoardYSideCenterSeg-Uup-10" unit="cm"
       x="0"
-      y="-325.37875"
-      z="591.4975"/>
+      y="-326.01375"
+      z="591.576875"/>
         <rotationref ref="rIdentity"/>
       </physvol>
 
@@ -70110,16 +70247,16 @@ z="474.585"/>
         <volumeref ref="volG10BoardYSideCenterSeg"/>
         <position name="posG10BoardYSideCenterSeg-Vdown-10" unit="cm"
       x="0"
-      y="-325.37875"
-      z="822.135"/>
+      y="-326.01375"
+      z="821.896875"/>
         <rotationref ref="rIdentity"/>
       </physvol>
       <physvol>
         <volumeref ref="volG10BoardYSideCenterSeg"/>
         <position name="posG10BoardYSideCenterSeg-Udown-10" unit="cm"
       x="0"
-      y="-325.37875"
-      z="822.4525"/>
+      y="-326.01375"
+      z="822.373125"/>
         <rotationref ref="rIdentity"/>
       </physvol>
 
@@ -70127,7 +70264,7 @@ z="474.585"/>
         <volumeref ref="volG10BoardZSideCenterSeg"/>
         <position name="posG10BoardZSideCenterSeg-Z-10" unit="cm"
       x="0"
-      y="-22.22"
+      y="-22.775625"
       z="706.975"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -70135,7 +70272,7 @@ z="474.585"/>
         <volumeref ref="volG10BoardZSideCenterSeg"/>
         <position name="posG10BoardZSideCenterSeg-V-10" unit="cm"
       x="0"
-      y="-21.9025"
+      y="-22.2993750000001"
       z="706.975"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -70143,7 +70280,7 @@ z="474.585"/>
         <volumeref ref="volG10BoardZSideCenterSeg"/>
         <position name="posG10BoardZSideCenterSeg-U-10" unit="cm"
       x="0"
-      y="-21.585"
+      y="-21.8231250000001"
       z="706.975"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -70151,7 +70288,7 @@ z="474.585"/>
         <volumeref ref="volG10BoardZSideCenterSeg"/>
         <position name="posG10BoardZSideCenterSeg-Grid-10" unit="cm"
       x="0"
-      y="-21.2675"
+      y="-21.3468750000001"
       z="706.975"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -70160,7 +70297,7 @@ z="474.585"/>
 <volumeref ref="volArapuca_10-0"/>
 <position name="posArapuca10-0-TPC-12-0-5" unit="cm"
 x="0"
-y="-612.31875"
+y="-612.95375"
 z="706.975"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -70168,7 +70305,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_10-0-0"/>
        <position name="posOpArapuca10-0-0-TPC-12-0-5" unit="cm"
          x="-0.0500000000000002"
-       y="-612.31875"
+       y="-612.95375"
          z="626.775"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -70176,7 +70313,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_10-0-1"/>
        <position name="posOpArapuca10-0-1-TPC-12-0-5" unit="cm"
          x="-0.0500000000000002"
-       y="-612.31875"
+       y="-612.95375"
          z="675.575"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -70184,7 +70321,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_10-0-2"/>
        <position name="posOpArapuca10-0-2-TPC-12-0-5" unit="cm"
          x="-0.0500000000000002"
-       y="-612.31875"
+       y="-612.95375"
          z="738.375"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -70192,7 +70329,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_10-0-3"/>
        <position name="posOpArapuca10-0-3-TPC-12-0-5" unit="cm"
          x="-0.0500000000000002"
-       y="-612.31875"
+       y="-612.95375"
          z="787.175"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -70200,7 +70337,7 @@ z="706.975"/>
 <volumeref ref="volArapuca_10-1"/>
 <position name="posArapuca10-1-TPC-12-0-5" unit="cm"
 x="0"
-y="-550.048355263158"
+y="-550.616513157895"
 z="706.975"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -70208,7 +70345,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_10-1-0"/>
        <position name="posOpArapuca10-1-0-TPC-12-0-5" unit="cm"
          x="-0.0500000000000002"
-       y="-550.048355263158"
+       y="-550.616513157895"
          z="626.775"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -70216,7 +70353,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_10-1-1"/>
        <position name="posOpArapuca10-1-1-TPC-12-0-5" unit="cm"
          x="-0.0500000000000002"
-       y="-550.048355263158"
+       y="-550.616513157895"
          z="675.575"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -70224,7 +70361,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_10-1-2"/>
        <position name="posOpArapuca10-1-2-TPC-12-0-5" unit="cm"
          x="-0.0500000000000002"
-       y="-550.048355263158"
+       y="-550.616513157895"
          z="738.375"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -70232,7 +70369,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_10-1-3"/>
        <position name="posOpArapuca10-1-3-TPC-12-0-5" unit="cm"
          x="-0.0500000000000002"
-       y="-550.048355263158"
+       y="-550.616513157895"
          z="787.175"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -70240,7 +70377,7 @@ z="706.975"/>
 <volumeref ref="volArapuca_10-2"/>
 <position name="posArapuca10-2-TPC-12-0-5" unit="cm"
 x="0"
-y="-487.777960526316"
+y="-488.27927631579"
 z="706.975"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -70248,7 +70385,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_10-2-0"/>
        <position name="posOpArapuca10-2-0-TPC-12-0-5" unit="cm"
          x="-0.0500000000000002"
-       y="-487.777960526316"
+       y="-488.27927631579"
          z="626.775"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -70256,7 +70393,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_10-2-1"/>
        <position name="posOpArapuca10-2-1-TPC-12-0-5" unit="cm"
          x="-0.0500000000000002"
-       y="-487.777960526316"
+       y="-488.27927631579"
          z="675.575"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -70264,7 +70401,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_10-2-2"/>
        <position name="posOpArapuca10-2-2-TPC-12-0-5" unit="cm"
          x="-0.0500000000000002"
-       y="-487.777960526316"
+       y="-488.27927631579"
          z="738.375"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -70272,7 +70409,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_10-2-3"/>
        <position name="posOpArapuca10-2-3-TPC-12-0-5" unit="cm"
          x="-0.0500000000000002"
-       y="-487.777960526316"
+       y="-488.27927631579"
          z="787.175"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -70280,7 +70417,7 @@ z="706.975"/>
 <volumeref ref="volArapuca_10-3"/>
 <position name="posArapuca10-3-TPC-12-0-5" unit="cm"
 x="0"
-y="-425.507565789474"
+y="-425.942039473684"
 z="706.975"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -70288,7 +70425,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_10-3-0"/>
        <position name="posOpArapuca10-3-0-TPC-12-0-5" unit="cm"
          x="-0.0500000000000002"
-       y="-425.507565789474"
+       y="-425.942039473684"
          z="626.775"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -70296,7 +70433,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_10-3-1"/>
        <position name="posOpArapuca10-3-1-TPC-12-0-5" unit="cm"
          x="-0.0500000000000002"
-       y="-425.507565789474"
+       y="-425.942039473684"
          z="675.575"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -70304,7 +70441,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_10-3-2"/>
        <position name="posOpArapuca10-3-2-TPC-12-0-5" unit="cm"
          x="-0.0500000000000002"
-       y="-425.507565789474"
+       y="-425.942039473684"
          z="738.375"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -70312,7 +70449,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_10-3-3"/>
        <position name="posOpArapuca10-3-3-TPC-12-0-5" unit="cm"
          x="-0.0500000000000002"
-       y="-425.507565789474"
+       y="-425.942039473684"
          z="787.175"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -70320,7 +70457,7 @@ z="706.975"/>
 <volumeref ref="volArapuca_10-4"/>
 <position name="posArapuca10-4-TPC-12-0-5" unit="cm"
 x="0"
-y="-363.237171052632"
+y="-363.604802631579"
 z="706.975"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -70328,7 +70465,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_10-4-0"/>
        <position name="posOpArapuca10-4-0-TPC-12-0-5" unit="cm"
          x="-0.0500000000000002"
-       y="-363.237171052632"
+       y="-363.604802631579"
          z="626.775"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -70336,7 +70473,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_10-4-1"/>
        <position name="posOpArapuca10-4-1-TPC-12-0-5" unit="cm"
          x="-0.0500000000000002"
-       y="-363.237171052632"
+       y="-363.604802631579"
          z="675.575"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -70344,7 +70481,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_10-4-2"/>
        <position name="posOpArapuca10-4-2-TPC-12-0-5" unit="cm"
          x="-0.0500000000000002"
-       y="-363.237171052632"
+       y="-363.604802631579"
          z="738.375"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -70352,7 +70489,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_10-4-3"/>
        <position name="posOpArapuca10-4-3-TPC-12-0-5" unit="cm"
          x="-0.0500000000000002"
-       y="-363.237171052632"
+       y="-363.604802631579"
          z="787.175"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -70360,7 +70497,7 @@ z="706.975"/>
 <volumeref ref="volArapuca_10-5"/>
 <position name="posArapuca10-5-TPC-12-0-5" unit="cm"
 x="0"
-y="-300.96677631579"
+y="-301.267565789474"
 z="706.975"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -70368,7 +70505,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_10-5-0"/>
        <position name="posOpArapuca10-5-0-TPC-12-0-5" unit="cm"
          x="-0.0500000000000002"
-       y="-300.96677631579"
+       y="-301.267565789474"
          z="626.775"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -70376,7 +70513,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_10-5-1"/>
        <position name="posOpArapuca10-5-1-TPC-12-0-5" unit="cm"
          x="-0.0500000000000002"
-       y="-300.96677631579"
+       y="-301.267565789474"
          z="675.575"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -70384,7 +70521,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_10-5-2"/>
        <position name="posOpArapuca10-5-2-TPC-12-0-5" unit="cm"
          x="-0.0500000000000002"
-       y="-300.96677631579"
+       y="-301.267565789474"
          z="738.375"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -70392,7 +70529,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_10-5-3"/>
        <position name="posOpArapuca10-5-3-TPC-12-0-5" unit="cm"
          x="-0.0500000000000002"
-       y="-300.96677631579"
+       y="-301.267565789474"
          z="787.175"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -70400,7 +70537,7 @@ z="706.975"/>
 <volumeref ref="volArapuca_10-6"/>
 <position name="posArapuca10-6-TPC-12-0-5" unit="cm"
 x="0"
-y="-238.696381578947"
+y="-238.930328947368"
 z="706.975"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -70408,7 +70545,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_10-6-0"/>
        <position name="posOpArapuca10-6-0-TPC-12-0-5" unit="cm"
          x="-0.0500000000000002"
-       y="-238.696381578947"
+       y="-238.930328947368"
          z="626.775"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -70416,7 +70553,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_10-6-1"/>
        <position name="posOpArapuca10-6-1-TPC-12-0-5" unit="cm"
          x="-0.0500000000000002"
-       y="-238.696381578947"
+       y="-238.930328947368"
          z="675.575"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -70424,7 +70561,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_10-6-2"/>
        <position name="posOpArapuca10-6-2-TPC-12-0-5" unit="cm"
          x="-0.0500000000000002"
-       y="-238.696381578947"
+       y="-238.930328947368"
          z="738.375"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -70432,7 +70569,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_10-6-3"/>
        <position name="posOpArapuca10-6-3-TPC-12-0-5" unit="cm"
          x="-0.0500000000000002"
-       y="-238.696381578947"
+       y="-238.930328947368"
          z="787.175"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -70440,7 +70577,7 @@ z="706.975"/>
 <volumeref ref="volArapuca_10-7"/>
 <position name="posArapuca10-7-TPC-12-0-5" unit="cm"
 x="0"
-y="-176.425986842105"
+y="-176.593092105263"
 z="706.975"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -70448,7 +70585,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_10-7-0"/>
        <position name="posOpArapuca10-7-0-TPC-12-0-5" unit="cm"
          x="-0.0500000000000002"
-       y="-176.425986842105"
+       y="-176.593092105263"
          z="626.775"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -70456,7 +70593,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_10-7-1"/>
        <position name="posOpArapuca10-7-1-TPC-12-0-5" unit="cm"
          x="-0.0500000000000002"
-       y="-176.425986842105"
+       y="-176.593092105263"
          z="675.575"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -70464,7 +70601,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_10-7-2"/>
        <position name="posOpArapuca10-7-2-TPC-12-0-5" unit="cm"
          x="-0.0500000000000002"
-       y="-176.425986842105"
+       y="-176.593092105263"
          z="738.375"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -70472,7 +70609,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_10-7-3"/>
        <position name="posOpArapuca10-7-3-TPC-12-0-5" unit="cm"
          x="-0.0500000000000002"
-       y="-176.425986842105"
+       y="-176.593092105263"
          z="787.175"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -70480,7 +70617,7 @@ z="706.975"/>
 <volumeref ref="volArapuca_10-8"/>
 <position name="posArapuca10-8-TPC-12-0-5" unit="cm"
 x="0"
-y="-114.155592105263"
+y="-114.255855263158"
 z="706.975"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -70488,7 +70625,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_10-8-0"/>
        <position name="posOpArapuca10-8-0-TPC-12-0-5" unit="cm"
          x="-0.0500000000000002"
-       y="-114.155592105263"
+       y="-114.255855263158"
          z="626.775"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -70496,7 +70633,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_10-8-1"/>
        <position name="posOpArapuca10-8-1-TPC-12-0-5" unit="cm"
          x="-0.0500000000000002"
-       y="-114.155592105263"
+       y="-114.255855263158"
          z="675.575"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -70504,7 +70641,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_10-8-2"/>
        <position name="posOpArapuca10-8-2-TPC-12-0-5" unit="cm"
          x="-0.0500000000000002"
-       y="-114.155592105263"
+       y="-114.255855263158"
          z="738.375"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -70512,7 +70649,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_10-8-3"/>
        <position name="posOpArapuca10-8-3-TPC-12-0-5" unit="cm"
          x="-0.0500000000000002"
-       y="-114.155592105263"
+       y="-114.255855263158"
          z="787.175"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -70520,7 +70657,7 @@ z="706.975"/>
 <volumeref ref="volArapuca_10-9"/>
 <position name="posArapuca10-9-TPC-12-0-5" unit="cm"
 x="0"
-y="-51.885197368421"
+y="-51.9186184210527"
 z="706.975"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -70528,7 +70665,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_10-9-0"/>
        <position name="posOpArapuca10-9-0-TPC-12-0-5" unit="cm"
          x="-0.0500000000000002"
-       y="-51.885197368421"
+       y="-51.9186184210527"
          z="626.775"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -70536,7 +70673,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_10-9-1"/>
        <position name="posOpArapuca10-9-1-TPC-12-0-5" unit="cm"
          x="-0.0500000000000002"
-       y="-51.885197368421"
+       y="-51.9186184210527"
          z="675.575"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -70544,7 +70681,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_10-9-2"/>
        <position name="posOpArapuca10-9-2-TPC-12-0-5" unit="cm"
          x="-0.0500000000000002"
-       y="-51.885197368421"
+       y="-51.9186184210527"
          z="738.375"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -70552,7 +70689,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_10-9-3"/>
        <position name="posOpArapuca10-9-3-TPC-12-0-5" unit="cm"
          x="-0.0500000000000002"
-       y="-51.885197368421"
+       y="-51.9186184210527"
          z="787.175"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -70561,7 +70698,7 @@ z="706.975"/>
         <volumeref ref="volTPCInner"/>
         <position name="posTPC-20" unit="cm"
         x="-182.95455"
-        y="-324.664375"
+        y="-324.981875"
         z="706.975"/>
         <rotationref ref="rPlus180AboutXPlus180AboutY"/>
       </physvol>
@@ -70569,7 +70706,7 @@ z="706.975"/>
         <volumeref ref="volTPCInner"/>
         <position name="posTPC-21" unit="cm"
         x="182.95455"
-        y="-324.664375"
+        y="-324.981875"
         z="706.975"/>
         <rotationref ref="rPlus180AboutX"/>
       </physvol>
@@ -70577,16 +70714,16 @@ z="706.975"/>
       <physvol>
         <volumeref ref="volCathode"/>
         <position name="posCathode-11-0" unit="cm"
-      x="-363.38405"
-      y="-324.664375"
+      x="-363.52605"
+      y="-324.981875"
       z="706.975"/>
         <rotationref ref="rIdentity"/>
       </physvol>
       <physvol>
         <volumeref ref="volCathode"/>
         <position name="posCathode-11-1" unit="cm"
-      x="363.38405"
-      y="-324.664375"
+      x="363.52605"
+      y="-324.981875"
       z="706.975"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -70595,23 +70732,23 @@ z="706.975"/>
         <volumeref ref="volAPAFrameYSide"/>
         <position name="posAPAFrameYSideNeg-11" unit="cm"
       x="0"
-      y="283.87875"
-      z="597.05375"/>
+      y="284.51375"
+      z="597.37125"/>
         <rotationref ref="rIdentity"/>
       </physvol>
       <physvol>
         <volumeref ref="volAPAFrameYSide"/>
         <position name="posAPAFrameYSidePos-11" unit="cm"
       x="0"
-      y="283.87875"
-      z="816.89625"/>
+      y="284.51375"
+      z="816.57875"/>
         <rotationref ref="rIdentity"/>
       </physvol>
       <physvol>
         <volumeref ref="volAPAFrameZSide"/>
         <position name="posAPAFrameZSidePos-11" unit="cm"
       x="0"
-      y="581.79875"
+      y="582.43375"
       z="706.975"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -70619,7 +70756,7 @@ z="706.975"/>
         <volumeref ref="volAPAFrameZSide"/>
         <position name="posAPAFrameZSideNeg-11" unit="cm"
       x="0"
-      y="-14.0412500000001"
+      y="-13.40625"
       z="706.975"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -70630,22 +70767,33 @@ z="706.975"/>
       - There are two boards on each the up and downstream end,
           one each to wrap the U and V views around the APA frame
       - There are 4 on the bottom which anchor the U V and Z wires and the grid plane
-      - The rest of the parts of the G10 boards must be placed directly in volTPC   -->
+      FIXME: This is not true -> - The rest of the parts of the G10 boards must be placed directly in volTPC   -->
+
+      <!-- Position readout boards -->
+      <physvol>
+        <volumeref ref="volG10HeadBoards"/>
+        <position name="posG10HeadBoards-11" unit="cm"
+	  x="0"
+	  y="598.01775"
+      	  z="706.975"/>
+        <rotationref ref="rIdentity"/>
+      </physvol>
 
       <physvol>
         <volumeref ref="volG10BoardYSideCenterSeg"/>
         <position name="posG10BoardYSideCenterSeg-Vup-11" unit="cm"
-      x="0"
-      y="283.87875"
-      z="591.815"/>
-        <rotationref ref="rIdentity"/>
+         x="0"
+         y="284.51375"
+         z="592.053125"/>
+         <rotationref ref="rIdentity"/>
       </physvol>
+
       <physvol>
         <volumeref ref="volG10BoardYSideCenterSeg"/>
         <position name="posG10BoardYSideCenterSeg-Uup-11" unit="cm"
       x="0"
-      y="283.87875"
-      z="591.4975"/>
+      y="284.51375"
+      z="591.576875"/>
         <rotationref ref="rIdentity"/>
       </physvol>
 
@@ -70653,16 +70801,16 @@ z="706.975"/>
         <volumeref ref="volG10BoardYSideCenterSeg"/>
         <position name="posG10BoardYSideCenterSeg-Vdown-11" unit="cm"
       x="0"
-      y="283.87875"
-      z="822.135"/>
+      y="284.51375"
+      z="821.896875"/>
         <rotationref ref="rIdentity"/>
       </physvol>
       <physvol>
         <volumeref ref="volG10BoardYSideCenterSeg"/>
         <position name="posG10BoardYSideCenterSeg-Udown-11" unit="cm"
       x="0"
-      y="283.87875"
-      z="822.4525"/>
+      y="284.51375"
+      z="822.373125"/>
         <rotationref ref="rIdentity"/>
       </physvol>
 
@@ -70670,7 +70818,7 @@ z="706.975"/>
         <volumeref ref="volG10BoardZSideCenterSeg"/>
         <position name="posG10BoardZSideCenterSeg-Z-11" unit="cm"
       x="0"
-      y="-19.2800000000001"
+      y="-18.7243750000001"
       z="706.975"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -70678,7 +70826,7 @@ z="706.975"/>
         <volumeref ref="volG10BoardZSideCenterSeg"/>
         <position name="posG10BoardZSideCenterSeg-V-11" unit="cm"
       x="0"
-      y="-19.5975000000001"
+      y="-19.2006250000001"
       z="706.975"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -70686,7 +70834,7 @@ z="706.975"/>
         <volumeref ref="volG10BoardZSideCenterSeg"/>
         <position name="posG10BoardZSideCenterSeg-U-11" unit="cm"
       x="0"
-      y="-19.9150000000001"
+      y="-19.6768750000001"
       z="706.975"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -70694,7 +70842,7 @@ z="706.975"/>
         <volumeref ref="volG10BoardZSideCenterSeg"/>
         <position name="posG10BoardZSideCenterSeg-Grid-11" unit="cm"
       x="0"
-      y="-20.2325000000001"
+      y="-20.153125"
       z="706.975"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -70703,7 +70851,7 @@ z="706.975"/>
 <volumeref ref="volArapuca_11-0"/>
 <position name="posArapuca11-0-TPC-12-1-5" unit="cm"
 x="0"
-y="10.385197368421"
+y="10.4186184210526"
 z="706.975"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -70711,7 +70859,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_11-0-0"/>
        <position name="posOpArapuca11-0-0-TPC-12-1-5" unit="cm"
          x="0.0500000000000002"
-       y="10.385197368421"
+       y="10.4186184210526"
          z="626.775"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -70719,7 +70867,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_11-0-1"/>
        <position name="posOpArapuca11-0-1-TPC-12-1-5" unit="cm"
          x="0.0500000000000002"
-       y="10.385197368421"
+       y="10.4186184210526"
          z="675.575"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -70727,7 +70875,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_11-0-2"/>
        <position name="posOpArapuca11-0-2-TPC-12-1-5" unit="cm"
          x="0.0500000000000002"
-       y="10.385197368421"
+       y="10.4186184210526"
          z="738.375"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -70735,7 +70883,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_11-0-3"/>
        <position name="posOpArapuca11-0-3-TPC-12-1-5" unit="cm"
          x="0.0500000000000002"
-       y="10.385197368421"
+       y="10.4186184210526"
          z="787.175"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -70743,7 +70891,7 @@ z="706.975"/>
 <volumeref ref="volArapuca_11-1"/>
 <position name="posArapuca11-1-TPC-12-1-5" unit="cm"
 x="0"
-y="72.6555921052631"
+y="72.7558552631579"
 z="706.975"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -70751,7 +70899,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_11-1-0"/>
        <position name="posOpArapuca11-1-0-TPC-12-1-5" unit="cm"
          x="0.0500000000000002"
-       y="72.6555921052631"
+       y="72.7558552631579"
          z="626.775"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -70759,7 +70907,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_11-1-1"/>
        <position name="posOpArapuca11-1-1-TPC-12-1-5" unit="cm"
          x="0.0500000000000002"
-       y="72.6555921052631"
+       y="72.7558552631579"
          z="675.575"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -70767,7 +70915,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_11-1-2"/>
        <position name="posOpArapuca11-1-2-TPC-12-1-5" unit="cm"
          x="0.0500000000000002"
-       y="72.6555921052631"
+       y="72.7558552631579"
          z="738.375"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -70775,7 +70923,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_11-1-3"/>
        <position name="posOpArapuca11-1-3-TPC-12-1-5" unit="cm"
          x="0.0500000000000002"
-       y="72.6555921052631"
+       y="72.7558552631579"
          z="787.175"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -70783,7 +70931,7 @@ z="706.975"/>
 <volumeref ref="volArapuca_11-2"/>
 <position name="posArapuca11-2-TPC-12-1-5" unit="cm"
 x="0"
-y="134.925986842105"
+y="135.093092105263"
 z="706.975"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -70791,7 +70939,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_11-2-0"/>
        <position name="posOpArapuca11-2-0-TPC-12-1-5" unit="cm"
          x="0.0500000000000002"
-       y="134.925986842105"
+       y="135.093092105263"
          z="626.775"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -70799,7 +70947,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_11-2-1"/>
        <position name="posOpArapuca11-2-1-TPC-12-1-5" unit="cm"
          x="0.0500000000000002"
-       y="134.925986842105"
+       y="135.093092105263"
          z="675.575"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -70807,7 +70955,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_11-2-2"/>
        <position name="posOpArapuca11-2-2-TPC-12-1-5" unit="cm"
          x="0.0500000000000002"
-       y="134.925986842105"
+       y="135.093092105263"
          z="738.375"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -70815,7 +70963,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_11-2-3"/>
        <position name="posOpArapuca11-2-3-TPC-12-1-5" unit="cm"
          x="0.0500000000000002"
-       y="134.925986842105"
+       y="135.093092105263"
          z="787.175"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -70823,7 +70971,7 @@ z="706.975"/>
 <volumeref ref="volArapuca_11-3"/>
 <position name="posArapuca11-3-TPC-12-1-5" unit="cm"
 x="0"
-y="197.196381578947"
+y="197.430328947368"
 z="706.975"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -70831,7 +70979,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_11-3-0"/>
        <position name="posOpArapuca11-3-0-TPC-12-1-5" unit="cm"
          x="0.0500000000000002"
-       y="197.196381578947"
+       y="197.430328947368"
          z="626.775"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -70839,7 +70987,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_11-3-1"/>
        <position name="posOpArapuca11-3-1-TPC-12-1-5" unit="cm"
          x="0.0500000000000002"
-       y="197.196381578947"
+       y="197.430328947368"
          z="675.575"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -70847,7 +70995,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_11-3-2"/>
        <position name="posOpArapuca11-3-2-TPC-12-1-5" unit="cm"
          x="0.0500000000000002"
-       y="197.196381578947"
+       y="197.430328947368"
          z="738.375"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -70855,7 +71003,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_11-3-3"/>
        <position name="posOpArapuca11-3-3-TPC-12-1-5" unit="cm"
          x="0.0500000000000002"
-       y="197.196381578947"
+       y="197.430328947368"
          z="787.175"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -70863,7 +71011,7 @@ z="706.975"/>
 <volumeref ref="volArapuca_11-4"/>
 <position name="posArapuca11-4-TPC-12-1-5" unit="cm"
 x="0"
-y="259.46677631579"
+y="259.767565789474"
 z="706.975"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -70871,7 +71019,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_11-4-0"/>
        <position name="posOpArapuca11-4-0-TPC-12-1-5" unit="cm"
          x="0.0500000000000002"
-       y="259.46677631579"
+       y="259.767565789474"
          z="626.775"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -70879,7 +71027,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_11-4-1"/>
        <position name="posOpArapuca11-4-1-TPC-12-1-5" unit="cm"
          x="0.0500000000000002"
-       y="259.46677631579"
+       y="259.767565789474"
          z="675.575"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -70887,7 +71035,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_11-4-2"/>
        <position name="posOpArapuca11-4-2-TPC-12-1-5" unit="cm"
          x="0.0500000000000002"
-       y="259.46677631579"
+       y="259.767565789474"
          z="738.375"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -70895,7 +71043,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_11-4-3"/>
        <position name="posOpArapuca11-4-3-TPC-12-1-5" unit="cm"
          x="0.0500000000000002"
-       y="259.46677631579"
+       y="259.767565789474"
          z="787.175"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -70903,7 +71051,7 @@ z="706.975"/>
 <volumeref ref="volArapuca_11-5"/>
 <position name="posArapuca11-5-TPC-12-1-5" unit="cm"
 x="0"
-y="321.737171052632"
+y="322.104802631579"
 z="706.975"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -70911,7 +71059,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_11-5-0"/>
        <position name="posOpArapuca11-5-0-TPC-12-1-5" unit="cm"
          x="0.0500000000000002"
-       y="321.737171052632"
+       y="322.104802631579"
          z="626.775"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -70919,7 +71067,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_11-5-1"/>
        <position name="posOpArapuca11-5-1-TPC-12-1-5" unit="cm"
          x="0.0500000000000002"
-       y="321.737171052632"
+       y="322.104802631579"
          z="675.575"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -70927,7 +71075,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_11-5-2"/>
        <position name="posOpArapuca11-5-2-TPC-12-1-5" unit="cm"
          x="0.0500000000000002"
-       y="321.737171052632"
+       y="322.104802631579"
          z="738.375"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -70935,7 +71083,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_11-5-3"/>
        <position name="posOpArapuca11-5-3-TPC-12-1-5" unit="cm"
          x="0.0500000000000002"
-       y="321.737171052632"
+       y="322.104802631579"
          z="787.175"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -70943,7 +71091,7 @@ z="706.975"/>
 <volumeref ref="volArapuca_11-6"/>
 <position name="posArapuca11-6-TPC-12-1-5" unit="cm"
 x="0"
-y="384.007565789474"
+y="384.442039473684"
 z="706.975"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -70951,7 +71099,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_11-6-0"/>
        <position name="posOpArapuca11-6-0-TPC-12-1-5" unit="cm"
          x="0.0500000000000002"
-       y="384.007565789474"
+       y="384.442039473684"
          z="626.775"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -70959,7 +71107,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_11-6-1"/>
        <position name="posOpArapuca11-6-1-TPC-12-1-5" unit="cm"
          x="0.0500000000000002"
-       y="384.007565789474"
+       y="384.442039473684"
          z="675.575"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -70967,7 +71115,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_11-6-2"/>
        <position name="posOpArapuca11-6-2-TPC-12-1-5" unit="cm"
          x="0.0500000000000002"
-       y="384.007565789474"
+       y="384.442039473684"
          z="738.375"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -70975,7 +71123,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_11-6-3"/>
        <position name="posOpArapuca11-6-3-TPC-12-1-5" unit="cm"
          x="0.0500000000000002"
-       y="384.007565789474"
+       y="384.442039473684"
          z="787.175"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -70983,7 +71131,7 @@ z="706.975"/>
 <volumeref ref="volArapuca_11-7"/>
 <position name="posArapuca11-7-TPC-12-1-5" unit="cm"
 x="0"
-y="446.277960526316"
+y="446.77927631579"
 z="706.975"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -70991,7 +71139,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_11-7-0"/>
        <position name="posOpArapuca11-7-0-TPC-12-1-5" unit="cm"
          x="0.0500000000000002"
-       y="446.277960526316"
+       y="446.77927631579"
          z="626.775"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -70999,7 +71147,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_11-7-1"/>
        <position name="posOpArapuca11-7-1-TPC-12-1-5" unit="cm"
          x="0.0500000000000002"
-       y="446.277960526316"
+       y="446.77927631579"
          z="675.575"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -71007,7 +71155,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_11-7-2"/>
        <position name="posOpArapuca11-7-2-TPC-12-1-5" unit="cm"
          x="0.0500000000000002"
-       y="446.277960526316"
+       y="446.77927631579"
          z="738.375"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -71015,7 +71163,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_11-7-3"/>
        <position name="posOpArapuca11-7-3-TPC-12-1-5" unit="cm"
          x="0.0500000000000002"
-       y="446.277960526316"
+       y="446.77927631579"
          z="787.175"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -71023,7 +71171,7 @@ z="706.975"/>
 <volumeref ref="volArapuca_11-8"/>
 <position name="posArapuca11-8-TPC-12-1-5" unit="cm"
 x="0"
-y="508.548355263158"
+y="509.116513157895"
 z="706.975"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -71031,7 +71179,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_11-8-0"/>
        <position name="posOpArapuca11-8-0-TPC-12-1-5" unit="cm"
          x="0.0500000000000002"
-       y="508.548355263158"
+       y="509.116513157895"
          z="626.775"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -71039,7 +71187,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_11-8-1"/>
        <position name="posOpArapuca11-8-1-TPC-12-1-5" unit="cm"
          x="0.0500000000000002"
-       y="508.548355263158"
+       y="509.116513157895"
          z="675.575"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -71047,7 +71195,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_11-8-2"/>
        <position name="posOpArapuca11-8-2-TPC-12-1-5" unit="cm"
          x="0.0500000000000002"
-       y="508.548355263158"
+       y="509.116513157895"
          z="738.375"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -71055,7 +71203,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_11-8-3"/>
        <position name="posOpArapuca11-8-3-TPC-12-1-5" unit="cm"
          x="0.0500000000000002"
-       y="508.548355263158"
+       y="509.116513157895"
          z="787.175"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -71063,7 +71211,7 @@ z="706.975"/>
 <volumeref ref="volArapuca_11-9"/>
 <position name="posArapuca11-9-TPC-12-1-5" unit="cm"
 x="0"
-y="570.81875"
+y="571.45375"
 z="706.975"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -71071,7 +71219,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_11-9-0"/>
        <position name="posOpArapuca11-9-0-TPC-12-1-5" unit="cm"
          x="0.0500000000000002"
-       y="570.81875"
+       y="571.45375"
          z="626.775"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -71079,7 +71227,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_11-9-1"/>
        <position name="posOpArapuca11-9-1-TPC-12-1-5" unit="cm"
          x="0.0500000000000002"
-       y="570.81875"
+       y="571.45375"
          z="675.575"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -71087,7 +71235,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_11-9-2"/>
        <position name="posOpArapuca11-9-2-TPC-12-1-5" unit="cm"
          x="0.0500000000000002"
-       y="570.81875"
+       y="571.45375"
          z="738.375"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -71095,7 +71243,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_11-9-3"/>
        <position name="posOpArapuca11-9-3-TPC-12-1-5" unit="cm"
          x="0.0500000000000002"
-       y="570.81875"
+       y="571.45375"
          z="787.175"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -71104,7 +71252,7 @@ z="706.975"/>
         <volumeref ref="volTPCInner"/>
         <position name="posTPC-22" unit="cm"
         x="-182.95455"
-        y="283.164375"
+        y="283.481875"
         z="706.975"/>
         <rotationref ref="rPlus180AboutY"/>
       </physvol>
@@ -71112,7 +71260,7 @@ z="706.975"/>
         <volumeref ref="volTPCInner"/>
         <position name="posTPC-23" unit="cm"
         x="182.95455"
-        y="283.164375"
+        y="283.481875"
         z="706.975"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -71120,16 +71268,16 @@ z="706.975"/>
       <physvol>
         <volumeref ref="volCathode"/>
         <position name="posCathode-12-0" unit="cm"
-      x="-363.38405"
-      y="283.164375"
+      x="-363.52605"
+      y="283.481875"
       z="706.975"/>
         <rotationref ref="rIdentity"/>
       </physvol>
       <physvol>
         <volumeref ref="volCathode"/>
         <position name="posCathode-12-1" unit="cm"
-      x="363.38405"
-      y="283.164375"
+      x="363.52605"
+      y="283.481875"
       z="706.975"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -71170,7 +71318,7 @@ z="706.975"/>
 
       <physvol>
         <volumeref ref="volDetEnclosure"/>
-      <position name="posDetEnclosure" unit="cm" x="0" y="120.75" z="570.29375"/>
+      <position name="posDetEnclosure" unit="cm" x="0" y="120.75" z="570.135"/>
       </physvol>
 
     </volume>

--- a/dunecore/Geometry/gdml/dune10kt_v5_refactored_1x2x6_nowires.gdml
+++ b/dunecore/Geometry/gdml/dune10kt_v5_refactored_1x2x6_nowires.gdml
@@ -215,6 +215,11 @@
    <fraction n="0.53" ref="fibrous_glass"/>
   </material>
 
+  <material name="FR4SussexAPA">
+   <D value="1.75" unit="g/cm3"/>
+   <fraction n="1" ref="FR4"/>
+  </material>
+
   <material name="STEEL_STAINLESS_Fe7Cr2Ni" formula="STEEL_STAINLESS_Fe7Cr2Ni">
    <D value="7.9300" unit="g/cm3"/>
    <fraction n="0.0010" ref="carbon"/>
@@ -391,7 +396,7 @@
 <solids>
     <box name="Inner" lunit="cm"
       x="360.843"
-      y="607.82875"
+      y="608.46375"
       z="232.39"/>
     <box name="InnerUPlane" lunit="cm"
       x="0.015"
@@ -407,7 +412,7 @@
       z="229.456"/>
     <box name="InnerActive" lunit="cm"
       x="359.415"
-      y="600.01875"
+      y="600.65375"
       z="232.39"/>
 
     <tube name="InnerWireVert"
@@ -419,7 +424,7 @@
 
     <box name="Outer" lunit="cm"
       x="16.443"
-      y="607.82875"
+      y="608.46375"
       z="232.39"/>
     <box name="OuterUPlane" lunit="cm"
       x="0.015"
@@ -435,7 +440,7 @@
       z="229.456"/>
     <box name="OuterActive" lunit="cm"
       x="15.015"
-      y="600.01875"
+      y="600.65375"
       z="232.39"/>
 
     <tube name="OuterWireVert"
@@ -452,27 +457,27 @@
       aunit="deg"
       lunit="cm"/>
     <box name="Cryostat" lunit="cm"
-      x="759.3241"
-      y="1357.6975"
+      x="759.8921"
+      y="1358.9675"
       z="1746.48"/>
     <box name="ArgonInterior" lunit="cm"
-      x="756.7841"
-      y="1355.1575"
+      x="757.3521"
+      y="1356.4275"
       z="1743.94"/>
     <box name="FieldCageOut" lunit="cm"
-      x="726.7841"
-      y="1216.1655"
-      z="1394.848"/>
+      x="727.3521"
+      y="1219.4355"
+      z="1396.848"/>
     <box name="FieldCageIn" lunit="cm"
-      x="727.7841"
-      y="1215.6575"
-      z="1394.34"/>
+      x="728.3521"
+      y="1218.9275"
+      z="1396.34"/>
     <subtraction name="FieldCage">
       <first ref="FieldCageOut"/>
       <second ref="FieldCageIn"/>
     </subtraction>
     <box name="GaseousArgon" lunit="cm"
-      x="756.7841"
+      x="757.3521"
       y="50"
       z="1743.94"/>
     <subtraction name="SteelShell">
@@ -480,8 +485,8 @@
       <second ref="ArgonInterior"/>
     </subtraction>
     <box name="Cathode" lunit="cm"
-      x="0.016"
-      y="602.36275"
+      x="0.3"
+      y="602.99775"
       z="226.524"/>
 
     <box name="ArapucaOut" lunit="cm"
@@ -538,11 +543,11 @@
      <box name="APAFrameZSideHollow" lunit="cm"
       x="4.4565"
       y="9.5504"
-      z="230.0025"/>
+      z="229.3675"/>
      <box name="APAFrameZSideShell" lunit="cm"
       x="5.0661"
       y="10.16"
-      z="230.0025"/>
+      z="229.3675"/>
      <subtraction name="APAFrameZSide">
       <first  ref="APAFrameZSideShell"/>
       <second ref="APAFrameZSideHollow"/>
@@ -559,23 +564,29 @@
      <box name="G10BoardYSideCenterSeg" lunit="cm"
       x="5.0661"
       y="606"
-      z="0.3175"/>
+      z="0.47625"/>
 
      <box name="G10BoardZSideCenterSeg" lunit="cm"
       x="5.0661"
-      y="0.3175"
-      z="230.0025"/>
+      y="0.47625"
+      z="229.3675"/>
+
+      <!-- Approximate stack of FR-4 readout boards at APA head -->
+     <box name="G10HeadBoards" lunit="cm"
+      x="3.81"
+      y="16.5"
+      z="229.3675"/>
 
 
 
     <box name="FoamPadBlock" lunit="cm"
-      x="919.3241"
-      y="1517.6975"
+      x="919.8921"
+      y="1518.9675"
       z="1906.48" />
 
     <box name="FoamPadInner" lunit="cm"
-      x="759.3341"
-      y="1357.7075"
+      x="759.9021"
+      y="1358.9775"
       z="1746.49" />
 
     <subtraction name="FoamPadding">
@@ -585,13 +596,13 @@
     </subtraction>
 
     <box name="SteelSupportBlock" lunit="cm"
-      x="1119.3241"
-      y="1617.6975"
+      x="1119.8921"
+      y="1618.9675"
       z="2106.48" />
 
     <box name="SteelSupportInner" lunit="cm"
-      x="919.3341"
-      y="1517.7075"
+      x="919.9021"
+      y="1518.9775"
       z="1906.49" />
 
     <subtraction name="SteelSupport">
@@ -601,14 +612,14 @@
     </subtraction>
 
     <box name="DetEnclosure" lunit="cm"
-      x="1219.3241"
-      y="1817.6975"
+      x="1219.8921"
+      y="1818.9675"
       z="2306.48"/>
 
 
     <box name="World" lunit="cm"
-      x="7219.3241"
-      y="7817.6975"
+      x="7219.8921"
+      y="7818.9675"
       z="8306.48"/>
 </solids>
 <structure>
@@ -647,19 +658,19 @@
      <physvol>
        <volumeref ref="volTPCPlaneZInner"/>
        <position name="posInnerPlaneZ" unit="cm"
-         x="-179.953" y="-3.09062500000005" z="0"/>
+         x="-179.953" y="-2.77312500000005" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volTPCPlaneVInner"/>
        <position name="posInnerPlaneV" unit="cm"
-         x="-179.477" y="-3.24937500000004" z="0"/>
+         x="-179.477" y="-3.01125000000002" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volTPCPlaneUInner"/>
        <position name="posInnerPlaneU" unit="cm"
-         x="-179.001" y="-3.40812500000004" z="0"/>
+         x="-179.001" y="-3.24937500000004" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
@@ -705,19 +716,19 @@
      <physvol>
        <volumeref ref="volTPCPlaneZOuter"/>
        <position name="posOuterPlaneZ" unit="cm"
-         x="-7.753" y="-3.09062500000005" z="0"/>
+         x="-7.753" y="-2.77312500000005" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volTPCPlaneVOuter"/>
        <position name="posOuterPlaneV" unit="cm"
-         x="-7.277" y="-3.24937500000004" z="0"/>
+         x="-7.277" y="-3.01125000000002" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volTPCPlaneUOuter"/>
        <position name="posOuterPlaneU" unit="cm"
-         x="-6.801" y="-3.40812500000004" z="0"/>
+         x="-6.801" y="-3.24937500000004" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
@@ -745,7 +756,7 @@
       <solidref ref="GaseousArgon"/>
     </volume>
     <volume name="volCathode">
-      <materialref ref="STEEL_STAINLESS_Fe7Cr2Ni" />
+      <materialref ref="FR4SussexAPA" />
       <solidref ref="Cathode" />
     </volume>
    <volume name="volOpDetSensitive_0-0-0">
@@ -2669,483 +2680,483 @@
      <solidref ref="ArapucaAcceptanceWindow"/>
    </volume>
    <volume name="volArapuca_0-0">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_0-1">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_0-2">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_0-3">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_0-4">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_0-5">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_0-6">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_0-7">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_0-8">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_0-9">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_1-0">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_1-1">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_1-2">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_1-3">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_1-4">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_1-5">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_1-6">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_1-7">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_1-8">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_1-9">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_2-0">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_2-1">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_2-2">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_2-3">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_2-4">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_2-5">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_2-6">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_2-7">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_2-8">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_2-9">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_3-0">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_3-1">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_3-2">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_3-3">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_3-4">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_3-5">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_3-6">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_3-7">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_3-8">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_3-9">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_4-0">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_4-1">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_4-2">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_4-3">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_4-4">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_4-5">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_4-6">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_4-7">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_4-8">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_4-9">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_5-0">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_5-1">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_5-2">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_5-3">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_5-4">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_5-5">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_5-6">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_5-7">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_5-8">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_5-9">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_6-0">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_6-1">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_6-2">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_6-3">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_6-4">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_6-5">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_6-6">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_6-7">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_6-8">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_6-9">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_7-0">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_7-1">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_7-2">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_7-3">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_7-4">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_7-5">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_7-6">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_7-7">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_7-8">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_7-9">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_8-0">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_8-1">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_8-2">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_8-3">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_8-4">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_8-5">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_8-6">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_8-7">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_8-8">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_8-9">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_9-0">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_9-1">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_9-2">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_9-3">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_9-4">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_9-5">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_9-6">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_9-7">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_9-8">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_9-9">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_10-0">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_10-1">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_10-2">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_10-3">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_10-4">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_10-5">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_10-6">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_10-7">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_10-8">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_10-9">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_11-0">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_11-1">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_11-2">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_11-3">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_11-4">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_11-5">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_11-6">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_11-7">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_11-8">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
    <volume name="volArapuca_11-9">
-     <materialref ref="G10"/>
+     <materialref ref="FR4SussexAPA"/>
      <solidref ref="ArapucaWalls"/>
    </volume>
 
@@ -3165,13 +3176,18 @@
     </volume>
 
     <volume name="volG10BoardYSideCenterSeg">
-      <materialref ref="G10"/>
+      <materialref ref="FR4SussexAPA"/>
       <solidref ref="G10BoardYSideCenterSeg"/>
     </volume>
 
     <volume name="volG10BoardZSideCenterSeg">
-      <materialref ref="G10"/>
+      <materialref ref="FR4SussexAPA"/>
       <solidref ref="G10BoardZSideCenterSeg"/>
+    </volume>
+
+    <volume name="volG10HeadBoards">
+      <materialref ref="FR4SussexAPA"/>
+      <solidref ref="G10HeadBoards"/>
     </volume>
 
     <volume name="volCryostat">
@@ -3179,14 +3195,14 @@
       <solidref ref="Cryostat" />
       <physvol>
         <volumeref ref="volGaseousArgon"/>
-        <position name="posGaseousArgon" unit="cm" x="0" y="652.57875" z="0"/>
+        <position name="posGaseousArgon" unit="cm" x="0" y="653.21375" z="0"/>
       </physvol>
       <physvol>
         <volumeref ref="volSourceModerator"/>
         <position name="posSourceModerator" unit="cm"
           x="220"
 	        y="280"
-	        z="-607.424"/>
+	        z="-608.424"/>
         <rotationref ref="rPlus90AboutX"/>
       </physvol>
       <physvol>
@@ -3204,23 +3220,23 @@
         <volumeref ref="volAPAFrameYSide"/>
         <position name="posAPAFrameYSideNeg-0" unit="cm"
       x="0"
-      y="-325.37875"
-      z="-564.89625"/>
+      y="-326.01375"
+      z="-564.57875"/>
         <rotationref ref="rIdentity"/>
       </physvol>
       <physvol>
         <volumeref ref="volAPAFrameYSide"/>
         <position name="posAPAFrameYSidePos-0" unit="cm"
       x="0"
-      y="-325.37875"
-      z="-345.05375"/>
+      y="-326.01375"
+      z="-345.37125"/>
         <rotationref ref="rIdentity"/>
       </physvol>
       <physvol>
         <volumeref ref="volAPAFrameZSide"/>
         <position name="posAPAFrameZSidePos-0" unit="cm"
       x="0"
-      y="-27.45875"
+      y="-28.0937500000001"
       z="-454.975"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -3228,7 +3244,7 @@
         <volumeref ref="volAPAFrameZSide"/>
         <position name="posAPAFrameZSideNeg-0" unit="cm"
       x="0"
-      y="-623.29875"
+      y="-623.93375"
       z="-454.975"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -3239,22 +3255,33 @@
       - There are two boards on each the up and downstream end,
           one each to wrap the U and V views around the APA frame
       - There are 4 on the bottom which anchor the U V and Z wires and the grid plane
-      - The rest of the parts of the G10 boards must be placed directly in volTPC   -->
+      FIXME: This is not true -> - The rest of the parts of the G10 boards must be placed directly in volTPC   -->
+
+      <!-- Position readout boards -->
+      <physvol>
+        <volumeref ref="volG10HeadBoards"/>
+        <position name="posG10HeadBoards-0" unit="cm"
+	  x="0"
+	  y="-639.51775"
+      	  z="-454.975"/>
+        <rotationref ref="rIdentity"/>
+      </physvol>
 
       <physvol>
         <volumeref ref="volG10BoardYSideCenterSeg"/>
         <position name="posG10BoardYSideCenterSeg-Vup-0" unit="cm"
-      x="0"
-      y="-325.37875"
-      z="-570.135"/>
-        <rotationref ref="rIdentity"/>
+         x="0"
+         y="-326.01375"
+         z="-569.896875"/>
+         <rotationref ref="rIdentity"/>
       </physvol>
+
       <physvol>
         <volumeref ref="volG10BoardYSideCenterSeg"/>
         <position name="posG10BoardYSideCenterSeg-Uup-0" unit="cm"
       x="0"
-      y="-325.37875"
-      z="-570.4525"/>
+      y="-326.01375"
+      z="-570.373125"/>
         <rotationref ref="rIdentity"/>
       </physvol>
 
@@ -3262,16 +3289,16 @@
         <volumeref ref="volG10BoardYSideCenterSeg"/>
         <position name="posG10BoardYSideCenterSeg-Vdown-0" unit="cm"
       x="0"
-      y="-325.37875"
-      z="-339.815"/>
+      y="-326.01375"
+      z="-340.053125"/>
         <rotationref ref="rIdentity"/>
       </physvol>
       <physvol>
         <volumeref ref="volG10BoardYSideCenterSeg"/>
         <position name="posG10BoardYSideCenterSeg-Udown-0" unit="cm"
       x="0"
-      y="-325.37875"
-      z="-339.4975"/>
+      y="-326.01375"
+      z="-339.576875"/>
         <rotationref ref="rIdentity"/>
       </physvol>
 
@@ -3279,7 +3306,7 @@
         <volumeref ref="volG10BoardZSideCenterSeg"/>
         <position name="posG10BoardZSideCenterSeg-Z-0" unit="cm"
       x="0"
-      y="-22.22"
+      y="-22.775625"
       z="-454.975"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -3287,7 +3314,7 @@
         <volumeref ref="volG10BoardZSideCenterSeg"/>
         <position name="posG10BoardZSideCenterSeg-V-0" unit="cm"
       x="0"
-      y="-21.9025"
+      y="-22.2993750000001"
       z="-454.975"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -3295,7 +3322,7 @@
         <volumeref ref="volG10BoardZSideCenterSeg"/>
         <position name="posG10BoardZSideCenterSeg-U-0" unit="cm"
       x="0"
-      y="-21.585"
+      y="-21.8231250000001"
       z="-454.975"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -3303,7 +3330,7 @@
         <volumeref ref="volG10BoardZSideCenterSeg"/>
         <position name="posG10BoardZSideCenterSeg-Grid-0" unit="cm"
       x="0"
-      y="-21.2675"
+      y="-21.3468750000001"
       z="-454.975"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -3312,7 +3339,7 @@
 <volumeref ref="volArapuca_0-0"/>
 <position name="posArapuca0-0-TPC-12-0-0" unit="cm"
 x="0"
-y="-612.31875"
+y="-612.95375"
 z="-454.975"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -3320,7 +3347,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_0-0-0"/>
        <position name="posOpArapuca0-0-0-TPC-12-0-0" unit="cm"
          x="-0.0500000000000002"
-       y="-612.31875"
+       y="-612.95375"
          z="-535.175"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -3328,7 +3355,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_0-0-1"/>
        <position name="posOpArapuca0-0-1-TPC-12-0-0" unit="cm"
          x="-0.0500000000000002"
-       y="-612.31875"
+       y="-612.95375"
          z="-486.375"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -3336,7 +3363,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_0-0-2"/>
        <position name="posOpArapuca0-0-2-TPC-12-0-0" unit="cm"
          x="-0.0500000000000002"
-       y="-612.31875"
+       y="-612.95375"
          z="-423.575"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -3344,7 +3371,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_0-0-3"/>
        <position name="posOpArapuca0-0-3-TPC-12-0-0" unit="cm"
          x="-0.0500000000000002"
-       y="-612.31875"
+       y="-612.95375"
          z="-374.775"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -3352,7 +3379,7 @@ z="-454.975"/>
 <volumeref ref="volArapuca_0-1"/>
 <position name="posArapuca0-1-TPC-12-0-0" unit="cm"
 x="0"
-y="-550.048355263158"
+y="-550.616513157895"
 z="-454.975"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -3360,7 +3387,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_0-1-0"/>
        <position name="posOpArapuca0-1-0-TPC-12-0-0" unit="cm"
          x="-0.0500000000000002"
-       y="-550.048355263158"
+       y="-550.616513157895"
          z="-535.175"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -3368,7 +3395,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_0-1-1"/>
        <position name="posOpArapuca0-1-1-TPC-12-0-0" unit="cm"
          x="-0.0500000000000002"
-       y="-550.048355263158"
+       y="-550.616513157895"
          z="-486.375"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -3376,7 +3403,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_0-1-2"/>
        <position name="posOpArapuca0-1-2-TPC-12-0-0" unit="cm"
          x="-0.0500000000000002"
-       y="-550.048355263158"
+       y="-550.616513157895"
          z="-423.575"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -3384,7 +3411,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_0-1-3"/>
        <position name="posOpArapuca0-1-3-TPC-12-0-0" unit="cm"
          x="-0.0500000000000002"
-       y="-550.048355263158"
+       y="-550.616513157895"
          z="-374.775"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -3392,7 +3419,7 @@ z="-454.975"/>
 <volumeref ref="volArapuca_0-2"/>
 <position name="posArapuca0-2-TPC-12-0-0" unit="cm"
 x="0"
-y="-487.777960526316"
+y="-488.27927631579"
 z="-454.975"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -3400,7 +3427,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_0-2-0"/>
        <position name="posOpArapuca0-2-0-TPC-12-0-0" unit="cm"
          x="-0.0500000000000002"
-       y="-487.777960526316"
+       y="-488.27927631579"
          z="-535.175"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -3408,7 +3435,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_0-2-1"/>
        <position name="posOpArapuca0-2-1-TPC-12-0-0" unit="cm"
          x="-0.0500000000000002"
-       y="-487.777960526316"
+       y="-488.27927631579"
          z="-486.375"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -3416,7 +3443,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_0-2-2"/>
        <position name="posOpArapuca0-2-2-TPC-12-0-0" unit="cm"
          x="-0.0500000000000002"
-       y="-487.777960526316"
+       y="-488.27927631579"
          z="-423.575"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -3424,7 +3451,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_0-2-3"/>
        <position name="posOpArapuca0-2-3-TPC-12-0-0" unit="cm"
          x="-0.0500000000000002"
-       y="-487.777960526316"
+       y="-488.27927631579"
          z="-374.775"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -3432,7 +3459,7 @@ z="-454.975"/>
 <volumeref ref="volArapuca_0-3"/>
 <position name="posArapuca0-3-TPC-12-0-0" unit="cm"
 x="0"
-y="-425.507565789474"
+y="-425.942039473684"
 z="-454.975"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -3440,7 +3467,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_0-3-0"/>
        <position name="posOpArapuca0-3-0-TPC-12-0-0" unit="cm"
          x="-0.0500000000000002"
-       y="-425.507565789474"
+       y="-425.942039473684"
          z="-535.175"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -3448,7 +3475,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_0-3-1"/>
        <position name="posOpArapuca0-3-1-TPC-12-0-0" unit="cm"
          x="-0.0500000000000002"
-       y="-425.507565789474"
+       y="-425.942039473684"
          z="-486.375"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -3456,7 +3483,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_0-3-2"/>
        <position name="posOpArapuca0-3-2-TPC-12-0-0" unit="cm"
          x="-0.0500000000000002"
-       y="-425.507565789474"
+       y="-425.942039473684"
          z="-423.575"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -3464,7 +3491,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_0-3-3"/>
        <position name="posOpArapuca0-3-3-TPC-12-0-0" unit="cm"
          x="-0.0500000000000002"
-       y="-425.507565789474"
+       y="-425.942039473684"
          z="-374.775"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -3472,7 +3499,7 @@ z="-454.975"/>
 <volumeref ref="volArapuca_0-4"/>
 <position name="posArapuca0-4-TPC-12-0-0" unit="cm"
 x="0"
-y="-363.237171052632"
+y="-363.604802631579"
 z="-454.975"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -3480,7 +3507,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_0-4-0"/>
        <position name="posOpArapuca0-4-0-TPC-12-0-0" unit="cm"
          x="-0.0500000000000002"
-       y="-363.237171052632"
+       y="-363.604802631579"
          z="-535.175"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -3488,7 +3515,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_0-4-1"/>
        <position name="posOpArapuca0-4-1-TPC-12-0-0" unit="cm"
          x="-0.0500000000000002"
-       y="-363.237171052632"
+       y="-363.604802631579"
          z="-486.375"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -3496,7 +3523,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_0-4-2"/>
        <position name="posOpArapuca0-4-2-TPC-12-0-0" unit="cm"
          x="-0.0500000000000002"
-       y="-363.237171052632"
+       y="-363.604802631579"
          z="-423.575"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -3504,7 +3531,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_0-4-3"/>
        <position name="posOpArapuca0-4-3-TPC-12-0-0" unit="cm"
          x="-0.0500000000000002"
-       y="-363.237171052632"
+       y="-363.604802631579"
          z="-374.775"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -3512,7 +3539,7 @@ z="-454.975"/>
 <volumeref ref="volArapuca_0-5"/>
 <position name="posArapuca0-5-TPC-12-0-0" unit="cm"
 x="0"
-y="-300.96677631579"
+y="-301.267565789474"
 z="-454.975"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -3520,7 +3547,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_0-5-0"/>
        <position name="posOpArapuca0-5-0-TPC-12-0-0" unit="cm"
          x="-0.0500000000000002"
-       y="-300.96677631579"
+       y="-301.267565789474"
          z="-535.175"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -3528,7 +3555,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_0-5-1"/>
        <position name="posOpArapuca0-5-1-TPC-12-0-0" unit="cm"
          x="-0.0500000000000002"
-       y="-300.96677631579"
+       y="-301.267565789474"
          z="-486.375"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -3536,7 +3563,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_0-5-2"/>
        <position name="posOpArapuca0-5-2-TPC-12-0-0" unit="cm"
          x="-0.0500000000000002"
-       y="-300.96677631579"
+       y="-301.267565789474"
          z="-423.575"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -3544,7 +3571,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_0-5-3"/>
        <position name="posOpArapuca0-5-3-TPC-12-0-0" unit="cm"
          x="-0.0500000000000002"
-       y="-300.96677631579"
+       y="-301.267565789474"
          z="-374.775"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -3552,7 +3579,7 @@ z="-454.975"/>
 <volumeref ref="volArapuca_0-6"/>
 <position name="posArapuca0-6-TPC-12-0-0" unit="cm"
 x="0"
-y="-238.696381578947"
+y="-238.930328947368"
 z="-454.975"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -3560,7 +3587,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_0-6-0"/>
        <position name="posOpArapuca0-6-0-TPC-12-0-0" unit="cm"
          x="-0.0500000000000002"
-       y="-238.696381578947"
+       y="-238.930328947368"
          z="-535.175"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -3568,7 +3595,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_0-6-1"/>
        <position name="posOpArapuca0-6-1-TPC-12-0-0" unit="cm"
          x="-0.0500000000000002"
-       y="-238.696381578947"
+       y="-238.930328947368"
          z="-486.375"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -3576,7 +3603,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_0-6-2"/>
        <position name="posOpArapuca0-6-2-TPC-12-0-0" unit="cm"
          x="-0.0500000000000002"
-       y="-238.696381578947"
+       y="-238.930328947368"
          z="-423.575"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -3584,7 +3611,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_0-6-3"/>
        <position name="posOpArapuca0-6-3-TPC-12-0-0" unit="cm"
          x="-0.0500000000000002"
-       y="-238.696381578947"
+       y="-238.930328947368"
          z="-374.775"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -3592,7 +3619,7 @@ z="-454.975"/>
 <volumeref ref="volArapuca_0-7"/>
 <position name="posArapuca0-7-TPC-12-0-0" unit="cm"
 x="0"
-y="-176.425986842105"
+y="-176.593092105263"
 z="-454.975"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -3600,7 +3627,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_0-7-0"/>
        <position name="posOpArapuca0-7-0-TPC-12-0-0" unit="cm"
          x="-0.0500000000000002"
-       y="-176.425986842105"
+       y="-176.593092105263"
          z="-535.175"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -3608,7 +3635,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_0-7-1"/>
        <position name="posOpArapuca0-7-1-TPC-12-0-0" unit="cm"
          x="-0.0500000000000002"
-       y="-176.425986842105"
+       y="-176.593092105263"
          z="-486.375"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -3616,7 +3643,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_0-7-2"/>
        <position name="posOpArapuca0-7-2-TPC-12-0-0" unit="cm"
          x="-0.0500000000000002"
-       y="-176.425986842105"
+       y="-176.593092105263"
          z="-423.575"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -3624,7 +3651,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_0-7-3"/>
        <position name="posOpArapuca0-7-3-TPC-12-0-0" unit="cm"
          x="-0.0500000000000002"
-       y="-176.425986842105"
+       y="-176.593092105263"
          z="-374.775"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -3632,7 +3659,7 @@ z="-454.975"/>
 <volumeref ref="volArapuca_0-8"/>
 <position name="posArapuca0-8-TPC-12-0-0" unit="cm"
 x="0"
-y="-114.155592105263"
+y="-114.255855263158"
 z="-454.975"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -3640,7 +3667,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_0-8-0"/>
        <position name="posOpArapuca0-8-0-TPC-12-0-0" unit="cm"
          x="-0.0500000000000002"
-       y="-114.155592105263"
+       y="-114.255855263158"
          z="-535.175"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -3648,7 +3675,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_0-8-1"/>
        <position name="posOpArapuca0-8-1-TPC-12-0-0" unit="cm"
          x="-0.0500000000000002"
-       y="-114.155592105263"
+       y="-114.255855263158"
          z="-486.375"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -3656,7 +3683,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_0-8-2"/>
        <position name="posOpArapuca0-8-2-TPC-12-0-0" unit="cm"
          x="-0.0500000000000002"
-       y="-114.155592105263"
+       y="-114.255855263158"
          z="-423.575"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -3664,7 +3691,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_0-8-3"/>
        <position name="posOpArapuca0-8-3-TPC-12-0-0" unit="cm"
          x="-0.0500000000000002"
-       y="-114.155592105263"
+       y="-114.255855263158"
          z="-374.775"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -3672,7 +3699,7 @@ z="-454.975"/>
 <volumeref ref="volArapuca_0-9"/>
 <position name="posArapuca0-9-TPC-12-0-0" unit="cm"
 x="0"
-y="-51.885197368421"
+y="-51.9186184210527"
 z="-454.975"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -3680,7 +3707,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_0-9-0"/>
        <position name="posOpArapuca0-9-0-TPC-12-0-0" unit="cm"
          x="-0.0500000000000002"
-       y="-51.885197368421"
+       y="-51.9186184210527"
          z="-535.175"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -3688,7 +3715,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_0-9-1"/>
        <position name="posOpArapuca0-9-1-TPC-12-0-0" unit="cm"
          x="-0.0500000000000002"
-       y="-51.885197368421"
+       y="-51.9186184210527"
          z="-486.375"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -3696,7 +3723,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_0-9-2"/>
        <position name="posOpArapuca0-9-2-TPC-12-0-0" unit="cm"
          x="-0.0500000000000002"
-       y="-51.885197368421"
+       y="-51.9186184210527"
          z="-423.575"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -3704,7 +3731,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_0-9-3"/>
        <position name="posOpArapuca0-9-3-TPC-12-0-0" unit="cm"
          x="-0.0500000000000002"
-       y="-51.885197368421"
+       y="-51.9186184210527"
          z="-374.775"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -3713,7 +3740,7 @@ z="-454.975"/>
         <volumeref ref="volTPCInner"/>
         <position name="posTPC-0" unit="cm"
         x="-182.95455"
-        y="-324.664375"
+        y="-324.981875"
         z="-454.975"/>
         <rotationref ref="rPlus180AboutXPlus180AboutY"/>
       </physvol>
@@ -3721,7 +3748,7 @@ z="-454.975"/>
         <volumeref ref="volTPCInner"/>
         <position name="posTPC-1" unit="cm"
         x="182.95455"
-        y="-324.664375"
+        y="-324.981875"
         z="-454.975"/>
         <rotationref ref="rPlus180AboutX"/>
       </physvol>
@@ -3729,16 +3756,16 @@ z="-454.975"/>
       <physvol>
         <volumeref ref="volCathode"/>
         <position name="posCathode-1-0" unit="cm"
-      x="-363.38405"
-      y="-324.664375"
+      x="-363.52605"
+      y="-324.981875"
       z="-454.975"/>
         <rotationref ref="rIdentity"/>
       </physvol>
       <physvol>
         <volumeref ref="volCathode"/>
         <position name="posCathode-1-1" unit="cm"
-      x="363.38405"
-      y="-324.664375"
+      x="363.52605"
+      y="-324.981875"
       z="-454.975"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -3747,23 +3774,23 @@ z="-454.975"/>
         <volumeref ref="volAPAFrameYSide"/>
         <position name="posAPAFrameYSideNeg-1" unit="cm"
       x="0"
-      y="283.87875"
-      z="-564.89625"/>
+      y="284.51375"
+      z="-564.57875"/>
         <rotationref ref="rIdentity"/>
       </physvol>
       <physvol>
         <volumeref ref="volAPAFrameYSide"/>
         <position name="posAPAFrameYSidePos-1" unit="cm"
       x="0"
-      y="283.87875"
-      z="-345.05375"/>
+      y="284.51375"
+      z="-345.37125"/>
         <rotationref ref="rIdentity"/>
       </physvol>
       <physvol>
         <volumeref ref="volAPAFrameZSide"/>
         <position name="posAPAFrameZSidePos-1" unit="cm"
       x="0"
-      y="581.79875"
+      y="582.43375"
       z="-454.975"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -3771,7 +3798,7 @@ z="-454.975"/>
         <volumeref ref="volAPAFrameZSide"/>
         <position name="posAPAFrameZSideNeg-1" unit="cm"
       x="0"
-      y="-14.0412500000001"
+      y="-13.40625"
       z="-454.975"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -3782,22 +3809,33 @@ z="-454.975"/>
       - There are two boards on each the up and downstream end,
           one each to wrap the U and V views around the APA frame
       - There are 4 on the bottom which anchor the U V and Z wires and the grid plane
-      - The rest of the parts of the G10 boards must be placed directly in volTPC   -->
+      FIXME: This is not true -> - The rest of the parts of the G10 boards must be placed directly in volTPC   -->
+
+      <!-- Position readout boards -->
+      <physvol>
+        <volumeref ref="volG10HeadBoards"/>
+        <position name="posG10HeadBoards-1" unit="cm"
+	  x="0"
+	  y="598.01775"
+      	  z="-454.975"/>
+        <rotationref ref="rIdentity"/>
+      </physvol>
 
       <physvol>
         <volumeref ref="volG10BoardYSideCenterSeg"/>
         <position name="posG10BoardYSideCenterSeg-Vup-1" unit="cm"
-      x="0"
-      y="283.87875"
-      z="-570.135"/>
-        <rotationref ref="rIdentity"/>
+         x="0"
+         y="284.51375"
+         z="-569.896875"/>
+         <rotationref ref="rIdentity"/>
       </physvol>
+
       <physvol>
         <volumeref ref="volG10BoardYSideCenterSeg"/>
         <position name="posG10BoardYSideCenterSeg-Uup-1" unit="cm"
       x="0"
-      y="283.87875"
-      z="-570.4525"/>
+      y="284.51375"
+      z="-570.373125"/>
         <rotationref ref="rIdentity"/>
       </physvol>
 
@@ -3805,16 +3843,16 @@ z="-454.975"/>
         <volumeref ref="volG10BoardYSideCenterSeg"/>
         <position name="posG10BoardYSideCenterSeg-Vdown-1" unit="cm"
       x="0"
-      y="283.87875"
-      z="-339.815"/>
+      y="284.51375"
+      z="-340.053125"/>
         <rotationref ref="rIdentity"/>
       </physvol>
       <physvol>
         <volumeref ref="volG10BoardYSideCenterSeg"/>
         <position name="posG10BoardYSideCenterSeg-Udown-1" unit="cm"
       x="0"
-      y="283.87875"
-      z="-339.4975"/>
+      y="284.51375"
+      z="-339.576875"/>
         <rotationref ref="rIdentity"/>
       </physvol>
 
@@ -3822,7 +3860,7 @@ z="-454.975"/>
         <volumeref ref="volG10BoardZSideCenterSeg"/>
         <position name="posG10BoardZSideCenterSeg-Z-1" unit="cm"
       x="0"
-      y="-19.2800000000001"
+      y="-18.7243750000001"
       z="-454.975"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -3830,7 +3868,7 @@ z="-454.975"/>
         <volumeref ref="volG10BoardZSideCenterSeg"/>
         <position name="posG10BoardZSideCenterSeg-V-1" unit="cm"
       x="0"
-      y="-19.5975000000001"
+      y="-19.2006250000001"
       z="-454.975"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -3838,7 +3876,7 @@ z="-454.975"/>
         <volumeref ref="volG10BoardZSideCenterSeg"/>
         <position name="posG10BoardZSideCenterSeg-U-1" unit="cm"
       x="0"
-      y="-19.9150000000001"
+      y="-19.6768750000001"
       z="-454.975"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -3846,7 +3884,7 @@ z="-454.975"/>
         <volumeref ref="volG10BoardZSideCenterSeg"/>
         <position name="posG10BoardZSideCenterSeg-Grid-1" unit="cm"
       x="0"
-      y="-20.2325000000001"
+      y="-20.153125"
       z="-454.975"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -3855,7 +3893,7 @@ z="-454.975"/>
 <volumeref ref="volArapuca_1-0"/>
 <position name="posArapuca1-0-TPC-12-1-0" unit="cm"
 x="0"
-y="10.385197368421"
+y="10.4186184210526"
 z="-454.975"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -3863,7 +3901,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_1-0-0"/>
        <position name="posOpArapuca1-0-0-TPC-12-1-0" unit="cm"
          x="0.0500000000000002"
-       y="10.385197368421"
+       y="10.4186184210526"
          z="-535.175"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -3871,7 +3909,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_1-0-1"/>
        <position name="posOpArapuca1-0-1-TPC-12-1-0" unit="cm"
          x="0.0500000000000002"
-       y="10.385197368421"
+       y="10.4186184210526"
          z="-486.375"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -3879,7 +3917,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_1-0-2"/>
        <position name="posOpArapuca1-0-2-TPC-12-1-0" unit="cm"
          x="0.0500000000000002"
-       y="10.385197368421"
+       y="10.4186184210526"
          z="-423.575"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -3887,7 +3925,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_1-0-3"/>
        <position name="posOpArapuca1-0-3-TPC-12-1-0" unit="cm"
          x="0.0500000000000002"
-       y="10.385197368421"
+       y="10.4186184210526"
          z="-374.775"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -3895,7 +3933,7 @@ z="-454.975"/>
 <volumeref ref="volArapuca_1-1"/>
 <position name="posArapuca1-1-TPC-12-1-0" unit="cm"
 x="0"
-y="72.6555921052631"
+y="72.7558552631579"
 z="-454.975"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -3903,7 +3941,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_1-1-0"/>
        <position name="posOpArapuca1-1-0-TPC-12-1-0" unit="cm"
          x="0.0500000000000002"
-       y="72.6555921052631"
+       y="72.7558552631579"
          z="-535.175"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -3911,7 +3949,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_1-1-1"/>
        <position name="posOpArapuca1-1-1-TPC-12-1-0" unit="cm"
          x="0.0500000000000002"
-       y="72.6555921052631"
+       y="72.7558552631579"
          z="-486.375"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -3919,7 +3957,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_1-1-2"/>
        <position name="posOpArapuca1-1-2-TPC-12-1-0" unit="cm"
          x="0.0500000000000002"
-       y="72.6555921052631"
+       y="72.7558552631579"
          z="-423.575"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -3927,7 +3965,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_1-1-3"/>
        <position name="posOpArapuca1-1-3-TPC-12-1-0" unit="cm"
          x="0.0500000000000002"
-       y="72.6555921052631"
+       y="72.7558552631579"
          z="-374.775"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -3935,7 +3973,7 @@ z="-454.975"/>
 <volumeref ref="volArapuca_1-2"/>
 <position name="posArapuca1-2-TPC-12-1-0" unit="cm"
 x="0"
-y="134.925986842105"
+y="135.093092105263"
 z="-454.975"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -3943,7 +3981,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_1-2-0"/>
        <position name="posOpArapuca1-2-0-TPC-12-1-0" unit="cm"
          x="0.0500000000000002"
-       y="134.925986842105"
+       y="135.093092105263"
          z="-535.175"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -3951,7 +3989,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_1-2-1"/>
        <position name="posOpArapuca1-2-1-TPC-12-1-0" unit="cm"
          x="0.0500000000000002"
-       y="134.925986842105"
+       y="135.093092105263"
          z="-486.375"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -3959,7 +3997,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_1-2-2"/>
        <position name="posOpArapuca1-2-2-TPC-12-1-0" unit="cm"
          x="0.0500000000000002"
-       y="134.925986842105"
+       y="135.093092105263"
          z="-423.575"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -3967,7 +4005,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_1-2-3"/>
        <position name="posOpArapuca1-2-3-TPC-12-1-0" unit="cm"
          x="0.0500000000000002"
-       y="134.925986842105"
+       y="135.093092105263"
          z="-374.775"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -3975,7 +4013,7 @@ z="-454.975"/>
 <volumeref ref="volArapuca_1-3"/>
 <position name="posArapuca1-3-TPC-12-1-0" unit="cm"
 x="0"
-y="197.196381578947"
+y="197.430328947368"
 z="-454.975"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -3983,7 +4021,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_1-3-0"/>
        <position name="posOpArapuca1-3-0-TPC-12-1-0" unit="cm"
          x="0.0500000000000002"
-       y="197.196381578947"
+       y="197.430328947368"
          z="-535.175"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -3991,7 +4029,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_1-3-1"/>
        <position name="posOpArapuca1-3-1-TPC-12-1-0" unit="cm"
          x="0.0500000000000002"
-       y="197.196381578947"
+       y="197.430328947368"
          z="-486.375"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -3999,7 +4037,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_1-3-2"/>
        <position name="posOpArapuca1-3-2-TPC-12-1-0" unit="cm"
          x="0.0500000000000002"
-       y="197.196381578947"
+       y="197.430328947368"
          z="-423.575"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -4007,7 +4045,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_1-3-3"/>
        <position name="posOpArapuca1-3-3-TPC-12-1-0" unit="cm"
          x="0.0500000000000002"
-       y="197.196381578947"
+       y="197.430328947368"
          z="-374.775"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -4015,7 +4053,7 @@ z="-454.975"/>
 <volumeref ref="volArapuca_1-4"/>
 <position name="posArapuca1-4-TPC-12-1-0" unit="cm"
 x="0"
-y="259.46677631579"
+y="259.767565789474"
 z="-454.975"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -4023,7 +4061,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_1-4-0"/>
        <position name="posOpArapuca1-4-0-TPC-12-1-0" unit="cm"
          x="0.0500000000000002"
-       y="259.46677631579"
+       y="259.767565789474"
          z="-535.175"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -4031,7 +4069,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_1-4-1"/>
        <position name="posOpArapuca1-4-1-TPC-12-1-0" unit="cm"
          x="0.0500000000000002"
-       y="259.46677631579"
+       y="259.767565789474"
          z="-486.375"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -4039,7 +4077,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_1-4-2"/>
        <position name="posOpArapuca1-4-2-TPC-12-1-0" unit="cm"
          x="0.0500000000000002"
-       y="259.46677631579"
+       y="259.767565789474"
          z="-423.575"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -4047,7 +4085,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_1-4-3"/>
        <position name="posOpArapuca1-4-3-TPC-12-1-0" unit="cm"
          x="0.0500000000000002"
-       y="259.46677631579"
+       y="259.767565789474"
          z="-374.775"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -4055,7 +4093,7 @@ z="-454.975"/>
 <volumeref ref="volArapuca_1-5"/>
 <position name="posArapuca1-5-TPC-12-1-0" unit="cm"
 x="0"
-y="321.737171052632"
+y="322.104802631579"
 z="-454.975"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -4063,7 +4101,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_1-5-0"/>
        <position name="posOpArapuca1-5-0-TPC-12-1-0" unit="cm"
          x="0.0500000000000002"
-       y="321.737171052632"
+       y="322.104802631579"
          z="-535.175"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -4071,7 +4109,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_1-5-1"/>
        <position name="posOpArapuca1-5-1-TPC-12-1-0" unit="cm"
          x="0.0500000000000002"
-       y="321.737171052632"
+       y="322.104802631579"
          z="-486.375"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -4079,7 +4117,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_1-5-2"/>
        <position name="posOpArapuca1-5-2-TPC-12-1-0" unit="cm"
          x="0.0500000000000002"
-       y="321.737171052632"
+       y="322.104802631579"
          z="-423.575"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -4087,7 +4125,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_1-5-3"/>
        <position name="posOpArapuca1-5-3-TPC-12-1-0" unit="cm"
          x="0.0500000000000002"
-       y="321.737171052632"
+       y="322.104802631579"
          z="-374.775"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -4095,7 +4133,7 @@ z="-454.975"/>
 <volumeref ref="volArapuca_1-6"/>
 <position name="posArapuca1-6-TPC-12-1-0" unit="cm"
 x="0"
-y="384.007565789474"
+y="384.442039473684"
 z="-454.975"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -4103,7 +4141,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_1-6-0"/>
        <position name="posOpArapuca1-6-0-TPC-12-1-0" unit="cm"
          x="0.0500000000000002"
-       y="384.007565789474"
+       y="384.442039473684"
          z="-535.175"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -4111,7 +4149,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_1-6-1"/>
        <position name="posOpArapuca1-6-1-TPC-12-1-0" unit="cm"
          x="0.0500000000000002"
-       y="384.007565789474"
+       y="384.442039473684"
          z="-486.375"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -4119,7 +4157,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_1-6-2"/>
        <position name="posOpArapuca1-6-2-TPC-12-1-0" unit="cm"
          x="0.0500000000000002"
-       y="384.007565789474"
+       y="384.442039473684"
          z="-423.575"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -4127,7 +4165,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_1-6-3"/>
        <position name="posOpArapuca1-6-3-TPC-12-1-0" unit="cm"
          x="0.0500000000000002"
-       y="384.007565789474"
+       y="384.442039473684"
          z="-374.775"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -4135,7 +4173,7 @@ z="-454.975"/>
 <volumeref ref="volArapuca_1-7"/>
 <position name="posArapuca1-7-TPC-12-1-0" unit="cm"
 x="0"
-y="446.277960526316"
+y="446.77927631579"
 z="-454.975"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -4143,7 +4181,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_1-7-0"/>
        <position name="posOpArapuca1-7-0-TPC-12-1-0" unit="cm"
          x="0.0500000000000002"
-       y="446.277960526316"
+       y="446.77927631579"
          z="-535.175"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -4151,7 +4189,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_1-7-1"/>
        <position name="posOpArapuca1-7-1-TPC-12-1-0" unit="cm"
          x="0.0500000000000002"
-       y="446.277960526316"
+       y="446.77927631579"
          z="-486.375"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -4159,7 +4197,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_1-7-2"/>
        <position name="posOpArapuca1-7-2-TPC-12-1-0" unit="cm"
          x="0.0500000000000002"
-       y="446.277960526316"
+       y="446.77927631579"
          z="-423.575"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -4167,7 +4205,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_1-7-3"/>
        <position name="posOpArapuca1-7-3-TPC-12-1-0" unit="cm"
          x="0.0500000000000002"
-       y="446.277960526316"
+       y="446.77927631579"
          z="-374.775"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -4175,7 +4213,7 @@ z="-454.975"/>
 <volumeref ref="volArapuca_1-8"/>
 <position name="posArapuca1-8-TPC-12-1-0" unit="cm"
 x="0"
-y="508.548355263158"
+y="509.116513157895"
 z="-454.975"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -4183,7 +4221,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_1-8-0"/>
        <position name="posOpArapuca1-8-0-TPC-12-1-0" unit="cm"
          x="0.0500000000000002"
-       y="508.548355263158"
+       y="509.116513157895"
          z="-535.175"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -4191,7 +4229,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_1-8-1"/>
        <position name="posOpArapuca1-8-1-TPC-12-1-0" unit="cm"
          x="0.0500000000000002"
-       y="508.548355263158"
+       y="509.116513157895"
          z="-486.375"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -4199,7 +4237,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_1-8-2"/>
        <position name="posOpArapuca1-8-2-TPC-12-1-0" unit="cm"
          x="0.0500000000000002"
-       y="508.548355263158"
+       y="509.116513157895"
          z="-423.575"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -4207,7 +4245,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_1-8-3"/>
        <position name="posOpArapuca1-8-3-TPC-12-1-0" unit="cm"
          x="0.0500000000000002"
-       y="508.548355263158"
+       y="509.116513157895"
          z="-374.775"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -4215,7 +4253,7 @@ z="-454.975"/>
 <volumeref ref="volArapuca_1-9"/>
 <position name="posArapuca1-9-TPC-12-1-0" unit="cm"
 x="0"
-y="570.81875"
+y="571.45375"
 z="-454.975"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -4223,7 +4261,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_1-9-0"/>
        <position name="posOpArapuca1-9-0-TPC-12-1-0" unit="cm"
          x="0.0500000000000002"
-       y="570.81875"
+       y="571.45375"
          z="-535.175"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -4231,7 +4269,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_1-9-1"/>
        <position name="posOpArapuca1-9-1-TPC-12-1-0" unit="cm"
          x="0.0500000000000002"
-       y="570.81875"
+       y="571.45375"
          z="-486.375"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -4239,7 +4277,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_1-9-2"/>
        <position name="posOpArapuca1-9-2-TPC-12-1-0" unit="cm"
          x="0.0500000000000002"
-       y="570.81875"
+       y="571.45375"
          z="-423.575"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -4247,7 +4285,7 @@ z="-454.975"/>
        <volumeref ref="volOpDetSensitive_1-9-3"/>
        <position name="posOpArapuca1-9-3-TPC-12-1-0" unit="cm"
          x="0.0500000000000002"
-       y="570.81875"
+       y="571.45375"
          z="-374.775"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -4256,7 +4294,7 @@ z="-454.975"/>
         <volumeref ref="volTPCInner"/>
         <position name="posTPC-2" unit="cm"
         x="-182.95455"
-        y="283.164375"
+        y="283.481875"
         z="-454.975"/>
         <rotationref ref="rPlus180AboutY"/>
       </physvol>
@@ -4264,7 +4302,7 @@ z="-454.975"/>
         <volumeref ref="volTPCInner"/>
         <position name="posTPC-3" unit="cm"
         x="182.95455"
-        y="283.164375"
+        y="283.481875"
         z="-454.975"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -4272,16 +4310,16 @@ z="-454.975"/>
       <physvol>
         <volumeref ref="volCathode"/>
         <position name="posCathode-2-0" unit="cm"
-      x="-363.38405"
-      y="283.164375"
+      x="-363.52605"
+      y="283.481875"
       z="-454.975"/>
         <rotationref ref="rIdentity"/>
       </physvol>
       <physvol>
         <volumeref ref="volCathode"/>
         <position name="posCathode-2-1" unit="cm"
-      x="363.38405"
-      y="283.164375"
+      x="363.52605"
+      y="283.481875"
       z="-454.975"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -4290,23 +4328,23 @@ z="-454.975"/>
         <volumeref ref="volAPAFrameYSide"/>
         <position name="posAPAFrameYSideNeg-2" unit="cm"
       x="0"
-      y="-325.37875"
-      z="-332.50625"/>
+      y="-326.01375"
+      z="-332.18875"/>
         <rotationref ref="rIdentity"/>
       </physvol>
       <physvol>
         <volumeref ref="volAPAFrameYSide"/>
         <position name="posAPAFrameYSidePos-2" unit="cm"
       x="0"
-      y="-325.37875"
-      z="-112.66375"/>
+      y="-326.01375"
+      z="-112.98125"/>
         <rotationref ref="rIdentity"/>
       </physvol>
       <physvol>
         <volumeref ref="volAPAFrameZSide"/>
         <position name="posAPAFrameZSidePos-2" unit="cm"
       x="0"
-      y="-27.45875"
+      y="-28.0937500000001"
       z="-222.585"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -4314,7 +4352,7 @@ z="-454.975"/>
         <volumeref ref="volAPAFrameZSide"/>
         <position name="posAPAFrameZSideNeg-2" unit="cm"
       x="0"
-      y="-623.29875"
+      y="-623.93375"
       z="-222.585"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -4325,22 +4363,33 @@ z="-454.975"/>
       - There are two boards on each the up and downstream end,
           one each to wrap the U and V views around the APA frame
       - There are 4 on the bottom which anchor the U V and Z wires and the grid plane
-      - The rest of the parts of the G10 boards must be placed directly in volTPC   -->
+      FIXME: This is not true -> - The rest of the parts of the G10 boards must be placed directly in volTPC   -->
+
+      <!-- Position readout boards -->
+      <physvol>
+        <volumeref ref="volG10HeadBoards"/>
+        <position name="posG10HeadBoards-2" unit="cm"
+	  x="0"
+	  y="-639.51775"
+      	  z="-222.585"/>
+        <rotationref ref="rIdentity"/>
+      </physvol>
 
       <physvol>
         <volumeref ref="volG10BoardYSideCenterSeg"/>
         <position name="posG10BoardYSideCenterSeg-Vup-2" unit="cm"
-      x="0"
-      y="-325.37875"
-      z="-337.745"/>
-        <rotationref ref="rIdentity"/>
+         x="0"
+         y="-326.01375"
+         z="-337.506875"/>
+         <rotationref ref="rIdentity"/>
       </physvol>
+
       <physvol>
         <volumeref ref="volG10BoardYSideCenterSeg"/>
         <position name="posG10BoardYSideCenterSeg-Uup-2" unit="cm"
       x="0"
-      y="-325.37875"
-      z="-338.0625"/>
+      y="-326.01375"
+      z="-337.983125"/>
         <rotationref ref="rIdentity"/>
       </physvol>
 
@@ -4348,16 +4397,16 @@ z="-454.975"/>
         <volumeref ref="volG10BoardYSideCenterSeg"/>
         <position name="posG10BoardYSideCenterSeg-Vdown-2" unit="cm"
       x="0"
-      y="-325.37875"
-      z="-107.425"/>
+      y="-326.01375"
+      z="-107.663125"/>
         <rotationref ref="rIdentity"/>
       </physvol>
       <physvol>
         <volumeref ref="volG10BoardYSideCenterSeg"/>
         <position name="posG10BoardYSideCenterSeg-Udown-2" unit="cm"
       x="0"
-      y="-325.37875"
-      z="-107.1075"/>
+      y="-326.01375"
+      z="-107.186875"/>
         <rotationref ref="rIdentity"/>
       </physvol>
 
@@ -4365,7 +4414,7 @@ z="-454.975"/>
         <volumeref ref="volG10BoardZSideCenterSeg"/>
         <position name="posG10BoardZSideCenterSeg-Z-2" unit="cm"
       x="0"
-      y="-22.22"
+      y="-22.775625"
       z="-222.585"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -4373,7 +4422,7 @@ z="-454.975"/>
         <volumeref ref="volG10BoardZSideCenterSeg"/>
         <position name="posG10BoardZSideCenterSeg-V-2" unit="cm"
       x="0"
-      y="-21.9025"
+      y="-22.2993750000001"
       z="-222.585"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -4381,7 +4430,7 @@ z="-454.975"/>
         <volumeref ref="volG10BoardZSideCenterSeg"/>
         <position name="posG10BoardZSideCenterSeg-U-2" unit="cm"
       x="0"
-      y="-21.585"
+      y="-21.8231250000001"
       z="-222.585"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -4389,7 +4438,7 @@ z="-454.975"/>
         <volumeref ref="volG10BoardZSideCenterSeg"/>
         <position name="posG10BoardZSideCenterSeg-Grid-2" unit="cm"
       x="0"
-      y="-21.2675"
+      y="-21.3468750000001"
       z="-222.585"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -4398,7 +4447,7 @@ z="-454.975"/>
 <volumeref ref="volArapuca_2-0"/>
 <position name="posArapuca2-0-TPC-12-0-1" unit="cm"
 x="0"
-y="-612.31875"
+y="-612.95375"
 z="-222.585"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -4406,7 +4455,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_2-0-0"/>
        <position name="posOpArapuca2-0-0-TPC-12-0-1" unit="cm"
          x="-0.0500000000000002"
-       y="-612.31875"
+       y="-612.95375"
          z="-302.785"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -4414,7 +4463,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_2-0-1"/>
        <position name="posOpArapuca2-0-1-TPC-12-0-1" unit="cm"
          x="-0.0500000000000002"
-       y="-612.31875"
+       y="-612.95375"
          z="-253.985"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -4422,7 +4471,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_2-0-2"/>
        <position name="posOpArapuca2-0-2-TPC-12-0-1" unit="cm"
          x="-0.0500000000000002"
-       y="-612.31875"
+       y="-612.95375"
          z="-191.185"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -4430,7 +4479,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_2-0-3"/>
        <position name="posOpArapuca2-0-3-TPC-12-0-1" unit="cm"
          x="-0.0500000000000002"
-       y="-612.31875"
+       y="-612.95375"
          z="-142.385"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -4438,7 +4487,7 @@ z="-222.585"/>
 <volumeref ref="volArapuca_2-1"/>
 <position name="posArapuca2-1-TPC-12-0-1" unit="cm"
 x="0"
-y="-550.048355263158"
+y="-550.616513157895"
 z="-222.585"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -4446,7 +4495,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_2-1-0"/>
        <position name="posOpArapuca2-1-0-TPC-12-0-1" unit="cm"
          x="-0.0500000000000002"
-       y="-550.048355263158"
+       y="-550.616513157895"
          z="-302.785"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -4454,7 +4503,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_2-1-1"/>
        <position name="posOpArapuca2-1-1-TPC-12-0-1" unit="cm"
          x="-0.0500000000000002"
-       y="-550.048355263158"
+       y="-550.616513157895"
          z="-253.985"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -4462,7 +4511,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_2-1-2"/>
        <position name="posOpArapuca2-1-2-TPC-12-0-1" unit="cm"
          x="-0.0500000000000002"
-       y="-550.048355263158"
+       y="-550.616513157895"
          z="-191.185"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -4470,7 +4519,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_2-1-3"/>
        <position name="posOpArapuca2-1-3-TPC-12-0-1" unit="cm"
          x="-0.0500000000000002"
-       y="-550.048355263158"
+       y="-550.616513157895"
          z="-142.385"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -4478,7 +4527,7 @@ z="-222.585"/>
 <volumeref ref="volArapuca_2-2"/>
 <position name="posArapuca2-2-TPC-12-0-1" unit="cm"
 x="0"
-y="-487.777960526316"
+y="-488.27927631579"
 z="-222.585"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -4486,7 +4535,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_2-2-0"/>
        <position name="posOpArapuca2-2-0-TPC-12-0-1" unit="cm"
          x="-0.0500000000000002"
-       y="-487.777960526316"
+       y="-488.27927631579"
          z="-302.785"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -4494,7 +4543,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_2-2-1"/>
        <position name="posOpArapuca2-2-1-TPC-12-0-1" unit="cm"
          x="-0.0500000000000002"
-       y="-487.777960526316"
+       y="-488.27927631579"
          z="-253.985"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -4502,7 +4551,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_2-2-2"/>
        <position name="posOpArapuca2-2-2-TPC-12-0-1" unit="cm"
          x="-0.0500000000000002"
-       y="-487.777960526316"
+       y="-488.27927631579"
          z="-191.185"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -4510,7 +4559,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_2-2-3"/>
        <position name="posOpArapuca2-2-3-TPC-12-0-1" unit="cm"
          x="-0.0500000000000002"
-       y="-487.777960526316"
+       y="-488.27927631579"
          z="-142.385"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -4518,7 +4567,7 @@ z="-222.585"/>
 <volumeref ref="volArapuca_2-3"/>
 <position name="posArapuca2-3-TPC-12-0-1" unit="cm"
 x="0"
-y="-425.507565789474"
+y="-425.942039473684"
 z="-222.585"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -4526,7 +4575,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_2-3-0"/>
        <position name="posOpArapuca2-3-0-TPC-12-0-1" unit="cm"
          x="-0.0500000000000002"
-       y="-425.507565789474"
+       y="-425.942039473684"
          z="-302.785"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -4534,7 +4583,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_2-3-1"/>
        <position name="posOpArapuca2-3-1-TPC-12-0-1" unit="cm"
          x="-0.0500000000000002"
-       y="-425.507565789474"
+       y="-425.942039473684"
          z="-253.985"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -4542,7 +4591,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_2-3-2"/>
        <position name="posOpArapuca2-3-2-TPC-12-0-1" unit="cm"
          x="-0.0500000000000002"
-       y="-425.507565789474"
+       y="-425.942039473684"
          z="-191.185"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -4550,7 +4599,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_2-3-3"/>
        <position name="posOpArapuca2-3-3-TPC-12-0-1" unit="cm"
          x="-0.0500000000000002"
-       y="-425.507565789474"
+       y="-425.942039473684"
          z="-142.385"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -4558,7 +4607,7 @@ z="-222.585"/>
 <volumeref ref="volArapuca_2-4"/>
 <position name="posArapuca2-4-TPC-12-0-1" unit="cm"
 x="0"
-y="-363.237171052632"
+y="-363.604802631579"
 z="-222.585"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -4566,7 +4615,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_2-4-0"/>
        <position name="posOpArapuca2-4-0-TPC-12-0-1" unit="cm"
          x="-0.0500000000000002"
-       y="-363.237171052632"
+       y="-363.604802631579"
          z="-302.785"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -4574,7 +4623,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_2-4-1"/>
        <position name="posOpArapuca2-4-1-TPC-12-0-1" unit="cm"
          x="-0.0500000000000002"
-       y="-363.237171052632"
+       y="-363.604802631579"
          z="-253.985"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -4582,7 +4631,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_2-4-2"/>
        <position name="posOpArapuca2-4-2-TPC-12-0-1" unit="cm"
          x="-0.0500000000000002"
-       y="-363.237171052632"
+       y="-363.604802631579"
          z="-191.185"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -4590,7 +4639,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_2-4-3"/>
        <position name="posOpArapuca2-4-3-TPC-12-0-1" unit="cm"
          x="-0.0500000000000002"
-       y="-363.237171052632"
+       y="-363.604802631579"
          z="-142.385"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -4598,7 +4647,7 @@ z="-222.585"/>
 <volumeref ref="volArapuca_2-5"/>
 <position name="posArapuca2-5-TPC-12-0-1" unit="cm"
 x="0"
-y="-300.96677631579"
+y="-301.267565789474"
 z="-222.585"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -4606,7 +4655,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_2-5-0"/>
        <position name="posOpArapuca2-5-0-TPC-12-0-1" unit="cm"
          x="-0.0500000000000002"
-       y="-300.96677631579"
+       y="-301.267565789474"
          z="-302.785"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -4614,7 +4663,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_2-5-1"/>
        <position name="posOpArapuca2-5-1-TPC-12-0-1" unit="cm"
          x="-0.0500000000000002"
-       y="-300.96677631579"
+       y="-301.267565789474"
          z="-253.985"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -4622,7 +4671,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_2-5-2"/>
        <position name="posOpArapuca2-5-2-TPC-12-0-1" unit="cm"
          x="-0.0500000000000002"
-       y="-300.96677631579"
+       y="-301.267565789474"
          z="-191.185"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -4630,7 +4679,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_2-5-3"/>
        <position name="posOpArapuca2-5-3-TPC-12-0-1" unit="cm"
          x="-0.0500000000000002"
-       y="-300.96677631579"
+       y="-301.267565789474"
          z="-142.385"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -4638,7 +4687,7 @@ z="-222.585"/>
 <volumeref ref="volArapuca_2-6"/>
 <position name="posArapuca2-6-TPC-12-0-1" unit="cm"
 x="0"
-y="-238.696381578947"
+y="-238.930328947368"
 z="-222.585"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -4646,7 +4695,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_2-6-0"/>
        <position name="posOpArapuca2-6-0-TPC-12-0-1" unit="cm"
          x="-0.0500000000000002"
-       y="-238.696381578947"
+       y="-238.930328947368"
          z="-302.785"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -4654,7 +4703,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_2-6-1"/>
        <position name="posOpArapuca2-6-1-TPC-12-0-1" unit="cm"
          x="-0.0500000000000002"
-       y="-238.696381578947"
+       y="-238.930328947368"
          z="-253.985"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -4662,7 +4711,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_2-6-2"/>
        <position name="posOpArapuca2-6-2-TPC-12-0-1" unit="cm"
          x="-0.0500000000000002"
-       y="-238.696381578947"
+       y="-238.930328947368"
          z="-191.185"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -4670,7 +4719,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_2-6-3"/>
        <position name="posOpArapuca2-6-3-TPC-12-0-1" unit="cm"
          x="-0.0500000000000002"
-       y="-238.696381578947"
+       y="-238.930328947368"
          z="-142.385"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -4678,7 +4727,7 @@ z="-222.585"/>
 <volumeref ref="volArapuca_2-7"/>
 <position name="posArapuca2-7-TPC-12-0-1" unit="cm"
 x="0"
-y="-176.425986842105"
+y="-176.593092105263"
 z="-222.585"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -4686,7 +4735,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_2-7-0"/>
        <position name="posOpArapuca2-7-0-TPC-12-0-1" unit="cm"
          x="-0.0500000000000002"
-       y="-176.425986842105"
+       y="-176.593092105263"
          z="-302.785"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -4694,7 +4743,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_2-7-1"/>
        <position name="posOpArapuca2-7-1-TPC-12-0-1" unit="cm"
          x="-0.0500000000000002"
-       y="-176.425986842105"
+       y="-176.593092105263"
          z="-253.985"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -4702,7 +4751,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_2-7-2"/>
        <position name="posOpArapuca2-7-2-TPC-12-0-1" unit="cm"
          x="-0.0500000000000002"
-       y="-176.425986842105"
+       y="-176.593092105263"
          z="-191.185"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -4710,7 +4759,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_2-7-3"/>
        <position name="posOpArapuca2-7-3-TPC-12-0-1" unit="cm"
          x="-0.0500000000000002"
-       y="-176.425986842105"
+       y="-176.593092105263"
          z="-142.385"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -4718,7 +4767,7 @@ z="-222.585"/>
 <volumeref ref="volArapuca_2-8"/>
 <position name="posArapuca2-8-TPC-12-0-1" unit="cm"
 x="0"
-y="-114.155592105263"
+y="-114.255855263158"
 z="-222.585"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -4726,7 +4775,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_2-8-0"/>
        <position name="posOpArapuca2-8-0-TPC-12-0-1" unit="cm"
          x="-0.0500000000000002"
-       y="-114.155592105263"
+       y="-114.255855263158"
          z="-302.785"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -4734,7 +4783,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_2-8-1"/>
        <position name="posOpArapuca2-8-1-TPC-12-0-1" unit="cm"
          x="-0.0500000000000002"
-       y="-114.155592105263"
+       y="-114.255855263158"
          z="-253.985"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -4742,7 +4791,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_2-8-2"/>
        <position name="posOpArapuca2-8-2-TPC-12-0-1" unit="cm"
          x="-0.0500000000000002"
-       y="-114.155592105263"
+       y="-114.255855263158"
          z="-191.185"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -4750,7 +4799,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_2-8-3"/>
        <position name="posOpArapuca2-8-3-TPC-12-0-1" unit="cm"
          x="-0.0500000000000002"
-       y="-114.155592105263"
+       y="-114.255855263158"
          z="-142.385"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -4758,7 +4807,7 @@ z="-222.585"/>
 <volumeref ref="volArapuca_2-9"/>
 <position name="posArapuca2-9-TPC-12-0-1" unit="cm"
 x="0"
-y="-51.885197368421"
+y="-51.9186184210527"
 z="-222.585"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -4766,7 +4815,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_2-9-0"/>
        <position name="posOpArapuca2-9-0-TPC-12-0-1" unit="cm"
          x="-0.0500000000000002"
-       y="-51.885197368421"
+       y="-51.9186184210527"
          z="-302.785"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -4774,7 +4823,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_2-9-1"/>
        <position name="posOpArapuca2-9-1-TPC-12-0-1" unit="cm"
          x="-0.0500000000000002"
-       y="-51.885197368421"
+       y="-51.9186184210527"
          z="-253.985"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -4782,7 +4831,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_2-9-2"/>
        <position name="posOpArapuca2-9-2-TPC-12-0-1" unit="cm"
          x="-0.0500000000000002"
-       y="-51.885197368421"
+       y="-51.9186184210527"
          z="-191.185"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -4790,7 +4839,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_2-9-3"/>
        <position name="posOpArapuca2-9-3-TPC-12-0-1" unit="cm"
          x="-0.0500000000000002"
-       y="-51.885197368421"
+       y="-51.9186184210527"
          z="-142.385"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -4799,7 +4848,7 @@ z="-222.585"/>
         <volumeref ref="volTPCInner"/>
         <position name="posTPC-4" unit="cm"
         x="-182.95455"
-        y="-324.664375"
+        y="-324.981875"
         z="-222.585"/>
         <rotationref ref="rPlus180AboutXPlus180AboutY"/>
       </physvol>
@@ -4807,7 +4856,7 @@ z="-222.585"/>
         <volumeref ref="volTPCInner"/>
         <position name="posTPC-5" unit="cm"
         x="182.95455"
-        y="-324.664375"
+        y="-324.981875"
         z="-222.585"/>
         <rotationref ref="rPlus180AboutX"/>
       </physvol>
@@ -4815,16 +4864,16 @@ z="-222.585"/>
       <physvol>
         <volumeref ref="volCathode"/>
         <position name="posCathode-3-0" unit="cm"
-      x="-363.38405"
-      y="-324.664375"
+      x="-363.52605"
+      y="-324.981875"
       z="-222.585"/>
         <rotationref ref="rIdentity"/>
       </physvol>
       <physvol>
         <volumeref ref="volCathode"/>
         <position name="posCathode-3-1" unit="cm"
-      x="363.38405"
-      y="-324.664375"
+      x="363.52605"
+      y="-324.981875"
       z="-222.585"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -4833,23 +4882,23 @@ z="-222.585"/>
         <volumeref ref="volAPAFrameYSide"/>
         <position name="posAPAFrameYSideNeg-3" unit="cm"
       x="0"
-      y="283.87875"
-      z="-332.50625"/>
+      y="284.51375"
+      z="-332.18875"/>
         <rotationref ref="rIdentity"/>
       </physvol>
       <physvol>
         <volumeref ref="volAPAFrameYSide"/>
         <position name="posAPAFrameYSidePos-3" unit="cm"
       x="0"
-      y="283.87875"
-      z="-112.66375"/>
+      y="284.51375"
+      z="-112.98125"/>
         <rotationref ref="rIdentity"/>
       </physvol>
       <physvol>
         <volumeref ref="volAPAFrameZSide"/>
         <position name="posAPAFrameZSidePos-3" unit="cm"
       x="0"
-      y="581.79875"
+      y="582.43375"
       z="-222.585"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -4857,7 +4906,7 @@ z="-222.585"/>
         <volumeref ref="volAPAFrameZSide"/>
         <position name="posAPAFrameZSideNeg-3" unit="cm"
       x="0"
-      y="-14.0412500000001"
+      y="-13.40625"
       z="-222.585"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -4868,22 +4917,33 @@ z="-222.585"/>
       - There are two boards on each the up and downstream end,
           one each to wrap the U and V views around the APA frame
       - There are 4 on the bottom which anchor the U V and Z wires and the grid plane
-      - The rest of the parts of the G10 boards must be placed directly in volTPC   -->
+      FIXME: This is not true -> - The rest of the parts of the G10 boards must be placed directly in volTPC   -->
+
+      <!-- Position readout boards -->
+      <physvol>
+        <volumeref ref="volG10HeadBoards"/>
+        <position name="posG10HeadBoards-3" unit="cm"
+	  x="0"
+	  y="598.01775"
+      	  z="-222.585"/>
+        <rotationref ref="rIdentity"/>
+      </physvol>
 
       <physvol>
         <volumeref ref="volG10BoardYSideCenterSeg"/>
         <position name="posG10BoardYSideCenterSeg-Vup-3" unit="cm"
-      x="0"
-      y="283.87875"
-      z="-337.745"/>
-        <rotationref ref="rIdentity"/>
+         x="0"
+         y="284.51375"
+         z="-337.506875"/>
+         <rotationref ref="rIdentity"/>
       </physvol>
+
       <physvol>
         <volumeref ref="volG10BoardYSideCenterSeg"/>
         <position name="posG10BoardYSideCenterSeg-Uup-3" unit="cm"
       x="0"
-      y="283.87875"
-      z="-338.0625"/>
+      y="284.51375"
+      z="-337.983125"/>
         <rotationref ref="rIdentity"/>
       </physvol>
 
@@ -4891,16 +4951,16 @@ z="-222.585"/>
         <volumeref ref="volG10BoardYSideCenterSeg"/>
         <position name="posG10BoardYSideCenterSeg-Vdown-3" unit="cm"
       x="0"
-      y="283.87875"
-      z="-107.425"/>
+      y="284.51375"
+      z="-107.663125"/>
         <rotationref ref="rIdentity"/>
       </physvol>
       <physvol>
         <volumeref ref="volG10BoardYSideCenterSeg"/>
         <position name="posG10BoardYSideCenterSeg-Udown-3" unit="cm"
       x="0"
-      y="283.87875"
-      z="-107.1075"/>
+      y="284.51375"
+      z="-107.186875"/>
         <rotationref ref="rIdentity"/>
       </physvol>
 
@@ -4908,7 +4968,7 @@ z="-222.585"/>
         <volumeref ref="volG10BoardZSideCenterSeg"/>
         <position name="posG10BoardZSideCenterSeg-Z-3" unit="cm"
       x="0"
-      y="-19.2800000000001"
+      y="-18.7243750000001"
       z="-222.585"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -4916,7 +4976,7 @@ z="-222.585"/>
         <volumeref ref="volG10BoardZSideCenterSeg"/>
         <position name="posG10BoardZSideCenterSeg-V-3" unit="cm"
       x="0"
-      y="-19.5975000000001"
+      y="-19.2006250000001"
       z="-222.585"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -4924,7 +4984,7 @@ z="-222.585"/>
         <volumeref ref="volG10BoardZSideCenterSeg"/>
         <position name="posG10BoardZSideCenterSeg-U-3" unit="cm"
       x="0"
-      y="-19.9150000000001"
+      y="-19.6768750000001"
       z="-222.585"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -4932,7 +4992,7 @@ z="-222.585"/>
         <volumeref ref="volG10BoardZSideCenterSeg"/>
         <position name="posG10BoardZSideCenterSeg-Grid-3" unit="cm"
       x="0"
-      y="-20.2325000000001"
+      y="-20.153125"
       z="-222.585"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -4941,7 +5001,7 @@ z="-222.585"/>
 <volumeref ref="volArapuca_3-0"/>
 <position name="posArapuca3-0-TPC-12-1-1" unit="cm"
 x="0"
-y="10.385197368421"
+y="10.4186184210526"
 z="-222.585"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -4949,7 +5009,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_3-0-0"/>
        <position name="posOpArapuca3-0-0-TPC-12-1-1" unit="cm"
          x="0.0500000000000002"
-       y="10.385197368421"
+       y="10.4186184210526"
          z="-302.785"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -4957,7 +5017,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_3-0-1"/>
        <position name="posOpArapuca3-0-1-TPC-12-1-1" unit="cm"
          x="0.0500000000000002"
-       y="10.385197368421"
+       y="10.4186184210526"
          z="-253.985"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -4965,7 +5025,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_3-0-2"/>
        <position name="posOpArapuca3-0-2-TPC-12-1-1" unit="cm"
          x="0.0500000000000002"
-       y="10.385197368421"
+       y="10.4186184210526"
          z="-191.185"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -4973,7 +5033,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_3-0-3"/>
        <position name="posOpArapuca3-0-3-TPC-12-1-1" unit="cm"
          x="0.0500000000000002"
-       y="10.385197368421"
+       y="10.4186184210526"
          z="-142.385"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -4981,7 +5041,7 @@ z="-222.585"/>
 <volumeref ref="volArapuca_3-1"/>
 <position name="posArapuca3-1-TPC-12-1-1" unit="cm"
 x="0"
-y="72.6555921052631"
+y="72.7558552631579"
 z="-222.585"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -4989,7 +5049,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_3-1-0"/>
        <position name="posOpArapuca3-1-0-TPC-12-1-1" unit="cm"
          x="0.0500000000000002"
-       y="72.6555921052631"
+       y="72.7558552631579"
          z="-302.785"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -4997,7 +5057,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_3-1-1"/>
        <position name="posOpArapuca3-1-1-TPC-12-1-1" unit="cm"
          x="0.0500000000000002"
-       y="72.6555921052631"
+       y="72.7558552631579"
          z="-253.985"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -5005,7 +5065,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_3-1-2"/>
        <position name="posOpArapuca3-1-2-TPC-12-1-1" unit="cm"
          x="0.0500000000000002"
-       y="72.6555921052631"
+       y="72.7558552631579"
          z="-191.185"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -5013,7 +5073,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_3-1-3"/>
        <position name="posOpArapuca3-1-3-TPC-12-1-1" unit="cm"
          x="0.0500000000000002"
-       y="72.6555921052631"
+       y="72.7558552631579"
          z="-142.385"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -5021,7 +5081,7 @@ z="-222.585"/>
 <volumeref ref="volArapuca_3-2"/>
 <position name="posArapuca3-2-TPC-12-1-1" unit="cm"
 x="0"
-y="134.925986842105"
+y="135.093092105263"
 z="-222.585"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -5029,7 +5089,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_3-2-0"/>
        <position name="posOpArapuca3-2-0-TPC-12-1-1" unit="cm"
          x="0.0500000000000002"
-       y="134.925986842105"
+       y="135.093092105263"
          z="-302.785"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -5037,7 +5097,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_3-2-1"/>
        <position name="posOpArapuca3-2-1-TPC-12-1-1" unit="cm"
          x="0.0500000000000002"
-       y="134.925986842105"
+       y="135.093092105263"
          z="-253.985"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -5045,7 +5105,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_3-2-2"/>
        <position name="posOpArapuca3-2-2-TPC-12-1-1" unit="cm"
          x="0.0500000000000002"
-       y="134.925986842105"
+       y="135.093092105263"
          z="-191.185"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -5053,7 +5113,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_3-2-3"/>
        <position name="posOpArapuca3-2-3-TPC-12-1-1" unit="cm"
          x="0.0500000000000002"
-       y="134.925986842105"
+       y="135.093092105263"
          z="-142.385"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -5061,7 +5121,7 @@ z="-222.585"/>
 <volumeref ref="volArapuca_3-3"/>
 <position name="posArapuca3-3-TPC-12-1-1" unit="cm"
 x="0"
-y="197.196381578947"
+y="197.430328947368"
 z="-222.585"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -5069,7 +5129,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_3-3-0"/>
        <position name="posOpArapuca3-3-0-TPC-12-1-1" unit="cm"
          x="0.0500000000000002"
-       y="197.196381578947"
+       y="197.430328947368"
          z="-302.785"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -5077,7 +5137,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_3-3-1"/>
        <position name="posOpArapuca3-3-1-TPC-12-1-1" unit="cm"
          x="0.0500000000000002"
-       y="197.196381578947"
+       y="197.430328947368"
          z="-253.985"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -5085,7 +5145,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_3-3-2"/>
        <position name="posOpArapuca3-3-2-TPC-12-1-1" unit="cm"
          x="0.0500000000000002"
-       y="197.196381578947"
+       y="197.430328947368"
          z="-191.185"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -5093,7 +5153,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_3-3-3"/>
        <position name="posOpArapuca3-3-3-TPC-12-1-1" unit="cm"
          x="0.0500000000000002"
-       y="197.196381578947"
+       y="197.430328947368"
          z="-142.385"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -5101,7 +5161,7 @@ z="-222.585"/>
 <volumeref ref="volArapuca_3-4"/>
 <position name="posArapuca3-4-TPC-12-1-1" unit="cm"
 x="0"
-y="259.46677631579"
+y="259.767565789474"
 z="-222.585"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -5109,7 +5169,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_3-4-0"/>
        <position name="posOpArapuca3-4-0-TPC-12-1-1" unit="cm"
          x="0.0500000000000002"
-       y="259.46677631579"
+       y="259.767565789474"
          z="-302.785"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -5117,7 +5177,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_3-4-1"/>
        <position name="posOpArapuca3-4-1-TPC-12-1-1" unit="cm"
          x="0.0500000000000002"
-       y="259.46677631579"
+       y="259.767565789474"
          z="-253.985"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -5125,7 +5185,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_3-4-2"/>
        <position name="posOpArapuca3-4-2-TPC-12-1-1" unit="cm"
          x="0.0500000000000002"
-       y="259.46677631579"
+       y="259.767565789474"
          z="-191.185"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -5133,7 +5193,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_3-4-3"/>
        <position name="posOpArapuca3-4-3-TPC-12-1-1" unit="cm"
          x="0.0500000000000002"
-       y="259.46677631579"
+       y="259.767565789474"
          z="-142.385"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -5141,7 +5201,7 @@ z="-222.585"/>
 <volumeref ref="volArapuca_3-5"/>
 <position name="posArapuca3-5-TPC-12-1-1" unit="cm"
 x="0"
-y="321.737171052632"
+y="322.104802631579"
 z="-222.585"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -5149,7 +5209,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_3-5-0"/>
        <position name="posOpArapuca3-5-0-TPC-12-1-1" unit="cm"
          x="0.0500000000000002"
-       y="321.737171052632"
+       y="322.104802631579"
          z="-302.785"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -5157,7 +5217,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_3-5-1"/>
        <position name="posOpArapuca3-5-1-TPC-12-1-1" unit="cm"
          x="0.0500000000000002"
-       y="321.737171052632"
+       y="322.104802631579"
          z="-253.985"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -5165,7 +5225,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_3-5-2"/>
        <position name="posOpArapuca3-5-2-TPC-12-1-1" unit="cm"
          x="0.0500000000000002"
-       y="321.737171052632"
+       y="322.104802631579"
          z="-191.185"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -5173,7 +5233,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_3-5-3"/>
        <position name="posOpArapuca3-5-3-TPC-12-1-1" unit="cm"
          x="0.0500000000000002"
-       y="321.737171052632"
+       y="322.104802631579"
          z="-142.385"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -5181,7 +5241,7 @@ z="-222.585"/>
 <volumeref ref="volArapuca_3-6"/>
 <position name="posArapuca3-6-TPC-12-1-1" unit="cm"
 x="0"
-y="384.007565789474"
+y="384.442039473684"
 z="-222.585"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -5189,7 +5249,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_3-6-0"/>
        <position name="posOpArapuca3-6-0-TPC-12-1-1" unit="cm"
          x="0.0500000000000002"
-       y="384.007565789474"
+       y="384.442039473684"
          z="-302.785"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -5197,7 +5257,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_3-6-1"/>
        <position name="posOpArapuca3-6-1-TPC-12-1-1" unit="cm"
          x="0.0500000000000002"
-       y="384.007565789474"
+       y="384.442039473684"
          z="-253.985"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -5205,7 +5265,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_3-6-2"/>
        <position name="posOpArapuca3-6-2-TPC-12-1-1" unit="cm"
          x="0.0500000000000002"
-       y="384.007565789474"
+       y="384.442039473684"
          z="-191.185"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -5213,7 +5273,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_3-6-3"/>
        <position name="posOpArapuca3-6-3-TPC-12-1-1" unit="cm"
          x="0.0500000000000002"
-       y="384.007565789474"
+       y="384.442039473684"
          z="-142.385"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -5221,7 +5281,7 @@ z="-222.585"/>
 <volumeref ref="volArapuca_3-7"/>
 <position name="posArapuca3-7-TPC-12-1-1" unit="cm"
 x="0"
-y="446.277960526316"
+y="446.77927631579"
 z="-222.585"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -5229,7 +5289,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_3-7-0"/>
        <position name="posOpArapuca3-7-0-TPC-12-1-1" unit="cm"
          x="0.0500000000000002"
-       y="446.277960526316"
+       y="446.77927631579"
          z="-302.785"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -5237,7 +5297,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_3-7-1"/>
        <position name="posOpArapuca3-7-1-TPC-12-1-1" unit="cm"
          x="0.0500000000000002"
-       y="446.277960526316"
+       y="446.77927631579"
          z="-253.985"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -5245,7 +5305,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_3-7-2"/>
        <position name="posOpArapuca3-7-2-TPC-12-1-1" unit="cm"
          x="0.0500000000000002"
-       y="446.277960526316"
+       y="446.77927631579"
          z="-191.185"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -5253,7 +5313,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_3-7-3"/>
        <position name="posOpArapuca3-7-3-TPC-12-1-1" unit="cm"
          x="0.0500000000000002"
-       y="446.277960526316"
+       y="446.77927631579"
          z="-142.385"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -5261,7 +5321,7 @@ z="-222.585"/>
 <volumeref ref="volArapuca_3-8"/>
 <position name="posArapuca3-8-TPC-12-1-1" unit="cm"
 x="0"
-y="508.548355263158"
+y="509.116513157895"
 z="-222.585"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -5269,7 +5329,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_3-8-0"/>
        <position name="posOpArapuca3-8-0-TPC-12-1-1" unit="cm"
          x="0.0500000000000002"
-       y="508.548355263158"
+       y="509.116513157895"
          z="-302.785"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -5277,7 +5337,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_3-8-1"/>
        <position name="posOpArapuca3-8-1-TPC-12-1-1" unit="cm"
          x="0.0500000000000002"
-       y="508.548355263158"
+       y="509.116513157895"
          z="-253.985"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -5285,7 +5345,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_3-8-2"/>
        <position name="posOpArapuca3-8-2-TPC-12-1-1" unit="cm"
          x="0.0500000000000002"
-       y="508.548355263158"
+       y="509.116513157895"
          z="-191.185"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -5293,7 +5353,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_3-8-3"/>
        <position name="posOpArapuca3-8-3-TPC-12-1-1" unit="cm"
          x="0.0500000000000002"
-       y="508.548355263158"
+       y="509.116513157895"
          z="-142.385"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -5301,7 +5361,7 @@ z="-222.585"/>
 <volumeref ref="volArapuca_3-9"/>
 <position name="posArapuca3-9-TPC-12-1-1" unit="cm"
 x="0"
-y="570.81875"
+y="571.45375"
 z="-222.585"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -5309,7 +5369,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_3-9-0"/>
        <position name="posOpArapuca3-9-0-TPC-12-1-1" unit="cm"
          x="0.0500000000000002"
-       y="570.81875"
+       y="571.45375"
          z="-302.785"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -5317,7 +5377,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_3-9-1"/>
        <position name="posOpArapuca3-9-1-TPC-12-1-1" unit="cm"
          x="0.0500000000000002"
-       y="570.81875"
+       y="571.45375"
          z="-253.985"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -5325,7 +5385,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_3-9-2"/>
        <position name="posOpArapuca3-9-2-TPC-12-1-1" unit="cm"
          x="0.0500000000000002"
-       y="570.81875"
+       y="571.45375"
          z="-191.185"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -5333,7 +5393,7 @@ z="-222.585"/>
        <volumeref ref="volOpDetSensitive_3-9-3"/>
        <position name="posOpArapuca3-9-3-TPC-12-1-1" unit="cm"
          x="0.0500000000000002"
-       y="570.81875"
+       y="571.45375"
          z="-142.385"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -5342,7 +5402,7 @@ z="-222.585"/>
         <volumeref ref="volTPCInner"/>
         <position name="posTPC-6" unit="cm"
         x="-182.95455"
-        y="283.164375"
+        y="283.481875"
         z="-222.585"/>
         <rotationref ref="rPlus180AboutY"/>
       </physvol>
@@ -5350,7 +5410,7 @@ z="-222.585"/>
         <volumeref ref="volTPCInner"/>
         <position name="posTPC-7" unit="cm"
         x="182.95455"
-        y="283.164375"
+        y="283.481875"
         z="-222.585"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -5358,16 +5418,16 @@ z="-222.585"/>
       <physvol>
         <volumeref ref="volCathode"/>
         <position name="posCathode-4-0" unit="cm"
-      x="-363.38405"
-      y="283.164375"
+      x="-363.52605"
+      y="283.481875"
       z="-222.585"/>
         <rotationref ref="rIdentity"/>
       </physvol>
       <physvol>
         <volumeref ref="volCathode"/>
         <position name="posCathode-4-1" unit="cm"
-      x="363.38405"
-      y="283.164375"
+      x="363.52605"
+      y="283.481875"
       z="-222.585"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -5376,23 +5436,23 @@ z="-222.585"/>
         <volumeref ref="volAPAFrameYSide"/>
         <position name="posAPAFrameYSideNeg-4" unit="cm"
       x="0"
-      y="-325.37875"
-      z="-100.11625"/>
+      y="-326.01375"
+      z="-99.7987499999999"/>
         <rotationref ref="rIdentity"/>
       </physvol>
       <physvol>
         <volumeref ref="volAPAFrameYSide"/>
         <position name="posAPAFrameYSidePos-4" unit="cm"
       x="0"
-      y="-325.37875"
-      z="119.72625"/>
+      y="-326.01375"
+      z="119.40875"/>
         <rotationref ref="rIdentity"/>
       </physvol>
       <physvol>
         <volumeref ref="volAPAFrameZSide"/>
         <position name="posAPAFrameZSidePos-4" unit="cm"
       x="0"
-      y="-27.45875"
+      y="-28.0937500000001"
       z="9.80500000000006"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -5400,7 +5460,7 @@ z="-222.585"/>
         <volumeref ref="volAPAFrameZSide"/>
         <position name="posAPAFrameZSideNeg-4" unit="cm"
       x="0"
-      y="-623.29875"
+      y="-623.93375"
       z="9.80500000000006"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -5411,22 +5471,33 @@ z="-222.585"/>
       - There are two boards on each the up and downstream end,
           one each to wrap the U and V views around the APA frame
       - There are 4 on the bottom which anchor the U V and Z wires and the grid plane
-      - The rest of the parts of the G10 boards must be placed directly in volTPC   -->
+      FIXME: This is not true -> - The rest of the parts of the G10 boards must be placed directly in volTPC   -->
+
+      <!-- Position readout boards -->
+      <physvol>
+        <volumeref ref="volG10HeadBoards"/>
+        <position name="posG10HeadBoards-4" unit="cm"
+	  x="0"
+	  y="-639.51775"
+      	  z="9.80500000000006"/>
+        <rotationref ref="rIdentity"/>
+      </physvol>
 
       <physvol>
         <volumeref ref="volG10BoardYSideCenterSeg"/>
         <position name="posG10BoardYSideCenterSeg-Vup-4" unit="cm"
-      x="0"
-      y="-325.37875"
-      z="-105.355"/>
-        <rotationref ref="rIdentity"/>
+         x="0"
+         y="-326.01375"
+         z="-105.116875"/>
+         <rotationref ref="rIdentity"/>
       </physvol>
+
       <physvol>
         <volumeref ref="volG10BoardYSideCenterSeg"/>
         <position name="posG10BoardYSideCenterSeg-Uup-4" unit="cm"
       x="0"
-      y="-325.37875"
-      z="-105.6725"/>
+      y="-326.01375"
+      z="-105.593125"/>
         <rotationref ref="rIdentity"/>
       </physvol>
 
@@ -5434,16 +5505,16 @@ z="-222.585"/>
         <volumeref ref="volG10BoardYSideCenterSeg"/>
         <position name="posG10BoardYSideCenterSeg-Vdown-4" unit="cm"
       x="0"
-      y="-325.37875"
-      z="124.965"/>
+      y="-326.01375"
+      z="124.726875"/>
         <rotationref ref="rIdentity"/>
       </physvol>
       <physvol>
         <volumeref ref="volG10BoardYSideCenterSeg"/>
         <position name="posG10BoardYSideCenterSeg-Udown-4" unit="cm"
       x="0"
-      y="-325.37875"
-      z="125.2825"/>
+      y="-326.01375"
+      z="125.203125"/>
         <rotationref ref="rIdentity"/>
       </physvol>
 
@@ -5451,7 +5522,7 @@ z="-222.585"/>
         <volumeref ref="volG10BoardZSideCenterSeg"/>
         <position name="posG10BoardZSideCenterSeg-Z-4" unit="cm"
       x="0"
-      y="-22.22"
+      y="-22.775625"
       z="9.80500000000006"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -5459,7 +5530,7 @@ z="-222.585"/>
         <volumeref ref="volG10BoardZSideCenterSeg"/>
         <position name="posG10BoardZSideCenterSeg-V-4" unit="cm"
       x="0"
-      y="-21.9025"
+      y="-22.2993750000001"
       z="9.80500000000006"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -5467,7 +5538,7 @@ z="-222.585"/>
         <volumeref ref="volG10BoardZSideCenterSeg"/>
         <position name="posG10BoardZSideCenterSeg-U-4" unit="cm"
       x="0"
-      y="-21.585"
+      y="-21.8231250000001"
       z="9.80500000000006"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -5475,7 +5546,7 @@ z="-222.585"/>
         <volumeref ref="volG10BoardZSideCenterSeg"/>
         <position name="posG10BoardZSideCenterSeg-Grid-4" unit="cm"
       x="0"
-      y="-21.2675"
+      y="-21.3468750000001"
       z="9.80500000000006"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -5484,7 +5555,7 @@ z="-222.585"/>
 <volumeref ref="volArapuca_4-0"/>
 <position name="posArapuca4-0-TPC-12-0-2" unit="cm"
 x="0"
-y="-612.31875"
+y="-612.95375"
 z="9.80500000000006"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -5492,7 +5563,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_4-0-0"/>
        <position name="posOpArapuca4-0-0-TPC-12-0-2" unit="cm"
          x="-0.0500000000000002"
-       y="-612.31875"
+       y="-612.95375"
          z="-70.3949999999999"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -5500,7 +5571,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_4-0-1"/>
        <position name="posOpArapuca4-0-1-TPC-12-0-2" unit="cm"
          x="-0.0500000000000002"
-       y="-612.31875"
+       y="-612.95375"
          z="-21.5949999999999"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -5508,7 +5579,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_4-0-2"/>
        <position name="posOpArapuca4-0-2-TPC-12-0-2" unit="cm"
          x="-0.0500000000000002"
-       y="-612.31875"
+       y="-612.95375"
          z="41.2050000000001"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -5516,7 +5587,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_4-0-3"/>
        <position name="posOpArapuca4-0-3-TPC-12-0-2" unit="cm"
          x="-0.0500000000000002"
-       y="-612.31875"
+       y="-612.95375"
          z="90.0050000000001"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -5524,7 +5595,7 @@ z="9.80500000000006"/>
 <volumeref ref="volArapuca_4-1"/>
 <position name="posArapuca4-1-TPC-12-0-2" unit="cm"
 x="0"
-y="-550.048355263158"
+y="-550.616513157895"
 z="9.80500000000006"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -5532,7 +5603,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_4-1-0"/>
        <position name="posOpArapuca4-1-0-TPC-12-0-2" unit="cm"
          x="-0.0500000000000002"
-       y="-550.048355263158"
+       y="-550.616513157895"
          z="-70.3949999999999"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -5540,7 +5611,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_4-1-1"/>
        <position name="posOpArapuca4-1-1-TPC-12-0-2" unit="cm"
          x="-0.0500000000000002"
-       y="-550.048355263158"
+       y="-550.616513157895"
          z="-21.5949999999999"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -5548,7 +5619,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_4-1-2"/>
        <position name="posOpArapuca4-1-2-TPC-12-0-2" unit="cm"
          x="-0.0500000000000002"
-       y="-550.048355263158"
+       y="-550.616513157895"
          z="41.2050000000001"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -5556,7 +5627,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_4-1-3"/>
        <position name="posOpArapuca4-1-3-TPC-12-0-2" unit="cm"
          x="-0.0500000000000002"
-       y="-550.048355263158"
+       y="-550.616513157895"
          z="90.0050000000001"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -5564,7 +5635,7 @@ z="9.80500000000006"/>
 <volumeref ref="volArapuca_4-2"/>
 <position name="posArapuca4-2-TPC-12-0-2" unit="cm"
 x="0"
-y="-487.777960526316"
+y="-488.27927631579"
 z="9.80500000000006"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -5572,7 +5643,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_4-2-0"/>
        <position name="posOpArapuca4-2-0-TPC-12-0-2" unit="cm"
          x="-0.0500000000000002"
-       y="-487.777960526316"
+       y="-488.27927631579"
          z="-70.3949999999999"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -5580,7 +5651,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_4-2-1"/>
        <position name="posOpArapuca4-2-1-TPC-12-0-2" unit="cm"
          x="-0.0500000000000002"
-       y="-487.777960526316"
+       y="-488.27927631579"
          z="-21.5949999999999"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -5588,7 +5659,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_4-2-2"/>
        <position name="posOpArapuca4-2-2-TPC-12-0-2" unit="cm"
          x="-0.0500000000000002"
-       y="-487.777960526316"
+       y="-488.27927631579"
          z="41.2050000000001"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -5596,7 +5667,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_4-2-3"/>
        <position name="posOpArapuca4-2-3-TPC-12-0-2" unit="cm"
          x="-0.0500000000000002"
-       y="-487.777960526316"
+       y="-488.27927631579"
          z="90.0050000000001"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -5604,7 +5675,7 @@ z="9.80500000000006"/>
 <volumeref ref="volArapuca_4-3"/>
 <position name="posArapuca4-3-TPC-12-0-2" unit="cm"
 x="0"
-y="-425.507565789474"
+y="-425.942039473684"
 z="9.80500000000006"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -5612,7 +5683,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_4-3-0"/>
        <position name="posOpArapuca4-3-0-TPC-12-0-2" unit="cm"
          x="-0.0500000000000002"
-       y="-425.507565789474"
+       y="-425.942039473684"
          z="-70.3949999999999"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -5620,7 +5691,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_4-3-1"/>
        <position name="posOpArapuca4-3-1-TPC-12-0-2" unit="cm"
          x="-0.0500000000000002"
-       y="-425.507565789474"
+       y="-425.942039473684"
          z="-21.5949999999999"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -5628,7 +5699,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_4-3-2"/>
        <position name="posOpArapuca4-3-2-TPC-12-0-2" unit="cm"
          x="-0.0500000000000002"
-       y="-425.507565789474"
+       y="-425.942039473684"
          z="41.2050000000001"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -5636,7 +5707,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_4-3-3"/>
        <position name="posOpArapuca4-3-3-TPC-12-0-2" unit="cm"
          x="-0.0500000000000002"
-       y="-425.507565789474"
+       y="-425.942039473684"
          z="90.0050000000001"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -5644,7 +5715,7 @@ z="9.80500000000006"/>
 <volumeref ref="volArapuca_4-4"/>
 <position name="posArapuca4-4-TPC-12-0-2" unit="cm"
 x="0"
-y="-363.237171052632"
+y="-363.604802631579"
 z="9.80500000000006"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -5652,7 +5723,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_4-4-0"/>
        <position name="posOpArapuca4-4-0-TPC-12-0-2" unit="cm"
          x="-0.0500000000000002"
-       y="-363.237171052632"
+       y="-363.604802631579"
          z="-70.3949999999999"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -5660,7 +5731,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_4-4-1"/>
        <position name="posOpArapuca4-4-1-TPC-12-0-2" unit="cm"
          x="-0.0500000000000002"
-       y="-363.237171052632"
+       y="-363.604802631579"
          z="-21.5949999999999"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -5668,7 +5739,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_4-4-2"/>
        <position name="posOpArapuca4-4-2-TPC-12-0-2" unit="cm"
          x="-0.0500000000000002"
-       y="-363.237171052632"
+       y="-363.604802631579"
          z="41.2050000000001"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -5676,7 +5747,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_4-4-3"/>
        <position name="posOpArapuca4-4-3-TPC-12-0-2" unit="cm"
          x="-0.0500000000000002"
-       y="-363.237171052632"
+       y="-363.604802631579"
          z="90.0050000000001"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -5684,7 +5755,7 @@ z="9.80500000000006"/>
 <volumeref ref="volArapuca_4-5"/>
 <position name="posArapuca4-5-TPC-12-0-2" unit="cm"
 x="0"
-y="-300.96677631579"
+y="-301.267565789474"
 z="9.80500000000006"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -5692,7 +5763,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_4-5-0"/>
        <position name="posOpArapuca4-5-0-TPC-12-0-2" unit="cm"
          x="-0.0500000000000002"
-       y="-300.96677631579"
+       y="-301.267565789474"
          z="-70.3949999999999"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -5700,7 +5771,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_4-5-1"/>
        <position name="posOpArapuca4-5-1-TPC-12-0-2" unit="cm"
          x="-0.0500000000000002"
-       y="-300.96677631579"
+       y="-301.267565789474"
          z="-21.5949999999999"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -5708,7 +5779,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_4-5-2"/>
        <position name="posOpArapuca4-5-2-TPC-12-0-2" unit="cm"
          x="-0.0500000000000002"
-       y="-300.96677631579"
+       y="-301.267565789474"
          z="41.2050000000001"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -5716,7 +5787,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_4-5-3"/>
        <position name="posOpArapuca4-5-3-TPC-12-0-2" unit="cm"
          x="-0.0500000000000002"
-       y="-300.96677631579"
+       y="-301.267565789474"
          z="90.0050000000001"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -5724,7 +5795,7 @@ z="9.80500000000006"/>
 <volumeref ref="volArapuca_4-6"/>
 <position name="posArapuca4-6-TPC-12-0-2" unit="cm"
 x="0"
-y="-238.696381578947"
+y="-238.930328947368"
 z="9.80500000000006"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -5732,7 +5803,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_4-6-0"/>
        <position name="posOpArapuca4-6-0-TPC-12-0-2" unit="cm"
          x="-0.0500000000000002"
-       y="-238.696381578947"
+       y="-238.930328947368"
          z="-70.3949999999999"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -5740,7 +5811,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_4-6-1"/>
        <position name="posOpArapuca4-6-1-TPC-12-0-2" unit="cm"
          x="-0.0500000000000002"
-       y="-238.696381578947"
+       y="-238.930328947368"
          z="-21.5949999999999"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -5748,7 +5819,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_4-6-2"/>
        <position name="posOpArapuca4-6-2-TPC-12-0-2" unit="cm"
          x="-0.0500000000000002"
-       y="-238.696381578947"
+       y="-238.930328947368"
          z="41.2050000000001"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -5756,7 +5827,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_4-6-3"/>
        <position name="posOpArapuca4-6-3-TPC-12-0-2" unit="cm"
          x="-0.0500000000000002"
-       y="-238.696381578947"
+       y="-238.930328947368"
          z="90.0050000000001"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -5764,7 +5835,7 @@ z="9.80500000000006"/>
 <volumeref ref="volArapuca_4-7"/>
 <position name="posArapuca4-7-TPC-12-0-2" unit="cm"
 x="0"
-y="-176.425986842105"
+y="-176.593092105263"
 z="9.80500000000006"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -5772,7 +5843,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_4-7-0"/>
        <position name="posOpArapuca4-7-0-TPC-12-0-2" unit="cm"
          x="-0.0500000000000002"
-       y="-176.425986842105"
+       y="-176.593092105263"
          z="-70.3949999999999"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -5780,7 +5851,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_4-7-1"/>
        <position name="posOpArapuca4-7-1-TPC-12-0-2" unit="cm"
          x="-0.0500000000000002"
-       y="-176.425986842105"
+       y="-176.593092105263"
          z="-21.5949999999999"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -5788,7 +5859,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_4-7-2"/>
        <position name="posOpArapuca4-7-2-TPC-12-0-2" unit="cm"
          x="-0.0500000000000002"
-       y="-176.425986842105"
+       y="-176.593092105263"
          z="41.2050000000001"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -5796,7 +5867,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_4-7-3"/>
        <position name="posOpArapuca4-7-3-TPC-12-0-2" unit="cm"
          x="-0.0500000000000002"
-       y="-176.425986842105"
+       y="-176.593092105263"
          z="90.0050000000001"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -5804,7 +5875,7 @@ z="9.80500000000006"/>
 <volumeref ref="volArapuca_4-8"/>
 <position name="posArapuca4-8-TPC-12-0-2" unit="cm"
 x="0"
-y="-114.155592105263"
+y="-114.255855263158"
 z="9.80500000000006"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -5812,7 +5883,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_4-8-0"/>
        <position name="posOpArapuca4-8-0-TPC-12-0-2" unit="cm"
          x="-0.0500000000000002"
-       y="-114.155592105263"
+       y="-114.255855263158"
          z="-70.3949999999999"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -5820,7 +5891,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_4-8-1"/>
        <position name="posOpArapuca4-8-1-TPC-12-0-2" unit="cm"
          x="-0.0500000000000002"
-       y="-114.155592105263"
+       y="-114.255855263158"
          z="-21.5949999999999"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -5828,7 +5899,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_4-8-2"/>
        <position name="posOpArapuca4-8-2-TPC-12-0-2" unit="cm"
          x="-0.0500000000000002"
-       y="-114.155592105263"
+       y="-114.255855263158"
          z="41.2050000000001"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -5836,7 +5907,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_4-8-3"/>
        <position name="posOpArapuca4-8-3-TPC-12-0-2" unit="cm"
          x="-0.0500000000000002"
-       y="-114.155592105263"
+       y="-114.255855263158"
          z="90.0050000000001"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -5844,7 +5915,7 @@ z="9.80500000000006"/>
 <volumeref ref="volArapuca_4-9"/>
 <position name="posArapuca4-9-TPC-12-0-2" unit="cm"
 x="0"
-y="-51.885197368421"
+y="-51.9186184210527"
 z="9.80500000000006"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -5852,7 +5923,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_4-9-0"/>
        <position name="posOpArapuca4-9-0-TPC-12-0-2" unit="cm"
          x="-0.0500000000000002"
-       y="-51.885197368421"
+       y="-51.9186184210527"
          z="-70.3949999999999"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -5860,7 +5931,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_4-9-1"/>
        <position name="posOpArapuca4-9-1-TPC-12-0-2" unit="cm"
          x="-0.0500000000000002"
-       y="-51.885197368421"
+       y="-51.9186184210527"
          z="-21.5949999999999"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -5868,7 +5939,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_4-9-2"/>
        <position name="posOpArapuca4-9-2-TPC-12-0-2" unit="cm"
          x="-0.0500000000000002"
-       y="-51.885197368421"
+       y="-51.9186184210527"
          z="41.2050000000001"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -5876,7 +5947,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_4-9-3"/>
        <position name="posOpArapuca4-9-3-TPC-12-0-2" unit="cm"
          x="-0.0500000000000002"
-       y="-51.885197368421"
+       y="-51.9186184210527"
          z="90.0050000000001"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -5885,7 +5956,7 @@ z="9.80500000000006"/>
         <volumeref ref="volTPCInner"/>
         <position name="posTPC-8" unit="cm"
         x="-182.95455"
-        y="-324.664375"
+        y="-324.981875"
         z="9.80500000000006"/>
         <rotationref ref="rPlus180AboutXPlus180AboutY"/>
       </physvol>
@@ -5893,7 +5964,7 @@ z="9.80500000000006"/>
         <volumeref ref="volTPCInner"/>
         <position name="posTPC-9" unit="cm"
         x="182.95455"
-        y="-324.664375"
+        y="-324.981875"
         z="9.80500000000006"/>
         <rotationref ref="rPlus180AboutX"/>
       </physvol>
@@ -5901,16 +5972,16 @@ z="9.80500000000006"/>
       <physvol>
         <volumeref ref="volCathode"/>
         <position name="posCathode-5-0" unit="cm"
-      x="-363.38405"
-      y="-324.664375"
+      x="-363.52605"
+      y="-324.981875"
       z="9.80500000000006"/>
         <rotationref ref="rIdentity"/>
       </physvol>
       <physvol>
         <volumeref ref="volCathode"/>
         <position name="posCathode-5-1" unit="cm"
-      x="363.38405"
-      y="-324.664375"
+      x="363.52605"
+      y="-324.981875"
       z="9.80500000000006"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -5919,23 +5990,23 @@ z="9.80500000000006"/>
         <volumeref ref="volAPAFrameYSide"/>
         <position name="posAPAFrameYSideNeg-5" unit="cm"
       x="0"
-      y="283.87875"
-      z="-100.11625"/>
+      y="284.51375"
+      z="-99.7987499999999"/>
         <rotationref ref="rIdentity"/>
       </physvol>
       <physvol>
         <volumeref ref="volAPAFrameYSide"/>
         <position name="posAPAFrameYSidePos-5" unit="cm"
       x="0"
-      y="283.87875"
-      z="119.72625"/>
+      y="284.51375"
+      z="119.40875"/>
         <rotationref ref="rIdentity"/>
       </physvol>
       <physvol>
         <volumeref ref="volAPAFrameZSide"/>
         <position name="posAPAFrameZSidePos-5" unit="cm"
       x="0"
-      y="581.79875"
+      y="582.43375"
       z="9.80500000000006"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -5943,7 +6014,7 @@ z="9.80500000000006"/>
         <volumeref ref="volAPAFrameZSide"/>
         <position name="posAPAFrameZSideNeg-5" unit="cm"
       x="0"
-      y="-14.0412500000001"
+      y="-13.40625"
       z="9.80500000000006"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -5954,22 +6025,33 @@ z="9.80500000000006"/>
       - There are two boards on each the up and downstream end,
           one each to wrap the U and V views around the APA frame
       - There are 4 on the bottom which anchor the U V and Z wires and the grid plane
-      - The rest of the parts of the G10 boards must be placed directly in volTPC   -->
+      FIXME: This is not true -> - The rest of the parts of the G10 boards must be placed directly in volTPC   -->
+
+      <!-- Position readout boards -->
+      <physvol>
+        <volumeref ref="volG10HeadBoards"/>
+        <position name="posG10HeadBoards-5" unit="cm"
+	  x="0"
+	  y="598.01775"
+      	  z="9.80500000000006"/>
+        <rotationref ref="rIdentity"/>
+      </physvol>
 
       <physvol>
         <volumeref ref="volG10BoardYSideCenterSeg"/>
         <position name="posG10BoardYSideCenterSeg-Vup-5" unit="cm"
-      x="0"
-      y="283.87875"
-      z="-105.355"/>
-        <rotationref ref="rIdentity"/>
+         x="0"
+         y="284.51375"
+         z="-105.116875"/>
+         <rotationref ref="rIdentity"/>
       </physvol>
+
       <physvol>
         <volumeref ref="volG10BoardYSideCenterSeg"/>
         <position name="posG10BoardYSideCenterSeg-Uup-5" unit="cm"
       x="0"
-      y="283.87875"
-      z="-105.6725"/>
+      y="284.51375"
+      z="-105.593125"/>
         <rotationref ref="rIdentity"/>
       </physvol>
 
@@ -5977,16 +6059,16 @@ z="9.80500000000006"/>
         <volumeref ref="volG10BoardYSideCenterSeg"/>
         <position name="posG10BoardYSideCenterSeg-Vdown-5" unit="cm"
       x="0"
-      y="283.87875"
-      z="124.965"/>
+      y="284.51375"
+      z="124.726875"/>
         <rotationref ref="rIdentity"/>
       </physvol>
       <physvol>
         <volumeref ref="volG10BoardYSideCenterSeg"/>
         <position name="posG10BoardYSideCenterSeg-Udown-5" unit="cm"
       x="0"
-      y="283.87875"
-      z="125.2825"/>
+      y="284.51375"
+      z="125.203125"/>
         <rotationref ref="rIdentity"/>
       </physvol>
 
@@ -5994,7 +6076,7 @@ z="9.80500000000006"/>
         <volumeref ref="volG10BoardZSideCenterSeg"/>
         <position name="posG10BoardZSideCenterSeg-Z-5" unit="cm"
       x="0"
-      y="-19.2800000000001"
+      y="-18.7243750000001"
       z="9.80500000000006"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -6002,7 +6084,7 @@ z="9.80500000000006"/>
         <volumeref ref="volG10BoardZSideCenterSeg"/>
         <position name="posG10BoardZSideCenterSeg-V-5" unit="cm"
       x="0"
-      y="-19.5975000000001"
+      y="-19.2006250000001"
       z="9.80500000000006"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -6010,7 +6092,7 @@ z="9.80500000000006"/>
         <volumeref ref="volG10BoardZSideCenterSeg"/>
         <position name="posG10BoardZSideCenterSeg-U-5" unit="cm"
       x="0"
-      y="-19.9150000000001"
+      y="-19.6768750000001"
       z="9.80500000000006"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -6018,7 +6100,7 @@ z="9.80500000000006"/>
         <volumeref ref="volG10BoardZSideCenterSeg"/>
         <position name="posG10BoardZSideCenterSeg-Grid-5" unit="cm"
       x="0"
-      y="-20.2325000000001"
+      y="-20.153125"
       z="9.80500000000006"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -6027,7 +6109,7 @@ z="9.80500000000006"/>
 <volumeref ref="volArapuca_5-0"/>
 <position name="posArapuca5-0-TPC-12-1-2" unit="cm"
 x="0"
-y="10.385197368421"
+y="10.4186184210526"
 z="9.80500000000006"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -6035,7 +6117,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_5-0-0"/>
        <position name="posOpArapuca5-0-0-TPC-12-1-2" unit="cm"
          x="0.0500000000000002"
-       y="10.385197368421"
+       y="10.4186184210526"
          z="-70.3949999999999"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -6043,7 +6125,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_5-0-1"/>
        <position name="posOpArapuca5-0-1-TPC-12-1-2" unit="cm"
          x="0.0500000000000002"
-       y="10.385197368421"
+       y="10.4186184210526"
          z="-21.5949999999999"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -6051,7 +6133,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_5-0-2"/>
        <position name="posOpArapuca5-0-2-TPC-12-1-2" unit="cm"
          x="0.0500000000000002"
-       y="10.385197368421"
+       y="10.4186184210526"
          z="41.2050000000001"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -6059,7 +6141,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_5-0-3"/>
        <position name="posOpArapuca5-0-3-TPC-12-1-2" unit="cm"
          x="0.0500000000000002"
-       y="10.385197368421"
+       y="10.4186184210526"
          z="90.0050000000001"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -6067,7 +6149,7 @@ z="9.80500000000006"/>
 <volumeref ref="volArapuca_5-1"/>
 <position name="posArapuca5-1-TPC-12-1-2" unit="cm"
 x="0"
-y="72.6555921052631"
+y="72.7558552631579"
 z="9.80500000000006"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -6075,7 +6157,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_5-1-0"/>
        <position name="posOpArapuca5-1-0-TPC-12-1-2" unit="cm"
          x="0.0500000000000002"
-       y="72.6555921052631"
+       y="72.7558552631579"
          z="-70.3949999999999"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -6083,7 +6165,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_5-1-1"/>
        <position name="posOpArapuca5-1-1-TPC-12-1-2" unit="cm"
          x="0.0500000000000002"
-       y="72.6555921052631"
+       y="72.7558552631579"
          z="-21.5949999999999"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -6091,7 +6173,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_5-1-2"/>
        <position name="posOpArapuca5-1-2-TPC-12-1-2" unit="cm"
          x="0.0500000000000002"
-       y="72.6555921052631"
+       y="72.7558552631579"
          z="41.2050000000001"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -6099,7 +6181,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_5-1-3"/>
        <position name="posOpArapuca5-1-3-TPC-12-1-2" unit="cm"
          x="0.0500000000000002"
-       y="72.6555921052631"
+       y="72.7558552631579"
          z="90.0050000000001"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -6107,7 +6189,7 @@ z="9.80500000000006"/>
 <volumeref ref="volArapuca_5-2"/>
 <position name="posArapuca5-2-TPC-12-1-2" unit="cm"
 x="0"
-y="134.925986842105"
+y="135.093092105263"
 z="9.80500000000006"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -6115,7 +6197,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_5-2-0"/>
        <position name="posOpArapuca5-2-0-TPC-12-1-2" unit="cm"
          x="0.0500000000000002"
-       y="134.925986842105"
+       y="135.093092105263"
          z="-70.3949999999999"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -6123,7 +6205,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_5-2-1"/>
        <position name="posOpArapuca5-2-1-TPC-12-1-2" unit="cm"
          x="0.0500000000000002"
-       y="134.925986842105"
+       y="135.093092105263"
          z="-21.5949999999999"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -6131,7 +6213,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_5-2-2"/>
        <position name="posOpArapuca5-2-2-TPC-12-1-2" unit="cm"
          x="0.0500000000000002"
-       y="134.925986842105"
+       y="135.093092105263"
          z="41.2050000000001"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -6139,7 +6221,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_5-2-3"/>
        <position name="posOpArapuca5-2-3-TPC-12-1-2" unit="cm"
          x="0.0500000000000002"
-       y="134.925986842105"
+       y="135.093092105263"
          z="90.0050000000001"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -6147,7 +6229,7 @@ z="9.80500000000006"/>
 <volumeref ref="volArapuca_5-3"/>
 <position name="posArapuca5-3-TPC-12-1-2" unit="cm"
 x="0"
-y="197.196381578947"
+y="197.430328947368"
 z="9.80500000000006"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -6155,7 +6237,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_5-3-0"/>
        <position name="posOpArapuca5-3-0-TPC-12-1-2" unit="cm"
          x="0.0500000000000002"
-       y="197.196381578947"
+       y="197.430328947368"
          z="-70.3949999999999"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -6163,7 +6245,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_5-3-1"/>
        <position name="posOpArapuca5-3-1-TPC-12-1-2" unit="cm"
          x="0.0500000000000002"
-       y="197.196381578947"
+       y="197.430328947368"
          z="-21.5949999999999"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -6171,7 +6253,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_5-3-2"/>
        <position name="posOpArapuca5-3-2-TPC-12-1-2" unit="cm"
          x="0.0500000000000002"
-       y="197.196381578947"
+       y="197.430328947368"
          z="41.2050000000001"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -6179,7 +6261,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_5-3-3"/>
        <position name="posOpArapuca5-3-3-TPC-12-1-2" unit="cm"
          x="0.0500000000000002"
-       y="197.196381578947"
+       y="197.430328947368"
          z="90.0050000000001"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -6187,7 +6269,7 @@ z="9.80500000000006"/>
 <volumeref ref="volArapuca_5-4"/>
 <position name="posArapuca5-4-TPC-12-1-2" unit="cm"
 x="0"
-y="259.46677631579"
+y="259.767565789474"
 z="9.80500000000006"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -6195,7 +6277,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_5-4-0"/>
        <position name="posOpArapuca5-4-0-TPC-12-1-2" unit="cm"
          x="0.0500000000000002"
-       y="259.46677631579"
+       y="259.767565789474"
          z="-70.3949999999999"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -6203,7 +6285,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_5-4-1"/>
        <position name="posOpArapuca5-4-1-TPC-12-1-2" unit="cm"
          x="0.0500000000000002"
-       y="259.46677631579"
+       y="259.767565789474"
          z="-21.5949999999999"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -6211,7 +6293,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_5-4-2"/>
        <position name="posOpArapuca5-4-2-TPC-12-1-2" unit="cm"
          x="0.0500000000000002"
-       y="259.46677631579"
+       y="259.767565789474"
          z="41.2050000000001"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -6219,7 +6301,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_5-4-3"/>
        <position name="posOpArapuca5-4-3-TPC-12-1-2" unit="cm"
          x="0.0500000000000002"
-       y="259.46677631579"
+       y="259.767565789474"
          z="90.0050000000001"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -6227,7 +6309,7 @@ z="9.80500000000006"/>
 <volumeref ref="volArapuca_5-5"/>
 <position name="posArapuca5-5-TPC-12-1-2" unit="cm"
 x="0"
-y="321.737171052632"
+y="322.104802631579"
 z="9.80500000000006"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -6235,7 +6317,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_5-5-0"/>
        <position name="posOpArapuca5-5-0-TPC-12-1-2" unit="cm"
          x="0.0500000000000002"
-       y="321.737171052632"
+       y="322.104802631579"
          z="-70.3949999999999"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -6243,7 +6325,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_5-5-1"/>
        <position name="posOpArapuca5-5-1-TPC-12-1-2" unit="cm"
          x="0.0500000000000002"
-       y="321.737171052632"
+       y="322.104802631579"
          z="-21.5949999999999"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -6251,7 +6333,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_5-5-2"/>
        <position name="posOpArapuca5-5-2-TPC-12-1-2" unit="cm"
          x="0.0500000000000002"
-       y="321.737171052632"
+       y="322.104802631579"
          z="41.2050000000001"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -6259,7 +6341,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_5-5-3"/>
        <position name="posOpArapuca5-5-3-TPC-12-1-2" unit="cm"
          x="0.0500000000000002"
-       y="321.737171052632"
+       y="322.104802631579"
          z="90.0050000000001"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -6267,7 +6349,7 @@ z="9.80500000000006"/>
 <volumeref ref="volArapuca_5-6"/>
 <position name="posArapuca5-6-TPC-12-1-2" unit="cm"
 x="0"
-y="384.007565789474"
+y="384.442039473684"
 z="9.80500000000006"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -6275,7 +6357,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_5-6-0"/>
        <position name="posOpArapuca5-6-0-TPC-12-1-2" unit="cm"
          x="0.0500000000000002"
-       y="384.007565789474"
+       y="384.442039473684"
          z="-70.3949999999999"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -6283,7 +6365,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_5-6-1"/>
        <position name="posOpArapuca5-6-1-TPC-12-1-2" unit="cm"
          x="0.0500000000000002"
-       y="384.007565789474"
+       y="384.442039473684"
          z="-21.5949999999999"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -6291,7 +6373,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_5-6-2"/>
        <position name="posOpArapuca5-6-2-TPC-12-1-2" unit="cm"
          x="0.0500000000000002"
-       y="384.007565789474"
+       y="384.442039473684"
          z="41.2050000000001"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -6299,7 +6381,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_5-6-3"/>
        <position name="posOpArapuca5-6-3-TPC-12-1-2" unit="cm"
          x="0.0500000000000002"
-       y="384.007565789474"
+       y="384.442039473684"
          z="90.0050000000001"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -6307,7 +6389,7 @@ z="9.80500000000006"/>
 <volumeref ref="volArapuca_5-7"/>
 <position name="posArapuca5-7-TPC-12-1-2" unit="cm"
 x="0"
-y="446.277960526316"
+y="446.77927631579"
 z="9.80500000000006"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -6315,7 +6397,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_5-7-0"/>
        <position name="posOpArapuca5-7-0-TPC-12-1-2" unit="cm"
          x="0.0500000000000002"
-       y="446.277960526316"
+       y="446.77927631579"
          z="-70.3949999999999"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -6323,7 +6405,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_5-7-1"/>
        <position name="posOpArapuca5-7-1-TPC-12-1-2" unit="cm"
          x="0.0500000000000002"
-       y="446.277960526316"
+       y="446.77927631579"
          z="-21.5949999999999"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -6331,7 +6413,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_5-7-2"/>
        <position name="posOpArapuca5-7-2-TPC-12-1-2" unit="cm"
          x="0.0500000000000002"
-       y="446.277960526316"
+       y="446.77927631579"
          z="41.2050000000001"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -6339,7 +6421,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_5-7-3"/>
        <position name="posOpArapuca5-7-3-TPC-12-1-2" unit="cm"
          x="0.0500000000000002"
-       y="446.277960526316"
+       y="446.77927631579"
          z="90.0050000000001"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -6347,7 +6429,7 @@ z="9.80500000000006"/>
 <volumeref ref="volArapuca_5-8"/>
 <position name="posArapuca5-8-TPC-12-1-2" unit="cm"
 x="0"
-y="508.548355263158"
+y="509.116513157895"
 z="9.80500000000006"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -6355,7 +6437,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_5-8-0"/>
        <position name="posOpArapuca5-8-0-TPC-12-1-2" unit="cm"
          x="0.0500000000000002"
-       y="508.548355263158"
+       y="509.116513157895"
          z="-70.3949999999999"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -6363,7 +6445,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_5-8-1"/>
        <position name="posOpArapuca5-8-1-TPC-12-1-2" unit="cm"
          x="0.0500000000000002"
-       y="508.548355263158"
+       y="509.116513157895"
          z="-21.5949999999999"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -6371,7 +6453,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_5-8-2"/>
        <position name="posOpArapuca5-8-2-TPC-12-1-2" unit="cm"
          x="0.0500000000000002"
-       y="508.548355263158"
+       y="509.116513157895"
          z="41.2050000000001"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -6379,7 +6461,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_5-8-3"/>
        <position name="posOpArapuca5-8-3-TPC-12-1-2" unit="cm"
          x="0.0500000000000002"
-       y="508.548355263158"
+       y="509.116513157895"
          z="90.0050000000001"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -6387,7 +6469,7 @@ z="9.80500000000006"/>
 <volumeref ref="volArapuca_5-9"/>
 <position name="posArapuca5-9-TPC-12-1-2" unit="cm"
 x="0"
-y="570.81875"
+y="571.45375"
 z="9.80500000000006"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -6395,7 +6477,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_5-9-0"/>
        <position name="posOpArapuca5-9-0-TPC-12-1-2" unit="cm"
          x="0.0500000000000002"
-       y="570.81875"
+       y="571.45375"
          z="-70.3949999999999"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -6403,7 +6485,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_5-9-1"/>
        <position name="posOpArapuca5-9-1-TPC-12-1-2" unit="cm"
          x="0.0500000000000002"
-       y="570.81875"
+       y="571.45375"
          z="-21.5949999999999"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -6411,7 +6493,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_5-9-2"/>
        <position name="posOpArapuca5-9-2-TPC-12-1-2" unit="cm"
          x="0.0500000000000002"
-       y="570.81875"
+       y="571.45375"
          z="41.2050000000001"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -6419,7 +6501,7 @@ z="9.80500000000006"/>
        <volumeref ref="volOpDetSensitive_5-9-3"/>
        <position name="posOpArapuca5-9-3-TPC-12-1-2" unit="cm"
          x="0.0500000000000002"
-       y="570.81875"
+       y="571.45375"
          z="90.0050000000001"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -6428,7 +6510,7 @@ z="9.80500000000006"/>
         <volumeref ref="volTPCInner"/>
         <position name="posTPC-10" unit="cm"
         x="-182.95455"
-        y="283.164375"
+        y="283.481875"
         z="9.80500000000006"/>
         <rotationref ref="rPlus180AboutY"/>
       </physvol>
@@ -6436,7 +6518,7 @@ z="9.80500000000006"/>
         <volumeref ref="volTPCInner"/>
         <position name="posTPC-11" unit="cm"
         x="182.95455"
-        y="283.164375"
+        y="283.481875"
         z="9.80500000000006"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -6444,16 +6526,16 @@ z="9.80500000000006"/>
       <physvol>
         <volumeref ref="volCathode"/>
         <position name="posCathode-6-0" unit="cm"
-      x="-363.38405"
-      y="283.164375"
+      x="-363.52605"
+      y="283.481875"
       z="9.80500000000006"/>
         <rotationref ref="rIdentity"/>
       </physvol>
       <physvol>
         <volumeref ref="volCathode"/>
         <position name="posCathode-6-1" unit="cm"
-      x="363.38405"
-      y="283.164375"
+      x="363.52605"
+      y="283.481875"
       z="9.80500000000006"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -6462,23 +6544,23 @@ z="9.80500000000006"/>
         <volumeref ref="volAPAFrameYSide"/>
         <position name="posAPAFrameYSideNeg-6" unit="cm"
       x="0"
-      y="-325.37875"
-      z="132.27375"/>
+      y="-326.01375"
+      z="132.59125"/>
         <rotationref ref="rIdentity"/>
       </physvol>
       <physvol>
         <volumeref ref="volAPAFrameYSide"/>
         <position name="posAPAFrameYSidePos-6" unit="cm"
       x="0"
-      y="-325.37875"
-      z="352.11625"/>
+      y="-326.01375"
+      z="351.79875"/>
         <rotationref ref="rIdentity"/>
       </physvol>
       <physvol>
         <volumeref ref="volAPAFrameZSide"/>
         <position name="posAPAFrameZSidePos-6" unit="cm"
       x="0"
-      y="-27.45875"
+      y="-28.0937500000001"
       z="242.195"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -6486,7 +6568,7 @@ z="9.80500000000006"/>
         <volumeref ref="volAPAFrameZSide"/>
         <position name="posAPAFrameZSideNeg-6" unit="cm"
       x="0"
-      y="-623.29875"
+      y="-623.93375"
       z="242.195"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -6497,22 +6579,33 @@ z="9.80500000000006"/>
       - There are two boards on each the up and downstream end,
           one each to wrap the U and V views around the APA frame
       - There are 4 on the bottom which anchor the U V and Z wires and the grid plane
-      - The rest of the parts of the G10 boards must be placed directly in volTPC   -->
+      FIXME: This is not true -> - The rest of the parts of the G10 boards must be placed directly in volTPC   -->
+
+      <!-- Position readout boards -->
+      <physvol>
+        <volumeref ref="volG10HeadBoards"/>
+        <position name="posG10HeadBoards-6" unit="cm"
+	  x="0"
+	  y="-639.51775"
+      	  z="242.195"/>
+        <rotationref ref="rIdentity"/>
+      </physvol>
 
       <physvol>
         <volumeref ref="volG10BoardYSideCenterSeg"/>
         <position name="posG10BoardYSideCenterSeg-Vup-6" unit="cm"
-      x="0"
-      y="-325.37875"
-      z="127.035"/>
-        <rotationref ref="rIdentity"/>
+         x="0"
+         y="-326.01375"
+         z="127.273125"/>
+         <rotationref ref="rIdentity"/>
       </physvol>
+
       <physvol>
         <volumeref ref="volG10BoardYSideCenterSeg"/>
         <position name="posG10BoardYSideCenterSeg-Uup-6" unit="cm"
       x="0"
-      y="-325.37875"
-      z="126.7175"/>
+      y="-326.01375"
+      z="126.796875"/>
         <rotationref ref="rIdentity"/>
       </physvol>
 
@@ -6520,16 +6613,16 @@ z="9.80500000000006"/>
         <volumeref ref="volG10BoardYSideCenterSeg"/>
         <position name="posG10BoardYSideCenterSeg-Vdown-6" unit="cm"
       x="0"
-      y="-325.37875"
-      z="357.355"/>
+      y="-326.01375"
+      z="357.116875"/>
         <rotationref ref="rIdentity"/>
       </physvol>
       <physvol>
         <volumeref ref="volG10BoardYSideCenterSeg"/>
         <position name="posG10BoardYSideCenterSeg-Udown-6" unit="cm"
       x="0"
-      y="-325.37875"
-      z="357.6725"/>
+      y="-326.01375"
+      z="357.593125"/>
         <rotationref ref="rIdentity"/>
       </physvol>
 
@@ -6537,7 +6630,7 @@ z="9.80500000000006"/>
         <volumeref ref="volG10BoardZSideCenterSeg"/>
         <position name="posG10BoardZSideCenterSeg-Z-6" unit="cm"
       x="0"
-      y="-22.22"
+      y="-22.775625"
       z="242.195"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -6545,7 +6638,7 @@ z="9.80500000000006"/>
         <volumeref ref="volG10BoardZSideCenterSeg"/>
         <position name="posG10BoardZSideCenterSeg-V-6" unit="cm"
       x="0"
-      y="-21.9025"
+      y="-22.2993750000001"
       z="242.195"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -6553,7 +6646,7 @@ z="9.80500000000006"/>
         <volumeref ref="volG10BoardZSideCenterSeg"/>
         <position name="posG10BoardZSideCenterSeg-U-6" unit="cm"
       x="0"
-      y="-21.585"
+      y="-21.8231250000001"
       z="242.195"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -6561,7 +6654,7 @@ z="9.80500000000006"/>
         <volumeref ref="volG10BoardZSideCenterSeg"/>
         <position name="posG10BoardZSideCenterSeg-Grid-6" unit="cm"
       x="0"
-      y="-21.2675"
+      y="-21.3468750000001"
       z="242.195"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -6570,7 +6663,7 @@ z="9.80500000000006"/>
 <volumeref ref="volArapuca_6-0"/>
 <position name="posArapuca6-0-TPC-12-0-3" unit="cm"
 x="0"
-y="-612.31875"
+y="-612.95375"
 z="242.195"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -6578,7 +6671,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_6-0-0"/>
        <position name="posOpArapuca6-0-0-TPC-12-0-3" unit="cm"
          x="-0.0500000000000002"
-       y="-612.31875"
+       y="-612.95375"
          z="161.995"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -6586,7 +6679,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_6-0-1"/>
        <position name="posOpArapuca6-0-1-TPC-12-0-3" unit="cm"
          x="-0.0500000000000002"
-       y="-612.31875"
+       y="-612.95375"
          z="210.795"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -6594,7 +6687,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_6-0-2"/>
        <position name="posOpArapuca6-0-2-TPC-12-0-3" unit="cm"
          x="-0.0500000000000002"
-       y="-612.31875"
+       y="-612.95375"
          z="273.595"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -6602,7 +6695,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_6-0-3"/>
        <position name="posOpArapuca6-0-3-TPC-12-0-3" unit="cm"
          x="-0.0500000000000002"
-       y="-612.31875"
+       y="-612.95375"
          z="322.395"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -6610,7 +6703,7 @@ z="242.195"/>
 <volumeref ref="volArapuca_6-1"/>
 <position name="posArapuca6-1-TPC-12-0-3" unit="cm"
 x="0"
-y="-550.048355263158"
+y="-550.616513157895"
 z="242.195"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -6618,7 +6711,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_6-1-0"/>
        <position name="posOpArapuca6-1-0-TPC-12-0-3" unit="cm"
          x="-0.0500000000000002"
-       y="-550.048355263158"
+       y="-550.616513157895"
          z="161.995"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -6626,7 +6719,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_6-1-1"/>
        <position name="posOpArapuca6-1-1-TPC-12-0-3" unit="cm"
          x="-0.0500000000000002"
-       y="-550.048355263158"
+       y="-550.616513157895"
          z="210.795"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -6634,7 +6727,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_6-1-2"/>
        <position name="posOpArapuca6-1-2-TPC-12-0-3" unit="cm"
          x="-0.0500000000000002"
-       y="-550.048355263158"
+       y="-550.616513157895"
          z="273.595"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -6642,7 +6735,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_6-1-3"/>
        <position name="posOpArapuca6-1-3-TPC-12-0-3" unit="cm"
          x="-0.0500000000000002"
-       y="-550.048355263158"
+       y="-550.616513157895"
          z="322.395"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -6650,7 +6743,7 @@ z="242.195"/>
 <volumeref ref="volArapuca_6-2"/>
 <position name="posArapuca6-2-TPC-12-0-3" unit="cm"
 x="0"
-y="-487.777960526316"
+y="-488.27927631579"
 z="242.195"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -6658,7 +6751,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_6-2-0"/>
        <position name="posOpArapuca6-2-0-TPC-12-0-3" unit="cm"
          x="-0.0500000000000002"
-       y="-487.777960526316"
+       y="-488.27927631579"
          z="161.995"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -6666,7 +6759,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_6-2-1"/>
        <position name="posOpArapuca6-2-1-TPC-12-0-3" unit="cm"
          x="-0.0500000000000002"
-       y="-487.777960526316"
+       y="-488.27927631579"
          z="210.795"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -6674,7 +6767,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_6-2-2"/>
        <position name="posOpArapuca6-2-2-TPC-12-0-3" unit="cm"
          x="-0.0500000000000002"
-       y="-487.777960526316"
+       y="-488.27927631579"
          z="273.595"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -6682,7 +6775,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_6-2-3"/>
        <position name="posOpArapuca6-2-3-TPC-12-0-3" unit="cm"
          x="-0.0500000000000002"
-       y="-487.777960526316"
+       y="-488.27927631579"
          z="322.395"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -6690,7 +6783,7 @@ z="242.195"/>
 <volumeref ref="volArapuca_6-3"/>
 <position name="posArapuca6-3-TPC-12-0-3" unit="cm"
 x="0"
-y="-425.507565789474"
+y="-425.942039473684"
 z="242.195"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -6698,7 +6791,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_6-3-0"/>
        <position name="posOpArapuca6-3-0-TPC-12-0-3" unit="cm"
          x="-0.0500000000000002"
-       y="-425.507565789474"
+       y="-425.942039473684"
          z="161.995"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -6706,7 +6799,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_6-3-1"/>
        <position name="posOpArapuca6-3-1-TPC-12-0-3" unit="cm"
          x="-0.0500000000000002"
-       y="-425.507565789474"
+       y="-425.942039473684"
          z="210.795"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -6714,7 +6807,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_6-3-2"/>
        <position name="posOpArapuca6-3-2-TPC-12-0-3" unit="cm"
          x="-0.0500000000000002"
-       y="-425.507565789474"
+       y="-425.942039473684"
          z="273.595"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -6722,7 +6815,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_6-3-3"/>
        <position name="posOpArapuca6-3-3-TPC-12-0-3" unit="cm"
          x="-0.0500000000000002"
-       y="-425.507565789474"
+       y="-425.942039473684"
          z="322.395"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -6730,7 +6823,7 @@ z="242.195"/>
 <volumeref ref="volArapuca_6-4"/>
 <position name="posArapuca6-4-TPC-12-0-3" unit="cm"
 x="0"
-y="-363.237171052632"
+y="-363.604802631579"
 z="242.195"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -6738,7 +6831,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_6-4-0"/>
        <position name="posOpArapuca6-4-0-TPC-12-0-3" unit="cm"
          x="-0.0500000000000002"
-       y="-363.237171052632"
+       y="-363.604802631579"
          z="161.995"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -6746,7 +6839,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_6-4-1"/>
        <position name="posOpArapuca6-4-1-TPC-12-0-3" unit="cm"
          x="-0.0500000000000002"
-       y="-363.237171052632"
+       y="-363.604802631579"
          z="210.795"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -6754,7 +6847,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_6-4-2"/>
        <position name="posOpArapuca6-4-2-TPC-12-0-3" unit="cm"
          x="-0.0500000000000002"
-       y="-363.237171052632"
+       y="-363.604802631579"
          z="273.595"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -6762,7 +6855,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_6-4-3"/>
        <position name="posOpArapuca6-4-3-TPC-12-0-3" unit="cm"
          x="-0.0500000000000002"
-       y="-363.237171052632"
+       y="-363.604802631579"
          z="322.395"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -6770,7 +6863,7 @@ z="242.195"/>
 <volumeref ref="volArapuca_6-5"/>
 <position name="posArapuca6-5-TPC-12-0-3" unit="cm"
 x="0"
-y="-300.96677631579"
+y="-301.267565789474"
 z="242.195"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -6778,7 +6871,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_6-5-0"/>
        <position name="posOpArapuca6-5-0-TPC-12-0-3" unit="cm"
          x="-0.0500000000000002"
-       y="-300.96677631579"
+       y="-301.267565789474"
          z="161.995"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -6786,7 +6879,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_6-5-1"/>
        <position name="posOpArapuca6-5-1-TPC-12-0-3" unit="cm"
          x="-0.0500000000000002"
-       y="-300.96677631579"
+       y="-301.267565789474"
          z="210.795"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -6794,7 +6887,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_6-5-2"/>
        <position name="posOpArapuca6-5-2-TPC-12-0-3" unit="cm"
          x="-0.0500000000000002"
-       y="-300.96677631579"
+       y="-301.267565789474"
          z="273.595"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -6802,7 +6895,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_6-5-3"/>
        <position name="posOpArapuca6-5-3-TPC-12-0-3" unit="cm"
          x="-0.0500000000000002"
-       y="-300.96677631579"
+       y="-301.267565789474"
          z="322.395"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -6810,7 +6903,7 @@ z="242.195"/>
 <volumeref ref="volArapuca_6-6"/>
 <position name="posArapuca6-6-TPC-12-0-3" unit="cm"
 x="0"
-y="-238.696381578947"
+y="-238.930328947368"
 z="242.195"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -6818,7 +6911,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_6-6-0"/>
        <position name="posOpArapuca6-6-0-TPC-12-0-3" unit="cm"
          x="-0.0500000000000002"
-       y="-238.696381578947"
+       y="-238.930328947368"
          z="161.995"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -6826,7 +6919,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_6-6-1"/>
        <position name="posOpArapuca6-6-1-TPC-12-0-3" unit="cm"
          x="-0.0500000000000002"
-       y="-238.696381578947"
+       y="-238.930328947368"
          z="210.795"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -6834,7 +6927,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_6-6-2"/>
        <position name="posOpArapuca6-6-2-TPC-12-0-3" unit="cm"
          x="-0.0500000000000002"
-       y="-238.696381578947"
+       y="-238.930328947368"
          z="273.595"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -6842,7 +6935,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_6-6-3"/>
        <position name="posOpArapuca6-6-3-TPC-12-0-3" unit="cm"
          x="-0.0500000000000002"
-       y="-238.696381578947"
+       y="-238.930328947368"
          z="322.395"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -6850,7 +6943,7 @@ z="242.195"/>
 <volumeref ref="volArapuca_6-7"/>
 <position name="posArapuca6-7-TPC-12-0-3" unit="cm"
 x="0"
-y="-176.425986842105"
+y="-176.593092105263"
 z="242.195"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -6858,7 +6951,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_6-7-0"/>
        <position name="posOpArapuca6-7-0-TPC-12-0-3" unit="cm"
          x="-0.0500000000000002"
-       y="-176.425986842105"
+       y="-176.593092105263"
          z="161.995"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -6866,7 +6959,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_6-7-1"/>
        <position name="posOpArapuca6-7-1-TPC-12-0-3" unit="cm"
          x="-0.0500000000000002"
-       y="-176.425986842105"
+       y="-176.593092105263"
          z="210.795"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -6874,7 +6967,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_6-7-2"/>
        <position name="posOpArapuca6-7-2-TPC-12-0-3" unit="cm"
          x="-0.0500000000000002"
-       y="-176.425986842105"
+       y="-176.593092105263"
          z="273.595"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -6882,7 +6975,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_6-7-3"/>
        <position name="posOpArapuca6-7-3-TPC-12-0-3" unit="cm"
          x="-0.0500000000000002"
-       y="-176.425986842105"
+       y="-176.593092105263"
          z="322.395"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -6890,7 +6983,7 @@ z="242.195"/>
 <volumeref ref="volArapuca_6-8"/>
 <position name="posArapuca6-8-TPC-12-0-3" unit="cm"
 x="0"
-y="-114.155592105263"
+y="-114.255855263158"
 z="242.195"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -6898,7 +6991,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_6-8-0"/>
        <position name="posOpArapuca6-8-0-TPC-12-0-3" unit="cm"
          x="-0.0500000000000002"
-       y="-114.155592105263"
+       y="-114.255855263158"
          z="161.995"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -6906,7 +6999,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_6-8-1"/>
        <position name="posOpArapuca6-8-1-TPC-12-0-3" unit="cm"
          x="-0.0500000000000002"
-       y="-114.155592105263"
+       y="-114.255855263158"
          z="210.795"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -6914,7 +7007,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_6-8-2"/>
        <position name="posOpArapuca6-8-2-TPC-12-0-3" unit="cm"
          x="-0.0500000000000002"
-       y="-114.155592105263"
+       y="-114.255855263158"
          z="273.595"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -6922,7 +7015,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_6-8-3"/>
        <position name="posOpArapuca6-8-3-TPC-12-0-3" unit="cm"
          x="-0.0500000000000002"
-       y="-114.155592105263"
+       y="-114.255855263158"
          z="322.395"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -6930,7 +7023,7 @@ z="242.195"/>
 <volumeref ref="volArapuca_6-9"/>
 <position name="posArapuca6-9-TPC-12-0-3" unit="cm"
 x="0"
-y="-51.885197368421"
+y="-51.9186184210527"
 z="242.195"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -6938,7 +7031,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_6-9-0"/>
        <position name="posOpArapuca6-9-0-TPC-12-0-3" unit="cm"
          x="-0.0500000000000002"
-       y="-51.885197368421"
+       y="-51.9186184210527"
          z="161.995"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -6946,7 +7039,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_6-9-1"/>
        <position name="posOpArapuca6-9-1-TPC-12-0-3" unit="cm"
          x="-0.0500000000000002"
-       y="-51.885197368421"
+       y="-51.9186184210527"
          z="210.795"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -6954,7 +7047,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_6-9-2"/>
        <position name="posOpArapuca6-9-2-TPC-12-0-3" unit="cm"
          x="-0.0500000000000002"
-       y="-51.885197368421"
+       y="-51.9186184210527"
          z="273.595"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -6962,7 +7055,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_6-9-3"/>
        <position name="posOpArapuca6-9-3-TPC-12-0-3" unit="cm"
          x="-0.0500000000000002"
-       y="-51.885197368421"
+       y="-51.9186184210527"
          z="322.395"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -6971,7 +7064,7 @@ z="242.195"/>
         <volumeref ref="volTPCInner"/>
         <position name="posTPC-12" unit="cm"
         x="-182.95455"
-        y="-324.664375"
+        y="-324.981875"
         z="242.195"/>
         <rotationref ref="rPlus180AboutXPlus180AboutY"/>
       </physvol>
@@ -6979,7 +7072,7 @@ z="242.195"/>
         <volumeref ref="volTPCInner"/>
         <position name="posTPC-13" unit="cm"
         x="182.95455"
-        y="-324.664375"
+        y="-324.981875"
         z="242.195"/>
         <rotationref ref="rPlus180AboutX"/>
       </physvol>
@@ -6987,16 +7080,16 @@ z="242.195"/>
       <physvol>
         <volumeref ref="volCathode"/>
         <position name="posCathode-7-0" unit="cm"
-      x="-363.38405"
-      y="-324.664375"
+      x="-363.52605"
+      y="-324.981875"
       z="242.195"/>
         <rotationref ref="rIdentity"/>
       </physvol>
       <physvol>
         <volumeref ref="volCathode"/>
         <position name="posCathode-7-1" unit="cm"
-      x="363.38405"
-      y="-324.664375"
+      x="363.52605"
+      y="-324.981875"
       z="242.195"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -7005,23 +7098,23 @@ z="242.195"/>
         <volumeref ref="volAPAFrameYSide"/>
         <position name="posAPAFrameYSideNeg-7" unit="cm"
       x="0"
-      y="283.87875"
-      z="132.27375"/>
+      y="284.51375"
+      z="132.59125"/>
         <rotationref ref="rIdentity"/>
       </physvol>
       <physvol>
         <volumeref ref="volAPAFrameYSide"/>
         <position name="posAPAFrameYSidePos-7" unit="cm"
       x="0"
-      y="283.87875"
-      z="352.11625"/>
+      y="284.51375"
+      z="351.79875"/>
         <rotationref ref="rIdentity"/>
       </physvol>
       <physvol>
         <volumeref ref="volAPAFrameZSide"/>
         <position name="posAPAFrameZSidePos-7" unit="cm"
       x="0"
-      y="581.79875"
+      y="582.43375"
       z="242.195"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -7029,7 +7122,7 @@ z="242.195"/>
         <volumeref ref="volAPAFrameZSide"/>
         <position name="posAPAFrameZSideNeg-7" unit="cm"
       x="0"
-      y="-14.0412500000001"
+      y="-13.40625"
       z="242.195"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -7040,22 +7133,33 @@ z="242.195"/>
       - There are two boards on each the up and downstream end,
           one each to wrap the U and V views around the APA frame
       - There are 4 on the bottom which anchor the U V and Z wires and the grid plane
-      - The rest of the parts of the G10 boards must be placed directly in volTPC   -->
+      FIXME: This is not true -> - The rest of the parts of the G10 boards must be placed directly in volTPC   -->
+
+      <!-- Position readout boards -->
+      <physvol>
+        <volumeref ref="volG10HeadBoards"/>
+        <position name="posG10HeadBoards-7" unit="cm"
+	  x="0"
+	  y="598.01775"
+      	  z="242.195"/>
+        <rotationref ref="rIdentity"/>
+      </physvol>
 
       <physvol>
         <volumeref ref="volG10BoardYSideCenterSeg"/>
         <position name="posG10BoardYSideCenterSeg-Vup-7" unit="cm"
-      x="0"
-      y="283.87875"
-      z="127.035"/>
-        <rotationref ref="rIdentity"/>
+         x="0"
+         y="284.51375"
+         z="127.273125"/>
+         <rotationref ref="rIdentity"/>
       </physvol>
+
       <physvol>
         <volumeref ref="volG10BoardYSideCenterSeg"/>
         <position name="posG10BoardYSideCenterSeg-Uup-7" unit="cm"
       x="0"
-      y="283.87875"
-      z="126.7175"/>
+      y="284.51375"
+      z="126.796875"/>
         <rotationref ref="rIdentity"/>
       </physvol>
 
@@ -7063,16 +7167,16 @@ z="242.195"/>
         <volumeref ref="volG10BoardYSideCenterSeg"/>
         <position name="posG10BoardYSideCenterSeg-Vdown-7" unit="cm"
       x="0"
-      y="283.87875"
-      z="357.355"/>
+      y="284.51375"
+      z="357.116875"/>
         <rotationref ref="rIdentity"/>
       </physvol>
       <physvol>
         <volumeref ref="volG10BoardYSideCenterSeg"/>
         <position name="posG10BoardYSideCenterSeg-Udown-7" unit="cm"
       x="0"
-      y="283.87875"
-      z="357.6725"/>
+      y="284.51375"
+      z="357.593125"/>
         <rotationref ref="rIdentity"/>
       </physvol>
 
@@ -7080,7 +7184,7 @@ z="242.195"/>
         <volumeref ref="volG10BoardZSideCenterSeg"/>
         <position name="posG10BoardZSideCenterSeg-Z-7" unit="cm"
       x="0"
-      y="-19.2800000000001"
+      y="-18.7243750000001"
       z="242.195"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -7088,7 +7192,7 @@ z="242.195"/>
         <volumeref ref="volG10BoardZSideCenterSeg"/>
         <position name="posG10BoardZSideCenterSeg-V-7" unit="cm"
       x="0"
-      y="-19.5975000000001"
+      y="-19.2006250000001"
       z="242.195"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -7096,7 +7200,7 @@ z="242.195"/>
         <volumeref ref="volG10BoardZSideCenterSeg"/>
         <position name="posG10BoardZSideCenterSeg-U-7" unit="cm"
       x="0"
-      y="-19.9150000000001"
+      y="-19.6768750000001"
       z="242.195"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -7104,7 +7208,7 @@ z="242.195"/>
         <volumeref ref="volG10BoardZSideCenterSeg"/>
         <position name="posG10BoardZSideCenterSeg-Grid-7" unit="cm"
       x="0"
-      y="-20.2325000000001"
+      y="-20.153125"
       z="242.195"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -7113,7 +7217,7 @@ z="242.195"/>
 <volumeref ref="volArapuca_7-0"/>
 <position name="posArapuca7-0-TPC-12-1-3" unit="cm"
 x="0"
-y="10.385197368421"
+y="10.4186184210526"
 z="242.195"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -7121,7 +7225,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_7-0-0"/>
        <position name="posOpArapuca7-0-0-TPC-12-1-3" unit="cm"
          x="0.0500000000000002"
-       y="10.385197368421"
+       y="10.4186184210526"
          z="161.995"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -7129,7 +7233,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_7-0-1"/>
        <position name="posOpArapuca7-0-1-TPC-12-1-3" unit="cm"
          x="0.0500000000000002"
-       y="10.385197368421"
+       y="10.4186184210526"
          z="210.795"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -7137,7 +7241,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_7-0-2"/>
        <position name="posOpArapuca7-0-2-TPC-12-1-3" unit="cm"
          x="0.0500000000000002"
-       y="10.385197368421"
+       y="10.4186184210526"
          z="273.595"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -7145,7 +7249,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_7-0-3"/>
        <position name="posOpArapuca7-0-3-TPC-12-1-3" unit="cm"
          x="0.0500000000000002"
-       y="10.385197368421"
+       y="10.4186184210526"
          z="322.395"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -7153,7 +7257,7 @@ z="242.195"/>
 <volumeref ref="volArapuca_7-1"/>
 <position name="posArapuca7-1-TPC-12-1-3" unit="cm"
 x="0"
-y="72.6555921052631"
+y="72.7558552631579"
 z="242.195"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -7161,7 +7265,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_7-1-0"/>
        <position name="posOpArapuca7-1-0-TPC-12-1-3" unit="cm"
          x="0.0500000000000002"
-       y="72.6555921052631"
+       y="72.7558552631579"
          z="161.995"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -7169,7 +7273,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_7-1-1"/>
        <position name="posOpArapuca7-1-1-TPC-12-1-3" unit="cm"
          x="0.0500000000000002"
-       y="72.6555921052631"
+       y="72.7558552631579"
          z="210.795"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -7177,7 +7281,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_7-1-2"/>
        <position name="posOpArapuca7-1-2-TPC-12-1-3" unit="cm"
          x="0.0500000000000002"
-       y="72.6555921052631"
+       y="72.7558552631579"
          z="273.595"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -7185,7 +7289,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_7-1-3"/>
        <position name="posOpArapuca7-1-3-TPC-12-1-3" unit="cm"
          x="0.0500000000000002"
-       y="72.6555921052631"
+       y="72.7558552631579"
          z="322.395"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -7193,7 +7297,7 @@ z="242.195"/>
 <volumeref ref="volArapuca_7-2"/>
 <position name="posArapuca7-2-TPC-12-1-3" unit="cm"
 x="0"
-y="134.925986842105"
+y="135.093092105263"
 z="242.195"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -7201,7 +7305,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_7-2-0"/>
        <position name="posOpArapuca7-2-0-TPC-12-1-3" unit="cm"
          x="0.0500000000000002"
-       y="134.925986842105"
+       y="135.093092105263"
          z="161.995"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -7209,7 +7313,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_7-2-1"/>
        <position name="posOpArapuca7-2-1-TPC-12-1-3" unit="cm"
          x="0.0500000000000002"
-       y="134.925986842105"
+       y="135.093092105263"
          z="210.795"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -7217,7 +7321,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_7-2-2"/>
        <position name="posOpArapuca7-2-2-TPC-12-1-3" unit="cm"
          x="0.0500000000000002"
-       y="134.925986842105"
+       y="135.093092105263"
          z="273.595"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -7225,7 +7329,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_7-2-3"/>
        <position name="posOpArapuca7-2-3-TPC-12-1-3" unit="cm"
          x="0.0500000000000002"
-       y="134.925986842105"
+       y="135.093092105263"
          z="322.395"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -7233,7 +7337,7 @@ z="242.195"/>
 <volumeref ref="volArapuca_7-3"/>
 <position name="posArapuca7-3-TPC-12-1-3" unit="cm"
 x="0"
-y="197.196381578947"
+y="197.430328947368"
 z="242.195"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -7241,7 +7345,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_7-3-0"/>
        <position name="posOpArapuca7-3-0-TPC-12-1-3" unit="cm"
          x="0.0500000000000002"
-       y="197.196381578947"
+       y="197.430328947368"
          z="161.995"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -7249,7 +7353,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_7-3-1"/>
        <position name="posOpArapuca7-3-1-TPC-12-1-3" unit="cm"
          x="0.0500000000000002"
-       y="197.196381578947"
+       y="197.430328947368"
          z="210.795"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -7257,7 +7361,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_7-3-2"/>
        <position name="posOpArapuca7-3-2-TPC-12-1-3" unit="cm"
          x="0.0500000000000002"
-       y="197.196381578947"
+       y="197.430328947368"
          z="273.595"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -7265,7 +7369,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_7-3-3"/>
        <position name="posOpArapuca7-3-3-TPC-12-1-3" unit="cm"
          x="0.0500000000000002"
-       y="197.196381578947"
+       y="197.430328947368"
          z="322.395"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -7273,7 +7377,7 @@ z="242.195"/>
 <volumeref ref="volArapuca_7-4"/>
 <position name="posArapuca7-4-TPC-12-1-3" unit="cm"
 x="0"
-y="259.46677631579"
+y="259.767565789474"
 z="242.195"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -7281,7 +7385,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_7-4-0"/>
        <position name="posOpArapuca7-4-0-TPC-12-1-3" unit="cm"
          x="0.0500000000000002"
-       y="259.46677631579"
+       y="259.767565789474"
          z="161.995"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -7289,7 +7393,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_7-4-1"/>
        <position name="posOpArapuca7-4-1-TPC-12-1-3" unit="cm"
          x="0.0500000000000002"
-       y="259.46677631579"
+       y="259.767565789474"
          z="210.795"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -7297,7 +7401,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_7-4-2"/>
        <position name="posOpArapuca7-4-2-TPC-12-1-3" unit="cm"
          x="0.0500000000000002"
-       y="259.46677631579"
+       y="259.767565789474"
          z="273.595"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -7305,7 +7409,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_7-4-3"/>
        <position name="posOpArapuca7-4-3-TPC-12-1-3" unit="cm"
          x="0.0500000000000002"
-       y="259.46677631579"
+       y="259.767565789474"
          z="322.395"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -7313,7 +7417,7 @@ z="242.195"/>
 <volumeref ref="volArapuca_7-5"/>
 <position name="posArapuca7-5-TPC-12-1-3" unit="cm"
 x="0"
-y="321.737171052632"
+y="322.104802631579"
 z="242.195"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -7321,7 +7425,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_7-5-0"/>
        <position name="posOpArapuca7-5-0-TPC-12-1-3" unit="cm"
          x="0.0500000000000002"
-       y="321.737171052632"
+       y="322.104802631579"
          z="161.995"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -7329,7 +7433,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_7-5-1"/>
        <position name="posOpArapuca7-5-1-TPC-12-1-3" unit="cm"
          x="0.0500000000000002"
-       y="321.737171052632"
+       y="322.104802631579"
          z="210.795"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -7337,7 +7441,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_7-5-2"/>
        <position name="posOpArapuca7-5-2-TPC-12-1-3" unit="cm"
          x="0.0500000000000002"
-       y="321.737171052632"
+       y="322.104802631579"
          z="273.595"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -7345,7 +7449,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_7-5-3"/>
        <position name="posOpArapuca7-5-3-TPC-12-1-3" unit="cm"
          x="0.0500000000000002"
-       y="321.737171052632"
+       y="322.104802631579"
          z="322.395"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -7353,7 +7457,7 @@ z="242.195"/>
 <volumeref ref="volArapuca_7-6"/>
 <position name="posArapuca7-6-TPC-12-1-3" unit="cm"
 x="0"
-y="384.007565789474"
+y="384.442039473684"
 z="242.195"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -7361,7 +7465,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_7-6-0"/>
        <position name="posOpArapuca7-6-0-TPC-12-1-3" unit="cm"
          x="0.0500000000000002"
-       y="384.007565789474"
+       y="384.442039473684"
          z="161.995"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -7369,7 +7473,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_7-6-1"/>
        <position name="posOpArapuca7-6-1-TPC-12-1-3" unit="cm"
          x="0.0500000000000002"
-       y="384.007565789474"
+       y="384.442039473684"
          z="210.795"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -7377,7 +7481,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_7-6-2"/>
        <position name="posOpArapuca7-6-2-TPC-12-1-3" unit="cm"
          x="0.0500000000000002"
-       y="384.007565789474"
+       y="384.442039473684"
          z="273.595"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -7385,7 +7489,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_7-6-3"/>
        <position name="posOpArapuca7-6-3-TPC-12-1-3" unit="cm"
          x="0.0500000000000002"
-       y="384.007565789474"
+       y="384.442039473684"
          z="322.395"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -7393,7 +7497,7 @@ z="242.195"/>
 <volumeref ref="volArapuca_7-7"/>
 <position name="posArapuca7-7-TPC-12-1-3" unit="cm"
 x="0"
-y="446.277960526316"
+y="446.77927631579"
 z="242.195"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -7401,7 +7505,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_7-7-0"/>
        <position name="posOpArapuca7-7-0-TPC-12-1-3" unit="cm"
          x="0.0500000000000002"
-       y="446.277960526316"
+       y="446.77927631579"
          z="161.995"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -7409,7 +7513,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_7-7-1"/>
        <position name="posOpArapuca7-7-1-TPC-12-1-3" unit="cm"
          x="0.0500000000000002"
-       y="446.277960526316"
+       y="446.77927631579"
          z="210.795"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -7417,7 +7521,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_7-7-2"/>
        <position name="posOpArapuca7-7-2-TPC-12-1-3" unit="cm"
          x="0.0500000000000002"
-       y="446.277960526316"
+       y="446.77927631579"
          z="273.595"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -7425,7 +7529,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_7-7-3"/>
        <position name="posOpArapuca7-7-3-TPC-12-1-3" unit="cm"
          x="0.0500000000000002"
-       y="446.277960526316"
+       y="446.77927631579"
          z="322.395"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -7433,7 +7537,7 @@ z="242.195"/>
 <volumeref ref="volArapuca_7-8"/>
 <position name="posArapuca7-8-TPC-12-1-3" unit="cm"
 x="0"
-y="508.548355263158"
+y="509.116513157895"
 z="242.195"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -7441,7 +7545,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_7-8-0"/>
        <position name="posOpArapuca7-8-0-TPC-12-1-3" unit="cm"
          x="0.0500000000000002"
-       y="508.548355263158"
+       y="509.116513157895"
          z="161.995"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -7449,7 +7553,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_7-8-1"/>
        <position name="posOpArapuca7-8-1-TPC-12-1-3" unit="cm"
          x="0.0500000000000002"
-       y="508.548355263158"
+       y="509.116513157895"
          z="210.795"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -7457,7 +7561,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_7-8-2"/>
        <position name="posOpArapuca7-8-2-TPC-12-1-3" unit="cm"
          x="0.0500000000000002"
-       y="508.548355263158"
+       y="509.116513157895"
          z="273.595"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -7465,7 +7569,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_7-8-3"/>
        <position name="posOpArapuca7-8-3-TPC-12-1-3" unit="cm"
          x="0.0500000000000002"
-       y="508.548355263158"
+       y="509.116513157895"
          z="322.395"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -7473,7 +7577,7 @@ z="242.195"/>
 <volumeref ref="volArapuca_7-9"/>
 <position name="posArapuca7-9-TPC-12-1-3" unit="cm"
 x="0"
-y="570.81875"
+y="571.45375"
 z="242.195"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -7481,7 +7585,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_7-9-0"/>
        <position name="posOpArapuca7-9-0-TPC-12-1-3" unit="cm"
          x="0.0500000000000002"
-       y="570.81875"
+       y="571.45375"
          z="161.995"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -7489,7 +7593,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_7-9-1"/>
        <position name="posOpArapuca7-9-1-TPC-12-1-3" unit="cm"
          x="0.0500000000000002"
-       y="570.81875"
+       y="571.45375"
          z="210.795"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -7497,7 +7601,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_7-9-2"/>
        <position name="posOpArapuca7-9-2-TPC-12-1-3" unit="cm"
          x="0.0500000000000002"
-       y="570.81875"
+       y="571.45375"
          z="273.595"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -7505,7 +7609,7 @@ z="242.195"/>
        <volumeref ref="volOpDetSensitive_7-9-3"/>
        <position name="posOpArapuca7-9-3-TPC-12-1-3" unit="cm"
          x="0.0500000000000002"
-       y="570.81875"
+       y="571.45375"
          z="322.395"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -7514,7 +7618,7 @@ z="242.195"/>
         <volumeref ref="volTPCInner"/>
         <position name="posTPC-14" unit="cm"
         x="-182.95455"
-        y="283.164375"
+        y="283.481875"
         z="242.195"/>
         <rotationref ref="rPlus180AboutY"/>
       </physvol>
@@ -7522,7 +7626,7 @@ z="242.195"/>
         <volumeref ref="volTPCInner"/>
         <position name="posTPC-15" unit="cm"
         x="182.95455"
-        y="283.164375"
+        y="283.481875"
         z="242.195"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -7530,16 +7634,16 @@ z="242.195"/>
       <physvol>
         <volumeref ref="volCathode"/>
         <position name="posCathode-8-0" unit="cm"
-      x="-363.38405"
-      y="283.164375"
+      x="-363.52605"
+      y="283.481875"
       z="242.195"/>
         <rotationref ref="rIdentity"/>
       </physvol>
       <physvol>
         <volumeref ref="volCathode"/>
         <position name="posCathode-8-1" unit="cm"
-      x="363.38405"
-      y="283.164375"
+      x="363.52605"
+      y="283.481875"
       z="242.195"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -7548,23 +7652,23 @@ z="242.195"/>
         <volumeref ref="volAPAFrameYSide"/>
         <position name="posAPAFrameYSideNeg-8" unit="cm"
       x="0"
-      y="-325.37875"
-      z="364.66375"/>
+      y="-326.01375"
+      z="364.98125"/>
         <rotationref ref="rIdentity"/>
       </physvol>
       <physvol>
         <volumeref ref="volAPAFrameYSide"/>
         <position name="posAPAFrameYSidePos-8" unit="cm"
       x="0"
-      y="-325.37875"
-      z="584.50625"/>
+      y="-326.01375"
+      z="584.18875"/>
         <rotationref ref="rIdentity"/>
       </physvol>
       <physvol>
         <volumeref ref="volAPAFrameZSide"/>
         <position name="posAPAFrameZSidePos-8" unit="cm"
       x="0"
-      y="-27.45875"
+      y="-28.0937500000001"
       z="474.585"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -7572,7 +7676,7 @@ z="242.195"/>
         <volumeref ref="volAPAFrameZSide"/>
         <position name="posAPAFrameZSideNeg-8" unit="cm"
       x="0"
-      y="-623.29875"
+      y="-623.93375"
       z="474.585"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -7583,22 +7687,33 @@ z="242.195"/>
       - There are two boards on each the up and downstream end,
           one each to wrap the U and V views around the APA frame
       - There are 4 on the bottom which anchor the U V and Z wires and the grid plane
-      - The rest of the parts of the G10 boards must be placed directly in volTPC   -->
+      FIXME: This is not true -> - The rest of the parts of the G10 boards must be placed directly in volTPC   -->
+
+      <!-- Position readout boards -->
+      <physvol>
+        <volumeref ref="volG10HeadBoards"/>
+        <position name="posG10HeadBoards-8" unit="cm"
+	  x="0"
+	  y="-639.51775"
+      	  z="474.585"/>
+        <rotationref ref="rIdentity"/>
+      </physvol>
 
       <physvol>
         <volumeref ref="volG10BoardYSideCenterSeg"/>
         <position name="posG10BoardYSideCenterSeg-Vup-8" unit="cm"
-      x="0"
-      y="-325.37875"
-      z="359.425"/>
-        <rotationref ref="rIdentity"/>
+         x="0"
+         y="-326.01375"
+         z="359.663125"/>
+         <rotationref ref="rIdentity"/>
       </physvol>
+
       <physvol>
         <volumeref ref="volG10BoardYSideCenterSeg"/>
         <position name="posG10BoardYSideCenterSeg-Uup-8" unit="cm"
       x="0"
-      y="-325.37875"
-      z="359.1075"/>
+      y="-326.01375"
+      z="359.186875"/>
         <rotationref ref="rIdentity"/>
       </physvol>
 
@@ -7606,16 +7721,16 @@ z="242.195"/>
         <volumeref ref="volG10BoardYSideCenterSeg"/>
         <position name="posG10BoardYSideCenterSeg-Vdown-8" unit="cm"
       x="0"
-      y="-325.37875"
-      z="589.745"/>
+      y="-326.01375"
+      z="589.506875"/>
         <rotationref ref="rIdentity"/>
       </physvol>
       <physvol>
         <volumeref ref="volG10BoardYSideCenterSeg"/>
         <position name="posG10BoardYSideCenterSeg-Udown-8" unit="cm"
       x="0"
-      y="-325.37875"
-      z="590.0625"/>
+      y="-326.01375"
+      z="589.983125"/>
         <rotationref ref="rIdentity"/>
       </physvol>
 
@@ -7623,7 +7738,7 @@ z="242.195"/>
         <volumeref ref="volG10BoardZSideCenterSeg"/>
         <position name="posG10BoardZSideCenterSeg-Z-8" unit="cm"
       x="0"
-      y="-22.22"
+      y="-22.775625"
       z="474.585"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -7631,7 +7746,7 @@ z="242.195"/>
         <volumeref ref="volG10BoardZSideCenterSeg"/>
         <position name="posG10BoardZSideCenterSeg-V-8" unit="cm"
       x="0"
-      y="-21.9025"
+      y="-22.2993750000001"
       z="474.585"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -7639,7 +7754,7 @@ z="242.195"/>
         <volumeref ref="volG10BoardZSideCenterSeg"/>
         <position name="posG10BoardZSideCenterSeg-U-8" unit="cm"
       x="0"
-      y="-21.585"
+      y="-21.8231250000001"
       z="474.585"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -7647,7 +7762,7 @@ z="242.195"/>
         <volumeref ref="volG10BoardZSideCenterSeg"/>
         <position name="posG10BoardZSideCenterSeg-Grid-8" unit="cm"
       x="0"
-      y="-21.2675"
+      y="-21.3468750000001"
       z="474.585"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -7656,7 +7771,7 @@ z="242.195"/>
 <volumeref ref="volArapuca_8-0"/>
 <position name="posArapuca8-0-TPC-12-0-4" unit="cm"
 x="0"
-y="-612.31875"
+y="-612.95375"
 z="474.585"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -7664,7 +7779,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_8-0-0"/>
        <position name="posOpArapuca8-0-0-TPC-12-0-4" unit="cm"
          x="-0.0500000000000002"
-       y="-612.31875"
+       y="-612.95375"
          z="394.385"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -7672,7 +7787,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_8-0-1"/>
        <position name="posOpArapuca8-0-1-TPC-12-0-4" unit="cm"
          x="-0.0500000000000002"
-       y="-612.31875"
+       y="-612.95375"
          z="443.185"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -7680,7 +7795,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_8-0-2"/>
        <position name="posOpArapuca8-0-2-TPC-12-0-4" unit="cm"
          x="-0.0500000000000002"
-       y="-612.31875"
+       y="-612.95375"
          z="505.985"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -7688,7 +7803,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_8-0-3"/>
        <position name="posOpArapuca8-0-3-TPC-12-0-4" unit="cm"
          x="-0.0500000000000002"
-       y="-612.31875"
+       y="-612.95375"
          z="554.785"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -7696,7 +7811,7 @@ z="474.585"/>
 <volumeref ref="volArapuca_8-1"/>
 <position name="posArapuca8-1-TPC-12-0-4" unit="cm"
 x="0"
-y="-550.048355263158"
+y="-550.616513157895"
 z="474.585"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -7704,7 +7819,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_8-1-0"/>
        <position name="posOpArapuca8-1-0-TPC-12-0-4" unit="cm"
          x="-0.0500000000000002"
-       y="-550.048355263158"
+       y="-550.616513157895"
          z="394.385"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -7712,7 +7827,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_8-1-1"/>
        <position name="posOpArapuca8-1-1-TPC-12-0-4" unit="cm"
          x="-0.0500000000000002"
-       y="-550.048355263158"
+       y="-550.616513157895"
          z="443.185"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -7720,7 +7835,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_8-1-2"/>
        <position name="posOpArapuca8-1-2-TPC-12-0-4" unit="cm"
          x="-0.0500000000000002"
-       y="-550.048355263158"
+       y="-550.616513157895"
          z="505.985"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -7728,7 +7843,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_8-1-3"/>
        <position name="posOpArapuca8-1-3-TPC-12-0-4" unit="cm"
          x="-0.0500000000000002"
-       y="-550.048355263158"
+       y="-550.616513157895"
          z="554.785"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -7736,7 +7851,7 @@ z="474.585"/>
 <volumeref ref="volArapuca_8-2"/>
 <position name="posArapuca8-2-TPC-12-0-4" unit="cm"
 x="0"
-y="-487.777960526316"
+y="-488.27927631579"
 z="474.585"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -7744,7 +7859,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_8-2-0"/>
        <position name="posOpArapuca8-2-0-TPC-12-0-4" unit="cm"
          x="-0.0500000000000002"
-       y="-487.777960526316"
+       y="-488.27927631579"
          z="394.385"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -7752,7 +7867,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_8-2-1"/>
        <position name="posOpArapuca8-2-1-TPC-12-0-4" unit="cm"
          x="-0.0500000000000002"
-       y="-487.777960526316"
+       y="-488.27927631579"
          z="443.185"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -7760,7 +7875,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_8-2-2"/>
        <position name="posOpArapuca8-2-2-TPC-12-0-4" unit="cm"
          x="-0.0500000000000002"
-       y="-487.777960526316"
+       y="-488.27927631579"
          z="505.985"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -7768,7 +7883,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_8-2-3"/>
        <position name="posOpArapuca8-2-3-TPC-12-0-4" unit="cm"
          x="-0.0500000000000002"
-       y="-487.777960526316"
+       y="-488.27927631579"
          z="554.785"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -7776,7 +7891,7 @@ z="474.585"/>
 <volumeref ref="volArapuca_8-3"/>
 <position name="posArapuca8-3-TPC-12-0-4" unit="cm"
 x="0"
-y="-425.507565789474"
+y="-425.942039473684"
 z="474.585"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -7784,7 +7899,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_8-3-0"/>
        <position name="posOpArapuca8-3-0-TPC-12-0-4" unit="cm"
          x="-0.0500000000000002"
-       y="-425.507565789474"
+       y="-425.942039473684"
          z="394.385"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -7792,7 +7907,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_8-3-1"/>
        <position name="posOpArapuca8-3-1-TPC-12-0-4" unit="cm"
          x="-0.0500000000000002"
-       y="-425.507565789474"
+       y="-425.942039473684"
          z="443.185"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -7800,7 +7915,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_8-3-2"/>
        <position name="posOpArapuca8-3-2-TPC-12-0-4" unit="cm"
          x="-0.0500000000000002"
-       y="-425.507565789474"
+       y="-425.942039473684"
          z="505.985"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -7808,7 +7923,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_8-3-3"/>
        <position name="posOpArapuca8-3-3-TPC-12-0-4" unit="cm"
          x="-0.0500000000000002"
-       y="-425.507565789474"
+       y="-425.942039473684"
          z="554.785"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -7816,7 +7931,7 @@ z="474.585"/>
 <volumeref ref="volArapuca_8-4"/>
 <position name="posArapuca8-4-TPC-12-0-4" unit="cm"
 x="0"
-y="-363.237171052632"
+y="-363.604802631579"
 z="474.585"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -7824,7 +7939,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_8-4-0"/>
        <position name="posOpArapuca8-4-0-TPC-12-0-4" unit="cm"
          x="-0.0500000000000002"
-       y="-363.237171052632"
+       y="-363.604802631579"
          z="394.385"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -7832,7 +7947,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_8-4-1"/>
        <position name="posOpArapuca8-4-1-TPC-12-0-4" unit="cm"
          x="-0.0500000000000002"
-       y="-363.237171052632"
+       y="-363.604802631579"
          z="443.185"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -7840,7 +7955,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_8-4-2"/>
        <position name="posOpArapuca8-4-2-TPC-12-0-4" unit="cm"
          x="-0.0500000000000002"
-       y="-363.237171052632"
+       y="-363.604802631579"
          z="505.985"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -7848,7 +7963,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_8-4-3"/>
        <position name="posOpArapuca8-4-3-TPC-12-0-4" unit="cm"
          x="-0.0500000000000002"
-       y="-363.237171052632"
+       y="-363.604802631579"
          z="554.785"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -7856,7 +7971,7 @@ z="474.585"/>
 <volumeref ref="volArapuca_8-5"/>
 <position name="posArapuca8-5-TPC-12-0-4" unit="cm"
 x="0"
-y="-300.96677631579"
+y="-301.267565789474"
 z="474.585"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -7864,7 +7979,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_8-5-0"/>
        <position name="posOpArapuca8-5-0-TPC-12-0-4" unit="cm"
          x="-0.0500000000000002"
-       y="-300.96677631579"
+       y="-301.267565789474"
          z="394.385"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -7872,7 +7987,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_8-5-1"/>
        <position name="posOpArapuca8-5-1-TPC-12-0-4" unit="cm"
          x="-0.0500000000000002"
-       y="-300.96677631579"
+       y="-301.267565789474"
          z="443.185"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -7880,7 +7995,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_8-5-2"/>
        <position name="posOpArapuca8-5-2-TPC-12-0-4" unit="cm"
          x="-0.0500000000000002"
-       y="-300.96677631579"
+       y="-301.267565789474"
          z="505.985"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -7888,7 +8003,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_8-5-3"/>
        <position name="posOpArapuca8-5-3-TPC-12-0-4" unit="cm"
          x="-0.0500000000000002"
-       y="-300.96677631579"
+       y="-301.267565789474"
          z="554.785"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -7896,7 +8011,7 @@ z="474.585"/>
 <volumeref ref="volArapuca_8-6"/>
 <position name="posArapuca8-6-TPC-12-0-4" unit="cm"
 x="0"
-y="-238.696381578947"
+y="-238.930328947368"
 z="474.585"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -7904,7 +8019,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_8-6-0"/>
        <position name="posOpArapuca8-6-0-TPC-12-0-4" unit="cm"
          x="-0.0500000000000002"
-       y="-238.696381578947"
+       y="-238.930328947368"
          z="394.385"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -7912,7 +8027,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_8-6-1"/>
        <position name="posOpArapuca8-6-1-TPC-12-0-4" unit="cm"
          x="-0.0500000000000002"
-       y="-238.696381578947"
+       y="-238.930328947368"
          z="443.185"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -7920,7 +8035,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_8-6-2"/>
        <position name="posOpArapuca8-6-2-TPC-12-0-4" unit="cm"
          x="-0.0500000000000002"
-       y="-238.696381578947"
+       y="-238.930328947368"
          z="505.985"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -7928,7 +8043,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_8-6-3"/>
        <position name="posOpArapuca8-6-3-TPC-12-0-4" unit="cm"
          x="-0.0500000000000002"
-       y="-238.696381578947"
+       y="-238.930328947368"
          z="554.785"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -7936,7 +8051,7 @@ z="474.585"/>
 <volumeref ref="volArapuca_8-7"/>
 <position name="posArapuca8-7-TPC-12-0-4" unit="cm"
 x="0"
-y="-176.425986842105"
+y="-176.593092105263"
 z="474.585"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -7944,7 +8059,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_8-7-0"/>
        <position name="posOpArapuca8-7-0-TPC-12-0-4" unit="cm"
          x="-0.0500000000000002"
-       y="-176.425986842105"
+       y="-176.593092105263"
          z="394.385"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -7952,7 +8067,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_8-7-1"/>
        <position name="posOpArapuca8-7-1-TPC-12-0-4" unit="cm"
          x="-0.0500000000000002"
-       y="-176.425986842105"
+       y="-176.593092105263"
          z="443.185"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -7960,7 +8075,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_8-7-2"/>
        <position name="posOpArapuca8-7-2-TPC-12-0-4" unit="cm"
          x="-0.0500000000000002"
-       y="-176.425986842105"
+       y="-176.593092105263"
          z="505.985"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -7968,7 +8083,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_8-7-3"/>
        <position name="posOpArapuca8-7-3-TPC-12-0-4" unit="cm"
          x="-0.0500000000000002"
-       y="-176.425986842105"
+       y="-176.593092105263"
          z="554.785"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -7976,7 +8091,7 @@ z="474.585"/>
 <volumeref ref="volArapuca_8-8"/>
 <position name="posArapuca8-8-TPC-12-0-4" unit="cm"
 x="0"
-y="-114.155592105263"
+y="-114.255855263158"
 z="474.585"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -7984,7 +8099,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_8-8-0"/>
        <position name="posOpArapuca8-8-0-TPC-12-0-4" unit="cm"
          x="-0.0500000000000002"
-       y="-114.155592105263"
+       y="-114.255855263158"
          z="394.385"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -7992,7 +8107,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_8-8-1"/>
        <position name="posOpArapuca8-8-1-TPC-12-0-4" unit="cm"
          x="-0.0500000000000002"
-       y="-114.155592105263"
+       y="-114.255855263158"
          z="443.185"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -8000,7 +8115,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_8-8-2"/>
        <position name="posOpArapuca8-8-2-TPC-12-0-4" unit="cm"
          x="-0.0500000000000002"
-       y="-114.155592105263"
+       y="-114.255855263158"
          z="505.985"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -8008,7 +8123,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_8-8-3"/>
        <position name="posOpArapuca8-8-3-TPC-12-0-4" unit="cm"
          x="-0.0500000000000002"
-       y="-114.155592105263"
+       y="-114.255855263158"
          z="554.785"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -8016,7 +8131,7 @@ z="474.585"/>
 <volumeref ref="volArapuca_8-9"/>
 <position name="posArapuca8-9-TPC-12-0-4" unit="cm"
 x="0"
-y="-51.885197368421"
+y="-51.9186184210527"
 z="474.585"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -8024,7 +8139,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_8-9-0"/>
        <position name="posOpArapuca8-9-0-TPC-12-0-4" unit="cm"
          x="-0.0500000000000002"
-       y="-51.885197368421"
+       y="-51.9186184210527"
          z="394.385"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -8032,7 +8147,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_8-9-1"/>
        <position name="posOpArapuca8-9-1-TPC-12-0-4" unit="cm"
          x="-0.0500000000000002"
-       y="-51.885197368421"
+       y="-51.9186184210527"
          z="443.185"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -8040,7 +8155,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_8-9-2"/>
        <position name="posOpArapuca8-9-2-TPC-12-0-4" unit="cm"
          x="-0.0500000000000002"
-       y="-51.885197368421"
+       y="-51.9186184210527"
          z="505.985"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -8048,7 +8163,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_8-9-3"/>
        <position name="posOpArapuca8-9-3-TPC-12-0-4" unit="cm"
          x="-0.0500000000000002"
-       y="-51.885197368421"
+       y="-51.9186184210527"
          z="554.785"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -8057,7 +8172,7 @@ z="474.585"/>
         <volumeref ref="volTPCInner"/>
         <position name="posTPC-16" unit="cm"
         x="-182.95455"
-        y="-324.664375"
+        y="-324.981875"
         z="474.585"/>
         <rotationref ref="rPlus180AboutXPlus180AboutY"/>
       </physvol>
@@ -8065,7 +8180,7 @@ z="474.585"/>
         <volumeref ref="volTPCInner"/>
         <position name="posTPC-17" unit="cm"
         x="182.95455"
-        y="-324.664375"
+        y="-324.981875"
         z="474.585"/>
         <rotationref ref="rPlus180AboutX"/>
       </physvol>
@@ -8073,16 +8188,16 @@ z="474.585"/>
       <physvol>
         <volumeref ref="volCathode"/>
         <position name="posCathode-9-0" unit="cm"
-      x="-363.38405"
-      y="-324.664375"
+      x="-363.52605"
+      y="-324.981875"
       z="474.585"/>
         <rotationref ref="rIdentity"/>
       </physvol>
       <physvol>
         <volumeref ref="volCathode"/>
         <position name="posCathode-9-1" unit="cm"
-      x="363.38405"
-      y="-324.664375"
+      x="363.52605"
+      y="-324.981875"
       z="474.585"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -8091,23 +8206,23 @@ z="474.585"/>
         <volumeref ref="volAPAFrameYSide"/>
         <position name="posAPAFrameYSideNeg-9" unit="cm"
       x="0"
-      y="283.87875"
-      z="364.66375"/>
+      y="284.51375"
+      z="364.98125"/>
         <rotationref ref="rIdentity"/>
       </physvol>
       <physvol>
         <volumeref ref="volAPAFrameYSide"/>
         <position name="posAPAFrameYSidePos-9" unit="cm"
       x="0"
-      y="283.87875"
-      z="584.50625"/>
+      y="284.51375"
+      z="584.18875"/>
         <rotationref ref="rIdentity"/>
       </physvol>
       <physvol>
         <volumeref ref="volAPAFrameZSide"/>
         <position name="posAPAFrameZSidePos-9" unit="cm"
       x="0"
-      y="581.79875"
+      y="582.43375"
       z="474.585"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -8115,7 +8230,7 @@ z="474.585"/>
         <volumeref ref="volAPAFrameZSide"/>
         <position name="posAPAFrameZSideNeg-9" unit="cm"
       x="0"
-      y="-14.0412500000001"
+      y="-13.40625"
       z="474.585"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -8126,22 +8241,33 @@ z="474.585"/>
       - There are two boards on each the up and downstream end,
           one each to wrap the U and V views around the APA frame
       - There are 4 on the bottom which anchor the U V and Z wires and the grid plane
-      - The rest of the parts of the G10 boards must be placed directly in volTPC   -->
+      FIXME: This is not true -> - The rest of the parts of the G10 boards must be placed directly in volTPC   -->
+
+      <!-- Position readout boards -->
+      <physvol>
+        <volumeref ref="volG10HeadBoards"/>
+        <position name="posG10HeadBoards-9" unit="cm"
+	  x="0"
+	  y="598.01775"
+      	  z="474.585"/>
+        <rotationref ref="rIdentity"/>
+      </physvol>
 
       <physvol>
         <volumeref ref="volG10BoardYSideCenterSeg"/>
         <position name="posG10BoardYSideCenterSeg-Vup-9" unit="cm"
-      x="0"
-      y="283.87875"
-      z="359.425"/>
-        <rotationref ref="rIdentity"/>
+         x="0"
+         y="284.51375"
+         z="359.663125"/>
+         <rotationref ref="rIdentity"/>
       </physvol>
+
       <physvol>
         <volumeref ref="volG10BoardYSideCenterSeg"/>
         <position name="posG10BoardYSideCenterSeg-Uup-9" unit="cm"
       x="0"
-      y="283.87875"
-      z="359.1075"/>
+      y="284.51375"
+      z="359.186875"/>
         <rotationref ref="rIdentity"/>
       </physvol>
 
@@ -8149,16 +8275,16 @@ z="474.585"/>
         <volumeref ref="volG10BoardYSideCenterSeg"/>
         <position name="posG10BoardYSideCenterSeg-Vdown-9" unit="cm"
       x="0"
-      y="283.87875"
-      z="589.745"/>
+      y="284.51375"
+      z="589.506875"/>
         <rotationref ref="rIdentity"/>
       </physvol>
       <physvol>
         <volumeref ref="volG10BoardYSideCenterSeg"/>
         <position name="posG10BoardYSideCenterSeg-Udown-9" unit="cm"
       x="0"
-      y="283.87875"
-      z="590.0625"/>
+      y="284.51375"
+      z="589.983125"/>
         <rotationref ref="rIdentity"/>
       </physvol>
 
@@ -8166,7 +8292,7 @@ z="474.585"/>
         <volumeref ref="volG10BoardZSideCenterSeg"/>
         <position name="posG10BoardZSideCenterSeg-Z-9" unit="cm"
       x="0"
-      y="-19.2800000000001"
+      y="-18.7243750000001"
       z="474.585"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -8174,7 +8300,7 @@ z="474.585"/>
         <volumeref ref="volG10BoardZSideCenterSeg"/>
         <position name="posG10BoardZSideCenterSeg-V-9" unit="cm"
       x="0"
-      y="-19.5975000000001"
+      y="-19.2006250000001"
       z="474.585"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -8182,7 +8308,7 @@ z="474.585"/>
         <volumeref ref="volG10BoardZSideCenterSeg"/>
         <position name="posG10BoardZSideCenterSeg-U-9" unit="cm"
       x="0"
-      y="-19.9150000000001"
+      y="-19.6768750000001"
       z="474.585"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -8190,7 +8316,7 @@ z="474.585"/>
         <volumeref ref="volG10BoardZSideCenterSeg"/>
         <position name="posG10BoardZSideCenterSeg-Grid-9" unit="cm"
       x="0"
-      y="-20.2325000000001"
+      y="-20.153125"
       z="474.585"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -8199,7 +8325,7 @@ z="474.585"/>
 <volumeref ref="volArapuca_9-0"/>
 <position name="posArapuca9-0-TPC-12-1-4" unit="cm"
 x="0"
-y="10.385197368421"
+y="10.4186184210526"
 z="474.585"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -8207,7 +8333,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_9-0-0"/>
        <position name="posOpArapuca9-0-0-TPC-12-1-4" unit="cm"
          x="0.0500000000000002"
-       y="10.385197368421"
+       y="10.4186184210526"
          z="394.385"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -8215,7 +8341,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_9-0-1"/>
        <position name="posOpArapuca9-0-1-TPC-12-1-4" unit="cm"
          x="0.0500000000000002"
-       y="10.385197368421"
+       y="10.4186184210526"
          z="443.185"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -8223,7 +8349,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_9-0-2"/>
        <position name="posOpArapuca9-0-2-TPC-12-1-4" unit="cm"
          x="0.0500000000000002"
-       y="10.385197368421"
+       y="10.4186184210526"
          z="505.985"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -8231,7 +8357,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_9-0-3"/>
        <position name="posOpArapuca9-0-3-TPC-12-1-4" unit="cm"
          x="0.0500000000000002"
-       y="10.385197368421"
+       y="10.4186184210526"
          z="554.785"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -8239,7 +8365,7 @@ z="474.585"/>
 <volumeref ref="volArapuca_9-1"/>
 <position name="posArapuca9-1-TPC-12-1-4" unit="cm"
 x="0"
-y="72.6555921052631"
+y="72.7558552631579"
 z="474.585"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -8247,7 +8373,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_9-1-0"/>
        <position name="posOpArapuca9-1-0-TPC-12-1-4" unit="cm"
          x="0.0500000000000002"
-       y="72.6555921052631"
+       y="72.7558552631579"
          z="394.385"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -8255,7 +8381,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_9-1-1"/>
        <position name="posOpArapuca9-1-1-TPC-12-1-4" unit="cm"
          x="0.0500000000000002"
-       y="72.6555921052631"
+       y="72.7558552631579"
          z="443.185"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -8263,7 +8389,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_9-1-2"/>
        <position name="posOpArapuca9-1-2-TPC-12-1-4" unit="cm"
          x="0.0500000000000002"
-       y="72.6555921052631"
+       y="72.7558552631579"
          z="505.985"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -8271,7 +8397,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_9-1-3"/>
        <position name="posOpArapuca9-1-3-TPC-12-1-4" unit="cm"
          x="0.0500000000000002"
-       y="72.6555921052631"
+       y="72.7558552631579"
          z="554.785"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -8279,7 +8405,7 @@ z="474.585"/>
 <volumeref ref="volArapuca_9-2"/>
 <position name="posArapuca9-2-TPC-12-1-4" unit="cm"
 x="0"
-y="134.925986842105"
+y="135.093092105263"
 z="474.585"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -8287,7 +8413,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_9-2-0"/>
        <position name="posOpArapuca9-2-0-TPC-12-1-4" unit="cm"
          x="0.0500000000000002"
-       y="134.925986842105"
+       y="135.093092105263"
          z="394.385"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -8295,7 +8421,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_9-2-1"/>
        <position name="posOpArapuca9-2-1-TPC-12-1-4" unit="cm"
          x="0.0500000000000002"
-       y="134.925986842105"
+       y="135.093092105263"
          z="443.185"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -8303,7 +8429,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_9-2-2"/>
        <position name="posOpArapuca9-2-2-TPC-12-1-4" unit="cm"
          x="0.0500000000000002"
-       y="134.925986842105"
+       y="135.093092105263"
          z="505.985"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -8311,7 +8437,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_9-2-3"/>
        <position name="posOpArapuca9-2-3-TPC-12-1-4" unit="cm"
          x="0.0500000000000002"
-       y="134.925986842105"
+       y="135.093092105263"
          z="554.785"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -8319,7 +8445,7 @@ z="474.585"/>
 <volumeref ref="volArapuca_9-3"/>
 <position name="posArapuca9-3-TPC-12-1-4" unit="cm"
 x="0"
-y="197.196381578947"
+y="197.430328947368"
 z="474.585"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -8327,7 +8453,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_9-3-0"/>
        <position name="posOpArapuca9-3-0-TPC-12-1-4" unit="cm"
          x="0.0500000000000002"
-       y="197.196381578947"
+       y="197.430328947368"
          z="394.385"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -8335,7 +8461,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_9-3-1"/>
        <position name="posOpArapuca9-3-1-TPC-12-1-4" unit="cm"
          x="0.0500000000000002"
-       y="197.196381578947"
+       y="197.430328947368"
          z="443.185"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -8343,7 +8469,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_9-3-2"/>
        <position name="posOpArapuca9-3-2-TPC-12-1-4" unit="cm"
          x="0.0500000000000002"
-       y="197.196381578947"
+       y="197.430328947368"
          z="505.985"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -8351,7 +8477,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_9-3-3"/>
        <position name="posOpArapuca9-3-3-TPC-12-1-4" unit="cm"
          x="0.0500000000000002"
-       y="197.196381578947"
+       y="197.430328947368"
          z="554.785"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -8359,7 +8485,7 @@ z="474.585"/>
 <volumeref ref="volArapuca_9-4"/>
 <position name="posArapuca9-4-TPC-12-1-4" unit="cm"
 x="0"
-y="259.46677631579"
+y="259.767565789474"
 z="474.585"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -8367,7 +8493,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_9-4-0"/>
        <position name="posOpArapuca9-4-0-TPC-12-1-4" unit="cm"
          x="0.0500000000000002"
-       y="259.46677631579"
+       y="259.767565789474"
          z="394.385"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -8375,7 +8501,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_9-4-1"/>
        <position name="posOpArapuca9-4-1-TPC-12-1-4" unit="cm"
          x="0.0500000000000002"
-       y="259.46677631579"
+       y="259.767565789474"
          z="443.185"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -8383,7 +8509,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_9-4-2"/>
        <position name="posOpArapuca9-4-2-TPC-12-1-4" unit="cm"
          x="0.0500000000000002"
-       y="259.46677631579"
+       y="259.767565789474"
          z="505.985"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -8391,7 +8517,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_9-4-3"/>
        <position name="posOpArapuca9-4-3-TPC-12-1-4" unit="cm"
          x="0.0500000000000002"
-       y="259.46677631579"
+       y="259.767565789474"
          z="554.785"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -8399,7 +8525,7 @@ z="474.585"/>
 <volumeref ref="volArapuca_9-5"/>
 <position name="posArapuca9-5-TPC-12-1-4" unit="cm"
 x="0"
-y="321.737171052632"
+y="322.104802631579"
 z="474.585"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -8407,7 +8533,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_9-5-0"/>
        <position name="posOpArapuca9-5-0-TPC-12-1-4" unit="cm"
          x="0.0500000000000002"
-       y="321.737171052632"
+       y="322.104802631579"
          z="394.385"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -8415,7 +8541,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_9-5-1"/>
        <position name="posOpArapuca9-5-1-TPC-12-1-4" unit="cm"
          x="0.0500000000000002"
-       y="321.737171052632"
+       y="322.104802631579"
          z="443.185"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -8423,7 +8549,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_9-5-2"/>
        <position name="posOpArapuca9-5-2-TPC-12-1-4" unit="cm"
          x="0.0500000000000002"
-       y="321.737171052632"
+       y="322.104802631579"
          z="505.985"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -8431,7 +8557,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_9-5-3"/>
        <position name="posOpArapuca9-5-3-TPC-12-1-4" unit="cm"
          x="0.0500000000000002"
-       y="321.737171052632"
+       y="322.104802631579"
          z="554.785"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -8439,7 +8565,7 @@ z="474.585"/>
 <volumeref ref="volArapuca_9-6"/>
 <position name="posArapuca9-6-TPC-12-1-4" unit="cm"
 x="0"
-y="384.007565789474"
+y="384.442039473684"
 z="474.585"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -8447,7 +8573,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_9-6-0"/>
        <position name="posOpArapuca9-6-0-TPC-12-1-4" unit="cm"
          x="0.0500000000000002"
-       y="384.007565789474"
+       y="384.442039473684"
          z="394.385"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -8455,7 +8581,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_9-6-1"/>
        <position name="posOpArapuca9-6-1-TPC-12-1-4" unit="cm"
          x="0.0500000000000002"
-       y="384.007565789474"
+       y="384.442039473684"
          z="443.185"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -8463,7 +8589,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_9-6-2"/>
        <position name="posOpArapuca9-6-2-TPC-12-1-4" unit="cm"
          x="0.0500000000000002"
-       y="384.007565789474"
+       y="384.442039473684"
          z="505.985"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -8471,7 +8597,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_9-6-3"/>
        <position name="posOpArapuca9-6-3-TPC-12-1-4" unit="cm"
          x="0.0500000000000002"
-       y="384.007565789474"
+       y="384.442039473684"
          z="554.785"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -8479,7 +8605,7 @@ z="474.585"/>
 <volumeref ref="volArapuca_9-7"/>
 <position name="posArapuca9-7-TPC-12-1-4" unit="cm"
 x="0"
-y="446.277960526316"
+y="446.77927631579"
 z="474.585"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -8487,7 +8613,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_9-7-0"/>
        <position name="posOpArapuca9-7-0-TPC-12-1-4" unit="cm"
          x="0.0500000000000002"
-       y="446.277960526316"
+       y="446.77927631579"
          z="394.385"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -8495,7 +8621,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_9-7-1"/>
        <position name="posOpArapuca9-7-1-TPC-12-1-4" unit="cm"
          x="0.0500000000000002"
-       y="446.277960526316"
+       y="446.77927631579"
          z="443.185"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -8503,7 +8629,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_9-7-2"/>
        <position name="posOpArapuca9-7-2-TPC-12-1-4" unit="cm"
          x="0.0500000000000002"
-       y="446.277960526316"
+       y="446.77927631579"
          z="505.985"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -8511,7 +8637,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_9-7-3"/>
        <position name="posOpArapuca9-7-3-TPC-12-1-4" unit="cm"
          x="0.0500000000000002"
-       y="446.277960526316"
+       y="446.77927631579"
          z="554.785"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -8519,7 +8645,7 @@ z="474.585"/>
 <volumeref ref="volArapuca_9-8"/>
 <position name="posArapuca9-8-TPC-12-1-4" unit="cm"
 x="0"
-y="508.548355263158"
+y="509.116513157895"
 z="474.585"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -8527,7 +8653,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_9-8-0"/>
        <position name="posOpArapuca9-8-0-TPC-12-1-4" unit="cm"
          x="0.0500000000000002"
-       y="508.548355263158"
+       y="509.116513157895"
          z="394.385"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -8535,7 +8661,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_9-8-1"/>
        <position name="posOpArapuca9-8-1-TPC-12-1-4" unit="cm"
          x="0.0500000000000002"
-       y="508.548355263158"
+       y="509.116513157895"
          z="443.185"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -8543,7 +8669,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_9-8-2"/>
        <position name="posOpArapuca9-8-2-TPC-12-1-4" unit="cm"
          x="0.0500000000000002"
-       y="508.548355263158"
+       y="509.116513157895"
          z="505.985"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -8551,7 +8677,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_9-8-3"/>
        <position name="posOpArapuca9-8-3-TPC-12-1-4" unit="cm"
          x="0.0500000000000002"
-       y="508.548355263158"
+       y="509.116513157895"
          z="554.785"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -8559,7 +8685,7 @@ z="474.585"/>
 <volumeref ref="volArapuca_9-9"/>
 <position name="posArapuca9-9-TPC-12-1-4" unit="cm"
 x="0"
-y="570.81875"
+y="571.45375"
 z="474.585"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -8567,7 +8693,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_9-9-0"/>
        <position name="posOpArapuca9-9-0-TPC-12-1-4" unit="cm"
          x="0.0500000000000002"
-       y="570.81875"
+       y="571.45375"
          z="394.385"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -8575,7 +8701,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_9-9-1"/>
        <position name="posOpArapuca9-9-1-TPC-12-1-4" unit="cm"
          x="0.0500000000000002"
-       y="570.81875"
+       y="571.45375"
          z="443.185"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -8583,7 +8709,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_9-9-2"/>
        <position name="posOpArapuca9-9-2-TPC-12-1-4" unit="cm"
          x="0.0500000000000002"
-       y="570.81875"
+       y="571.45375"
          z="505.985"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -8591,7 +8717,7 @@ z="474.585"/>
        <volumeref ref="volOpDetSensitive_9-9-3"/>
        <position name="posOpArapuca9-9-3-TPC-12-1-4" unit="cm"
          x="0.0500000000000002"
-       y="570.81875"
+       y="571.45375"
          z="554.785"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -8600,7 +8726,7 @@ z="474.585"/>
         <volumeref ref="volTPCInner"/>
         <position name="posTPC-18" unit="cm"
         x="-182.95455"
-        y="283.164375"
+        y="283.481875"
         z="474.585"/>
         <rotationref ref="rPlus180AboutY"/>
       </physvol>
@@ -8608,7 +8734,7 @@ z="474.585"/>
         <volumeref ref="volTPCInner"/>
         <position name="posTPC-19" unit="cm"
         x="182.95455"
-        y="283.164375"
+        y="283.481875"
         z="474.585"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -8616,16 +8742,16 @@ z="474.585"/>
       <physvol>
         <volumeref ref="volCathode"/>
         <position name="posCathode-10-0" unit="cm"
-      x="-363.38405"
-      y="283.164375"
+      x="-363.52605"
+      y="283.481875"
       z="474.585"/>
         <rotationref ref="rIdentity"/>
       </physvol>
       <physvol>
         <volumeref ref="volCathode"/>
         <position name="posCathode-10-1" unit="cm"
-      x="363.38405"
-      y="283.164375"
+      x="363.52605"
+      y="283.481875"
       z="474.585"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -8634,23 +8760,23 @@ z="474.585"/>
         <volumeref ref="volAPAFrameYSide"/>
         <position name="posAPAFrameYSideNeg-10" unit="cm"
       x="0"
-      y="-325.37875"
-      z="597.05375"/>
+      y="-326.01375"
+      z="597.37125"/>
         <rotationref ref="rIdentity"/>
       </physvol>
       <physvol>
         <volumeref ref="volAPAFrameYSide"/>
         <position name="posAPAFrameYSidePos-10" unit="cm"
       x="0"
-      y="-325.37875"
-      z="816.89625"/>
+      y="-326.01375"
+      z="816.57875"/>
         <rotationref ref="rIdentity"/>
       </physvol>
       <physvol>
         <volumeref ref="volAPAFrameZSide"/>
         <position name="posAPAFrameZSidePos-10" unit="cm"
       x="0"
-      y="-27.45875"
+      y="-28.0937500000001"
       z="706.975"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -8658,7 +8784,7 @@ z="474.585"/>
         <volumeref ref="volAPAFrameZSide"/>
         <position name="posAPAFrameZSideNeg-10" unit="cm"
       x="0"
-      y="-623.29875"
+      y="-623.93375"
       z="706.975"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -8669,22 +8795,33 @@ z="474.585"/>
       - There are two boards on each the up and downstream end,
           one each to wrap the U and V views around the APA frame
       - There are 4 on the bottom which anchor the U V and Z wires and the grid plane
-      - The rest of the parts of the G10 boards must be placed directly in volTPC   -->
+      FIXME: This is not true -> - The rest of the parts of the G10 boards must be placed directly in volTPC   -->
+
+      <!-- Position readout boards -->
+      <physvol>
+        <volumeref ref="volG10HeadBoards"/>
+        <position name="posG10HeadBoards-10" unit="cm"
+	  x="0"
+	  y="-639.51775"
+      	  z="706.975"/>
+        <rotationref ref="rIdentity"/>
+      </physvol>
 
       <physvol>
         <volumeref ref="volG10BoardYSideCenterSeg"/>
         <position name="posG10BoardYSideCenterSeg-Vup-10" unit="cm"
-      x="0"
-      y="-325.37875"
-      z="591.815"/>
-        <rotationref ref="rIdentity"/>
+         x="0"
+         y="-326.01375"
+         z="592.053125"/>
+         <rotationref ref="rIdentity"/>
       </physvol>
+
       <physvol>
         <volumeref ref="volG10BoardYSideCenterSeg"/>
         <position name="posG10BoardYSideCenterSeg-Uup-10" unit="cm"
       x="0"
-      y="-325.37875"
-      z="591.4975"/>
+      y="-326.01375"
+      z="591.576875"/>
         <rotationref ref="rIdentity"/>
       </physvol>
 
@@ -8692,16 +8829,16 @@ z="474.585"/>
         <volumeref ref="volG10BoardYSideCenterSeg"/>
         <position name="posG10BoardYSideCenterSeg-Vdown-10" unit="cm"
       x="0"
-      y="-325.37875"
-      z="822.135"/>
+      y="-326.01375"
+      z="821.896875"/>
         <rotationref ref="rIdentity"/>
       </physvol>
       <physvol>
         <volumeref ref="volG10BoardYSideCenterSeg"/>
         <position name="posG10BoardYSideCenterSeg-Udown-10" unit="cm"
       x="0"
-      y="-325.37875"
-      z="822.4525"/>
+      y="-326.01375"
+      z="822.373125"/>
         <rotationref ref="rIdentity"/>
       </physvol>
 
@@ -8709,7 +8846,7 @@ z="474.585"/>
         <volumeref ref="volG10BoardZSideCenterSeg"/>
         <position name="posG10BoardZSideCenterSeg-Z-10" unit="cm"
       x="0"
-      y="-22.22"
+      y="-22.775625"
       z="706.975"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -8717,7 +8854,7 @@ z="474.585"/>
         <volumeref ref="volG10BoardZSideCenterSeg"/>
         <position name="posG10BoardZSideCenterSeg-V-10" unit="cm"
       x="0"
-      y="-21.9025"
+      y="-22.2993750000001"
       z="706.975"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -8725,7 +8862,7 @@ z="474.585"/>
         <volumeref ref="volG10BoardZSideCenterSeg"/>
         <position name="posG10BoardZSideCenterSeg-U-10" unit="cm"
       x="0"
-      y="-21.585"
+      y="-21.8231250000001"
       z="706.975"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -8733,7 +8870,7 @@ z="474.585"/>
         <volumeref ref="volG10BoardZSideCenterSeg"/>
         <position name="posG10BoardZSideCenterSeg-Grid-10" unit="cm"
       x="0"
-      y="-21.2675"
+      y="-21.3468750000001"
       z="706.975"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -8742,7 +8879,7 @@ z="474.585"/>
 <volumeref ref="volArapuca_10-0"/>
 <position name="posArapuca10-0-TPC-12-0-5" unit="cm"
 x="0"
-y="-612.31875"
+y="-612.95375"
 z="706.975"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -8750,7 +8887,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_10-0-0"/>
        <position name="posOpArapuca10-0-0-TPC-12-0-5" unit="cm"
          x="-0.0500000000000002"
-       y="-612.31875"
+       y="-612.95375"
          z="626.775"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -8758,7 +8895,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_10-0-1"/>
        <position name="posOpArapuca10-0-1-TPC-12-0-5" unit="cm"
          x="-0.0500000000000002"
-       y="-612.31875"
+       y="-612.95375"
          z="675.575"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -8766,7 +8903,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_10-0-2"/>
        <position name="posOpArapuca10-0-2-TPC-12-0-5" unit="cm"
          x="-0.0500000000000002"
-       y="-612.31875"
+       y="-612.95375"
          z="738.375"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -8774,7 +8911,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_10-0-3"/>
        <position name="posOpArapuca10-0-3-TPC-12-0-5" unit="cm"
          x="-0.0500000000000002"
-       y="-612.31875"
+       y="-612.95375"
          z="787.175"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -8782,7 +8919,7 @@ z="706.975"/>
 <volumeref ref="volArapuca_10-1"/>
 <position name="posArapuca10-1-TPC-12-0-5" unit="cm"
 x="0"
-y="-550.048355263158"
+y="-550.616513157895"
 z="706.975"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -8790,7 +8927,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_10-1-0"/>
        <position name="posOpArapuca10-1-0-TPC-12-0-5" unit="cm"
          x="-0.0500000000000002"
-       y="-550.048355263158"
+       y="-550.616513157895"
          z="626.775"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -8798,7 +8935,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_10-1-1"/>
        <position name="posOpArapuca10-1-1-TPC-12-0-5" unit="cm"
          x="-0.0500000000000002"
-       y="-550.048355263158"
+       y="-550.616513157895"
          z="675.575"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -8806,7 +8943,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_10-1-2"/>
        <position name="posOpArapuca10-1-2-TPC-12-0-5" unit="cm"
          x="-0.0500000000000002"
-       y="-550.048355263158"
+       y="-550.616513157895"
          z="738.375"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -8814,7 +8951,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_10-1-3"/>
        <position name="posOpArapuca10-1-3-TPC-12-0-5" unit="cm"
          x="-0.0500000000000002"
-       y="-550.048355263158"
+       y="-550.616513157895"
          z="787.175"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -8822,7 +8959,7 @@ z="706.975"/>
 <volumeref ref="volArapuca_10-2"/>
 <position name="posArapuca10-2-TPC-12-0-5" unit="cm"
 x="0"
-y="-487.777960526316"
+y="-488.27927631579"
 z="706.975"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -8830,7 +8967,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_10-2-0"/>
        <position name="posOpArapuca10-2-0-TPC-12-0-5" unit="cm"
          x="-0.0500000000000002"
-       y="-487.777960526316"
+       y="-488.27927631579"
          z="626.775"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -8838,7 +8975,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_10-2-1"/>
        <position name="posOpArapuca10-2-1-TPC-12-0-5" unit="cm"
          x="-0.0500000000000002"
-       y="-487.777960526316"
+       y="-488.27927631579"
          z="675.575"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -8846,7 +8983,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_10-2-2"/>
        <position name="posOpArapuca10-2-2-TPC-12-0-5" unit="cm"
          x="-0.0500000000000002"
-       y="-487.777960526316"
+       y="-488.27927631579"
          z="738.375"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -8854,7 +8991,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_10-2-3"/>
        <position name="posOpArapuca10-2-3-TPC-12-0-5" unit="cm"
          x="-0.0500000000000002"
-       y="-487.777960526316"
+       y="-488.27927631579"
          z="787.175"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -8862,7 +8999,7 @@ z="706.975"/>
 <volumeref ref="volArapuca_10-3"/>
 <position name="posArapuca10-3-TPC-12-0-5" unit="cm"
 x="0"
-y="-425.507565789474"
+y="-425.942039473684"
 z="706.975"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -8870,7 +9007,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_10-3-0"/>
        <position name="posOpArapuca10-3-0-TPC-12-0-5" unit="cm"
          x="-0.0500000000000002"
-       y="-425.507565789474"
+       y="-425.942039473684"
          z="626.775"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -8878,7 +9015,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_10-3-1"/>
        <position name="posOpArapuca10-3-1-TPC-12-0-5" unit="cm"
          x="-0.0500000000000002"
-       y="-425.507565789474"
+       y="-425.942039473684"
          z="675.575"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -8886,7 +9023,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_10-3-2"/>
        <position name="posOpArapuca10-3-2-TPC-12-0-5" unit="cm"
          x="-0.0500000000000002"
-       y="-425.507565789474"
+       y="-425.942039473684"
          z="738.375"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -8894,7 +9031,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_10-3-3"/>
        <position name="posOpArapuca10-3-3-TPC-12-0-5" unit="cm"
          x="-0.0500000000000002"
-       y="-425.507565789474"
+       y="-425.942039473684"
          z="787.175"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -8902,7 +9039,7 @@ z="706.975"/>
 <volumeref ref="volArapuca_10-4"/>
 <position name="posArapuca10-4-TPC-12-0-5" unit="cm"
 x="0"
-y="-363.237171052632"
+y="-363.604802631579"
 z="706.975"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -8910,7 +9047,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_10-4-0"/>
        <position name="posOpArapuca10-4-0-TPC-12-0-5" unit="cm"
          x="-0.0500000000000002"
-       y="-363.237171052632"
+       y="-363.604802631579"
          z="626.775"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -8918,7 +9055,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_10-4-1"/>
        <position name="posOpArapuca10-4-1-TPC-12-0-5" unit="cm"
          x="-0.0500000000000002"
-       y="-363.237171052632"
+       y="-363.604802631579"
          z="675.575"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -8926,7 +9063,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_10-4-2"/>
        <position name="posOpArapuca10-4-2-TPC-12-0-5" unit="cm"
          x="-0.0500000000000002"
-       y="-363.237171052632"
+       y="-363.604802631579"
          z="738.375"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -8934,7 +9071,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_10-4-3"/>
        <position name="posOpArapuca10-4-3-TPC-12-0-5" unit="cm"
          x="-0.0500000000000002"
-       y="-363.237171052632"
+       y="-363.604802631579"
          z="787.175"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -8942,7 +9079,7 @@ z="706.975"/>
 <volumeref ref="volArapuca_10-5"/>
 <position name="posArapuca10-5-TPC-12-0-5" unit="cm"
 x="0"
-y="-300.96677631579"
+y="-301.267565789474"
 z="706.975"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -8950,7 +9087,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_10-5-0"/>
        <position name="posOpArapuca10-5-0-TPC-12-0-5" unit="cm"
          x="-0.0500000000000002"
-       y="-300.96677631579"
+       y="-301.267565789474"
          z="626.775"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -8958,7 +9095,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_10-5-1"/>
        <position name="posOpArapuca10-5-1-TPC-12-0-5" unit="cm"
          x="-0.0500000000000002"
-       y="-300.96677631579"
+       y="-301.267565789474"
          z="675.575"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -8966,7 +9103,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_10-5-2"/>
        <position name="posOpArapuca10-5-2-TPC-12-0-5" unit="cm"
          x="-0.0500000000000002"
-       y="-300.96677631579"
+       y="-301.267565789474"
          z="738.375"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -8974,7 +9111,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_10-5-3"/>
        <position name="posOpArapuca10-5-3-TPC-12-0-5" unit="cm"
          x="-0.0500000000000002"
-       y="-300.96677631579"
+       y="-301.267565789474"
          z="787.175"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -8982,7 +9119,7 @@ z="706.975"/>
 <volumeref ref="volArapuca_10-6"/>
 <position name="posArapuca10-6-TPC-12-0-5" unit="cm"
 x="0"
-y="-238.696381578947"
+y="-238.930328947368"
 z="706.975"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -8990,7 +9127,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_10-6-0"/>
        <position name="posOpArapuca10-6-0-TPC-12-0-5" unit="cm"
          x="-0.0500000000000002"
-       y="-238.696381578947"
+       y="-238.930328947368"
          z="626.775"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -8998,7 +9135,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_10-6-1"/>
        <position name="posOpArapuca10-6-1-TPC-12-0-5" unit="cm"
          x="-0.0500000000000002"
-       y="-238.696381578947"
+       y="-238.930328947368"
          z="675.575"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -9006,7 +9143,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_10-6-2"/>
        <position name="posOpArapuca10-6-2-TPC-12-0-5" unit="cm"
          x="-0.0500000000000002"
-       y="-238.696381578947"
+       y="-238.930328947368"
          z="738.375"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -9014,7 +9151,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_10-6-3"/>
        <position name="posOpArapuca10-6-3-TPC-12-0-5" unit="cm"
          x="-0.0500000000000002"
-       y="-238.696381578947"
+       y="-238.930328947368"
          z="787.175"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -9022,7 +9159,7 @@ z="706.975"/>
 <volumeref ref="volArapuca_10-7"/>
 <position name="posArapuca10-7-TPC-12-0-5" unit="cm"
 x="0"
-y="-176.425986842105"
+y="-176.593092105263"
 z="706.975"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -9030,7 +9167,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_10-7-0"/>
        <position name="posOpArapuca10-7-0-TPC-12-0-5" unit="cm"
          x="-0.0500000000000002"
-       y="-176.425986842105"
+       y="-176.593092105263"
          z="626.775"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -9038,7 +9175,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_10-7-1"/>
        <position name="posOpArapuca10-7-1-TPC-12-0-5" unit="cm"
          x="-0.0500000000000002"
-       y="-176.425986842105"
+       y="-176.593092105263"
          z="675.575"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -9046,7 +9183,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_10-7-2"/>
        <position name="posOpArapuca10-7-2-TPC-12-0-5" unit="cm"
          x="-0.0500000000000002"
-       y="-176.425986842105"
+       y="-176.593092105263"
          z="738.375"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -9054,7 +9191,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_10-7-3"/>
        <position name="posOpArapuca10-7-3-TPC-12-0-5" unit="cm"
          x="-0.0500000000000002"
-       y="-176.425986842105"
+       y="-176.593092105263"
          z="787.175"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -9062,7 +9199,7 @@ z="706.975"/>
 <volumeref ref="volArapuca_10-8"/>
 <position name="posArapuca10-8-TPC-12-0-5" unit="cm"
 x="0"
-y="-114.155592105263"
+y="-114.255855263158"
 z="706.975"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -9070,7 +9207,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_10-8-0"/>
        <position name="posOpArapuca10-8-0-TPC-12-0-5" unit="cm"
          x="-0.0500000000000002"
-       y="-114.155592105263"
+       y="-114.255855263158"
          z="626.775"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -9078,7 +9215,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_10-8-1"/>
        <position name="posOpArapuca10-8-1-TPC-12-0-5" unit="cm"
          x="-0.0500000000000002"
-       y="-114.155592105263"
+       y="-114.255855263158"
          z="675.575"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -9086,7 +9223,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_10-8-2"/>
        <position name="posOpArapuca10-8-2-TPC-12-0-5" unit="cm"
          x="-0.0500000000000002"
-       y="-114.155592105263"
+       y="-114.255855263158"
          z="738.375"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -9094,7 +9231,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_10-8-3"/>
        <position name="posOpArapuca10-8-3-TPC-12-0-5" unit="cm"
          x="-0.0500000000000002"
-       y="-114.155592105263"
+       y="-114.255855263158"
          z="787.175"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -9102,7 +9239,7 @@ z="706.975"/>
 <volumeref ref="volArapuca_10-9"/>
 <position name="posArapuca10-9-TPC-12-0-5" unit="cm"
 x="0"
-y="-51.885197368421"
+y="-51.9186184210527"
 z="706.975"/>
 <rotationref ref="rIdentity"/>
 </physvol>
@@ -9110,7 +9247,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_10-9-0"/>
        <position name="posOpArapuca10-9-0-TPC-12-0-5" unit="cm"
          x="-0.0500000000000002"
-       y="-51.885197368421"
+       y="-51.9186184210527"
          z="626.775"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -9118,7 +9255,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_10-9-1"/>
        <position name="posOpArapuca10-9-1-TPC-12-0-5" unit="cm"
          x="-0.0500000000000002"
-       y="-51.885197368421"
+       y="-51.9186184210527"
          z="675.575"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -9126,7 +9263,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_10-9-2"/>
        <position name="posOpArapuca10-9-2-TPC-12-0-5" unit="cm"
          x="-0.0500000000000002"
-       y="-51.885197368421"
+       y="-51.9186184210527"
          z="738.375"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -9134,7 +9271,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_10-9-3"/>
        <position name="posOpArapuca10-9-3-TPC-12-0-5" unit="cm"
          x="-0.0500000000000002"
-       y="-51.885197368421"
+       y="-51.9186184210527"
          z="787.175"/>
        <rotationref ref="rIdentity"/>
      </physvol>
@@ -9143,7 +9280,7 @@ z="706.975"/>
         <volumeref ref="volTPCInner"/>
         <position name="posTPC-20" unit="cm"
         x="-182.95455"
-        y="-324.664375"
+        y="-324.981875"
         z="706.975"/>
         <rotationref ref="rPlus180AboutXPlus180AboutY"/>
       </physvol>
@@ -9151,7 +9288,7 @@ z="706.975"/>
         <volumeref ref="volTPCInner"/>
         <position name="posTPC-21" unit="cm"
         x="182.95455"
-        y="-324.664375"
+        y="-324.981875"
         z="706.975"/>
         <rotationref ref="rPlus180AboutX"/>
       </physvol>
@@ -9159,16 +9296,16 @@ z="706.975"/>
       <physvol>
         <volumeref ref="volCathode"/>
         <position name="posCathode-11-0" unit="cm"
-      x="-363.38405"
-      y="-324.664375"
+      x="-363.52605"
+      y="-324.981875"
       z="706.975"/>
         <rotationref ref="rIdentity"/>
       </physvol>
       <physvol>
         <volumeref ref="volCathode"/>
         <position name="posCathode-11-1" unit="cm"
-      x="363.38405"
-      y="-324.664375"
+      x="363.52605"
+      y="-324.981875"
       z="706.975"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -9177,23 +9314,23 @@ z="706.975"/>
         <volumeref ref="volAPAFrameYSide"/>
         <position name="posAPAFrameYSideNeg-11" unit="cm"
       x="0"
-      y="283.87875"
-      z="597.05375"/>
+      y="284.51375"
+      z="597.37125"/>
         <rotationref ref="rIdentity"/>
       </physvol>
       <physvol>
         <volumeref ref="volAPAFrameYSide"/>
         <position name="posAPAFrameYSidePos-11" unit="cm"
       x="0"
-      y="283.87875"
-      z="816.89625"/>
+      y="284.51375"
+      z="816.57875"/>
         <rotationref ref="rIdentity"/>
       </physvol>
       <physvol>
         <volumeref ref="volAPAFrameZSide"/>
         <position name="posAPAFrameZSidePos-11" unit="cm"
       x="0"
-      y="581.79875"
+      y="582.43375"
       z="706.975"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -9201,7 +9338,7 @@ z="706.975"/>
         <volumeref ref="volAPAFrameZSide"/>
         <position name="posAPAFrameZSideNeg-11" unit="cm"
       x="0"
-      y="-14.0412500000001"
+      y="-13.40625"
       z="706.975"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -9212,22 +9349,33 @@ z="706.975"/>
       - There are two boards on each the up and downstream end,
           one each to wrap the U and V views around the APA frame
       - There are 4 on the bottom which anchor the U V and Z wires and the grid plane
-      - The rest of the parts of the G10 boards must be placed directly in volTPC   -->
+      FIXME: This is not true -> - The rest of the parts of the G10 boards must be placed directly in volTPC   -->
+
+      <!-- Position readout boards -->
+      <physvol>
+        <volumeref ref="volG10HeadBoards"/>
+        <position name="posG10HeadBoards-11" unit="cm"
+	  x="0"
+	  y="598.01775"
+      	  z="706.975"/>
+        <rotationref ref="rIdentity"/>
+      </physvol>
 
       <physvol>
         <volumeref ref="volG10BoardYSideCenterSeg"/>
         <position name="posG10BoardYSideCenterSeg-Vup-11" unit="cm"
-      x="0"
-      y="283.87875"
-      z="591.815"/>
-        <rotationref ref="rIdentity"/>
+         x="0"
+         y="284.51375"
+         z="592.053125"/>
+         <rotationref ref="rIdentity"/>
       </physvol>
+
       <physvol>
         <volumeref ref="volG10BoardYSideCenterSeg"/>
         <position name="posG10BoardYSideCenterSeg-Uup-11" unit="cm"
       x="0"
-      y="283.87875"
-      z="591.4975"/>
+      y="284.51375"
+      z="591.576875"/>
         <rotationref ref="rIdentity"/>
       </physvol>
 
@@ -9235,16 +9383,16 @@ z="706.975"/>
         <volumeref ref="volG10BoardYSideCenterSeg"/>
         <position name="posG10BoardYSideCenterSeg-Vdown-11" unit="cm"
       x="0"
-      y="283.87875"
-      z="822.135"/>
+      y="284.51375"
+      z="821.896875"/>
         <rotationref ref="rIdentity"/>
       </physvol>
       <physvol>
         <volumeref ref="volG10BoardYSideCenterSeg"/>
         <position name="posG10BoardYSideCenterSeg-Udown-11" unit="cm"
       x="0"
-      y="283.87875"
-      z="822.4525"/>
+      y="284.51375"
+      z="822.373125"/>
         <rotationref ref="rIdentity"/>
       </physvol>
 
@@ -9252,7 +9400,7 @@ z="706.975"/>
         <volumeref ref="volG10BoardZSideCenterSeg"/>
         <position name="posG10BoardZSideCenterSeg-Z-11" unit="cm"
       x="0"
-      y="-19.2800000000001"
+      y="-18.7243750000001"
       z="706.975"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -9260,7 +9408,7 @@ z="706.975"/>
         <volumeref ref="volG10BoardZSideCenterSeg"/>
         <position name="posG10BoardZSideCenterSeg-V-11" unit="cm"
       x="0"
-      y="-19.5975000000001"
+      y="-19.2006250000001"
       z="706.975"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -9268,7 +9416,7 @@ z="706.975"/>
         <volumeref ref="volG10BoardZSideCenterSeg"/>
         <position name="posG10BoardZSideCenterSeg-U-11" unit="cm"
       x="0"
-      y="-19.9150000000001"
+      y="-19.6768750000001"
       z="706.975"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -9276,7 +9424,7 @@ z="706.975"/>
         <volumeref ref="volG10BoardZSideCenterSeg"/>
         <position name="posG10BoardZSideCenterSeg-Grid-11" unit="cm"
       x="0"
-      y="-20.2325000000001"
+      y="-20.153125"
       z="706.975"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -9285,7 +9433,7 @@ z="706.975"/>
 <volumeref ref="volArapuca_11-0"/>
 <position name="posArapuca11-0-TPC-12-1-5" unit="cm"
 x="0"
-y="10.385197368421"
+y="10.4186184210526"
 z="706.975"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -9293,7 +9441,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_11-0-0"/>
        <position name="posOpArapuca11-0-0-TPC-12-1-5" unit="cm"
          x="0.0500000000000002"
-       y="10.385197368421"
+       y="10.4186184210526"
          z="626.775"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -9301,7 +9449,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_11-0-1"/>
        <position name="posOpArapuca11-0-1-TPC-12-1-5" unit="cm"
          x="0.0500000000000002"
-       y="10.385197368421"
+       y="10.4186184210526"
          z="675.575"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -9309,7 +9457,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_11-0-2"/>
        <position name="posOpArapuca11-0-2-TPC-12-1-5" unit="cm"
          x="0.0500000000000002"
-       y="10.385197368421"
+       y="10.4186184210526"
          z="738.375"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -9317,7 +9465,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_11-0-3"/>
        <position name="posOpArapuca11-0-3-TPC-12-1-5" unit="cm"
          x="0.0500000000000002"
-       y="10.385197368421"
+       y="10.4186184210526"
          z="787.175"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -9325,7 +9473,7 @@ z="706.975"/>
 <volumeref ref="volArapuca_11-1"/>
 <position name="posArapuca11-1-TPC-12-1-5" unit="cm"
 x="0"
-y="72.6555921052631"
+y="72.7558552631579"
 z="706.975"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -9333,7 +9481,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_11-1-0"/>
        <position name="posOpArapuca11-1-0-TPC-12-1-5" unit="cm"
          x="0.0500000000000002"
-       y="72.6555921052631"
+       y="72.7558552631579"
          z="626.775"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -9341,7 +9489,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_11-1-1"/>
        <position name="posOpArapuca11-1-1-TPC-12-1-5" unit="cm"
          x="0.0500000000000002"
-       y="72.6555921052631"
+       y="72.7558552631579"
          z="675.575"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -9349,7 +9497,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_11-1-2"/>
        <position name="posOpArapuca11-1-2-TPC-12-1-5" unit="cm"
          x="0.0500000000000002"
-       y="72.6555921052631"
+       y="72.7558552631579"
          z="738.375"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -9357,7 +9505,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_11-1-3"/>
        <position name="posOpArapuca11-1-3-TPC-12-1-5" unit="cm"
          x="0.0500000000000002"
-       y="72.6555921052631"
+       y="72.7558552631579"
          z="787.175"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -9365,7 +9513,7 @@ z="706.975"/>
 <volumeref ref="volArapuca_11-2"/>
 <position name="posArapuca11-2-TPC-12-1-5" unit="cm"
 x="0"
-y="134.925986842105"
+y="135.093092105263"
 z="706.975"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -9373,7 +9521,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_11-2-0"/>
        <position name="posOpArapuca11-2-0-TPC-12-1-5" unit="cm"
          x="0.0500000000000002"
-       y="134.925986842105"
+       y="135.093092105263"
          z="626.775"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -9381,7 +9529,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_11-2-1"/>
        <position name="posOpArapuca11-2-1-TPC-12-1-5" unit="cm"
          x="0.0500000000000002"
-       y="134.925986842105"
+       y="135.093092105263"
          z="675.575"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -9389,7 +9537,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_11-2-2"/>
        <position name="posOpArapuca11-2-2-TPC-12-1-5" unit="cm"
          x="0.0500000000000002"
-       y="134.925986842105"
+       y="135.093092105263"
          z="738.375"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -9397,7 +9545,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_11-2-3"/>
        <position name="posOpArapuca11-2-3-TPC-12-1-5" unit="cm"
          x="0.0500000000000002"
-       y="134.925986842105"
+       y="135.093092105263"
          z="787.175"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -9405,7 +9553,7 @@ z="706.975"/>
 <volumeref ref="volArapuca_11-3"/>
 <position name="posArapuca11-3-TPC-12-1-5" unit="cm"
 x="0"
-y="197.196381578947"
+y="197.430328947368"
 z="706.975"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -9413,7 +9561,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_11-3-0"/>
        <position name="posOpArapuca11-3-0-TPC-12-1-5" unit="cm"
          x="0.0500000000000002"
-       y="197.196381578947"
+       y="197.430328947368"
          z="626.775"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -9421,7 +9569,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_11-3-1"/>
        <position name="posOpArapuca11-3-1-TPC-12-1-5" unit="cm"
          x="0.0500000000000002"
-       y="197.196381578947"
+       y="197.430328947368"
          z="675.575"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -9429,7 +9577,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_11-3-2"/>
        <position name="posOpArapuca11-3-2-TPC-12-1-5" unit="cm"
          x="0.0500000000000002"
-       y="197.196381578947"
+       y="197.430328947368"
          z="738.375"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -9437,7 +9585,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_11-3-3"/>
        <position name="posOpArapuca11-3-3-TPC-12-1-5" unit="cm"
          x="0.0500000000000002"
-       y="197.196381578947"
+       y="197.430328947368"
          z="787.175"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -9445,7 +9593,7 @@ z="706.975"/>
 <volumeref ref="volArapuca_11-4"/>
 <position name="posArapuca11-4-TPC-12-1-5" unit="cm"
 x="0"
-y="259.46677631579"
+y="259.767565789474"
 z="706.975"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -9453,7 +9601,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_11-4-0"/>
        <position name="posOpArapuca11-4-0-TPC-12-1-5" unit="cm"
          x="0.0500000000000002"
-       y="259.46677631579"
+       y="259.767565789474"
          z="626.775"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -9461,7 +9609,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_11-4-1"/>
        <position name="posOpArapuca11-4-1-TPC-12-1-5" unit="cm"
          x="0.0500000000000002"
-       y="259.46677631579"
+       y="259.767565789474"
          z="675.575"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -9469,7 +9617,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_11-4-2"/>
        <position name="posOpArapuca11-4-2-TPC-12-1-5" unit="cm"
          x="0.0500000000000002"
-       y="259.46677631579"
+       y="259.767565789474"
          z="738.375"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -9477,7 +9625,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_11-4-3"/>
        <position name="posOpArapuca11-4-3-TPC-12-1-5" unit="cm"
          x="0.0500000000000002"
-       y="259.46677631579"
+       y="259.767565789474"
          z="787.175"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -9485,7 +9633,7 @@ z="706.975"/>
 <volumeref ref="volArapuca_11-5"/>
 <position name="posArapuca11-5-TPC-12-1-5" unit="cm"
 x="0"
-y="321.737171052632"
+y="322.104802631579"
 z="706.975"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -9493,7 +9641,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_11-5-0"/>
        <position name="posOpArapuca11-5-0-TPC-12-1-5" unit="cm"
          x="0.0500000000000002"
-       y="321.737171052632"
+       y="322.104802631579"
          z="626.775"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -9501,7 +9649,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_11-5-1"/>
        <position name="posOpArapuca11-5-1-TPC-12-1-5" unit="cm"
          x="0.0500000000000002"
-       y="321.737171052632"
+       y="322.104802631579"
          z="675.575"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -9509,7 +9657,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_11-5-2"/>
        <position name="posOpArapuca11-5-2-TPC-12-1-5" unit="cm"
          x="0.0500000000000002"
-       y="321.737171052632"
+       y="322.104802631579"
          z="738.375"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -9517,7 +9665,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_11-5-3"/>
        <position name="posOpArapuca11-5-3-TPC-12-1-5" unit="cm"
          x="0.0500000000000002"
-       y="321.737171052632"
+       y="322.104802631579"
          z="787.175"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -9525,7 +9673,7 @@ z="706.975"/>
 <volumeref ref="volArapuca_11-6"/>
 <position name="posArapuca11-6-TPC-12-1-5" unit="cm"
 x="0"
-y="384.007565789474"
+y="384.442039473684"
 z="706.975"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -9533,7 +9681,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_11-6-0"/>
        <position name="posOpArapuca11-6-0-TPC-12-1-5" unit="cm"
          x="0.0500000000000002"
-       y="384.007565789474"
+       y="384.442039473684"
          z="626.775"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -9541,7 +9689,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_11-6-1"/>
        <position name="posOpArapuca11-6-1-TPC-12-1-5" unit="cm"
          x="0.0500000000000002"
-       y="384.007565789474"
+       y="384.442039473684"
          z="675.575"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -9549,7 +9697,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_11-6-2"/>
        <position name="posOpArapuca11-6-2-TPC-12-1-5" unit="cm"
          x="0.0500000000000002"
-       y="384.007565789474"
+       y="384.442039473684"
          z="738.375"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -9557,7 +9705,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_11-6-3"/>
        <position name="posOpArapuca11-6-3-TPC-12-1-5" unit="cm"
          x="0.0500000000000002"
-       y="384.007565789474"
+       y="384.442039473684"
          z="787.175"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -9565,7 +9713,7 @@ z="706.975"/>
 <volumeref ref="volArapuca_11-7"/>
 <position name="posArapuca11-7-TPC-12-1-5" unit="cm"
 x="0"
-y="446.277960526316"
+y="446.77927631579"
 z="706.975"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -9573,7 +9721,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_11-7-0"/>
        <position name="posOpArapuca11-7-0-TPC-12-1-5" unit="cm"
          x="0.0500000000000002"
-       y="446.277960526316"
+       y="446.77927631579"
          z="626.775"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -9581,7 +9729,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_11-7-1"/>
        <position name="posOpArapuca11-7-1-TPC-12-1-5" unit="cm"
          x="0.0500000000000002"
-       y="446.277960526316"
+       y="446.77927631579"
          z="675.575"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -9589,7 +9737,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_11-7-2"/>
        <position name="posOpArapuca11-7-2-TPC-12-1-5" unit="cm"
          x="0.0500000000000002"
-       y="446.277960526316"
+       y="446.77927631579"
          z="738.375"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -9597,7 +9745,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_11-7-3"/>
        <position name="posOpArapuca11-7-3-TPC-12-1-5" unit="cm"
          x="0.0500000000000002"
-       y="446.277960526316"
+       y="446.77927631579"
          z="787.175"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -9605,7 +9753,7 @@ z="706.975"/>
 <volumeref ref="volArapuca_11-8"/>
 <position name="posArapuca11-8-TPC-12-1-5" unit="cm"
 x="0"
-y="508.548355263158"
+y="509.116513157895"
 z="706.975"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -9613,7 +9761,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_11-8-0"/>
        <position name="posOpArapuca11-8-0-TPC-12-1-5" unit="cm"
          x="0.0500000000000002"
-       y="508.548355263158"
+       y="509.116513157895"
          z="626.775"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -9621,7 +9769,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_11-8-1"/>
        <position name="posOpArapuca11-8-1-TPC-12-1-5" unit="cm"
          x="0.0500000000000002"
-       y="508.548355263158"
+       y="509.116513157895"
          z="675.575"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -9629,7 +9777,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_11-8-2"/>
        <position name="posOpArapuca11-8-2-TPC-12-1-5" unit="cm"
          x="0.0500000000000002"
-       y="508.548355263158"
+       y="509.116513157895"
          z="738.375"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -9637,7 +9785,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_11-8-3"/>
        <position name="posOpArapuca11-8-3-TPC-12-1-5" unit="cm"
          x="0.0500000000000002"
-       y="508.548355263158"
+       y="509.116513157895"
          z="787.175"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -9645,7 +9793,7 @@ z="706.975"/>
 <volumeref ref="volArapuca_11-9"/>
 <position name="posArapuca11-9-TPC-12-1-5" unit="cm"
 x="0"
-y="570.81875"
+y="571.45375"
 z="706.975"/>
 <rotationref ref="rPlus180AboutY"/>
 </physvol>
@@ -9653,7 +9801,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_11-9-0"/>
        <position name="posOpArapuca11-9-0-TPC-12-1-5" unit="cm"
          x="0.0500000000000002"
-       y="570.81875"
+       y="571.45375"
          z="626.775"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -9661,7 +9809,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_11-9-1"/>
        <position name="posOpArapuca11-9-1-TPC-12-1-5" unit="cm"
          x="0.0500000000000002"
-       y="570.81875"
+       y="571.45375"
          z="675.575"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -9669,7 +9817,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_11-9-2"/>
        <position name="posOpArapuca11-9-2-TPC-12-1-5" unit="cm"
          x="0.0500000000000002"
-       y="570.81875"
+       y="571.45375"
          z="738.375"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -9677,7 +9825,7 @@ z="706.975"/>
        <volumeref ref="volOpDetSensitive_11-9-3"/>
        <position name="posOpArapuca11-9-3-TPC-12-1-5" unit="cm"
          x="0.0500000000000002"
-       y="570.81875"
+       y="571.45375"
          z="787.175"/>
        <rotationref ref="rPlus180AboutY"/>
      </physvol>
@@ -9686,7 +9834,7 @@ z="706.975"/>
         <volumeref ref="volTPCInner"/>
         <position name="posTPC-22" unit="cm"
         x="-182.95455"
-        y="283.164375"
+        y="283.481875"
         z="706.975"/>
         <rotationref ref="rPlus180AboutY"/>
       </physvol>
@@ -9694,7 +9842,7 @@ z="706.975"/>
         <volumeref ref="volTPCInner"/>
         <position name="posTPC-23" unit="cm"
         x="182.95455"
-        y="283.164375"
+        y="283.481875"
         z="706.975"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -9702,16 +9850,16 @@ z="706.975"/>
       <physvol>
         <volumeref ref="volCathode"/>
         <position name="posCathode-12-0" unit="cm"
-      x="-363.38405"
-      y="283.164375"
+      x="-363.52605"
+      y="283.481875"
       z="706.975"/>
         <rotationref ref="rIdentity"/>
       </physvol>
       <physvol>
         <volumeref ref="volCathode"/>
         <position name="posCathode-12-1" unit="cm"
-      x="363.38405"
-      y="283.164375"
+      x="363.52605"
+      y="283.481875"
       z="706.975"/>
         <rotationref ref="rIdentity"/>
       </physvol>
@@ -9752,7 +9900,7 @@ z="706.975"/>
 
       <physvol>
         <volumeref ref="volDetEnclosure"/>
-      <position name="posDetEnclosure" unit="cm" x="0" y="120.75" z="570.29375"/>
+      <position name="posDetEnclosure" unit="cm" x="0" y="120.75" z="570.135"/>
       </physvol>
 
     </volume>


### PR DESCRIPTION
Regenerated FD HD 1x2x6 gdmls so that they contain G10/FR4 material changes and the have the old wire positions. They are up-to-date with the generator script. 