### PR TITLE
Updates on protodune hd and vd tables

### DIFF
--- a/dunecore/Utilities/services_protodunehd.fcl
+++ b/dunecore/Utilities/services_protodunehd.fcl
@@ -7,25 +7,33 @@ BEGIN_PROLOG
 ### ProtoDUNE-HD           ###
 ##############################
 
-protodunehd_services: @local::protodune_services 
+protodunehd_services: @local::protodune_services
 protodunehd_services.AuxDetGeometry: @local::protodunehdv6_auxdet_geo
 protodunehd_services.Geometry:  @local::protodunehdv6_geo
 protodunehd_services.DetectorClocksService: @local::protodunehd_detectorclocks
+protodunehd_services.LArPropertiesService.ScintPreScale: 1
+protodunehd_services.WireReadout.WireReadoutClass: DuneApaWireReadout
 
 protodunehd_rawdecoding_services: @local::protodune_rawdecoding_services
 protodunehd_rawdecoding_services.AuxDetGeometry: @local::protodunehdv6_auxdet_geo
 protodunehd_rawdecoding_services.Geometry: @local::protodunehdv6_geo
 protodunehd_rawdecoding_services.DetectorClocksService: @local::protodunehd_detectorclocks
+protodunehd_rawdecoding_services.LArPropertiesService.ScintPreScale: 1
+protodunehd_rawdecoding_services.WireReadout.WireReadoutClass: DuneApaWireReadout
 
 protodunehd_data_services: @local::protodune_data_services
 protodunehd_data_services.AuxDetGeometry: @local::protodunehdv6_auxdet_geo
 protodunehd_data_services.Geometry: @local::protodunehdv6_geo
 protodunehd_data_services.DetectorClocksService: @local::protodunehd_detectorclocks
+protodunehd_data_services.LArPropertiesService.ScintPreScale: 1
+protodunehd_data_services.WireReadout.WireReadoutClass: DuneApaWireReadout
 
 # Low memory configuration leaving out some heavy services
 protodunehd_minimal_simulation_services: @local::protodune_minimal_simulation_services
 protodunehd_minimal_simulation_services.AuxDetGeometry: @local::protodunehdv6_auxdet_geo
 protodunehd_minimal_simulation_services.Geometry: @local::protodunehdv6_geo
+protodunehd_minimal_simulation_services.LArPropertiesService.ScintPreScale: 1
+protodunehd_minimal_simulation_services.WireReadout.WireReadoutClass: DuneApaWireReadout
 
 # Full service configuration which includes memory-intensive services
 protodunehd_simulation_services: 
@@ -33,9 +41,11 @@ protodunehd_simulation_services:
   @table::protodunehd_minimal_simulation_services
   SignalShapingServiceDUNE:     @local::protodunesp_signalshapingservice
   PhotonVisibilityService:      @local::protodune_hd_photonvisibilityservice
-  OpDetResponseInterface:       @local::protodune_opdetresponse
+  OpDetResponseInterface:       @local::standard_opdetresponse
   DetectorClocksService: @local::protodunehd_detectorclocks
 }
+protodunehd_simulation_services.OpDetResponseInterface.QuantumEfficiency: 1
+
 
 # Reco services for ProtoDUNE simulation.
 protodunehd_reco_services:                            @local::protodunehd_services

--- a/dunecore/Utilities/services_protodunevd.fcl
+++ b/dunecore/Utilities/services_protodunevd.fcl
@@ -11,20 +11,25 @@ protodunevd_services:                                       @local::protodune_se
 protodunevd_services.Geometry:                              @local::protodunevd_v4_geo
 protodunevd_services.AuxDetGeometry:                        @local::protodunevd_v4_auxdet_geo
 protodunevd_services.DetectorPropertiesService:             @local::protodunevd_detproperties
+protodunevd_services.LArPropertiesService.ScintPreScale: 1
+
 
 protodunevd_rawdecoding_services:                           @local::protodune_rawdecoding_services
 protodunevd_rawdecoding_services.Geometry:                  @local::protodunevd_v4_geo
 protodunevd_rawdecoding_services.DetectorPropertiesService: @local::protodunevd_detproperties
+protodunevd_rawdecoding_services.LArPropertiesService.ScintPreScale: 1
 
 protodunevd_data_services:                                  @local::protodune_data_services
 protodunevd_data_services.Geometry:                         @local::protodunevd_v4_geo
 protodunevd_data_services.DetectorPropertiesService:        @local::protodunevd_detproperties
+protodunevd_data_services.LArPropertiesService.ScintPreScale: 1
 
 # Low memory configuration leaving out some heavy services
 protodunevd_minimal_simulation_services:                           @local::protodune_minimal_simulation_services
 protodunevd_minimal_simulation_services.Geometry:                  @local::protodunevd_v4_geo
 protodunevd_minimal_simulation_services.AuxDetGeometry:            @local::protodunevd_v4_auxdet_geo
 protodunevd_minimal_simulation_services.DetectorPropertiesService: @local::protodunevd_detproperties
+protodunevd_minimal_simulation_services.LArPropertiesService.ScintPreScale: 1
 
 # Full service configuration which includes memory-intensive services
 protodunevd_simulation_services: 
@@ -32,8 +37,9 @@ protodunevd_simulation_services:
   @table::protodunevd_minimal_simulation_services
   SignalShapingServiceDUNE:     @local::protodunesp_signalshapingservice
   PhotonVisibilityService:      @local::protodune_photonvisibilityservice
-  OpDetResponseInterface:       @local::protodune_opdetresponse
+  OpDetResponseInterface:       @local::standard_opdetresponse
 }
+protodunevd_simulation_services.OpDetResponseInterface.QuantumEfficiency: 1
 
 # Reco services for ProtoDUNE simulation.
 protodunevd_reco_services:                            @local::protodunevd_services
@@ -73,7 +79,7 @@ protodunevd_data_reco_services.DetectorPropertiesService:     @local::protodunev
 ####################
 ##### DRIFT Y ######
 ####################
-protodunevd_services_driftY: @local::protodune_services
+protodunevd_services_driftY: @local::protodunevd_services
 protodunevd_services_driftY.AuxDetGeometry: @local::protodunevd_v3_auxdet_geo
 protodunevd_services_driftY.Geometry:  @local::protodunevd_v3_geo_driftY
 
@@ -85,7 +91,7 @@ protodunevd_simulation_services_driftY.ParticleInventoryService: @local::standar
 protodunevd_simulation_services_driftY.PhotonBackTrackerService:     @local::dunefd_photonbacktrackerservice
 
 # Low memory configuration leaving out some heavy services
-protodunevd_minimal_simulation_services_driftY: @local::protodune_minimal_simulation_services
+protodunevd_minimal_simulation_services_driftY: @local::protodunevd_minimal_simulation_services
 protodunevd_minimal_simulation_services_driftY.AuxDetGeometry: @local::protodunevd_v3_auxdet_geo
 protodunevd_minimal_simulation_services_driftY.Geometry: @local::protodunevd_v3_geo_driftY
 


### PR DESCRIPTION
Changes:
- Changing opdetresponse interface from protodune to default, to avoid using the single-phase features.
- Set WireReadoutClass to DuneApaWireReadout to avoid using the SP map for PDS. This is not needed for VD.
- Set ScintPreScale to 1 by default (we are not doing full photon simulations, so this is fine).