### PR TITLE
update names of dune10kt 1x2x6 to be backward compatible as before v10 of larsoft

### DIFF
--- a/dunecore/Geometry/CRPWireReadoutGeom.cxx
+++ b/dunecore/Geometry/CRPWireReadoutGeom.cxx
@@ -78,18 +78,22 @@ namespace {
     unsigned int ncells  = 1U;  // number of drift volumes
     bool drift_direction_set{false};
     geo::Coordinate drift_axis{};
+    geo::DriftSign drift_sign{};
     for (geo::TPCGeo const& tpc: cryo.IterateTPCs()) {
       tpcs.push_back( &tpc );
-      auto const [axis, _] = tpc.DriftAxisWithSign();
+      auto const [axis, dasign] = tpc.DriftAxisWithSign();
       if( !drift_direction_set ) {
         drift_axis = axis;
+	drift_sign = dasign;
+	drift_direction_set = true;
 	continue;
       }
       
-      if( axis != drift_axis && ncells < 2U){
+      if( (axis != drift_axis || dasign != drift_sign) && ncells < 2U){
 	ncells++;
       }
       drift_axis = axis;
+      drift_sign = dasign;
       drift_direction_set = true;
     }
 
@@ -742,7 +746,6 @@ void geo::CRPWireReadoutGeom::buildReadoutPlanes
   
   mf::LogInfo(fLogCategory)
     << "Build readout planes for "<<NCryostats<<" "<<MaxTPCs<<" "<<MaxPlanes;
-  
 
   if( Cryostats.size() > 1 ){
     throw cet::exception(fLogCategory)

--- a/dunecore/Geometry/geometry_dune.fcl
+++ b/dunecore/Geometry/geometry_dune.fcl
@@ -164,8 +164,10 @@ dune10kt_1x2x6_v3_auxdet_geo.GDML: @local::dune10kt_1x2x6_v3_geo.GDML
 
 dune10kt_1x2x6_v4_geo:      @local::dune10kt_geo
 dune10kt_1x2x6_v4_geo.GDML: "dune10kt_v4_1x2x6.gdml"
+dune10kt_1x2x6_v4_geo.Name: "dune10kt_v4_1x2x6"
 dune10kt_1x2x6_v4_auxdet_geo:      @local::dune10kt_auxdet_geo
 dune10kt_1x2x6_v4_auxdet_geo.GDML: @local::dune10kt_1x2x6_v4_geo.GDML
+dune10kt_1x2x6_v4_auxdet_geo.Name: "dune10kt_v4_1x2x6"
 
 dune10kt_1x2x6_v4_refactored_geo:      @local::dune10kt_1x2x6_v4_geo
 dune10kt_1x2x6_v4_refactored_geo.GDML: "dune10kt_v4_refactored_1x2x6.gdml"
@@ -174,13 +176,17 @@ dune10kt_1x2x6_v4_refactored_auxdet_geo.GDML: @local::dune10kt_1x2x6_v4_refactor
 
 dune10kt_1x2x6_v5_refactored_geo:      @local::dune10kt_geo
 dune10kt_1x2x6_v5_refactored_geo.GDML: "dune10kt_v5_refactored_1x2x6.gdml"
+dune10kt_1x2x6_v5_refactored_geo.Name: "dune10kt_v5_1x2x6"
 dune10kt_1x2x6_v5_refactored_auxdet_geo:      @local::dune10kt_auxdet_geo
 dune10kt_1x2x6_v5_refactored_auxdet_geo.GDML: @local::dune10kt_1x2x6_v5_refactored_geo.GDML
+dune10kt_1x2x6_v5_refactored_auxdet_geo.Name: "dune10kt_v5_1x2x6"
 
 dune10kt_1x2x6_v6_refactored_geo:      @local::dune10kt_geo
 dune10kt_1x2x6_v6_refactored_geo.GDML: "dune10kt_v6_refactored_1x2x6.gdml"
+dune10kt_1x2x6_v6_refactored_geo.Name: "dune10kt_v6_1x2x6"
 dune10kt_1x2x6_v6_refactored_auxdet_geo:      @local::dune10kt_auxdet_geo
 dune10kt_1x2x6_v6_refactored_auxdet_geo.GDML: @local::dune10kt_1x2x6_v6_refactored_geo.GDML
+dune10kt_1x2x6_v6_refactored_auxdet_geo.Name: "dune10kt_v6_1x2x6"
 
 dune10kt_1x2x6_geo:              @local::dune10kt_1x2x6_v4_geo
 dune10kt_1x2x6_refactored_geo:   @local::dune10kt_1x2x6_v6_refactored_geo

--- a/dunecore/Geometry/geometry_dune.fcl
+++ b/dunecore/Geometry/geometry_dune.fcl
@@ -511,7 +511,10 @@ protodunevd_v4_geo: @local::protodunedphase_geo
 protodunevd_v4_geo.Name: "protodunevd_v4"
 protodunevd_v4_geo.GDML: "protodunevd_v4_refactored.gdml" #nowires.gdml
 protodunevd_v4_geo.ROOT: "protodunevd_v4_refactored.gdml"
-protodunevd_v4_geo.SortingParameters.SortTPCPDVD: true
+protodunevd_v4_geo.SortingParameters: {
+  tool_type: GeoObjectSorterCRU60D
+  SortTPCPDVD: true
+}
 
 protodunevd_v4_auxdet_geo: @local::standard_auxdet_sorter
 protodunevd_v4_auxdet_geo.Name: @local::protodunevd_v4_geo.Name

--- a/dunecore/Geometry/geometry_dune.fcl
+++ b/dunecore/Geometry/geometry_dune.fcl
@@ -136,14 +136,14 @@ dune10kt_1x2x2_v5_refactored_geo.GDML: "dune10kt_v5_refactored_1x2x2.gdml"
 dune10kt_1x2x2_v5_refactored_geo.Name: "dune10kt_v5_1x2x2"
 dune10kt_1x2x2_v5_refactored_auxdet_geo:      @local::dune10kt_auxdet_geo
 dune10kt_1x2x2_v5_refactored_auxdet_geo.GDML: @local::dune10kt_1x2x2_v5_refactored_geo.GDML
-dune10kt_1x2x2_v5_refactored_auxdet_geo.Name: "dune10kt_v5_1x2x2"
+dune10kt_1x2x2_v5_refactored_auxdet_geo.Name: @local::dune10kt_1x2x2_v5_refactored_geo.Name
 
 dune10kt_1x2x2_v6_refactored_geo:      @local::dune10kt_geo
 dune10kt_1x2x2_v6_refactored_geo.GDML: "dune10kt_v6_refactored_1x2x2.gdml"
-dune10kt_1x2x2_v5_refactored_geo.Name: "dune10kt_v6_1x2x2"
+dune10kt_1x2x2_v6_refactored_geo.Name: "dune10kt_v6_1x2x2"
 dune10kt_1x2x2_v6_refactored_auxdet_geo:      @local::dune10kt_auxdet_geo
 dune10kt_1x2x2_v6_refactored_auxdet_geo.GDML: @local::dune10kt_1x2x2_v6_refactored_geo.GDML
-dune10kt_1x2x2_v5_refactored_auxdet_geo.Name: "dune10kt_v6_1x2x2"
+dune10kt_1x2x2_v6_refactored_auxdet_geo.Name: @local::dune10kt_1x2x2_v6_refactored_geo.Name
 
 dune10kt_1x2x2_geo:              @local::dune10kt_1x2x2_v4_geo
 dune10kt_1x2x2_refactored_geo:   @local::dune10kt_1x2x2_v6_refactored_geo
@@ -171,7 +171,7 @@ dune10kt_1x2x6_v4_geo.GDML: "dune10kt_v4_1x2x6.gdml"
 dune10kt_1x2x6_v4_geo.Name: "dune10kt_v4_1x2x6"
 dune10kt_1x2x6_v4_auxdet_geo:      @local::dune10kt_auxdet_geo
 dune10kt_1x2x6_v4_auxdet_geo.GDML: @local::dune10kt_1x2x6_v4_geo.GDML
-dune10kt_1x2x6_v4_auxdet_geo.Name: "dune10kt_v4_1x2x6"
+dune10kt_1x2x6_v4_auxdet_geo.Name: @local::dune10kt_1x2x6_v4_geo.Name
 
 dune10kt_1x2x6_v4_refactored_geo:      @local::dune10kt_1x2x6_v4_geo
 dune10kt_1x2x6_v4_refactored_geo.GDML: "dune10kt_v4_refactored_1x2x6.gdml"
@@ -183,14 +183,14 @@ dune10kt_1x2x6_v5_refactored_geo.GDML: "dune10kt_v5_refactored_1x2x6.gdml"
 dune10kt_1x2x6_v5_refactored_geo.Name: "dune10kt_v5_1x2x6"
 dune10kt_1x2x6_v5_refactored_auxdet_geo:      @local::dune10kt_auxdet_geo
 dune10kt_1x2x6_v5_refactored_auxdet_geo.GDML: @local::dune10kt_1x2x6_v5_refactored_geo.GDML
-dune10kt_1x2x6_v5_refactored_auxdet_geo.Name: "dune10kt_v5_1x2x6"
+dune10kt_1x2x6_v5_refactored_auxdet_geo.Name: @local::dune10kt_1x2x6_v5_refactored_geo.Name
 
 dune10kt_1x2x6_v6_refactored_geo:      @local::dune10kt_geo
 dune10kt_1x2x6_v6_refactored_geo.GDML: "dune10kt_v6_refactored_1x2x6.gdml"
 dune10kt_1x2x6_v6_refactored_geo.Name: "dune10kt_v6_1x2x6"
 dune10kt_1x2x6_v6_refactored_auxdet_geo:      @local::dune10kt_auxdet_geo
 dune10kt_1x2x6_v6_refactored_auxdet_geo.GDML: @local::dune10kt_1x2x6_v6_refactored_geo.GDML
-dune10kt_1x2x6_v6_refactored_auxdet_geo.Name: "dune10kt_v6_1x2x6"
+dune10kt_1x2x6_v6_refactored_auxdet_geo.Name: @local::dune10kt_1x2x6_v6_refactored_geo.Name
 
 dune10kt_1x2x6_geo:              @local::dune10kt_1x2x6_v4_geo
 dune10kt_1x2x6_refactored_geo:   @local::dune10kt_1x2x6_v6_refactored_geo
@@ -513,6 +513,9 @@ protodunevd_v4_geo.GDML: "protodunevd_v4_refactored.gdml" #nowires.gdml
 protodunevd_v4_geo.ROOT: "protodunevd_v4_refactored.gdml"
 protodunevd_v4_geo.SortingParameters.SortTPCPDVD: true
 
+protodunevd_v4_auxdet_geo: @local::standard_auxdet_sorter
+protodunevd_v4_auxdet_geo.GDML: @local::protodunevd_v4_geo.Name
+protodunevd_v4_auxdet_geo.GDML: @local::protodunevd_v4_geo.GDML
 
 # protoDUNE VD with driftY
 protodunevd_v1_geo_driftY: @local::dune10kt_geo

--- a/dunecore/Geometry/geometry_dune.fcl
+++ b/dunecore/Geometry/geometry_dune.fcl
@@ -514,7 +514,7 @@ protodunevd_v4_geo.ROOT: "protodunevd_v4_refactored.gdml"
 protodunevd_v4_geo.SortingParameters.SortTPCPDVD: true
 
 protodunevd_v4_auxdet_geo: @local::standard_auxdet_sorter
-protodunevd_v4_auxdet_geo.GDML: @local::protodunevd_v4_geo.Name
+protodunevd_v4_auxdet_geo.Name: @local::protodunevd_v4_geo.Name
 protodunevd_v4_auxdet_geo.GDML: @local::protodunevd_v4_geo.GDML
 
 # protoDUNE VD with driftY

--- a/dunecore/Geometry/geometry_dune.fcl
+++ b/dunecore/Geometry/geometry_dune.fcl
@@ -133,13 +133,17 @@ dune10kt_1x2x2_v4_refactored_auxdet_geo.GDML: @local::dune10kt_1x2x2_v4_refactor
 
 dune10kt_1x2x2_v5_refactored_geo:      @local::dune10kt_geo
 dune10kt_1x2x2_v5_refactored_geo.GDML: "dune10kt_v5_refactored_1x2x2.gdml"
+dune10kt_1x2x2_v5_refactored_geo.Name: "dune10kt_v5_1x2x2"
 dune10kt_1x2x2_v5_refactored_auxdet_geo:      @local::dune10kt_auxdet_geo
 dune10kt_1x2x2_v5_refactored_auxdet_geo.GDML: @local::dune10kt_1x2x2_v5_refactored_geo.GDML
+dune10kt_1x2x2_v5_refactored_auxdet_geo.Name: "dune10kt_v5_1x2x2"
 
 dune10kt_1x2x2_v6_refactored_geo:      @local::dune10kt_geo
 dune10kt_1x2x2_v6_refactored_geo.GDML: "dune10kt_v6_refactored_1x2x2.gdml"
+dune10kt_1x2x2_v5_refactored_geo.Name: "dune10kt_v6_1x2x2"
 dune10kt_1x2x2_v6_refactored_auxdet_geo:      @local::dune10kt_auxdet_geo
 dune10kt_1x2x2_v6_refactored_auxdet_geo.GDML: @local::dune10kt_1x2x2_v6_refactored_geo.GDML
+dune10kt_1x2x2_v5_refactored_auxdet_geo.Name: "dune10kt_v6_1x2x2"
 
 dune10kt_1x2x2_geo:              @local::dune10kt_1x2x2_v4_geo
 dune10kt_1x2x2_refactored_geo:   @local::dune10kt_1x2x2_v6_refactored_geo
@@ -523,6 +527,7 @@ protodunevd_v1_auxdet_geo_driftY.GDML: @local::protodunevd_v1_geo_driftY.Name
 protodunevd_v1_auxdet_geo_driftY.GDML: @local::protodunevd_v1_geo_driftY.GDML
 
 protodunevd_v3_geo_driftY: @local::dune10kt_geo
+protodunevd_v3_geo_driftY.Name: "protodunevd_v3_driftY"
 protodunevd_v3_geo_driftY.GDML: "protodunevd_v3_driftY.gdml"
 protodunevd_v3_geo_driftY.SortingParameters: {
   tool_type: GeoObjectSorterCRU60D
@@ -530,6 +535,7 @@ protodunevd_v3_geo_driftY.SortingParameters: {
 }
 protodunevd_v3_auxdet_geo_driftY: @local::standard_auxdet_sorter
 protodunevd_v3_auxdet_geo_driftY.GDML: @local::protodunevd_v3_geo_driftY.GDML
+protodunevd_v3_auxdet_geo_driftY.Name: @local::protodunevd_v3_geo_driftY.Name
 
 protodunevd_v4_geo_driftY: @local::dune10kt_geo
 protodunevd_v4_geo_driftY.Name: "protodunevd_v4_driftY"

--- a/dunecore/Geometry/geometry_dune.fcl
+++ b/dunecore/Geometry/geometry_dune.fcl
@@ -527,7 +527,6 @@ protodunevd_v1_auxdet_geo_driftY.GDML: @local::protodunevd_v1_geo_driftY.Name
 protodunevd_v1_auxdet_geo_driftY.GDML: @local::protodunevd_v1_geo_driftY.GDML
 
 protodunevd_v3_geo_driftY: @local::dune10kt_geo
-protodunevd_v3_geo_driftY.Name: "protodunevd_v3_driftY"
 protodunevd_v3_geo_driftY.GDML: "protodunevd_v3_driftY.gdml"
 protodunevd_v3_geo_driftY.SortingParameters: {
   tool_type: GeoObjectSorterCRU60D
@@ -535,7 +534,6 @@ protodunevd_v3_geo_driftY.SortingParameters: {
 }
 protodunevd_v3_auxdet_geo_driftY: @local::standard_auxdet_sorter
 protodunevd_v3_auxdet_geo_driftY.GDML: @local::protodunevd_v3_geo_driftY.GDML
-protodunevd_v3_auxdet_geo_driftY.Name: @local::protodunevd_v3_geo_driftY.Name
 
 protodunevd_v4_geo_driftY: @local::dune10kt_geo
 protodunevd_v4_geo_driftY.Name: "protodunevd_v4_driftY"

--- a/dunecore/Utilities/services_protodunevd.fcl
+++ b/dunecore/Utilities/services_protodunevd.fcl
@@ -22,6 +22,7 @@ protodunevd_data_services.DetectorPropertiesService:        @local::protodunevd_
 # Low memory configuration leaving out some heavy services
 protodunevd_minimal_simulation_services:                           @local::protodune_minimal_simulation_services
 protodunevd_minimal_simulation_services.Geometry:                  @local::protodunevd_v4_geo
+protodunevd_minimal_simulation_services.AuxDetGeometry:            @local::protodunevd_v4_auxdet_geo
 protodunevd_minimal_simulation_services.DetectorPropertiesService: @local::protodunevd_detproperties
 
 

--- a/dunecore/Utilities/services_protodunevd.fcl
+++ b/dunecore/Utilities/services_protodunevd.fcl
@@ -9,6 +9,7 @@ BEGIN_PROLOG
 
 protodunevd_services:                                       @local::protodune_services 
 protodunevd_services.Geometry:                              @local::protodunevd_v4_geo
+protodunevd_services.AuxDetGeometry:                        @local::protodunevd_v4_auxdet_geo
 protodunevd_services.DetectorPropertiesService:             @local::protodunevd_detproperties
 
 protodunevd_rawdecoding_services:                           @local::protodune_rawdecoding_services
@@ -24,7 +25,6 @@ protodunevd_minimal_simulation_services:                           @local::proto
 protodunevd_minimal_simulation_services.Geometry:                  @local::protodunevd_v4_geo
 protodunevd_minimal_simulation_services.AuxDetGeometry:            @local::protodunevd_v4_auxdet_geo
 protodunevd_minimal_simulation_services.DetectorPropertiesService: @local::protodunevd_detproperties
-
 
 # Full service configuration which includes memory-intensive services
 protodunevd_simulation_services: 


### PR DESCRIPTION
Most of the Name blocks got carried over with the new PR, but the 1x2x6 FD-HD blocks didn't.  Rectifying this so the automatic Name-maker doesn't just use the GDML name, which causes a GeometryConfigurationWriter conflict