### PR TITLE
move PDVD opdet channel map to dunecore to clear circular dependencies

### DIFF
--- a/dunecore/ChannelMap/CMakeLists.txt
+++ b/dunecore/ChannelMap/CMakeLists.txt
@@ -1,4 +1,7 @@
 # Tom Junk 2022
+find_package( nlohmann_json REQUIRED )
+include_directories($ENV{NLOHMANN_JSON_INC})
+include_directories("${nlohmann_json_DIR}/../../../include")
 
 install_fhicl()
 install_headers()
@@ -17,3 +20,18 @@ art_make(SERVICE_LIBRARIES
  	                   dunecore::ChannelMap
 )
 
+art_make_library(
+  LIBRARY_NAME opdet_PDVDPDMapAlg
+  SOURCE
+    PDVDPDMapAlg_tool.cc
+  LIBRARIES
+    art::Framework_Core
+    art::Utilities
+    messagefacility::MF_MessageLogger
+    fhiclcpp::fhiclcpp
+    ROOT::Core
+    nlohmann_json::nlohmann_json
+)
+  
+# install PDVD_PDS_Mapping.json with mapping of the photon detectors
+install_fw(LIST PDVD_PDS_Mapping_v04152025.json)

--- a/dunecore/Geometry/CMakeLists.txt
+++ b/dunecore/Geometry/CMakeLists.txt
@@ -25,7 +25,6 @@ art_make( BASENAME_ONLY
                         canvas::canvas
                         ROOT::Geom
                         nlohmann_json::nlohmann_json
-                        duneprototypes::Protodune_vd_ChannelMap
                         opdet_PDVDPDMapAlg
           SERVICE_LIBRARIES larcorealg::Geometry
                         larcore::Geometry_Geometry_service
@@ -36,7 +35,6 @@ art_make( BASENAME_ONLY
                         ROOT::Geom
                         ROOT::XMLIO
                         ROOT::Gdml
-                        duneprototypes::Protodune_vd_ChannelMap
                         opdet_PDVDPDMapAlg
         )
 

--- a/dunecore/Geometry/CRPWireReadoutGeom.cxx
+++ b/dunecore/Geometry/CRPWireReadoutGeom.cxx
@@ -43,9 +43,6 @@
 #include "CRPWireReadoutGeom.h"
 #include "GeoObjectSorterCRU60D.h"
 
-#include "duneprototypes/Protodune/vd/ChannelMap/PDVDPDMapAlg.hh"
-
-
 using geo::dune::vd::crp::ChannelToWireMap;
 
 

--- a/dunecore/Geometry/CRPWireReadoutGeom.h
+++ b/dunecore/Geometry/CRPWireReadoutGeom.h
@@ -31,8 +31,8 @@
 // ART
 #include "art/Utilities/make_tool.h"
 
-#include "duneprototypes/Protodune/vd/ChannelMap/PDMapAlg.h"
-#include "duneprototypes/Protodune/vd/ChannelMap/PDVDPDMapAlg.hh"
+#include "dunecore/ChannelMap/PDMapAlg.h"
+#include "dunecore/ChannelMap/PDVDPDMapAlg.hh"
 
 // -----------------------------------------------------------------------------
 // forward declarations


### PR DESCRIPTION
The commits in duneopdet

https://github.com/DUNE/duneopdet/commit/b8f70045b501cd647878231c6da898e6229c7b13

and dunecore

https://github.com/DUNE/dunecore/pull/147

broke some users' builds. They introduce depencies on duneprototypes from dunecore and duneopdet, but the dependencies go the other direction, making a circular dependence. See the graph attached.
[dunesw_v10_08_00_e26_prof_graph.pdf](https://github.com/user-attachments/files/20890698/dunesw_v10_08_00_e26_prof_graph.pdf)
I moved the PDVD PDS channel map into dunecore/ChannelMap to fix this. PRs in dunecore and duneprototypes are associated with this and will be linked in the conversation when they are available.