### PR TITLE
Fix: Add missing override specifiers to CRPWireReadoutGeom for Clang compatibility

### DIFF
--- a/dunecore/Geometry/CRPWireReadoutGeom.h
+++ b/dunecore/Geometry/CRPWireReadoutGeom.h
@@ -598,14 +598,14 @@ class geo::CRPWireReadoutGeom: public geo::WireReadoutGeom {
 //  virtual unsigned int NOpChannels(unsigned int NOpDets) const override;
 //  unsigned int NOpChannels() const  override;
 //  unsigned int MaxOpChannel() const override;
-  bool IsValidOpChannel(unsigned int opChannel, unsigned int NOpDets) const;
+  bool IsValidOpChannel(unsigned int opChannel, unsigned int NOpDets) const override;
   bool IsValidOpChannel(int opChannel) const;
-  unsigned int NOpChannels(unsigned int NOpDets) const;
-  unsigned int MaxOpChannel(unsigned int NOpDets) const;
-  unsigned int NOpHardwareChannels(unsigned int opDet) const;
-  unsigned int OpChannel(unsigned int detNum, unsigned int ch) const;
-  unsigned int OpDetFromOpChannel(unsigned int opChannel) const;
-  unsigned int HardwareChannelFromOpChannel(unsigned int /* opChannel */) const;
+  unsigned int NOpChannels(unsigned int NOpDets) const override;
+  unsigned int MaxOpChannel(unsigned int NOpDets) const override;
+  unsigned int NOpHardwareChannels(unsigned int opDet) const override;
+  unsigned int OpChannel(unsigned int detNum, unsigned int ch) const override;
+  unsigned int OpDetFromOpChannel(unsigned int opChannel) const override;
+  unsigned int HardwareChannelFromOpChannel(unsigned int /* opChannel */) const override;
   unsigned int NOpChannels() const;
 
 }; // class geo::CRPWireReadoutGeom


### PR DESCRIPTION
Fix: Add missing override specifiers to CRPWireReadoutGeom for Clang compatibility.

This fixes build errors caused by -Winconsistent-missing-override when compiled with Clang 14 or newer. The issue was introduced in commit 7be102b.