### PR TITLE
Using LarG4Detector v6 in fdhd 1x2x2

### DIFF
--- a/dunecore/Utilities/services_dunefd_horizdrift_1x2x2.fcl
+++ b/dunecore/Utilities/services_dunefd_horizdrift_1x2x2.fcl
@@ -9,13 +9,13 @@ BEGIN_PROLOG
 
 dunefd_1x2x2_services_legacy: {
     @table::dunefd_services_legacy
-AuxDetGeometry: @local::dune10kt_1x2x2_auxdet_geo
+    AuxDetGeometry: @local::dune10kt_1x2x2_auxdet_geo
     Geometry: @local::dune10kt_1x2x2_geo
 }
 
 dunefd_1x2x2_simulation_services_legacy: {
     @table::dunefd_simulation_services_legacy
-AuxDetGeometry: @local::dune10kt_1x2x2_auxdet_geo
+    AuxDetGeometry: @local::dune10kt_1x2x2_auxdet_geo
     Geometry: @local::dune10kt_1x2x2_geo
     PhotonVisibilityService: @local::dune10kt_1x2x6_photonvisibilityservice
     LArG4Parameters: {
@@ -35,26 +35,26 @@ AuxDetGeometry: @local::dune10kt_1x2x2_auxdet_geo
                                                         
 dunefd_1x2x2_reco_services_legacy: {
     @table::dunefd_reco_services_legacy
-AuxDetGeometry: @local::dune10kt_1x2x2_auxdet_geo
+    AuxDetGeometry: @local::dune10kt_1x2x2_auxdet_geo
     Geometry: @local::dune10kt_1x2x2_geo
 }
 
 dunefd_1x2x2_services: {
     @table::dunefd_services
-AuxDetGeometry: @local::dune10kt_1x2x2_auxdet_geo
+    AuxDetGeometry: @local::dune10kt_1x2x2_refactored_auxdet_geo
     Geometry: @local::dune10kt_1x2x2_refactored_geo
 }
 
 dunefd_1x2x2_simulation_services: {
     @table::dunefd_simulation_services
-AuxDetGeometry: @local::dune10kt_1x2x2_auxdet_geo
+    AuxDetGeometry: @local::dune10kt_1x2x2_refactored_auxdet_geo
     Geometry: @local::dune10kt_1x2x2_refactored_geo
-    LArG4Detector:      @local::dune10kt_1x2x2_v4_larg4detector
+    LArG4Detector:      @local::dune10kt_1x2x2_larg4detector
 }
 
 dunefd_1x2x2_reco_services: {
     @table::dunefd_reco_services
-AuxDetGeometry: @local::dune10kt_1x2x2_auxdet_geo
+    AuxDetGeometry: @local::dune10kt_1x2x2_refactored_auxdet_geo
     Geometry: @local::dune10kt_1x2x2_refactored_geo
 }
 


### PR DESCRIPTION
Depends on https://github.com/DUNE/dunesim/pull/83 being approved. Using the new geometry v6 table instead of the v4 one.