### PR TITLE
Fix PDVD E-field and #sample detsim/reco mismatch

### DIFF
--- a/dunecore/Utilities/detectorproperties_dune.fcl
+++ b/dunecore/Utilities/detectorproperties_dune.fcl
@@ -96,7 +96,7 @@ protodune_detproperties.TimeOffsetZ:       0.
 protodunevd_detproperties:                   @local::standard_detproperties
 protodunevd_detproperties.Temperature:       87.68
 protodunevd_detproperties.Electronlifetime:  35.0e3
-protodunevd_detproperties.Efield:           [0.495, 4.0, 0.0]   #(predicted for microBooNE)
+protodunevd_detproperties.Efield:           [0.495, 3.125, 0.5, 3.125]   #(planned for PDVD)
 protodunevd_detproperties.ElectronsToADC:    6.8906513e-3 # 1fC = 43.008 ADC counts for DUNE fd
 protodunevd_detproperties.NumberTimeSamples: 6000         # 1 drift window = 4492 = drift length/drift velocity*sampling rate = (359.4 cm)/(0.16 cm/us)*(2 MHz)
 protodunevd_detproperties.ReadOutWindowSize: 6000         # 1 drift window = 4492 = drift length/drift velocity*sampling rate = (359.4 cm)/(0.16 cm/us)*(2 MHz)

--- a/dunecore/Utilities/services_protodunevd.fcl
+++ b/dunecore/Utilities/services_protodunevd.fcl
@@ -7,22 +7,23 @@ BEGIN_PROLOG
 ### ProtoDUNE-VD           ###
 ##############################
 
-protodunevd_services: @local::protodune_services 
-protodunevd_services.Geometry:  @local::protodunevd_v3_geo
-protodunevd_services.DetectorPropertiesService.NumberTimeSamples:     10000
-protodunevd_services.DetectorPropertiesService.ReadOutWindowSize:     10000
+protodunevd_services:                                       @local::protodune_services 
+protodunevd_services.Geometry:                              @local::protodunevd_v3_geo
+protodunevd_services.DetectorPropertiesService:             @local::protodunevd_detproperties
 
-protodunevd_rawdecoding_services: @local::protodune_rawdecoding_services
-protodunevd_rawdecoding_services.Geometry: @local::protodunevd_v3_geo
+protodunevd_rawdecoding_services:                           @local::protodune_rawdecoding_services
+protodunevd_rawdecoding_services.Geometry:                  @local::protodunevd_v3_geo
+protodunevd_rawdecoding_services.DetectorPropertiesService: @local::protodunevd_detproperties
 
-protodunevd_data_services: @local::protodune_data_services
-protodunevd_data_services.Geometry: @local::protodunevd_v3_geo
+protodunevd_data_services:                                  @local::protodune_data_services
+protodunevd_data_services.Geometry:                         @local::protodunevd_v3_geo
+protodunevd_data_services.DetectorPropertiesService:        @local::protodunevd_detproperties
 
 # Low memory configuration leaving out some heavy services
-protodunevd_minimal_simulation_services: @local::protodune_minimal_simulation_services
-protodunevd_minimal_simulation_services.Geometry: @local::protodunevd_v3_geo
-protodunevd_minimal_simulation_services.DetectorPropertiesService.NumberTimeSamples:     10000
-protodunevd_minimal_simulation_services.DetectorPropertiesService.ReadOutWindowSize:     10000
+protodunevd_minimal_simulation_services:                           @local::protodune_minimal_simulation_services
+protodunevd_minimal_simulation_services.Geometry:                  @local::protodunevd_v3_geo
+protodunevd_minimal_simulation_services.DetectorPropertiesService: @local::protodunevd_detproperties
+
 
 # Full service configuration which includes memory-intensive services
 protodunevd_simulation_services: 
@@ -58,11 +59,11 @@ protodunevd_data_reco_services:                       @local::protodunevd_reco_s
 protodunevd_data_reco_services.SignalShapingServiceDUNE.IndUFilter: "(x>0.01)*gaus"
 protodunevd_data_reco_services.SignalShapingServiceDUNE.IndVFilter: "(x>0.01)*gaus"
 # Use channel service for data
-protodunevd_data_reco_services.ChannelStatusService: @local::protodunevd_channel_status
+protodunevd_data_reco_services.ChannelStatusService:          @local::protodunevd_channel_status
 # Add the photon detector calibrator service
-protodunevd_data_reco_services.IPhotonCalibrator:    @local::protodunesp_photoncalibrator
+protodunevd_data_reco_services.IPhotonCalibrator:             @local::protodunesp_photoncalibrator
 # ProtoDUNE detector properties service
-protodunevd_data_reco_services.DetectorPropertiesService: @local::protodunesp_detproperties
+protodunevd_data_reco_services.DetectorPropertiesService:     @local::protodunevd_detproperties
 # Dataprep service.
 protodunevd_data_reco_services.RawDigitPrepService.ToolNames: @local::protodune_dataprep_tools_wirecell
 


### PR DESCRIPTION
While checking the PDVD sim/reco chain, found that `detsim` stage uses the default PDSP electric field of 486.7 V/cm (from local::protodunesp_detproperties) while the reconstruction has 495 V/cm (from local::protodunevd_detproperties).

Also, the `detsim` and `reco` have different number of samples. 
Suggest to have all simulated/reconstructed using 6000 sample (3000 us x 2 MHz).