### PR TITLE
Feature/calcuttj resampled pdhd detprop

### DIFF
--- a/dunecore/Utilities/detectorproperties_dune.fcl
+++ b/dunecore/Utilities/detectorproperties_dune.fcl
@@ -117,8 +117,8 @@ protodunehd_detproperties.TimeOffsetV:       0.
 protodunehd_detproperties.TimeOffsetZ:       0.
 
 protodunehd_detproperties_resampled: @local::protodunehd_detproperties
-protodunehd_detproperties_resampled.NumberTimeSamples: 5899         # Resampling up to 500ns ticks --> 5899 samples
-protodunehd_detproperties_resampled.ReadOutWindowSize: 5899
+protodunehd_detproperties_resampled.NumberTimeSamples: 5999         # Resampling up to 500ns ticks --> 5999 samples
+protodunehd_detproperties_resampled.ReadOutWindowSize: 5999
 
 
 protodunesp_detproperties :

--- a/dunecore/Utilities/detectorproperties_dune.fcl
+++ b/dunecore/Utilities/detectorproperties_dune.fcl
@@ -116,6 +116,9 @@ protodunehd_detproperties.TimeOffsetU:       0.
 protodunehd_detproperties.TimeOffsetV:       0.
 protodunehd_detproperties.TimeOffsetZ:       0.
 
+protodunehd_detproperties_resampled: @local::protodunehd_detproperties
+protodunehd_detproperties_resampled.NumberTimeSamples: 5899         # Resampling up to 500ns ticks --> 5899 samples
+protodunehd_detproperties_resampled.ReadOutWindowSize: 5899
 
 
 protodunesp_detproperties :


### PR DESCRIPTION
Because we're resampling the detector readout to match the efield we need to change the detector properties accordingly