### PR TITLE
trim services for pdvd

### DIFF
--- a/dunecore/Utilities/services_protodunevd.fcl
+++ b/dunecore/Utilities/services_protodunevd.fcl
@@ -36,14 +36,14 @@ protodunevd_simulation_services:
 
 # Reco services for ProtoDUNE simulation.
 protodunevd_reco_services:                            @local::protodunevd_services
-protodunevd_reco_services.RawDigitExtractService:     @local::rdx_std
-protodunevd_reco_services.RawDigitPrepService:        @local::adcprep_with_services_sim
-protodunevd_reco_services.AdcDeconvolutionService:    @local::adcdco_dunefd
-protodunevd_reco_services.AdcRoiBuildingService:      @local::adcroi_dunefd
-protodunevd_reco_services.AdcWireBuildingService:     @local::adcwire_std
+# protodunevd_reco_services.RawDigitExtractService:     @local::rdx_std
+# protodunevd_reco_services.RawDigitPrepService:        @local::adcprep_with_services_sim
+# protodunevd_reco_services.AdcDeconvolutionService:    @local::adcdco_dunefd
+# protodunevd_reco_services.AdcRoiBuildingService:      @local::adcroi_dunefd
+# protodunevd_reco_services.AdcWireBuildingService:     @local::adcwire_std
 # Switch to tool-based dataprep for ProtoDUNE simulation.
-protodunevd_reco_services.RawDigitPrepService:        @local::adcprep_with_tools_sim
-protodunevd_reco_services.RawDigitPrepService.ToolNames: @local::protodune_dataprep_tools_sim
+# protodunevd_reco_services.RawDigitPrepService:        @local::adcprep_with_tools_sim
+# protodunevd_reco_services.RawDigitPrepService.ToolNames: @local::protodune_dataprep_tools_sim
 # xyz calibration service
 protodunevd_reco_services.XYZCalibService:            @local::protodune_xyzcalib
 # lifetime calibration service
@@ -65,7 +65,7 @@ protodunevd_data_reco_services.IPhotonCalibrator:             @local::protodunes
 # ProtoDUNE detector properties service
 protodunevd_data_reco_services.DetectorPropertiesService:     @local::protodunevd_detproperties
 # Dataprep service.
-protodunevd_data_reco_services.RawDigitPrepService.ToolNames: @local::protodune_dataprep_tools_wirecell
+# protodunevd_data_reco_services.RawDigitPrepService.ToolNames: @local::protodune_dataprep_tools_wirecell
 
 
 


### PR DESCRIPTION
This PR removes some unused services in `protodunevd_reco.fcl`, e.g., 
```
AdcSampleFiller::ctor: Configuration parameters:
AdcThresholdSignalFinder::ctor: Configuration parameters:
ExpTailPedRemover::ctor: Parameters:
```