### PR TITLE
Fixing time synchronisation for PhotonBacktracker for ProtoDUNE HD MC.

### DIFF
--- a/dunecore/Utilities/services_protodunehd.fcl
+++ b/dunecore/Utilities/services_protodunehd.fcl
@@ -45,6 +45,12 @@ protodunehd_simulation_services:
   DetectorClocksService: @local::protodunehd_detectorclocks
 }
 protodunehd_simulation_services.OpDetResponseInterface.QuantumEfficiency: 1
+# Make sure that the backtracker looks at the correct time interval. 
+# The recob::OpFlash::Time() is at -250 us w.r.t. the true times and so should be the hit peak times. 
+# recob::OpFlash::AbsTime() is corrected for this offset. 
+# The Delay configurable is expected to be in ns.
+protodunehd_simulation_services.PhotonBackTrackerService.PhotonBackTracker.Delay: -250e3
+
 
 
 # Reco services for ProtoDUNE simulation.


### PR DESCRIPTION
I have observed the backtracker did not match OpHits to correct true particles and in general it failed to find corresponding true depositions. Looking at the OpFlash times w.r.t. the true times, the flash times came 250 us earlier. This fix is configuring the backtracker to account for that.