### PR TITLE
add HSIFrame objects to class def

### DIFF
--- a/dunecore/DuneObj/classes.h
+++ b/dunecore/DuneObj/classes.h
@@ -28,6 +28,8 @@
 #include "detdataformats/trigger/TriggerActivityData.hpp"
 #include "detdataformats/trigger/TriggerCandidateData.hpp"
 
+#include "detdataformats/hsi/HSIFrame.hpp"
+
 #include <vector>
 #include <map>
 //#include <array>

--- a/dunecore/DuneObj/classes_def.xml
+++ b/dunecore/DuneObj/classes_def.xml
@@ -175,5 +175,14 @@
   <class name="art::Wrapper<art::Assns<dunedaq::trgdataformats::TriggerCandidateData,dunedaq::trgdataformats::TriggerActivityData,void>>"/>
   <class name="art::Wrapper<art::Assns<dunedaq::trgdataformats::TriggerActivityData,dunedaq::trgdataformats::TriggerCandidateData,void>>"/>
 
+ <class name="dunedaq::detdataformats::HSIFrame" ClassVersion="10">
+  <version ClassVersion="10" checksum="3168665936"/>
+ </class>
+ <class name="std::vector<dunedaq::detdataformats::HSIFrame>"/>
+ <class name="art::Ptr<dunedaq::detdataformats::HSIFrame>"/>
+ <class name="art::PtrVector<dunedaq::detdataformats::HSIFrame>"/>
+ <class name="art::Wrapper<std::vector<dunedaq::detdataformats::HSIFrame>>"/>
+ <class name="art::Wrapper<art::PtrVector<dunedaq::detdataformats::HSIFrame>>"/>
+
 
 </lcgdict>


### PR DESCRIPTION
Needed for decoding protodune central trigger board (CTB) low-level trigger (LLT) and high-level trigger (HLT) bits.