### PR TITLE
add offset to tpc physvol

### DIFF
--- a/dunecore/Geometry/gdml/generate_protodunevd_v4_refactored.pl
+++ b/dunecore/Geometry/gdml/generate_protodunevd_v4_refactored.pl
@@ -1634,39 +1634,20 @@ print TPC <<EOF;
   </volume>
 EOF
 
-# offset of the active area from CRP envelope
-my $pcbOffsetY = 999;
-my $pcbOffsetZ = 999;
-if( $quad == 0 ){
-    $pcbOffsetY =  $borderCRP/2;
-    $pcbOffsetZ = ($borderCRP/2 - $gapCRU/4);
-} elsif( $quad == 1 ){
-    $pcbOffsetY =  -$borderCRP/2;
-    $pcbOffsetZ =  ($borderCRP/2 - $gapCRU/4);
-} elsif ( $quad == 2 ){
-    $pcbOffsetY =  $borderCRP/2;
-    $pcbOffsetZ = -($borderCRP/2 - $gapCRU/4);
-} elsif ( $quad == 3 ){
-    $pcbOffsetY = -$borderCRP/2;
-    $pcbOffsetZ = -($borderCRP/2 - $gapCRU/4);
-} else {
-    die "Uknown $quad quadrant index\n";
-}
-
 my @posUplane = (0, 0, 0);
 $posUplane[0] = 0.5*$TPC_x - 2.5*$padWidth;
-$posUplane[1] = $pcbOffsetY;
-$posUplane[2] = $pcbOffsetZ;
+$posUplane[1] = 0;
+$posUplane[2] = 0;
 
 my @posVplane = (0, 0, 0);
 $posVplane[0] = 0.5*$TPC_x - 1.5*$padWidth;
-$posVplane[1] = $pcbOffsetY;
-$posVplane[2] = $pcbOffsetZ;
+$posVplane[1] = 0;
+$posVplane[2] = 0;
 
 my @posZplane = (0, 0, 0);
 $posZplane[0] = 0.5*$TPC_x - 0.5*$padWidth;
-$posZplane[1] = $pcbOffsetY; 
-$posZplane[2] = $pcbOffsetZ;
+$posZplane[1] = 0;
+$posZplane[2] = 0;
 
 my @posTPCActive = (0, 0, 0);
 $posTPCActive[0] = -$ReadoutPlane/2;
@@ -2874,22 +2855,30 @@ if ($tpc_on==1) # place Top and Bottom TPCs inside croystat offsetting each pair
 	if($ii%2==0){
 	  if($jj%2==0){
 	    $quad=0;
-	    $myposTPCY = $posY-$CRP_y/4;
-	    $myposTPCZ = $posZ-$CRP_z/4;
+            $pcbOffsetY =  $borderCRP/2; # offset of the active area from CRP envelope
+            $pcbOffsetZ = ($borderCRP/2 - $gapCRU/4);
+	    $myposTPCY = $posY-$CRP_y/4 + $pcbOffsetY;
+	    $myposTPCZ = $posZ-$CRP_z/4 + $pcbOffsetZ;
 	  }else{
 	    $quad=1;
-	    $myposTPCY = $posY+$CRP_y/4;
-	    $myposTPCZ = $posZ-$CRP_z/4;
+            $pcbOffsetY =  -$borderCRP/2;
+            $pcbOffsetZ =  ($borderCRP/2 - $gapCRU/4);
+	    $myposTPCY = $posY+$CRP_y/4 + $pcbOffsetY;
+	    $myposTPCZ = $posZ-$CRP_z/4 + $pcbOffsetZ;
           }
 	}else{
 	  if($jj%2==0){
 	    $quad=2;
-	    $myposTPCY = $posY-$CRP_y/4;
-	    $myposTPCZ = $posZ+$CRP_z/4;
+            $pcbOffsetY =  $borderCRP/2;
+            $pcbOffsetZ = -($borderCRP/2 - $gapCRU/4);
+	    $myposTPCY = $posY-$CRP_y/4 + $pcbOffsetY;
+	    $myposTPCZ = $posZ+$CRP_z/4 + $pcbOffsetZ;
 	  }else{
 	    $quad=3;
-	    $myposTPCY = $posY+$CRP_y/4;
-	    $myposTPCZ = $posZ+$CRP_z/4;
+            $pcbOffsetY = -$borderCRP/2;
+            $pcbOffsetZ = -($borderCRP/2 - $gapCRU/4);
+	    $myposTPCY = $posY+$CRP_y/4 + $pcbOffsetY;
+	    $myposTPCZ = $posZ+$CRP_z/4 + $pcbOffsetZ;
 	    }
 	}
 	

--- a/dunecore/Geometry/gdml/protodunevd_v4_refactored.gdml
+++ b/dunecore/Geometry/gdml/protodunevd_v4_refactored.gdml
@@ -20625,19 +20625,19 @@
        <physvol>
        <volumeref ref="volTPCPlaneU0"/>
        <position name="posPlaneU0" unit="cm" 
-         x="169.23" y="0.3" z="0.275"/>
+         x="169.23" y="0" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volTPCPlaneV0"/>
        <position name="posPlaneY0" unit="cm" 
-         x="169.25" y="0.3" z="0.275"/>
+         x="169.25" y="0" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volTPCPlaneZ0"/>
        <position name="posPlaneZ0" unit="cm" 
-         x="169.27" y="0.3" z="0.275"/>
+         x="169.27" y="0" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
@@ -27287,19 +27287,19 @@
        <physvol>
        <volumeref ref="volTPCPlaneU1"/>
        <position name="posPlaneU1" unit="cm" 
-         x="169.23" y="-0.3" z="0.275"/>
+         x="169.23" y="0" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volTPCPlaneV1"/>
        <position name="posPlaneY1" unit="cm" 
-         x="169.25" y="-0.3" z="0.275"/>
+         x="169.25" y="0" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volTPCPlaneZ1"/>
        <position name="posPlaneZ1" unit="cm" 
-         x="169.27" y="-0.3" z="0.275"/>
+         x="169.27" y="0" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
@@ -33949,19 +33949,19 @@
        <physvol>
        <volumeref ref="volTPCPlaneU2"/>
        <position name="posPlaneU2" unit="cm" 
-         x="169.23" y="0.3" z="-0.275"/>
+         x="169.23" y="0" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volTPCPlaneV2"/>
        <position name="posPlaneY2" unit="cm" 
-         x="169.25" y="0.3" z="-0.275"/>
+         x="169.25" y="0" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volTPCPlaneZ2"/>
        <position name="posPlaneZ2" unit="cm" 
-         x="169.27" y="0.3" z="-0.275"/>
+         x="169.27" y="0" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
@@ -40611,19 +40611,19 @@
        <physvol>
        <volumeref ref="volTPCPlaneU3"/>
        <position name="posPlaneU3" unit="cm" 
-         x="169.23" y="-0.3" z="-0.275"/>
+         x="169.23" y="0" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volTPCPlaneV3"/>
        <position name="posPlaneY3" unit="cm" 
-         x="169.25" y="-0.3" z="-0.275"/>
+         x="169.25" y="0" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volTPCPlaneZ3"/>
        <position name="posPlaneZ3" unit="cm" 
-         x="169.27" y="-0.3" z="-0.275"/>
+         x="169.27" y="0" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
@@ -40904,89 +40904,89 @@
       <physvol>
         <volumeref ref="volTPC0"/>
 	<position name="posTopTPC-0" unit="cm"
-           x="152.28" y="-252.75" z="-74.825"/>
+           x="152.28" y="-252.45" z="-74.55"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC0"/>
 	<position name="posBotTPC-0" unit="cm"
-           x="-192.28" y="-252.75" z="-74.825"/>
+           x="-192.28" y="-252.45" z="-74.55"/>
          <rotationref ref="rPlus180AboutY"/>           
       </physvol>
       <physvol>
         <volumeref ref="volTPC1"/>
 	<position name="posTopTPC-1" unit="cm"
-           x="152.28" y="-84.25" z="-74.825"/>
+           x="152.28" y="-84.55" z="-74.55"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC1"/>
 	<position name="posBotTPC-1" unit="cm"
-           x="-192.28" y="-84.25" z="-74.825"/>
+           x="-192.28" y="-84.55" z="-74.55"/>
          <rotationref ref="rPlus180AboutY"/>           
       </physvol>
       <physvol>
         <volumeref ref="volTPC0"/>
 	<position name="posTopTPC-2" unit="cm"
-           x="152.28" y="84.25" z="-74.825"/>
+           x="152.28" y="84.55" z="-74.55"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC0"/>
 	<position name="posBotTPC-2" unit="cm"
-           x="-192.28" y="84.25" z="-74.825"/>
+           x="-192.28" y="84.55" z="-74.55"/>
          <rotationref ref="rPlus180AboutY"/>           
       </physvol>
       <physvol>
         <volumeref ref="volTPC1"/>
 	<position name="posTopTPC-3" unit="cm"
-           x="152.28" y="252.75" z="-74.825"/>
+           x="152.28" y="252.45" z="-74.55"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC1"/>
 	<position name="posBotTPC-3" unit="cm"
-           x="-192.28" y="252.75" z="-74.825"/>
+           x="-192.28" y="252.45" z="-74.55"/>
          <rotationref ref="rPlus180AboutY"/>           
       </physvol>
       <physvol>
         <volumeref ref="volTPC2"/>
 	<position name="posTopTPC-4" unit="cm"
-           x="152.28" y="-252.75" z="74.825"/>
+           x="152.28" y="-252.45" z="74.55"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC2"/>
 	<position name="posBotTPC-4" unit="cm"
-           x="-192.28" y="-252.75" z="74.825"/>
+           x="-192.28" y="-252.45" z="74.55"/>
          <rotationref ref="rPlus180AboutY"/>           
       </physvol>
       <physvol>
         <volumeref ref="volTPC3"/>
 	<position name="posTopTPC-5" unit="cm"
-           x="152.28" y="-84.25" z="74.825"/>
+           x="152.28" y="-84.55" z="74.55"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC3"/>
 	<position name="posBotTPC-5" unit="cm"
-           x="-192.28" y="-84.25" z="74.825"/>
+           x="-192.28" y="-84.55" z="74.55"/>
          <rotationref ref="rPlus180AboutY"/>           
       </physvol>
       <physvol>
         <volumeref ref="volTPC2"/>
 	<position name="posTopTPC-6" unit="cm"
-           x="152.28" y="84.25" z="74.825"/>
+           x="152.28" y="84.55" z="74.55"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC2"/>
 	<position name="posBotTPC-6" unit="cm"
-           x="-192.28" y="84.25" z="74.825"/>
+           x="-192.28" y="84.55" z="74.55"/>
          <rotationref ref="rPlus180AboutY"/>           
       </physvol>
       <physvol>
         <volumeref ref="volTPC3"/>
 	<position name="posTopTPC-7" unit="cm"
-           x="152.28" y="252.75" z="74.825"/>
+           x="152.28" y="252.45" z="74.55"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC3"/>
 	<position name="posBotTPC-7" unit="cm"
-           x="-192.28" y="252.75" z="74.825"/>
+           x="-192.28" y="252.45" z="74.55"/>
          <rotationref ref="rPlus180AboutY"/>           
       </physvol>
   <physvol>

--- a/dunecore/Geometry/gdml/protodunevd_v4_refactored_nowires.gdml
+++ b/dunecore/Geometry/gdml/protodunevd_v4_refactored_nowires.gdml
@@ -2524,19 +2524,19 @@
        <physvol>
        <volumeref ref="volTPCPlaneU0"/>
        <position name="posPlaneU0" unit="cm" 
-         x="169.23" y="0.3" z="0.275"/>
+         x="169.23" y="0" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volTPCPlaneV0"/>
        <position name="posPlaneY0" unit="cm" 
-         x="169.25" y="0.3" z="0.275"/>
+         x="169.25" y="0" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volTPCPlaneZ0"/>
        <position name="posPlaneZ0" unit="cm" 
-         x="169.27" y="0.3" z="0.275"/>
+         x="169.27" y="0" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
@@ -2565,19 +2565,19 @@
        <physvol>
        <volumeref ref="volTPCPlaneU1"/>
        <position name="posPlaneU1" unit="cm" 
-         x="169.23" y="-0.3" z="0.275"/>
+         x="169.23" y="0" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volTPCPlaneV1"/>
        <position name="posPlaneY1" unit="cm" 
-         x="169.25" y="-0.3" z="0.275"/>
+         x="169.25" y="0" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volTPCPlaneZ1"/>
        <position name="posPlaneZ1" unit="cm" 
-         x="169.27" y="-0.3" z="0.275"/>
+         x="169.27" y="0" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
@@ -2606,19 +2606,19 @@
        <physvol>
        <volumeref ref="volTPCPlaneU2"/>
        <position name="posPlaneU2" unit="cm" 
-         x="169.23" y="0.3" z="-0.275"/>
+         x="169.23" y="0" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volTPCPlaneV2"/>
        <position name="posPlaneY2" unit="cm" 
-         x="169.25" y="0.3" z="-0.275"/>
+         x="169.25" y="0" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volTPCPlaneZ2"/>
        <position name="posPlaneZ2" unit="cm" 
-         x="169.27" y="0.3" z="-0.275"/>
+         x="169.27" y="0" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
@@ -2647,19 +2647,19 @@
        <physvol>
        <volumeref ref="volTPCPlaneU3"/>
        <position name="posPlaneU3" unit="cm" 
-         x="169.23" y="-0.3" z="-0.275"/>
+         x="169.23" y="0" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volTPCPlaneV3"/>
        <position name="posPlaneY3" unit="cm" 
-         x="169.25" y="-0.3" z="-0.275"/>
+         x="169.25" y="0" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
        <volumeref ref="volTPCPlaneZ3"/>
        <position name="posPlaneZ3" unit="cm" 
-         x="169.27" y="-0.3" z="-0.275"/>
+         x="169.27" y="0" z="0"/>
        <rotationref ref="rIdentity"/>
      </physvol>
      <physvol>
@@ -2940,89 +2940,89 @@
       <physvol>
         <volumeref ref="volTPC0"/>
 	<position name="posTopTPC-0" unit="cm"
-           x="152.28" y="-252.75" z="-74.825"/>
+           x="152.28" y="-252.45" z="-74.55"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC0"/>
 	<position name="posBotTPC-0" unit="cm"
-           x="-192.28" y="-252.75" z="-74.825"/>
+           x="-192.28" y="-252.45" z="-74.55"/>
          <rotationref ref="rPlus180AboutY"/>           
       </physvol>
       <physvol>
         <volumeref ref="volTPC1"/>
 	<position name="posTopTPC-1" unit="cm"
-           x="152.28" y="-84.25" z="-74.825"/>
+           x="152.28" y="-84.55" z="-74.55"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC1"/>
 	<position name="posBotTPC-1" unit="cm"
-           x="-192.28" y="-84.25" z="-74.825"/>
+           x="-192.28" y="-84.55" z="-74.55"/>
          <rotationref ref="rPlus180AboutY"/>           
       </physvol>
       <physvol>
         <volumeref ref="volTPC0"/>
 	<position name="posTopTPC-2" unit="cm"
-           x="152.28" y="84.25" z="-74.825"/>
+           x="152.28" y="84.55" z="-74.55"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC0"/>
 	<position name="posBotTPC-2" unit="cm"
-           x="-192.28" y="84.25" z="-74.825"/>
+           x="-192.28" y="84.55" z="-74.55"/>
          <rotationref ref="rPlus180AboutY"/>           
       </physvol>
       <physvol>
         <volumeref ref="volTPC1"/>
 	<position name="posTopTPC-3" unit="cm"
-           x="152.28" y="252.75" z="-74.825"/>
+           x="152.28" y="252.45" z="-74.55"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC1"/>
 	<position name="posBotTPC-3" unit="cm"
-           x="-192.28" y="252.75" z="-74.825"/>
+           x="-192.28" y="252.45" z="-74.55"/>
          <rotationref ref="rPlus180AboutY"/>           
       </physvol>
       <physvol>
         <volumeref ref="volTPC2"/>
 	<position name="posTopTPC-4" unit="cm"
-           x="152.28" y="-252.75" z="74.825"/>
+           x="152.28" y="-252.45" z="74.55"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC2"/>
 	<position name="posBotTPC-4" unit="cm"
-           x="-192.28" y="-252.75" z="74.825"/>
+           x="-192.28" y="-252.45" z="74.55"/>
          <rotationref ref="rPlus180AboutY"/>           
       </physvol>
       <physvol>
         <volumeref ref="volTPC3"/>
 	<position name="posTopTPC-5" unit="cm"
-           x="152.28" y="-84.25" z="74.825"/>
+           x="152.28" y="-84.55" z="74.55"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC3"/>
 	<position name="posBotTPC-5" unit="cm"
-           x="-192.28" y="-84.25" z="74.825"/>
+           x="-192.28" y="-84.55" z="74.55"/>
          <rotationref ref="rPlus180AboutY"/>           
       </physvol>
       <physvol>
         <volumeref ref="volTPC2"/>
 	<position name="posTopTPC-6" unit="cm"
-           x="152.28" y="84.25" z="74.825"/>
+           x="152.28" y="84.55" z="74.55"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC2"/>
 	<position name="posBotTPC-6" unit="cm"
-           x="-192.28" y="84.25" z="74.825"/>
+           x="-192.28" y="84.55" z="74.55"/>
          <rotationref ref="rPlus180AboutY"/>           
       </physvol>
       <physvol>
         <volumeref ref="volTPC3"/>
 	<position name="posTopTPC-7" unit="cm"
-           x="152.28" y="252.75" z="74.825"/>
+           x="152.28" y="252.45" z="74.55"/>
       </physvol>
       <physvol>
         <volumeref ref="volTPC3"/>
 	<position name="posBotTPC-7" unit="cm"
-           x="-192.28" y="252.75" z="74.825"/>
+           x="-192.28" y="252.45" z="74.55"/>
          <rotationref ref="rPlus180AboutY"/>           
       </physvol>
   <physvol>


### PR DESCRIPTION
Fix a minor bug: slightly different TPC offset between top and bottom drift volumes in ProtoDUNE VD. See details in this [talk](https://indico.fnal.gov/event/65976/contributions/298696/attachments/181018/248162/GeometryChanges.pdf).