### PR TITLE
Updating labels for photon backtracker

### DIFF
--- a/dunecore/Utilities/services_refactored_pdune.fcl
+++ b/dunecore/Utilities/services_refactored_pdune.fcl
@@ -51,6 +51,7 @@ protodunevd_refactored_simulation_services:
 }
 protodunevd_larg4_services: @local::protodune_larg4_services
 protodunevd_larg4_services.LArG4Detector: @local::protodunevd_larg4detector
+protodunevd_refactored_simulation_services.PhotonBackTrackerService.PhotonBackTracker.G4ModuleLabels: [ "PDFastSimAr", "PDFastSimXe" ]
 
 ## DRIFT Y ##
 protodunevd_drifty_refactored_simulation_services: @local::protodunevd_refactored_simulation_services


### PR DESCRIPTION
The labels for the PDVD photon bracktracker were not ok. The FastSim labels used in the g4 fhicls are PDFastSimAr and PDFastSimXe.