### PR TITLE
Set PDVD E-field to nominal from data

### DIFF
--- a/dunecore/Utilities/detectorproperties_dune.fcl
+++ b/dunecore/Utilities/detectorproperties_dune.fcl
@@ -96,7 +96,7 @@ protodune_detproperties.TimeOffsetZ:       0.
 protodunevd_detproperties:                   @local::standard_detproperties
 protodunevd_detproperties.Temperature:       87.68
 protodunevd_detproperties.Electronlifetime:  35.0e3
-protodunevd_detproperties.Efield:           [0.495, 3.125, 0.5, 3.125]   #(planned for PDVD)
+protodunevd_detproperties.Efield:           [0.450, 3.125, 0.5, 3.125]   #(nominal PDVD / 154 kV)
 protodunevd_detproperties.ElectronsToADC:    6.8906513e-3 # 1fC = 43.008 ADC counts for DUNE fd
 protodunevd_detproperties.NumberTimeSamples: 6000         # 1 drift window = 4492 = drift length/drift velocity*sampling rate = (359.4 cm)/(0.16 cm/us)*(2 MHz)
 protodunevd_detproperties.ReadOutWindowSize: 6000         # 1 drift window = 4492 = drift length/drift velocity*sampling rate = (359.4 cm)/(0.16 cm/us)*(2 MHz)


### PR DESCRIPTION
Makes sure the nominal E-field is well propagated in the G4 simulation and reconstruction chain - which was not so far.