### PR TITLE
Setting LArQL model as default in ProtoDUNE-VD

### DIFF
--- a/dunecore/Utilities/services_refactored_pdune.fcl
+++ b/dunecore/Utilities/services_refactored_pdune.fcl
@@ -49,6 +49,8 @@ protodunevd_refactored_simulation_services:
   ParticleInventoryService:     @local::standard_particleinventoryservice
   PhotonBackTrackerService:     @local::dunefd_photonbacktrackerservice
 }
+protodunevd_refactored_simulation_services.LArG4Parameters.UseModLarqlRecomb: true
+
 protodunevd_larg4_services: @local::protodune_larg4_services
 protodunevd_larg4_services.LArG4Detector: @local::protodunevd_larg4detector
 protodunevd_refactored_simulation_services.PhotonBackTrackerService.PhotonBackTracker.G4ModuleLabels: [ "PDFastSimAr", "PDFastSimXe" ]


### PR DESCRIPTION
Given the PDs in the non-active volume of ProtoDUNE-VD, where the electric field is much lower than in the active volume, it is better to have as default the LY being calculated with a model that takes this into account. Currently, only LArQL is available to do so. Therefore, this PR sets it as the default.