### PR TITLE
Updating PDVD services: ScintPreScale + OpCalibrator

### DIFF
--- a/dunecore/Utilities/services_common_dune.fcl
+++ b/dunecore/Utilities/services_common_dune.fcl
@@ -30,6 +30,7 @@
 #include "xyzcalib_dune.fcl"
 #include "lifetimecalib_dune.fcl"
 #include "PhotonCalibratorProtoDUNESP.fcl"
+#include "PhotonCalibratorProtoDUNEVD.fcl"
 #include "time_memory_tracker_dune.fcl"
 #include "crp_dune.fcl"
 #include "larg4services_dune.fcl"

--- a/dunecore/Utilities/services_common_dune.fcl
+++ b/dunecore/Utilities/services_common_dune.fcl
@@ -30,7 +30,7 @@
 #include "xyzcalib_dune.fcl"
 #include "lifetimecalib_dune.fcl"
 #include "PhotonCalibratorProtoDUNESP.fcl"
-#include "PhotonCalibratorProtoDUNEVD.fcl"
+#include "PhotonCalibratorDUNE.fcl"
 #include "time_memory_tracker_dune.fcl"
 #include "crp_dune.fcl"
 #include "larg4services_dune.fcl"

--- a/dunecore/Utilities/services_common_dune.fcl
+++ b/dunecore/Utilities/services_common_dune.fcl
@@ -30,7 +30,6 @@
 #include "xyzcalib_dune.fcl"
 #include "lifetimecalib_dune.fcl"
 #include "PhotonCalibratorProtoDUNESP.fcl"
-#include "PhotonCalibratorDUNE.fcl"
 #include "time_memory_tracker_dune.fcl"
 #include "crp_dune.fcl"
 #include "larg4services_dune.fcl"

--- a/dunecore/Utilities/services_protodunevd.fcl
+++ b/dunecore/Utilities/services_protodunevd.fcl
@@ -13,21 +13,21 @@ protodunevd_services.AuxDetGeometry:                        @local::protodunevd_
 protodunevd_services.DetectorPropertiesService:             @local::protodunevd_detproperties
 protodunevd_services.DetectorClocksService:                 @local::protodunevd_detectorclocks
 protodunevd_services.WireReadout:                           @local::protodunevd_wire_readout
-protodunevd_services.LArPropertiesService.ScintPreScale: 1
+protodunevd_services.LArPropertiesService.ScintPreScale: 0.2
 
 protodunevd_rawdecoding_services:                           @local::protodune_rawdecoding_services
 protodunevd_rawdecoding_services.Geometry:                  @local::protodunevd_v5_geo
 protodunevd_rawdecoding_services.DetectorPropertiesService: @local::protodunevd_detproperties
 protodunevd_rawdecoding_services.DetectorClocksService:                 @local::protodunevd_detectorclocks
 protodunevd_rawdecoding_services.WireReadout:               @local::protodunevd_wire_readout
-protodunevd_rawdecoding_services.LArPropertiesService.ScintPreScale: 1
+protodunevd_rawdecoding_services.LArPropertiesService.ScintPreScale: 0.2
 
 protodunevd_data_services:                                  @local::protodune_data_services
 protodunevd_data_services.Geometry:                         @local::protodunevd_v5_geo
 protodunevd_data_services.DetectorPropertiesService:        @local::protodunevd_detproperties
 protodunevd_data_services.DetectorClocksService:                 @local::protodunevd_detectorclocks
 protodunevd_data_services.WireReadout:                      @local::protodunevd_wire_readout
-protodunevd_data_services.LArPropertiesService.ScintPreScale: 1
+protodunevd_data_services.LArPropertiesService.ScintPreScale: 0.2
 
 # Low memory configuration leaving out some heavy services
 protodunevd_minimal_simulation_services:                           @local::protodune_minimal_simulation_services
@@ -36,7 +36,7 @@ protodunevd_minimal_simulation_services.AuxDetGeometry:            @local::proto
 protodunevd_minimal_simulation_services.DetectorPropertiesService: @local::protodunevd_detproperties
 protodunevd_minimal_simulation_services.DetectorClocksService:     @local::protodunevd_detectorclocks
 protodunevd_minimal_simulation_services.WireReadout:               @local::protodunevd_wire_readout 
-protodunevd_minimal_simulation_services.LArPropertiesService.ScintPreScale: 1
+protodunevd_minimal_simulation_services.LArPropertiesService.ScintPreScale: 0.2
 
 
 # Full service configuration which includes memory-intensive services

--- a/dunecore/Utilities/services_protodunevd.fcl
+++ b/dunecore/Utilities/services_protodunevd.fcl
@@ -20,14 +20,12 @@ protodunevd_rawdecoding_services.Geometry:                  @local::protodunevd_
 protodunevd_rawdecoding_services.DetectorPropertiesService: @local::protodunevd_detproperties
 protodunevd_rawdecoding_services.DetectorClocksService:                 @local::protodunevd_detectorclocks
 protodunevd_rawdecoding_services.WireReadout:               @local::protodunevd_wire_readout
-protodunevd_rawdecoding_services.LArPropertiesService.ScintPreScale: 0.2
 
 protodunevd_data_services:                                  @local::protodune_data_services
 protodunevd_data_services.Geometry:                         @local::protodunevd_v5_geo
 protodunevd_data_services.DetectorPropertiesService:        @local::protodunevd_detproperties
 protodunevd_data_services.DetectorClocksService:                 @local::protodunevd_detectorclocks
 protodunevd_data_services.WireReadout:                      @local::protodunevd_wire_readout
-protodunevd_data_services.LArPropertiesService.ScintPreScale: 0.2
 
 # Low memory configuration leaving out some heavy services
 protodunevd_minimal_simulation_services:                           @local::protodune_minimal_simulation_services


### PR DESCRIPTION
Changing default ScintPreScale in ProtoDUNE-VD from 1 to 0.2 to address problems with memory and ROOT I/O limitations in cosmics simulation.
This PR should not be merged before https://github.com/DUNE/duneopdet/pull/128.