### PR TITLE
Add a detector type string as an argument and a default implementation to ignore it.  Useful for PDVD and FDVD

### DIFF
--- a/dunecore/DuneObj/PDSPTPCDataInterfaceParent.h
+++ b/dunecore/DuneObj/PDSPTPCDataInterfaceParent.h
@@ -32,4 +32,16 @@
 					     std::vector<raw::RDStatus> &rdstatuses,  
 					     std::vector<int> &apalist) = 0;
 
+   // the same, but with an argument for the detector type.  Overloaded with an extra argument.  Some decoders will override this with a version that
+   // respects the detector type string.
+
+    virtual int retrieveDataForSpecifiedAPAs(art::Event &evt, std::vector<raw::RawDigit> &raw_digits, std::vector<raw::RDTimeStamp> &rd_timestamps,
+					     std::vector<raw::RDStatus> &rdstatuses,  
+					     std::vector<int> &apalist,
+					     std::string detectortype)
+   {
+     return retrieveDataForSpecifiedAPAs(evt, raw_digits, rd_timestamps, rdstatuses, apalist);
+   }
+   
+   
   };


### PR DESCRIPTION
The new channel map for VD has five keys -- detector type, crate, slot, stream and channel.  The detector type key is needed because crate numbers are re-used between TDE and BDE.  But the decoder tool used for PDSP assumed that crates were unique (and associated with APAs).  So this PR adds an overloaded retrieveDataForSpecifiedAPAs() that includes a detectortype as a std::string.  The default implementation is to ignore it in case a tool does not override the method.

The VD TPC decoder tool will override this method and the one without the detectortype string argument in another PR in duneprototypes.  This PR can go in as is, but the one in duneprototypes has yet to be made.  I will put a link to it in the conversation.