### PR TITLE
Update on CRPWireReadout to update heritated functions from the defau…

### DIFF
--- a/dunecore/Geometry/CMakeLists.txt
+++ b/dunecore/Geometry/CMakeLists.txt
@@ -24,9 +24,11 @@ art_make( BASENAME_ONLY
                         art::Utilities
                         canvas::canvas
                         ROOT::Geom
-                        
+                        nlohmann_json::nlohmann_json
+                        duneprototypes::Protodune_vd_ChannelMap
+                        opdet_PDVDPDMapAlg
           SERVICE_LIBRARIES larcorealg::Geometry
-                     larcore::Geometry_Geometry_service
+                        larcore::Geometry_Geometry_service
                         dunecore_Geometry
                         fhiclcpp::fhiclcpp
                         cetlib::cetlib
@@ -34,6 +36,8 @@ art_make( BASENAME_ONLY
                         ROOT::Geom
                         ROOT::XMLIO
                         ROOT::Gdml
+                        duneprototypes::Protodune_vd_ChannelMap
+                        opdet_PDVDPDMapAlg
         )
 
 cet_build_plugin ( CheckGeometry art::module

--- a/dunecore/Geometry/CRPWireReadoutGeom.cxx
+++ b/dunecore/Geometry/CRPWireReadoutGeom.cxx
@@ -37,8 +37,14 @@
 #include <functional> // std::mem_fn()
 #include <tuple>
 
+// ART
+#include "art/Utilities/make_tool.h"
+
 #include "CRPWireReadoutGeom.h"
 #include "GeoObjectSorterCRU60D.h"
+
+#include "duneprototypes/Protodune/vd/ChannelMap/PDVDPDMapAlg.hh"
+
 
 using geo::dune::vd::crp::ChannelToWireMap;
 
@@ -307,7 +313,7 @@ geo::CRPWireReadoutGeom::CRPWireReadoutGeom(fhicl::ParameterSet const& p,
   
   buildReadoutPlanes(geom->Cryostats());
   fillChannelToWireMap(geom->Cryostats());
-  
+  fPDMapTool = art::make_tool<opdet::PDVDPDMapAlg>(p.get<fhicl::ParameterSet>("PDMapTool"));
   MF_LOG_TRACE(fLogCategory)
     << "CRPWireReadoutGeom::Initialize() completed.";
 }
@@ -952,5 +958,59 @@ std::string geo::CRPWireReadoutGeom::PlaneTypeName(PlaneType_t planeType) {
   
 } // geo::CRPWireReadoutGeom::PlaneTypeName()
 
-
 // ----------------------------------------------------------------------------
+bool geo::CRPWireReadoutGeom::IsValidOpChannel(unsigned int opChannel, unsigned int NOpDets) const {
+   return fPDMapTool->isValidHardwareChannel(opChannel);
+}
+bool geo::CRPWireReadoutGeom::IsValidOpChannel(int opChannel) const {
+   return fPDMapTool->isValidHardwareChannel(opChannel);
+}
+
+//----------------------------------------------------------------------------
+unsigned int geo::CRPWireReadoutGeom::NOpChannels(unsigned int NOpDets) const
+{
+  // By default just return the number of optical channels (hardware channels)
+  return fPDMapTool->NOpChannels();
+}
+
+//----------------------------------------------------------------------------
+unsigned int geo::CRPWireReadoutGeom::MaxOpChannel(unsigned int NOpDets) const
+{
+  // By default just return the number of optical channels
+  return fPDMapTool->NOpChannels();
+}
+
+//----------------------------------------------------------------------------
+unsigned int geo::CRPWireReadoutGeom::NOpHardwareChannels(unsigned int opDet) const
+{
+  // Number of hardware channels per opDet
+  return fPDMapTool->NOpHardwareChannels(opDet);
+}
+
+//----------------------------------------------------------------------------
+unsigned int geo::CRPWireReadoutGeom::OpChannel(unsigned int detNum, unsigned int ch) const
+{
+  //What is this?
+  return ch;
+}
+
+//----------------------------------------------------------------------------
+unsigned int geo::CRPWireReadoutGeom::OpDetFromOpChannel(unsigned int opChannel) const
+{
+  return fPDMapTool->OpDetFromOpChannel(opChannel);
+}
+//----------------------------------------------------------------------------
+unsigned int geo::CRPWireReadoutGeom::HardwareChannelFromOpChannel(unsigned int opDet) const
+{
+  if(fPDMapTool->NOpHardwareChannels(opDet)==1) return fPDMapTool->HardwareChannelPerOpDet(opDet).at(0);
+  else
+  {
+     throw cet::exception(fLogCategory)
+	<< "Ambiguous request of Op Hardware channel for an OpChannel that has more than one.\n";
+  }
+}
+//......................................................................
+unsigned int geo::CRPWireReadoutGeom::NOpChannels() const
+{
+  return fPDMapTool->NOpChannels();
+}

--- a/dunecore/Geometry/CRPWireReadoutGeom.h
+++ b/dunecore/Geometry/CRPWireReadoutGeom.h
@@ -28,6 +28,11 @@
 #include <cassert>
 #include <utility>
 
+// ART
+#include "art/Utilities/make_tool.h"
+
+#include "duneprototypes/Protodune/vd/ChannelMap/PDMapAlg.h"
+#include "duneprototypes/Protodune/vd/ChannelMap/PDVDPDMapAlg.hh"
 
 // -----------------------------------------------------------------------------
 // forward declarations
@@ -587,6 +592,22 @@ class geo::CRPWireReadoutGeom: public geo::WireReadoutGeom {
   //
   std::string fLogCategory = "CRPWireReadoutGeom";
   
+    /// @name Optical detector channel mapping
+
+  std::unique_ptr<opdet::PDVDPDMapAlg> fPDMapTool;
+//  virtual unsigned int NOpChannels(unsigned int NOpDets) const override;
+//  unsigned int NOpChannels() const  override;
+//  unsigned int MaxOpChannel() const override;
+  bool IsValidOpChannel(unsigned int opChannel, unsigned int NOpDets) const;
+  bool IsValidOpChannel(int opChannel) const;
+  unsigned int NOpChannels(unsigned int NOpDets) const;
+  unsigned int MaxOpChannel(unsigned int NOpDets) const;
+  unsigned int NOpHardwareChannels(unsigned int opDet) const;
+  unsigned int OpChannel(unsigned int detNum, unsigned int ch) const;
+  unsigned int OpDetFromOpChannel(unsigned int opChannel) const;
+  unsigned int HardwareChannelFromOpChannel(unsigned int /* opChannel */) const;
+  unsigned int NOpChannels() const;
+
 }; // class geo::CRPWireReadoutGeom
 
 


### PR DESCRIPTION
Updated default PDS-related WireReadout functions, to work with PDVD PDS.
They are linked to a map in duneprototypes, thus this PR should not be merged until this [PR is merged](https://github.com/DUNE/duneprototypes/pull/85).