### PR TITLE
Add definitions for PDHD structural radiologicals

### DIFF
--- a/dunecore/Geometry/gdml/protodunehd_v6_refactored.gdml
+++ b/dunecore/Geometry/gdml/protodunehd_v6_refactored.gdml
@@ -65838,7 +65838,7 @@ z="113.63"/>
 	  z="113.63"/> 
         <rotationref ref="rPlus180AboutX"/>
       </physvol>
-
+      
       <physvol>
         <volumeref ref="volCathode"/>
         <position name="posCathode-1" unit="cm" 
@@ -65846,7 +65846,8 @@ z="113.63"/>
 	y="-26.2" 
 	z="113.63"/> 
         <rotationref ref="rIdentity"/>
-      </physvol>
+     </physvol>
+      
       <physvol name="volFCModTopRight-1">
         <volumeref ref="volFCMod"/>
         <position name="posFCModTopRight-1" unit="cm"
@@ -92086,10 +92087,6 @@ z="113.63"/>
          <rotationref ref="rBeamWRev3"/>
       </physvol>
        <physvol>
-           <volumeref ref="volCryostat"/>
-           <positionref ref="posCryoInDetEnc"/>
-       </physvol>
-       <physvol>
            <volumeref ref="volSurrConcrete"/>
            <position name="posSurrConcrete" unit="cm" 
            x="0" 
@@ -92351,6 +92348,10 @@ z="113.63"/>
             y="-220.52" 
             z="699.78"/>
            <rotationref ref="rMinus90AboutYMinus90AboutX"/>
+       </physvol>
+       <physvol>
+           <volumeref ref="volCryostat"/>
+           <positionref ref="posCryoInDetEnc"/>
        </physvol>
 
     </volume>

--- a/dunecore/Geometry/gdml/protodunehd_v6_refactored_nowires.gdml
+++ b/dunecore/Geometry/gdml/protodunehd_v6_refactored_nowires.gdml
@@ -30678,10 +30678,6 @@ z="113.63"/>
          <rotationref ref="rBeamWRev3"/>
       </physvol>
        <physvol>
-           <volumeref ref="volCryostat"/>
-           <positionref ref="posCryoInDetEnc"/>
-       </physvol>
-       <physvol>
            <volumeref ref="volSurrConcrete"/>
            <position name="posSurrConcrete" unit="cm" 
            x="0" 
@@ -30943,6 +30939,10 @@ z="113.63"/>
             y="-220.52" 
             z="699.78"/>
            <rotationref ref="rMinus90AboutYMinus90AboutX"/>
+       </physvol>
+       <physvol>
+           <volumeref ref="volCryostat"/>
+           <positionref ref="posCryoInDetEnc"/>
        </physvol>
 
     </volume>


### PR DESCRIPTION
Very minor fix of the PDHD v6 geometry file to allow for generating radiological decays in structural parts (CPA, APA and FC beams).
I simply moved the `volCryostat` mother volume down to the end of the volumes list definition.

Without this fix, `BaseRadioGen` module is failing:

```
---- EventProcessorFailure BEGIN
  EventProcessor: an exception occurred during current event processing
  ---- ScheduleExecutionFailure BEGIN
    Path: ProcessingStopped.
    ---- OtherArt BEGIN
      ---- BaseRadioGen BEGIN
        Didn't find the mum of the following node: volCathode_0The above exception was thrown while processing module Decay0Gen/k40cpa run: 1 subRun: 0 event: 1
      ---- BaseRadioGen END
    ---- OtherArt END
    Exception going through path simulate
  ---- ScheduleExecutionFailure END
---- EventProcessorFailure END
```