### PR TITLE
rotate cryostat steel structure in protodune-vd driftx geometry

### DIFF
--- a/dunecore/Geometry/gdml/generate_protodunevd_v4_refactored.pl
+++ b/dunecore/Geometry/gdml/generate_protodunevd_v4_refactored.pl
@@ -59,6 +59,13 @@
 #                  Pablo Barham Alzás <pablo.barham@cern.ch>
 ##################################################################################
 
+# v4.1		tkosc (thomas.kosc@proton.me) 27th November 2023
+#		- Rotated (-90° along z) the Steel Structure of cryostat (as indicated in todo list of v1)
+#		This concerns the following physical volumes : 
+#			* volSteelSupport_Top, volSteelSupport_Bottom, volSteelSupport_TUS, volSteelSupport_DS
+#			* volSteelSupport_LS, volSteelSupport_RS
+
+
 # Each subroutine generates a fragment GDML file, and the last subroutine
 # creates an XML file that make_gdml.pl will use to appropriately arrange
 # the fragment GDML files to create the final desired DUNE GDML file, 

--- a/dunecore/Geometry/gdml/generate_protodunevd_v4_refactored.pl
+++ b/dunecore/Geometry/gdml/generate_protodunevd_v4_refactored.pl
@@ -86,7 +86,7 @@ my $Cathode_switch="on";
 $ArapucaMesh_switch="on";
 
 my $HD_CRT_switch="off";
-my $DP_CRT_switch="off";  # existing CRTs in NP02 (VD module 0), CRT used for the double phase DP
+my $DP_CRT_switch="on";  # existing CRTs in NP02 (VD module 0), CRT used for the double phase DP
 # DP_CRT switch is OFF due to overlaps with the beam pipe. Once solved it should be turned ON. 
 
 if ( defined $help )
@@ -112,7 +112,7 @@ else
 
 
 # set wires on to be the default, unless given an input by the user
-$wires_on = 0; # 1=on, 0=off
+$wires_on = 1; # 1=on, 0=off
 if (defined $wires)
 {
     $wires_on = $wires;
@@ -357,15 +357,23 @@ $posCryoInDetEnc_x = 0;
 $posCryoInDetEnc_y = 0;
 $posCryoInDetEnc_z = 0;
 
-$posTopSteelStruct = $Argon_y/2+$FoamPadding+$SteelSupport_y; #+ 61.8/2; ## JS Real, add boxCryoTop dz/2.
-$posBotSteelStruct = -$Argon_y/2-$FoamPadding-$SteelSupport_y; # - 61.8/2;
-$posZBackSteelStruct = $Argon_z/2+$FoamPadding+$SteelSupport_z;# + 61.8/2;  ## JS Real, add boxCryoWallSm dz/2.;
-$posZFrontSteelStruct = -$Argon_z/2-$FoamPadding-$SteelSupport_z;# - 61.8/2;
-$posLeftSteelStruct = $Argon_x/2+$FoamPadding+$SteelSupport_x; # + 61.8/2;  ## JS Real, add boxCryoWallLg dz/2.;
-$posRightSteelStruct = -$Argon_x/2-$FoamPadding-$SteelSupport_x;#  + 61.8/2;  ## JS Real, add boxCryoWallLg dz/2.;
+$boxCryoWidth = 61.8;
+$posTopSteelStruct = $Argon_x/2+$FoamPadding+$SteelSupport_x + $boxCryoWidth/2. + 0.4/2.; #tkosc elaborate a little more these numbers
+$posBotSteelStruct = -$Argon_x/2-$FoamPadding-$SteelSupport_x - $boxCryoWidth/2. - 0.4/2.;
+$posZBackSteelStruct = $Argon_z/2+$FoamPadding+$SteelSupport_z + $boxCryoWidth/2. + 0.4/2.;
+$posZFrontSteelStruct = -$Argon_z/2-$FoamPadding-$SteelSupport_z - $boxCryoWidth/2. - 0.4/2.;
+$posLeftSteelStruct = $Argon_y/2+$FoamPadding+$SteelSupport_y + $boxCryoWidth/2. + 0.4/2.; 
+$posRightSteelStruct = -$Argon_y/2-$FoamPadding-$SteelSupport_y - $boxCryoWidth/2. - 0.4/2.;
+#tkosc : the ±0.4/2 is added in order to compensate the reduction of $Argon_xyz dimensions by 0.4cm
+# and keep the cryostat positions correct
+#790.0 --> 789.6 in x
+#854.8 --> 854.4 in y
+#854.8 --> 854.4 in z
 
-$posTopSteelStruct -= 29.7 if $DP_CRT_switch eq "on";  # overlap volume otherwise
-$posBotSteelStruct += 29.7 if $DP_CRT_switch eq "on";
+
+
+#$posTopSteelStruct -= 29.7 if $DP_CRT_switch eq "on";  # overlap volume otherwise
+#$posBotSteelStruct += 29.7 if $DP_CRT_switch eq "on";
 
 # 2*AirThickness is added to the world volume in x, y and z
 $AirThickness = 3000;
@@ -4911,44 +4919,44 @@ EOF
     
     <physvol name="volSteelSupport_Top">
     <volumeref ref="volSteelSupport_TB"/>
-    <position name="posSteelSupport_Top" x="0" y="@{[$posTopSteelStruct+61.1]}" z="0" unit="cm"/>
-    <rotation name="rotSteelSupport_Top" x="90" y="0" z="0" unit="deg"/>
+    <position name="posSteelSupport_Top" x="$posTopSteelStruct" y="0" z="0" unit="cm"/>
+    <rotation name="rotSteelSupport_Top" x="90" y="-90" z="0" unit="deg"/>
     
     </physvol>
     
     
     <physvol name="volSteelSupport_Bottom">
     <volumeref ref="volSteelSupport_TB"/>
-    <position name="posSteelSupport_Bottom" x="0" y="@{[$posBotSteelStruct-61.1]}" z="0" unit="cm"/>
-    <rotation name="rotSteelSupport_Bottom" x="-90" y="0" z="0" unit="deg"/>
+    <position name="posSteelSupport_Bottom" x="$posBotSteelStruct" y="0" z="0" unit="cm"/>
+    <rotation name="rotSteelSupport_Bottom" x="-90" y="90" z="0" unit="deg"/>
     </physvol>
     
     
-    <physvol>
+    <physvol name="volSteelSupport_US">
     <volumeref ref="volSteelSupport_US"/>
-    <position name="posSteelSupport_US" x="0" y="0" z="@{[$posZFrontSteelStruct-31.1]}" unit="cm"/>
-    <rotation name="rotSteelSupport_Front" x="0" y="0" z="0" unit="deg"/>
+    <position name="posSteelSupport_US" x="0" y="0" z="$posZFrontSteelStruct" unit="cm"/>
+    <rotation name="rotSteelSupport_Front" x="0" y="0" z="90" unit="deg"/>
     </physvol>
     
     
     <physvol name="volSteelSupport_DS">
     <volumeref ref="volSteelSupport_WS"/>
-    <position name="posSteelSupport_DS" x="0" y="0" z="@{[$posZBackSteelStruct+31.1]}" unit="cm"/>
-    <rotation name="rotSteelSupport_Back" x="0" y="0" z="" unit="deg"/>
+    <position name="posSteelSupport_DS" x="0" y="0" z="$posZBackSteelStruct" unit="cm"/>
+    <rotation name="rotSteelSupport_Back" x="0" y="0" z="90" unit="deg"/>
     </physvol>
     
     
     <physvol name="volSteelSupport_LS">
     <volumeref ref="volSteelSupport_LR"/>
-    <position name="posSteelSupport_LS" x="@{[$posLeftSteelStruct+65.1]}" y="0" z="0" unit="cm"/>
-    <rotation name="rotSteelSupport_LS" x="0" y="-90" z="0" unit="deg"/>
+    <position name="posSteelSupport_LS" x="0" y="$posRightSteelStruct" z="0" unit="cm"/>
+    <rotation name="rotSteelSupport_LS" x="90" y="0" z="-90" unit="deg"/>
     </physvol>
     
     
     <physvol name="volSteelSupport_RS">
     <volumeref ref="volSteelSupport_LR"/>
-    <position name="posSteelSupport_RS" x="@{[$posRightSteelStruct-65.1]}" y="0" z="0" unit="cm"/>
-    <rotation name="rotSteelSupport_RS" x="0" y="90" z="0" unit="deg"/>
+    <position name="posSteelSupport_RS" x="0" y="$posLeftSteelStruct" z="0" unit="cm"/>
+    <rotation name="rotSteelSupport_RS" x="90" y="0" z="90" unit="deg"/>
     </physvol>
     
 EOF

--- a/dunecore/Geometry/gdml/protodunevd_v4_refactored.gdml
+++ b/dunecore/Geometry/gdml/protodunevd_v4_refactored.gdml
@@ -259,11 +259,6 @@
    <fraction n="0.53" ref="fibrous_glass"/>
   </material>
 
-  <material name="FR4SussexAPA">
-   <D value="1.75" unit="g/cm3"/>
-   <fraction n="1" ref="FR4"/>
-  </material>
-
   <material name="STEEL_STAINLESS_Fe7Cr2Ni" formula="STEEL_STAINLESS_Fe7Cr2Ni">
    <D value="7.9300" unit="g/cm3"/>
    <fraction n="0.0010" ref="carbon"/>
@@ -12763,6 +12758,10 @@
       <position name="posGasArSub2" x="-86.02" y="419.6" z="-2.8421709430404e-14" unit="cm"/>
     </subtraction>
 
+        <box name="scintBox_Top" lunit="mm" x="132" y="1440" z="20"/>
+        <box name="scintBox_Bottom" lunit="mm"  x="116" y="1440" z="20"/>
+        <box name="ModulescintBox_Top" lunit="mm" x="1126" y="21" z="1440"/>
+        <box name="ModulescintBox_Bottom" lunit="mm" x="1110" y="21" z="1440"/>
     <box name="CathodeBlock" lunit="cm"
       x="6"
       y="337"
@@ -42151,6 +42150,106 @@
       <materialref ref="STEEL_STAINLESS_Fe7Cr2Ni"/>
       <solidref ref="SteelSupport"/>
     </volume>
+    <volume name="volAuxDetSensitiveCRTDPPaddleTop">
+      <materialref ref="Polystyrene"/>
+      <solidref ref="scintBox_Top"/>
+      <auxiliary auxtype="SensDet" auxvalue="AuxDet"/>
+      <auxiliary auxtype="Solid" auxvalue="True"/>
+    </volume>
+    <volume name="volAuxDetSensitiveCRTDPPaddleBottom">
+      <materialref ref="Polystyrene"/>
+      <solidref ref="scintBox_Bottom"/>
+      <auxiliary auxtype="SensDet" auxvalue="AuxDet"/>
+      <auxiliary auxtype="Solid" auxvalue="True"/>
+    </volume>
+<volume name="volAuxDetCRTDPModuleTop">
+      <materialref ref="Air"/>
+      <solidref ref="ModulescintBox_Top"/>
+    <physvol name="CRTDPTOP0" copynumber="0">
+        <volumeref ref="volAuxDetSensitiveCRTDPPaddleTop"/>
+        <position name="posCRTPaddleSensitiveTop1" unit="mm" x="497" y="0" z="0"/> 
+        <rotationref ref="rMinus90AboutX"/>
+    </physvol>
+    <physvol name="CRTDPTOP1" copynumber="1">
+        <volumeref ref="volAuxDetSensitiveCRTDPPaddleTop"/>
+        <position name="posCRTPaddleSensitiveTop1" unit="mm" x="355" y="0" z="0"/> 
+        <rotationref ref="rMinus90AboutX"/>
+    </physvol>
+    <physvol name="CRTDPTOP2" copynumber="2">
+        <volumeref ref="volAuxDetSensitiveCRTDPPaddleTop"/>
+        <position name="posCRTPaddleSensitiveTop1" unit="mm" x="213" y="0" z="0"/> 
+        <rotationref ref="rMinus90AboutX"/>
+    </physvol>
+    <physvol name="CRTDPTOP3" copynumber="3">
+        <volumeref ref="volAuxDetSensitiveCRTDPPaddleTop"/>
+        <position name="posCRTPaddleSensitiveTop1" unit="mm" x="71" y="0" z="0"/> 
+        <rotationref ref="rMinus90AboutX"/>
+    </physvol>
+    <physvol name="CRTDPTOP4" copynumber="4">
+        <volumeref ref="volAuxDetSensitiveCRTDPPaddleTop"/>
+        <position name="posCRTPaddleSensitiveTop1" unit="mm" x="-71" y="0" z="0"/> 
+        <rotationref ref="rMinus90AboutX"/>
+    </physvol>
+    <physvol name="CRTDPTOP5" copynumber="5">
+        <volumeref ref="volAuxDetSensitiveCRTDPPaddleTop"/>
+        <position name="posCRTPaddleSensitiveTop1" unit="mm" x="-213" y="0" z="0"/> 
+        <rotationref ref="rMinus90AboutX"/>
+    </physvol>
+    <physvol name="CRTDPTOP6" copynumber="6">
+        <volumeref ref="volAuxDetSensitiveCRTDPPaddleTop"/>
+        <position name="posCRTPaddleSensitiveTop1" unit="mm" x="-355" y="0" z="0"/> 
+        <rotationref ref="rMinus90AboutX"/>
+    </physvol>
+    <physvol name="CRTDPTOP7" copynumber="7">
+        <volumeref ref="volAuxDetSensitiveCRTDPPaddleTop"/>
+        <position name="posCRTPaddleSensitiveTop1" unit="mm" x="-497" y="0" z="0"/> 
+        <rotationref ref="rMinus90AboutX"/>
+    </physvol>
+</volume>
+<volume name="volAuxDetCRTDPModuleBottom">
+      <materialref ref="Air"/>
+      <solidref ref="ModulescintBox_Bottom"/>
+    <physvol name="CRTDPBOTTOM0" copynumber="8">
+      <volumeref ref="volAuxDetSensitiveCRTDPPaddleBottom"/>
+      <position name="posCRTPaddleSensitiveBottom1" unit="mm" x="497" y="0" z="0"/> 
+      <rotationref ref="rMinus90AboutX"/>
+    </physvol>
+    <physvol name="CRTDPBOTTOM1" copynumber="9">
+      <volumeref ref="volAuxDetSensitiveCRTDPPaddleBottom"/>
+      <position name="posCRTPaddleSensitiveBottom1" unit="mm" x="355" y="0" z="0"/> 
+      <rotationref ref="rMinus90AboutX"/>
+    </physvol>
+    <physvol name="CRTDPBOTTOM2" copynumber="10">
+      <volumeref ref="volAuxDetSensitiveCRTDPPaddleBottom"/>
+      <position name="posCRTPaddleSensitiveBottom1" unit="mm" x="213" y="0" z="0"/> 
+      <rotationref ref="rMinus90AboutX"/>
+    </physvol>
+    <physvol name="CRTDPBOTTOM3" copynumber="11">
+      <volumeref ref="volAuxDetSensitiveCRTDPPaddleBottom"/>
+      <position name="posCRTPaddleSensitiveBottom1" unit="mm" x="71" y="0" z="0"/> 
+      <rotationref ref="rMinus90AboutX"/>
+    </physvol>
+    <physvol name="CRTDPBOTTOM4" copynumber="12">
+      <volumeref ref="volAuxDetSensitiveCRTDPPaddleBottom"/>
+      <position name="posCRTPaddleSensitiveBottom1" unit="mm" x="-71" y="0" z="0"/> 
+      <rotationref ref="rMinus90AboutX"/>
+    </physvol>
+    <physvol name="CRTDPBOTTOM5" copynumber="13">
+      <volumeref ref="volAuxDetSensitiveCRTDPPaddleBottom"/>
+      <position name="posCRTPaddleSensitiveBottom1" unit="mm" x="-213" y="0" z="0"/> 
+      <rotationref ref="rMinus90AboutX"/>
+    </physvol>
+    <physvol name="CRTDPBOTTOM6" copynumber="14">
+      <volumeref ref="volAuxDetSensitiveCRTDPPaddleBottom"/>
+      <position name="posCRTPaddleSensitiveBottom1" unit="mm" x="-355" y="0" z="0"/> 
+      <rotationref ref="rMinus90AboutX"/>
+    </physvol>
+    <physvol name="CRTDPBOTTOM7" copynumber="15">
+      <volumeref ref="volAuxDetSensitiveCRTDPPaddleBottom"/>
+      <position name="posCRTPaddleSensitiveBottom1" unit="mm" x="-497" y="0" z="0"/> 
+      <rotationref ref="rMinus90AboutX"/>
+    </physvol>
+	</volume>
     <volume name="volUnitCent">
     <materialref ref="STEEL_STAINLESS_Fe7Cr2Ni"/>
     <solidref ref="UnitCent"/>
@@ -43043,44 +43142,44 @@
     
     <physvol name="volSteelSupport_Top">
     <volumeref ref="volSteelSupport_TB"/>
-    <position name="posSteelSupport_Top" x="0" y="569.3" z="0" unit="cm"/>
-    <rotation name="rotSteelSupport_Top" x="90" y="0" z="0" unit="deg"/>
+    <position name="posSteelSupport_Top" x="506.9" y="0" z="0" unit="cm"/>
+    <rotation name="rotSteelSupport_Top" x="90" y="-90" z="0" unit="deg"/>
     
     </physvol>
     
     
     <physvol name="volSteelSupport_Bottom">
     <volumeref ref="volSteelSupport_TB"/>
-    <position name="posSteelSupport_Bottom" x="0" y="-569.3" z="0" unit="cm"/>
-    <rotation name="rotSteelSupport_Bottom" x="-90" y="0" z="0" unit="deg"/>
+    <position name="posSteelSupport_Bottom" x="-506.9" y="0" z="0" unit="cm"/>
+    <rotation name="rotSteelSupport_Bottom" x="-90" y="90" z="0" unit="deg"/>
     </physvol>
     
     
-    <physvol>
+    <physvol name="volSteelSupport_US">
     <volumeref ref="volSteelSupport_US"/>
     <position name="posSteelSupport_US" x="0" y="0" z="-539.3" unit="cm"/>
-    <rotation name="rotSteelSupport_Front" x="0" y="0" z="0" unit="deg"/>
+    <rotation name="rotSteelSupport_Front" x="0" y="0" z="90" unit="deg"/>
     </physvol>
     
     
     <physvol name="volSteelSupport_DS">
     <volumeref ref="volSteelSupport_WS"/>
     <position name="posSteelSupport_DS" x="0" y="0" z="539.3" unit="cm"/>
-    <rotation name="rotSteelSupport_Back" x="0" y="0" z="" unit="deg"/>
+    <rotation name="rotSteelSupport_Back" x="0" y="0" z="90" unit="deg"/>
     </physvol>
     
     
     <physvol name="volSteelSupport_LS">
     <volumeref ref="volSteelSupport_LR"/>
-    <position name="posSteelSupport_LS" x="540.9" y="0" z="0" unit="cm"/>
-    <rotation name="rotSteelSupport_LS" x="0" y="-90" z="0" unit="deg"/>
+    <position name="posSteelSupport_LS" x="0" y="-539.3" z="0" unit="cm"/>
+    <rotation name="rotSteelSupport_LS" x="90" y="0" z="-90" unit="deg"/>
     </physvol>
     
     
     <physvol name="volSteelSupport_RS">
     <volumeref ref="volSteelSupport_LR"/>
-    <position name="posSteelSupport_RS" x="-540.9" y="0" z="0" unit="cm"/>
-    <rotation name="rotSteelSupport_RS" x="0" y="90" z="0" unit="deg"/>
+    <position name="posSteelSupport_RS" x="0" y="539.3" z="0" unit="cm"/>
+    <rotation name="rotSteelSupport_RS" x="90" y="0" z="90" unit="deg"/>
     </physvol>
     
     <physvol>
@@ -43118,6 +43217,16 @@
     <physvol>
            <volumeref ref="volCryostat"/>
            <positionref ref="posCryoInDetEnc"/>
+    </physvol>
+    <physvol>
+        <volumeref ref="volAuxDetCRTDPModuleTop"/>
+        <position name="posCRTDPTOPSensitive_1" unit="mm" x="3848" y="5882" z="0"/>
+        <rotationref ref="rIdentity"/>
+    </physvol>
+    <physvol>
+        <volumeref ref="volAuxDetCRTDPModuleBottom"/>
+        <position name="posCRTDPBOTTOMSensitive_1" unit="mm" x="-4406" y="-5882" z="0"/>
+        <rotationref ref="rIdentity"/>
     </physvol>
     </volume>
 

--- a/dunecore/Geometry/gdml/protodunevd_v4_refactored_nowires.gdml
+++ b/dunecore/Geometry/gdml/protodunevd_v4_refactored_nowires.gdml
@@ -259,11 +259,6 @@
    <fraction n="0.53" ref="fibrous_glass"/>
   </material>
 
-  <material name="FR4SussexAPA">
-   <D value="1.75" unit="g/cm3"/>
-   <fraction n="1" ref="FR4"/>
-  </material>
-
   <material name="STEEL_STAINLESS_Fe7Cr2Ni" formula="STEEL_STAINLESS_Fe7Cr2Ni">
    <D value="7.9300" unit="g/cm3"/>
    <fraction n="0.0010" ref="carbon"/>
@@ -1283,6 +1278,10 @@
       <position name="posGasArSub2" x="-86.02" y="419.6" z="-2.8421709430404e-14" unit="cm"/>
     </subtraction>
 
+        <box name="scintBox_Top" lunit="mm" x="132" y="1440" z="20"/>
+        <box name="scintBox_Bottom" lunit="mm"  x="116" y="1440" z="20"/>
+        <box name="ModulescintBox_Top" lunit="mm" x="1126" y="21" z="1440"/>
+        <box name="ModulescintBox_Bottom" lunit="mm" x="1110" y="21" z="1440"/>
     <box name="CathodeBlock" lunit="cm"
       x="6"
       y="337"
@@ -4187,6 +4186,106 @@
       <materialref ref="STEEL_STAINLESS_Fe7Cr2Ni"/>
       <solidref ref="SteelSupport"/>
     </volume>
+    <volume name="volAuxDetSensitiveCRTDPPaddleTop">
+      <materialref ref="Polystyrene"/>
+      <solidref ref="scintBox_Top"/>
+      <auxiliary auxtype="SensDet" auxvalue="AuxDet"/>
+      <auxiliary auxtype="Solid" auxvalue="True"/>
+    </volume>
+    <volume name="volAuxDetSensitiveCRTDPPaddleBottom">
+      <materialref ref="Polystyrene"/>
+      <solidref ref="scintBox_Bottom"/>
+      <auxiliary auxtype="SensDet" auxvalue="AuxDet"/>
+      <auxiliary auxtype="Solid" auxvalue="True"/>
+    </volume>
+<volume name="volAuxDetCRTDPModuleTop">
+      <materialref ref="Air"/>
+      <solidref ref="ModulescintBox_Top"/>
+    <physvol name="CRTDPTOP0" copynumber="0">
+        <volumeref ref="volAuxDetSensitiveCRTDPPaddleTop"/>
+        <position name="posCRTPaddleSensitiveTop1" unit="mm" x="497" y="0" z="0"/> 
+        <rotationref ref="rMinus90AboutX"/>
+    </physvol>
+    <physvol name="CRTDPTOP1" copynumber="1">
+        <volumeref ref="volAuxDetSensitiveCRTDPPaddleTop"/>
+        <position name="posCRTPaddleSensitiveTop1" unit="mm" x="355" y="0" z="0"/> 
+        <rotationref ref="rMinus90AboutX"/>
+    </physvol>
+    <physvol name="CRTDPTOP2" copynumber="2">
+        <volumeref ref="volAuxDetSensitiveCRTDPPaddleTop"/>
+        <position name="posCRTPaddleSensitiveTop1" unit="mm" x="213" y="0" z="0"/> 
+        <rotationref ref="rMinus90AboutX"/>
+    </physvol>
+    <physvol name="CRTDPTOP3" copynumber="3">
+        <volumeref ref="volAuxDetSensitiveCRTDPPaddleTop"/>
+        <position name="posCRTPaddleSensitiveTop1" unit="mm" x="71" y="0" z="0"/> 
+        <rotationref ref="rMinus90AboutX"/>
+    </physvol>
+    <physvol name="CRTDPTOP4" copynumber="4">
+        <volumeref ref="volAuxDetSensitiveCRTDPPaddleTop"/>
+        <position name="posCRTPaddleSensitiveTop1" unit="mm" x="-71" y="0" z="0"/> 
+        <rotationref ref="rMinus90AboutX"/>
+    </physvol>
+    <physvol name="CRTDPTOP5" copynumber="5">
+        <volumeref ref="volAuxDetSensitiveCRTDPPaddleTop"/>
+        <position name="posCRTPaddleSensitiveTop1" unit="mm" x="-213" y="0" z="0"/> 
+        <rotationref ref="rMinus90AboutX"/>
+    </physvol>
+    <physvol name="CRTDPTOP6" copynumber="6">
+        <volumeref ref="volAuxDetSensitiveCRTDPPaddleTop"/>
+        <position name="posCRTPaddleSensitiveTop1" unit="mm" x="-355" y="0" z="0"/> 
+        <rotationref ref="rMinus90AboutX"/>
+    </physvol>
+    <physvol name="CRTDPTOP7" copynumber="7">
+        <volumeref ref="volAuxDetSensitiveCRTDPPaddleTop"/>
+        <position name="posCRTPaddleSensitiveTop1" unit="mm" x="-497" y="0" z="0"/> 
+        <rotationref ref="rMinus90AboutX"/>
+    </physvol>
+</volume>
+<volume name="volAuxDetCRTDPModuleBottom">
+      <materialref ref="Air"/>
+      <solidref ref="ModulescintBox_Bottom"/>
+    <physvol name="CRTDPBOTTOM0" copynumber="8">
+      <volumeref ref="volAuxDetSensitiveCRTDPPaddleBottom"/>
+      <position name="posCRTPaddleSensitiveBottom1" unit="mm" x="497" y="0" z="0"/> 
+      <rotationref ref="rMinus90AboutX"/>
+    </physvol>
+    <physvol name="CRTDPBOTTOM1" copynumber="9">
+      <volumeref ref="volAuxDetSensitiveCRTDPPaddleBottom"/>
+      <position name="posCRTPaddleSensitiveBottom1" unit="mm" x="355" y="0" z="0"/> 
+      <rotationref ref="rMinus90AboutX"/>
+    </physvol>
+    <physvol name="CRTDPBOTTOM2" copynumber="10">
+      <volumeref ref="volAuxDetSensitiveCRTDPPaddleBottom"/>
+      <position name="posCRTPaddleSensitiveBottom1" unit="mm" x="213" y="0" z="0"/> 
+      <rotationref ref="rMinus90AboutX"/>
+    </physvol>
+    <physvol name="CRTDPBOTTOM3" copynumber="11">
+      <volumeref ref="volAuxDetSensitiveCRTDPPaddleBottom"/>
+      <position name="posCRTPaddleSensitiveBottom1" unit="mm" x="71" y="0" z="0"/> 
+      <rotationref ref="rMinus90AboutX"/>
+    </physvol>
+    <physvol name="CRTDPBOTTOM4" copynumber="12">
+      <volumeref ref="volAuxDetSensitiveCRTDPPaddleBottom"/>
+      <position name="posCRTPaddleSensitiveBottom1" unit="mm" x="-71" y="0" z="0"/> 
+      <rotationref ref="rMinus90AboutX"/>
+    </physvol>
+    <physvol name="CRTDPBOTTOM5" copynumber="13">
+      <volumeref ref="volAuxDetSensitiveCRTDPPaddleBottom"/>
+      <position name="posCRTPaddleSensitiveBottom1" unit="mm" x="-213" y="0" z="0"/> 
+      <rotationref ref="rMinus90AboutX"/>
+    </physvol>
+    <physvol name="CRTDPBOTTOM6" copynumber="14">
+      <volumeref ref="volAuxDetSensitiveCRTDPPaddleBottom"/>
+      <position name="posCRTPaddleSensitiveBottom1" unit="mm" x="-355" y="0" z="0"/> 
+      <rotationref ref="rMinus90AboutX"/>
+    </physvol>
+    <physvol name="CRTDPBOTTOM7" copynumber="15">
+      <volumeref ref="volAuxDetSensitiveCRTDPPaddleBottom"/>
+      <position name="posCRTPaddleSensitiveBottom1" unit="mm" x="-497" y="0" z="0"/> 
+      <rotationref ref="rMinus90AboutX"/>
+    </physvol>
+	</volume>
     <volume name="volUnitCent">
     <materialref ref="STEEL_STAINLESS_Fe7Cr2Ni"/>
     <solidref ref="UnitCent"/>
@@ -5079,44 +5178,44 @@
     
     <physvol name="volSteelSupport_Top">
     <volumeref ref="volSteelSupport_TB"/>
-    <position name="posSteelSupport_Top" x="0" y="569.3" z="0" unit="cm"/>
-    <rotation name="rotSteelSupport_Top" x="90" y="0" z="0" unit="deg"/>
+    <position name="posSteelSupport_Top" x="506.9" y="0" z="0" unit="cm"/>
+    <rotation name="rotSteelSupport_Top" x="90" y="-90" z="0" unit="deg"/>
     
     </physvol>
     
     
     <physvol name="volSteelSupport_Bottom">
     <volumeref ref="volSteelSupport_TB"/>
-    <position name="posSteelSupport_Bottom" x="0" y="-569.3" z="0" unit="cm"/>
-    <rotation name="rotSteelSupport_Bottom" x="-90" y="0" z="0" unit="deg"/>
+    <position name="posSteelSupport_Bottom" x="-506.9" y="0" z="0" unit="cm"/>
+    <rotation name="rotSteelSupport_Bottom" x="-90" y="90" z="0" unit="deg"/>
     </physvol>
     
     
-    <physvol>
+    <physvol name="volSteelSupport_US">
     <volumeref ref="volSteelSupport_US"/>
     <position name="posSteelSupport_US" x="0" y="0" z="-539.3" unit="cm"/>
-    <rotation name="rotSteelSupport_Front" x="0" y="0" z="0" unit="deg"/>
+    <rotation name="rotSteelSupport_Front" x="0" y="0" z="90" unit="deg"/>
     </physvol>
     
     
     <physvol name="volSteelSupport_DS">
     <volumeref ref="volSteelSupport_WS"/>
     <position name="posSteelSupport_DS" x="0" y="0" z="539.3" unit="cm"/>
-    <rotation name="rotSteelSupport_Back" x="0" y="0" z="" unit="deg"/>
+    <rotation name="rotSteelSupport_Back" x="0" y="0" z="90" unit="deg"/>
     </physvol>
     
     
     <physvol name="volSteelSupport_LS">
     <volumeref ref="volSteelSupport_LR"/>
-    <position name="posSteelSupport_LS" x="540.9" y="0" z="0" unit="cm"/>
-    <rotation name="rotSteelSupport_LS" x="0" y="-90" z="0" unit="deg"/>
+    <position name="posSteelSupport_LS" x="0" y="-539.3" z="0" unit="cm"/>
+    <rotation name="rotSteelSupport_LS" x="90" y="0" z="-90" unit="deg"/>
     </physvol>
     
     
     <physvol name="volSteelSupport_RS">
     <volumeref ref="volSteelSupport_LR"/>
-    <position name="posSteelSupport_RS" x="-540.9" y="0" z="0" unit="cm"/>
-    <rotation name="rotSteelSupport_RS" x="0" y="90" z="0" unit="deg"/>
+    <position name="posSteelSupport_RS" x="0" y="539.3" z="0" unit="cm"/>
+    <rotation name="rotSteelSupport_RS" x="90" y="0" z="90" unit="deg"/>
     </physvol>
     
     <physvol>
@@ -5154,6 +5253,16 @@
     <physvol>
            <volumeref ref="volCryostat"/>
            <positionref ref="posCryoInDetEnc"/>
+    </physvol>
+    <physvol>
+        <volumeref ref="volAuxDetCRTDPModuleTop"/>
+        <position name="posCRTDPTOPSensitive_1" unit="mm" x="3848" y="5882" z="0"/>
+        <rotationref ref="rIdentity"/>
+    </physvol>
+    <physvol>
+        <volumeref ref="volAuxDetCRTDPModuleBottom"/>
+        <position name="posCRTDPBOTTOMSensitive_1" unit="mm" x="-4406" y="-5882" z="0"/>
+        <rotationref ref="rIdentity"/>
     </physvol>
     </volume>
 


### PR DESCRIPTION
Following header comment of file `generate_protodunevd_v4_refactored.pl`, I rotated the steel structure of the cryostat. As for now, protodune-vd with drift along x used a non-rotated cryostat (same as protodune-hd) with walls pushed a little bit to avoid overlaps with inside components (because protodune is less high than large).
The latter had become incompatible with the CRT pannels included later (v3), as CRTs were located inside the cryostat.
I also added header comment to explain the few changes.

I'm attaching with the pull request a script file to draw the gdml geometry files. It can be compiled and executed in a root session, with the file name as argument (I think package root-geom must be installed). Ht escript has extension 'txt' because github won't accept the '.C' extension, so you just need to change the extension manually.

This geometry now has 3 overlaps which are all beam related. I'm getting in touch with the beam experts to solve this.


[drawProtoDune.txt](https://github.com/DUNE/dunecore/files/13472783/drawProtoDune.txt)

