### PR TITLE
Use the correct AuxDet geometry for each VD 1x8x14 service

### DIFF
--- a/dunecore/Utilities/services_dunefd_vertdrift_1x8x14.fcl
+++ b/dunecore/Utilities/services_dunefd_vertdrift_1x8x14.fcl
@@ -9,77 +9,77 @@ BEGIN_PROLOG
 ###########################################
 dunefdvd_1x8x14_3view_services: {
     @table::dunefdvd_services
-AuxDetGeometry: @local::dunevd10kt_1x8x14_3view_auxdet_geo
+    AuxDetGeometry: @local::dunevd10kt_1x8x14_3view_auxdet_geo
     Geometry:                  @local::dunevd10kt_1x8x14_3view_geo
 }
 
 dunefdvd_1x8x14_3view_simulation_services: {
     @table::dunefdvd_simulation_services
-AuxDetGeometry: @local::dunevd10kt_1x8x14_3view_auxdet_geo
+    AuxDetGeometry: @local::dunevd10kt_1x8x14_3view_auxdet_geo
     Geometry:                  @local::dunevd10kt_1x8x14_3view_geo
     LArG4Detector:             @local::dunevd10kt_1x8x14_3view_larg4detector
 }
 
 dunefdvd_1x8x14_3view_reco_services: {
     @table::dunefdvd_reco_services
-AuxDetGeometry: @local::dunevd10kt_1x8x14_3view_auxdet_geo
+    AuxDetGeometry: @local::dunevd10kt_1x8x14_3view_auxdet_geo
     Geometry:                  @local::dunevd10kt_1x8x14_3view_geo
 }
 
 dunefdvd_1x8x14_3view_30deg_services: {
     @table::dunefdvd_services
-AuxDetGeometry: @local::dunevd10kt_1x8x14_3view_auxdet_geo
+    AuxDetGeometry: @local::dunevd10kt_1x8x14_3view_30deg_auxdet_geo
     Geometry:                  @local::dunevd10kt_1x8x14_3view_30deg_geo
 }
 
 dunefdvd_1x8x14_3view_30deg_simulation_services: {
     @table::dunefdvd_simulation_services
-AuxDetGeometry: @local::dunevd10kt_1x8x14_3view_auxdet_geo
+    AuxDetGeometry: @local::dunevd10kt_1x8x14_3view_30deg_auxdet_geo
     Geometry:                  @local::dunevd10kt_1x8x14_3view_30deg_geo
     LArG4Detector:             @local::dunevd10kt_1x8x14_3view_30deg_larg4detector
 }
 
 dunefdvd_1x8x14_3view_30deg_reco_services: {
     @table::dunefdvd_reco_services
-AuxDetGeometry: @local::dunevd10kt_1x8x14_3view_auxdet_geo
+    AuxDetGeometry: @local::dunevd10kt_1x8x14_3view_30deg_auxdet_geo
     Geometry:                  @local::dunevd10kt_1x8x14_3view_30deg_geo
 }
 
 dunefdvd_1x8x14_2view_services: {
     @table::dunefdvd_services
-AuxDetGeometry: @local::dunevd10kt_1x8x14_3view_auxdet_geo
+    AuxDetGeometry: @local::dunevd10kt_1x8x14_2view_auxdet_geo
     Geometry:                  @local::dunevd10kt_1x8x14_2view_geo
 }
 
 dunefdvd_1x8x14_2view_simulation_services: {
     @table::dunefdvd_simulation_services
-AuxDetGeometry: @local::dunevd10kt_1x8x14_3view_auxdet_geo
+    AuxDetGeometry: @local::dunevd10kt_1x8x14_2view_auxdet_geo
     Geometry:                  @local::dunevd10kt_1x8x14_2view_geo
     LArG4Detector:             @local::dunevd10kt_1x8x14_2view_larg4detector
 }
 
 dunefdvd_1x8x14_2view_reco_services: {
     @table::dunefdvd_reco_services
-AuxDetGeometry: @local::dunevd10kt_1x8x14_3view_auxdet_geo
+    AuxDetGeometry: @local::dunevd10kt_1x8x14_2view_auxdet_geo
     Geometry:                  @local::dunevd10kt_1x8x14_2view_geo
 }
 
 dunefdvd_1x8x14backup_3view_services: {
     @table::dunefdvd_services
-AuxDetGeometry: @local::dunevd10kt_1x8x14_3view_auxdet_geo
+    AuxDetGeometry: @local::dunevd10kt_1x8x14backup_3view_auxdet_geo
     Geometry:                  @local::dunevd10kt_1x8x14backup_3view_geo
 }
 
 dunefdvd_1x8x14backup_3view_simulation_services: {
     @table::dunefdvd_simulation_services
-AuxDetGeometry: @local::dunevd10kt_1x8x14_3view_auxdet_geo
+    AuxDetGeometry: @local::dunevd10kt_1x8x14backup_3view_auxdet_geo
     Geometry:                  @local::dunevd10kt_1x8x14backup_3view_geo
     LArG4Detector:             @local::dunevd10kt_1x8x14backup_3view_larg4detector
 }
 
 dunefdvd_1x8x14backup_3view_reco_services: {
     @table::dunefdvd_reco_services
-AuxDetGeometry: @local::dunevd10kt_1x8x14_3view_auxdet_geo
+    AuxDetGeometry: @local::dunevd10kt_1x8x14backup_3view_auxdet_geo
     Geometry:                  @local::dunevd10kt_1x8x14backup_3view_geo
 }
 


### PR DESCRIPTION
It looks like there was a small typo for the AuxDet geometry, because the 1x8x14 service fcl contains service blocks for 2 view, 3 view and 3 view 30 deg.  
The 3 view aux det geometry was being set for all of the service blocks.

I've also indented the AuxDet lines.