### PR TITLE
add trgdataformats2 versions of TP, TA and TC structs

### DIFF
--- a/dunecore/DuneObj/classes.h
+++ b/dunecore/DuneObj/classes.h
@@ -27,6 +27,9 @@
 #include "detdataformats/trigger/TriggerPrimitive.hpp"
 #include "detdataformats/trigger/TriggerActivityData.hpp"
 #include "detdataformats/trigger/TriggerCandidateData.hpp"
+#include "detdataformats/trigger/TriggerPrimitive2.hpp"
+#include "detdataformats/trigger/TriggerActivityData2.hpp"
+#include "detdataformats/trigger/TriggerCandidateData2.hpp"
 
 #include "detdataformats/hsi/HSIFrame.hpp"
 

--- a/dunecore/DuneObj/classes_def.xml
+++ b/dunecore/DuneObj/classes_def.xml
@@ -175,6 +175,44 @@
   <class name="art::Wrapper<art::Assns<dunedaq::trgdataformats::TriggerCandidateData,dunedaq::trgdataformats::TriggerActivityData,void>>"/>
   <class name="art::Wrapper<art::Assns<dunedaq::trgdataformats::TriggerActivityData,dunedaq::trgdataformats::TriggerCandidateData,void>>"/>
 
+  <class name="dunedaq::trgdataformats2::TriggerCandidateData" ClassVersion="10">
+   <version ClassVersion="10" checksum="1473877479"/>
+  </class>
+  <class name="dunedaq::trgdataformats2::TriggerPrimitive" ClassVersion="10">
+   <version ClassVersion="10" checksum="2799293222"/>
+  </class>
+  <class name="dunedaq::trgdataformats2::TriggerActivityData" ClassVersion="10">
+   <version ClassVersion="10" checksum="4129738310"/>
+  </class>
+  <class name="std::map<dunedaq::daqdataformats::SourceID,std::vector<dunedaq::trgdataformats2::TriggerCandidateData> >"/>
+  <class name="std::map<dunedaq::daqdataformats::SourceID,std::vector<dunedaq::trgdataformats2::TriggerPrimitive> >"/>
+  <class name="std::map<dunedaq::daqdataformats::SourceID,std::vector<dunedaq::trgdataformats2::TriggerActivityData> >"/>
+  <class name="std::vector<dunedaq::trgdataformats2::TriggerCandidateData>"/>
+  <class name="std::vector<dunedaq::trgdataformats2::TriggerPrimitive>"/>
+  <class name="std::vector<dunedaq::trgdataformats2::TriggerActivityData>"/>
+  <class name="art::Ptr<dunedaq::trgdataformats2::TriggerPrimitive>"/>
+  <class name="art::Ptr<dunedaq::trgdataformats2::TriggerActivityData>"/>
+  <class name="art::Ptr<dunedaq::trgdataformats2::TriggerCandidateData>"/>
+  <class name="art::PtrVector<dunedaq::trgdataformats2::TriggerPrimitive>"/>
+  <class name="art::PtrVector<dunedaq::trgdataformats2::TriggerActivityData>"/>
+  <class name="art::PtrVector<dunedaq::trgdataformats2::TriggerCandidateData>"/>
+  <class name="art::Wrapper<std::vector<dunedaq::trgdataformats2::TriggerCandidateData> >"/>
+  <class name="art::Wrapper<std::vector<dunedaq::trgdataformats2::TriggerPrimitive> >"/>
+  <class name="art::Wrapper<std::vector<dunedaq::trgdataformats2::TriggerActivityData> >"/>
+  <class name="art::Wrapper<art::PtrVector<dunedaq::trgdataformats2::TriggerCandidateData> >"/>
+  <class name="art::Wrapper<art::PtrVector<dunedaq::trgdataformats2::TriggerPrimitive> >"/>
+  <class name="art::Wrapper<art::PtrVector<dunedaq::trgdataformats2::TriggerActivityData> >"/>
+  <class name="std::pair< art::Ptr<dunedaq::trgdataformats2::TriggerActivityData>, art::Ptr<dunedaq::trgdataformats2::TriggerPrimitive> >"/>
+  <class name="std::pair< art::Ptr<dunedaq::trgdataformats2::TriggerCandidateData>, art::Ptr<dunedaq::trgdataformats2::TriggerActivityData> >"/>
+  <class name="art::Assns<dunedaq::trgdataformats2::TriggerActivityData,dunedaq::trgdataformats2::TriggerPrimitive,void>"/>
+  <class name="art::Assns<dunedaq::trgdataformats2::TriggerPrimitive,dunedaq::trgdataformats2::TriggerActivityData,void>"/>
+  <class name="art::Wrapper<art::Assns<dunedaq::trgdataformats2::TriggerActivityData,dunedaq::trgdataformats2::TriggerPrimitive,void>>"/>
+  <class name="art::Wrapper<art::Assns<dunedaq::trgdataformats2::TriggerPrimitive,dunedaq::trgdataformats2::TriggerActivityData,void>>"/>
+  <class name="art::Assns<dunedaq::trgdataformats2::TriggerCandidateData,dunedaq::trgdataformats2::TriggerActivityData,void>"/>
+  <class name="art::Assns<dunedaq::trgdataformats2::TriggerActivityData,dunedaq::trgdataformats2::TriggerCandidateData,void>"/>
+  <class name="art::Wrapper<art::Assns<dunedaq::trgdataformats2::TriggerCandidateData,dunedaq::trgdataformats2::TriggerActivityData,void>>"/>
+  <class name="art::Wrapper<art::Assns<dunedaq::trgdataformats2::TriggerActivityData,dunedaq::trgdataformats2::TriggerCandidateData,void>>"/>
+
  <class name="dunedaq::detdataformats::HSIFrame" ClassVersion="10">
   <version ClassVersion="10" checksum="3168665936"/>
  </class>


### PR DESCRIPTION
add trgdataformats2 versions of TP, TA and TC structs

These have changed size with respect to the original versions, which we must keep around for backward compatibility as data were written with the older version.  PDVD data will be written with the new format, and the decoder will write out new-formatted artROOT files instead of trying to convert.  So we need new class definitions.